### PR TITLE
Implement Phase 1 operable foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ Never place passwords, password digests, bearer tokens, reset tokens, private ke
 
 ## 9. Design for concurrency, retries, and delivery
 
-Use an integer `version` on mutable aggregate roots. Updates must compare the expected version and increment it atomically. Child changes increment the root version. Do not use `updated_at` as a concurrency token.
+Use Rails optimistic locking via an integer `lock_version` on mutable aggregate roots. Updates must compare the expected `lock_version` and increment it atomically. Child changes increment the root `lock_version`. Do not use `updated_at` as a concurrency token.
 
 Retryable commands require a scoped idempotency key, operation type, source identity, canonical payload hash, status, and stored outcome or response reference. Reusing a key with different input is an error.
 
@@ -131,7 +131,7 @@ Business changes and outbox messages commit in the same database transaction. De
 
 - PostgreSQL is authoritative. Do not introduce SQLite-specific behavior or assumptions.
 - Do not edit `db/schema.rb` directly; change the schema through migrations and commit the regenerated schema.
-- Use the project's UUIDv7 policy for new durable business entities. If framework support is not yet established, document and settle the implementation before creating affected tables.
+- Use the project's UUIDv7 policy for new durable business entities. Domain models assign UUIDv7 through the shared Rails concern (`SecureRandom.uuid_v7` before validation on create). Migrations use `create_uuid_table` / `id: :uuid, default: nil` so PostgreSQL does not install `gen_random_uuid()`.
 - Prefer explicit foreign keys and database constraints for durable invariants.
 - Use polymorphic references only when the open-ended relationship is intentional, such as audit subjects.
 - Name constraints and indexes consistently when the framework permits it.
@@ -206,7 +206,7 @@ Create an ADR when a decision is cross-cutting, difficult to reverse, affects of
 
 An ADR should include status, context, decision, and consequences. Mark unresolved choices `Proposed`; do not describe them as accepted elsewhere.
 
-Keep README setup instructions executable and current. Development procedures belong in `docs/development.md`; CI coverage and deferred checks belong in `docs/testing.md`.
+Keep README setup instructions executable and current. Development procedures belong in `docs/development.md`; CI coverage and deferred checks belong in `docs/testing.md`. Issue, PR, milestone, and release conventions belong in `docs/github-workflow.md`.
 
 Use Rails-native patterns unless an accepted ADR or an established project pattern requires otherwise. The frontend dependency strategy is not yet settled: do not assume the presence of `importmap-rails`, Turbo, or Stimulus in the Gemfile means those tools have been installed or adopted.
 

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem "stimulus-rails"
 gem "jbuilder"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
+gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     base64 (0.3.0)
+    bcrypt (3.1.22)
     bcrypt_pbkdf (1.1.2)
     bigdecimal (4.1.2)
     bindex (0.8.1)
@@ -382,6 +383,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap
   brakeman
   bundler-audit

--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ Two policies remain proposed and require later business decisions:
 
 ### Phase 1: Operable foundation
 
-Status: scaffold established; business implementation not yet begun.
+Status: operable foundation implemented (bootstrap, authentication, authorization, administration, audit).
+
+Phase 1 uses server-rendered Rails HTML. Turbo and Stimulus may be installed when a specific interaction requires them; no client-side application framework or JavaScript package-management strategy is required for early Phase 1 slices. Durable domain identifiers use Rails-generated UUIDv7 (`SecureRandom.uuid_v7`) while the project remains on PostgreSQL 17.
 
 Phase 1 implements only what is required to initialize, operate, and administer the application foundation:
 
@@ -167,8 +169,10 @@ Initial roles are expected to include `system_administrator`, `store_manager`, a
 Start with the [documentation index](docs/README.md). Key references include:
 
 - [Architecture Decision Records](docs/adr/README.md)
+- [Phase 1 plan](docs/planning/phase1-operational-foundation/phase1-plan.md), [schema](docs/planning/phase1-operational-foundation/phase1-schema.md), and [authorization contract](docs/planning/phase1-operational-foundation/phase1-authorization.md)
 - [Development guide](docs/development.md)
 - [Testing and CI](docs/testing.md)
+- [GitHub work management](docs/github-workflow.md)
 - [Contributor and coding-agent rules](AGENTS.md)
 
 When implementation reveals a conflict with an accepted ADR, propose a new ADR that supersedes the old decision. Do not silently diverge in code.

--- a/app/controllers/admin/audit_events_controller.rb
+++ b/app/controllers/admin/audit_events_controller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Admin
+  class AuditEventsController < BaseController
+    before_action -> { require_permission!("audit_events.view") }
+
+    def index
+      @audit_events = filtered_scope.order(occurred_at: :desc).limit(200)
+    end
+
+    def show
+      @audit_event = filtered_scope.find(params[:id])
+    end
+
+    private
+
+    def filtered_scope
+      scope = AuditEvent.all
+      global_view = Authorization::PermissionEvaluator.allowed?(
+        user: current_user,
+        permission_key: "audit_events.view",
+        store: nil
+      )
+
+      unless global_view
+        store_ids = accessible_stores.select(:id)
+        scope = scope.where(store_id: store_ids)
+      end
+
+      scope = scope.where(action: params[:action_key]) if params[:action_key].present?
+      scope = scope.where(outcome: params[:outcome]) if params[:outcome].present?
+      scope = scope.where(actor_user_id: params[:actor_user_id]) if params[:actor_user_id].present?
+      scope = scope.where(store_id: params[:store_id]) if params[:store_id].present? && global_view
+      scope = scope.where(subject_type: params[:subject_type]) if params[:subject_type].present?
+      if params[:from].present?
+        scope = scope.where("occurred_at >= ?", Time.zone.parse(params[:from]))
+      end
+      if params[:to].present?
+        scope = scope.where("occurred_at <= ?", Time.zone.parse(params[:to]))
+      end
+      scope
+    end
+  end
+end

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Admin
+  class BaseController < ApplicationController
+    private
+
+    def require_permission!(key)
+      return if Authorization::PermissionEvaluator.allowed?(
+        user: current_user,
+        permission_key: key,
+        store: current_store
+      )
+
+      Audit::Recorder.record!(
+        action: "authorization.denied",
+        outcome: "denied",
+        actor_user: current_user,
+        actor_label: current_user.display_name,
+        store: current_store,
+        reason_code: key,
+        metadata: { path: request.fullpath }
+      )
+      redirect_to root_path, alert: "You are not authorized to perform that action."
+    end
+
+    def rescue_stale
+      yield
+    rescue ActiveRecord::StaleObjectError
+      redirect_back fallback_location: root_path, alert: "This record was changed by someone else. Reload and try again."
+    end
+  end
+end

--- a/app/controllers/admin/role_assignments_controller.rb
+++ b/app/controllers/admin/role_assignments_controller.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Admin
+  class RoleAssignmentsController < BaseController
+    before_action -> { require_permission!("users.assign_roles") }
+
+    def index
+      @role_assignments = RoleAssignment.includes(:user, :role, :store).order(created_at: :desc)
+    end
+
+    def new
+      @role_assignment = RoleAssignment.new
+      @users = User.human.active.order(:username)
+      @roles = Role.active.order(:name)
+      @stores = Store.active.order(:name)
+    end
+
+    def create
+      @role_assignment = RoleAssignment.new(assignment_params.merge(assigned_by: current_user, effective_at: Time.current))
+      begin
+        Authorization::LastGlobalAdministrator.new.with_lock do
+          @role_assignment.save!
+          Audit::Recorder.record!(
+            action: "role_assignments.create",
+            outcome: "succeeded",
+            actor_user: current_user,
+            actor_label: current_user.display_name,
+            store: @role_assignment.store,
+            subject: @role_assignment,
+            after_values: {
+              user_id: @role_assignment.user_id,
+              role_id: @role_assignment.role_id,
+              store_id: @role_assignment.store_id
+            }
+          )
+        end
+        redirect_to admin_role_assignments_path, notice: "Role assigned."
+      rescue ActiveRecord::RecordInvalid
+        @users = User.human.active.order(:username)
+        @roles = Role.active.order(:name)
+        @stores = Store.active.order(:name)
+        render :new, status: :unprocessable_entity
+      rescue Authorization::LastGlobalAdministrator::WouldRemoveLastAdministrator => e
+        redirect_to admin_role_assignments_path, alert: e.message
+      end
+    end
+
+    def destroy
+      assignment = RoleAssignment.find(params[:id])
+      Authorization::LastGlobalAdministrator.new.with_lock do
+        assignment.update!(
+          revoked_at: Time.current,
+          revoked_by: current_user,
+          revocation_reason: params[:revocation_reason].presence || "revoked"
+        )
+        Audit::Recorder.record!(
+          action: "role_assignments.revoke",
+          outcome: "succeeded",
+          actor_user: current_user,
+          actor_label: current_user.display_name,
+          store: assignment.store,
+          subject: assignment
+        )
+      end
+      redirect_to admin_role_assignments_path, notice: "Role assignment revoked."
+    rescue Authorization::LastGlobalAdministrator::WouldRemoveLastAdministrator => e
+      redirect_to admin_role_assignments_path, alert: e.message
+    end
+
+    private
+
+    def assignment_params
+      params.require(:role_assignment).permit(:user_id, :role_id, :store_id).tap do |attrs|
+        attrs[:store_id] = attrs[:store_id].presence
+      end
+    end
+  end
+end

--- a/app/controllers/admin/roles_controller.rb
+++ b/app/controllers/admin/roles_controller.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module Admin
+  class RolesController < BaseController
+    before_action -> { require_permission!("roles.view") }, only: %i[index show]
+    before_action -> { require_permission!("roles.create") }, only: %i[new create]
+    before_action -> { require_permission!("roles.manage") }, only: %i[edit update]
+    before_action -> { require_permission!("roles.deactivate") }, only: :destroy
+    before_action :set_role, only: %i[show edit update destroy]
+
+    def index
+      @roles = Role.order(:name)
+    end
+
+    def show; end
+
+    def new
+      @role = Role.new(assignment_scope: "store")
+      @permissions = Permission.active.order(:group_key, :key)
+    end
+
+    def create
+      @role = Role.new(role_params.merge(system_role: false))
+      if @role.save
+        sync_permissions!(@role)
+        Audit::Recorder.record!(
+          action: "roles.create",
+          outcome: "succeeded",
+          actor_user: current_user,
+          actor_label: current_user.display_name,
+          subject: @role,
+          after_values: { key: @role.key, name: @role.name }
+        )
+        redirect_to admin_role_path(@role), notice: "Role created."
+      else
+        @permissions = Permission.active.order(:group_key, :key)
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def edit
+      @permissions = Permission.active.order(:group_key, :key)
+    end
+
+    def update
+      rescue_stale do
+        if @role.system_role?
+          redirect_to admin_role_path(@role), alert: "System roles are managed by application seeds."
+          return
+        end
+
+        if @role.update(role_params)
+          sync_permissions!(@role)
+          Audit::Recorder.record!(
+            action: "roles.update",
+            outcome: "succeeded",
+            actor_user: current_user,
+            actor_label: current_user.display_name,
+            subject: @role
+          )
+          redirect_to admin_role_path(@role), notice: "Role updated."
+        else
+          @permissions = Permission.active.order(:group_key, :key)
+          render :edit, status: :unprocessable_entity
+        end
+      end
+    end
+
+    def destroy
+      if @role.system_role?
+        redirect_to admin_role_path(@role), alert: "System roles cannot be deactivated here."
+        return
+      end
+
+      @role.update!(active: false, deactivated_at: Time.current, deactivated_by: current_user)
+      Audit::Recorder.record!(
+        action: "roles.deactivate",
+        outcome: "succeeded",
+        actor_user: current_user,
+        actor_label: current_user.display_name,
+        subject: @role
+      )
+      redirect_to admin_roles_path, notice: "Role deactivated."
+    end
+
+    private
+
+    def set_role
+      @role = Role.find(params[:id])
+    end
+
+    def role_params
+      params.require(:role).permit(:key, :name, :description, :assignment_scope, :lock_version)
+    end
+
+    def sync_permissions!(role)
+      selected = Array(params.dig(:role, :permission_ids)).reject(&:blank?)
+      desired = Permission.where(id: selected)
+      current_ids = role.permission_ids
+      (desired.map(&:id) - current_ids).each do |permission_id|
+        role.role_permissions.create!(permission_id: permission_id, granted_by: current_user)
+      end
+      role.role_permissions.where.not(permission_id: desired.map(&:id)).find_each(&:destroy!)
+    end
+  end
+end

--- a/app/controllers/admin/stores_controller.rb
+++ b/app/controllers/admin/stores_controller.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+module Admin
+  class StoresController < BaseController
+    before_action -> { require_permission!("stores.view") }, only: %i[index show]
+    before_action -> { require_permission!("stores.create") }, only: %i[new create]
+    before_action -> { require_permission!("stores.manage") }, only: %i[edit update]
+    before_action -> { require_permission!("stores.deactivate") }, only: :destroy
+    before_action :set_store, only: %i[show edit update destroy]
+
+    def index
+      @stores = if Authorization::PermissionEvaluator.allowed?(user: current_user, permission_key: "stores.view", store: nil)
+        Store.order(:name)
+      else
+        accessible_stores
+      end
+    end
+
+    def show; end
+
+    def new
+      @store = Store.new
+    end
+
+    def create
+      @store = Store.new(store_params.except(:lock_version))
+      if @store.save
+        Audit::Recorder.record!(
+          action: "stores.create",
+          outcome: "succeeded",
+          actor_user: current_user,
+          actor_label: current_user.display_name,
+          store: @store,
+          subject: @store,
+          after_values: { code: @store.code, name: @store.name }
+        )
+        redirect_to admin_store_path(@store), notice: "Store created."
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def edit; end
+
+    def update
+      rescue_stale do
+        before = @store.attributes.slice("name", "timezone", "receipt_header", "receipt_footer")
+        if @store.update(store_params)
+          Audit::Recorder.record!(
+            action: "stores.update",
+            outcome: "succeeded",
+            actor_user: current_user,
+            actor_label: current_user.display_name,
+            store: @store,
+            subject: @store,
+            before_values: before,
+            after_values: @store.attributes.slice(*before.keys)
+          )
+          redirect_to admin_store_path(@store), notice: "Store updated."
+        else
+          render :edit, status: :unprocessable_entity
+        end
+      end
+    end
+
+    def destroy
+      if Store.active.where.not(id: @store.id).none?
+        redirect_to admin_store_path(@store), alert: "Cannot deactivate the final active store."
+        return
+      end
+
+      @store.update!(active: false, deactivated_at: Time.current, deactivated_by: current_user)
+      Audit::Recorder.record!(
+        action: "stores.deactivate",
+        outcome: "succeeded",
+        actor_user: current_user,
+        actor_label: current_user.display_name,
+        store: @store,
+        subject: @store
+      )
+      redirect_to admin_stores_path, notice: "Store deactivated."
+    end
+
+    private
+
+    def set_store
+      @store = Store.find(params[:id])
+    end
+
+    def store_params
+      params.require(:store).permit(
+        :store_number, :code, :name, :legal_name, :street_address_1, :street_address_2,
+        :city, :region_code, :postal_code, :country_code, :phone, :san, :timezone,
+        :receipt_header, :receipt_footer, :lock_version
+      )
+    end
+  end
+end

--- a/app/controllers/admin/system_settings_controller.rb
+++ b/app/controllers/admin/system_settings_controller.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Admin
+  class SystemSettingsController < BaseController
+    before_action -> { require_permission!("system_settings.view") }, only: :show
+    before_action -> { require_permission!("system_settings.manage") }, only: %i[edit update]
+
+    def show
+      @settings = SystemSettings.current
+    end
+
+    def edit
+      @settings = SystemSettings.current
+    end
+
+    def update
+      rescue_stale do
+        @settings = SystemSettings.current
+        before = @settings.attributes.slice("organization_name", "legal_name", "default_timezone", "default_country_code", "default_receipt_header", "default_receipt_footer")
+        if @settings.update(settings_params)
+          Audit::Recorder.record!(
+            action: "system_settings.update",
+            outcome: "succeeded",
+            actor_user: current_user,
+            actor_label: current_user.display_name,
+            subject: @settings,
+            before_values: before,
+            after_values: @settings.attributes.slice(*before.keys)
+          )
+          redirect_to admin_system_settings_path, notice: "Settings updated."
+        else
+          render :edit, status: :unprocessable_entity
+        end
+      end
+    end
+
+    private
+
+    def settings_params
+      params.require(:system_settings).permit(
+        :organization_name, :legal_name, :base_currency_code, :default_timezone,
+        :default_country_code, :default_region_code, :fiscal_year_start_month,
+        :default_supplier_cancellation_days, :default_customer_reservation_expiration_days,
+        :default_receipt_header, :default_receipt_footer, :lock_version
+      )
+    end
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module Admin
+  class UsersController < BaseController
+    before_action -> { require_permission!("users.view") }, only: %i[index show]
+    before_action -> { require_permission!("users.create") }, only: %i[new create]
+    before_action -> { require_permission!("users.manage") }, only: %i[edit update]
+    before_action -> { require_permission!("users.deactivate") }, only: :deactivate
+    before_action -> { require_permission!("users.manage") }, only: :reset_password
+    before_action :set_user, only: %i[show edit update deactivate reset_password]
+
+    def index
+      @users = User.human.order(:username)
+    end
+
+    def show; end
+
+    def new
+      @user = User.new(actor_type: "human")
+    end
+
+    def create
+      @user = User.new(user_params.merge(actor_type: "human"))
+      if @user.save
+        Audit::Recorder.record!(
+          action: "users.create",
+          outcome: "succeeded",
+          actor_user: current_user,
+          actor_label: current_user.display_name,
+          subject: @user,
+          after_values: { username: @user.username }
+        )
+        redirect_to admin_user_path(@user), notice: "User created."
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def edit; end
+
+    def update
+      rescue_stale do
+        attrs = user_params
+        attrs = attrs.except(:password, :password_confirmation) if attrs[:password].blank?
+        if @user.update(attrs)
+          Audit::Recorder.record!(
+            action: "users.update",
+            outcome: "succeeded",
+            actor_user: current_user,
+            actor_label: current_user.display_name,
+            subject: @user,
+            after_values: { username: @user.username, display_name: @user.display_name }
+          )
+          redirect_to admin_user_path(@user), notice: "User updated."
+        else
+          render :edit, status: :unprocessable_entity
+        end
+      end
+    end
+
+    def deactivate
+      Users::Deactivate.call(user: @user, actor: current_user)
+      redirect_to admin_users_path, notice: "User deactivated."
+    rescue Authorization::LastGlobalAdministrator::WouldRemoveLastAdministrator => e
+      redirect_to admin_user_path(@user), alert: e.message
+    end
+
+    def reset_password
+      temporary = SecureRandom.base58(16)
+      Authentication::AdminPasswordReset.call(user: @user, actor: current_user, temporary_password: temporary)
+      redirect_to admin_user_path(@user), notice: "Temporary password: #{temporary}"
+    end
+
+    private
+
+    def set_user
+      @user = User.find(params[:id])
+    end
+
+    def user_params
+      params.require(:user).permit(
+        :username, :email, :display_name, :password, :password_confirmation, :lock_version
+      )
+    end
+  end
+end

--- a/app/controllers/admin/workstations_controller.rb
+++ b/app/controllers/admin/workstations_controller.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+module Admin
+  class WorkstationsController < BaseController
+    before_action -> { require_permission!("workstations.view") }, only: %i[index show]
+    before_action -> { require_permission!("workstations.create") }, only: %i[new create]
+    before_action -> { require_permission!("workstations.manage") }, only: %i[edit update]
+    before_action -> { require_permission!("workstations.deactivate") }, only: :destroy
+    before_action :require_store_context, except: %i[index show]
+    before_action :set_workstation, only: %i[show edit update destroy]
+
+    def index
+      @workstations = if current_store
+        Workstation.where(store: accessible_store_scope).order(:code)
+      else
+        Workstation.where(store: accessible_store_scope).order(:code)
+      end
+    end
+
+    def show; end
+
+    def new
+      @workstation = Workstation.new(store: current_store)
+    end
+
+    def create
+      @workstation = Workstation.new(workstation_params.merge(store: current_store))
+      if @workstation.save
+        Audit::Recorder.record!(
+          action: "workstations.create",
+          outcome: "succeeded",
+          actor_user: current_user,
+          actor_label: current_user.display_name,
+          store: @workstation.store,
+          workstation: @workstation,
+          subject: @workstation,
+          after_values: { code: @workstation.code, name: @workstation.name }
+        )
+        redirect_to admin_workstation_path(@workstation), notice: "Workstation created."
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def edit; end
+
+    def update
+      rescue_stale do
+        if @workstation.update(workstation_params)
+          Audit::Recorder.record!(
+            action: "workstations.update",
+            outcome: "succeeded",
+            actor_user: current_user,
+            actor_label: current_user.display_name,
+            store: @workstation.store,
+            workstation: @workstation,
+            subject: @workstation
+          )
+          redirect_to admin_workstation_path(@workstation), notice: "Workstation updated."
+        else
+          render :edit, status: :unprocessable_entity
+        end
+      end
+    end
+
+    def destroy
+      @workstation.update!(active: false, deactivated_at: Time.current, deactivated_by: current_user)
+      Audit::Recorder.record!(
+        action: "workstations.deactivate",
+        outcome: "succeeded",
+        actor_user: current_user,
+        actor_label: current_user.display_name,
+        store: @workstation.store,
+        workstation: @workstation,
+        subject: @workstation
+      )
+      redirect_to admin_workstations_path, notice: "Workstation deactivated."
+    end
+
+    private
+
+    def set_workstation
+      @workstation = Workstation.where(store: accessible_store_scope).find(params[:id])
+    end
+
+    def accessible_store_scope
+      if Authorization::PermissionEvaluator.allowed?(user: current_user, permission_key: "workstations.view", store: nil)
+        Store.all
+      else
+        accessible_stores
+      end
+    end
+
+    def workstation_params
+      params.require(:workstation).permit(:code, :name, :description, :lock_version)
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,9 @@
-class ApplicationController < ActionController::Base
-  # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
-  allow_browser versions: :modern
+# frozen_string_literal: true
 
-  # Changes to the importmap will invalidate the etag for HTML responses
-  stale_when_importmap_changes
+class ApplicationController < ActionController::Base
+  include SessionAuthentication
+  include AuthorizesRequests
+
+  allow_browser versions: :modern
+  before_action :require_authentication
 end

--- a/app/controllers/concerns/authorizes_requests.rb
+++ b/app/controllers/concerns/authorizes_requests.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module AuthorizesRequests
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :current_store, :effective_permissions, :accessible_stores
+  end
+
+  private
+
+  def current_store
+    return @current_store if defined?(@current_store)
+
+    @current_store = resolve_current_store
+  end
+
+  def accessible_stores
+    return Store.none unless current_user
+
+    @accessible_stores ||= Authorization::StoreAccess.accessible_stores_for(current_user)
+  end
+
+  def effective_permissions
+    return Set.new unless current_user
+
+    @effective_permissions ||= Authorization::PermissionEvaluator.permissions_for(
+      user: current_user,
+      store: current_store
+    )
+  end
+
+  def authorize!(permission_key, store: current_store)
+    return if Authorization::PermissionEvaluator.allowed?(
+      user: current_user,
+      permission_key: permission_key,
+      store: store
+    )
+
+    Audit::Recorder.record!(
+      action: "authorization.denied",
+      outcome: "denied",
+      actor_user: current_user,
+      actor_type: current_user ? "user" : "anonymous",
+      actor_label: current_user&.display_name || "anonymous",
+      store: store,
+      reason_code: permission_key,
+      metadata: { path: request.fullpath }
+    )
+    redirect_to root_path, alert: "You are not authorized to perform that action."
+  end
+
+  def require_store_context
+    return if current_store.present?
+    return redirect_to new_store_selection_path if accessible_stores.exists?
+
+    redirect_to root_path, alert: "No accessible store is available for your account."
+  end
+
+  def resolve_current_store
+    return unless current_user
+
+    stores = accessible_stores
+    selected_id = session[:current_store_id]
+    if selected_id.present?
+      selected = stores.find_by(id: selected_id)
+      return selected if selected
+    end
+
+    return stores.first if stores.one?
+
+    nil
+  end
+end

--- a/app/controllers/concerns/session_authentication.rb
+++ b/app/controllers/concerns/session_authentication.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module SessionAuthentication
+  extend ActiveSupport::Concern
+
+  SESSION_COOKIE = :shelfsense_session
+
+  included do
+    helper_method :current_user, :current_user_session, :signed_in?
+  end
+
+  private
+
+  def current_user_session
+    return @current_user_session if defined?(@current_user_session)
+
+    @current_user_session = find_current_user_session
+  end
+
+  def current_user
+    current_user_session&.user
+  end
+
+  def signed_in?
+    current_user.present?
+  end
+
+  def require_authentication
+    return if signed_in?
+
+    redirect_to new_session_path, alert: "Please sign in to continue."
+  end
+
+  def find_current_user_session
+    token = cookies.signed[SESSION_COOKIE]
+    return if token.blank?
+
+    session_record = UserSession.find_by(token_digest: UserSession.digest(token))
+    return if session_record.nil?
+
+    unless session_record.active? && session_record.user.authenticatable?
+      cookies.delete(SESSION_COOKIE)
+      return
+    end
+
+    session_record.touch_last_seen!
+    session_record
+  end
+
+  def start_session!(raw_token)
+    cookies.signed[SESSION_COOKIE] = {
+      value: raw_token,
+      httponly: true,
+      same_site: :lax,
+      expires: UserSession::ABSOLUTE_TTL.from_now
+    }
+  end
+
+  def clear_session_cookie!
+    cookies.delete(SESSION_COOKIE)
+  end
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class HomeController < ApplicationController
+  def show
+    if accessible_stores.many? && current_store.nil?
+      redirect_to new_store_selection_path
+    end
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class SessionsController < ApplicationController
+  skip_before_action :require_authentication, only: %i[new create]
+  before_action :redirect_if_signed_in, only: %i[new create]
+
+  def new
+  end
+
+  def create
+    result = Authentication::SignIn.call(
+      username: params.require(:session)[:username],
+      password: params.require(:session)[:password],
+      ip_address: request.remote_ip,
+      user_agent: request.user_agent
+    )
+
+    if result.success?
+      start_session!(result.raw_token)
+      redirect_to root_path, notice: "Signed in successfully."
+    else
+      flash.now[:alert] = result.error
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    Authentication::SignOut.call(
+      session: current_user_session,
+      ip_address: request.remote_ip,
+      user_agent: request.user_agent
+    )
+    clear_session_cookie!
+    redirect_to new_session_path, notice: "Signed out."
+  end
+
+  private
+
+  def redirect_if_signed_in
+    redirect_to root_path if signed_in?
+  end
+end

--- a/app/controllers/store_selections_controller.rb
+++ b/app/controllers/store_selections_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class StoreSelectionsController < ApplicationController
+  def new
+    @stores = accessible_stores
+  end
+
+  def create
+    store = accessible_stores.find_by(id: params.require(:store_id))
+    unless store
+      redirect_to new_store_selection_path, alert: "That store is not available."
+      return
+    end
+
+    session[:current_store_id] = store.id
+    redirect_to root_path, notice: "Working in #{store.name}."
+  end
+end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
+
+  include UuidV7PrimaryKey
 end

--- a/app/models/audit_event.rb
+++ b/app/models/audit_event.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class AuditEvent < ApplicationRecord
+  OUTCOMES = %w[succeeded failed denied].freeze
+  ACTOR_TYPES = %w[user system integration scheduled_job anonymous].freeze
+
+  belongs_to :actor_user, class_name: "User", optional: true
+  belongs_to :store, optional: true
+  belongs_to :workstation, optional: true
+
+  validates :occurred_at, :recorded_at, :actor_type, :actor_label, :action, :outcome, :correlation_id, presence: true
+  validates :outcome, inclusion: { in: OUTCOMES }
+  validates :actor_type, inclusion: { in: ACTOR_TYPES }
+
+  before_validation :set_recorded_defaults, on: :create
+
+  def readonly?
+    !new_record?
+  end
+
+  private
+
+  def set_recorded_defaults
+    self.occurred_at ||= Time.current
+    self.recorded_at ||= Time.current
+    self.created_at ||= recorded_at
+    self.correlation_id ||= SecureRandom.uuid_v7
+    self.metadata ||= {}
+  end
+end

--- a/app/models/concerns/uuid_v7_primary_key.rb
+++ b/app/models/concerns/uuid_v7_primary_key.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module UuidV7PrimaryKey
+  extend ActiveSupport::Concern
+
+  included do
+    before_validation :assign_uuid_v7, on: :create
+  end
+
+  private
+
+  def assign_uuid_v7
+    return unless uuid_primary_key?
+
+    self.id ||= SecureRandom.uuid_v7
+  end
+
+  def uuid_primary_key?
+    self.class.type_for_attribute("id").type == :uuid
+  end
+end

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Permission < ApplicationRecord
+  SCOPE_TYPES = %w[global store either].freeze
+
+  has_many :role_permissions, dependent: :restrict_with_exception
+  has_many :roles, through: :role_permissions
+
+  validates :key, :group_key, :name, :scope_type, presence: true
+  validates :key, uniqueness: true
+  validates :scope_type, inclusion: { in: SCOPE_TYPES }
+
+  scope :active, -> { where(active: true) }
+end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Role < ApplicationRecord
+  ASSIGNMENT_SCOPES = %w[global store either].freeze
+
+  belongs_to :deactivated_by, class_name: "User", optional: true
+  has_many :role_permissions, dependent: :restrict_with_exception
+  has_many :permissions, through: :role_permissions
+  has_many :role_assignments, dependent: :restrict_with_exception
+
+  validates :key, :name, :assignment_scope, presence: true
+  validates :key, uniqueness: true
+  validates :name, uniqueness: { case_sensitive: false }
+  validates :assignment_scope, inclusion: { in: ASSIGNMENT_SCOPES }
+
+  scope :active, -> { where(active: true) }
+
+  def allows_global_assignment?
+    assignment_scope.in?(%w[global either])
+  end
+
+  def allows_store_assignment?
+    assignment_scope.in?(%w[store either])
+  end
+end

--- a/app/models/role_assignment.rb
+++ b/app/models/role_assignment.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+class RoleAssignment < ApplicationRecord
+  belongs_to :user
+  belongs_to :role
+  belongs_to :store, optional: true
+  belongs_to :assigned_by, class_name: "User"
+  belongs_to :revoked_by, class_name: "User", optional: true
+
+  before_validation :set_effective_at, on: :create
+
+  validates :effective_at, presence: true
+  validate :assignment_scope_matches_role
+  validate :user_must_be_assignable
+  validate :expiration_after_effective
+  validate :revocation_consistency
+
+  scope :not_revoked, -> { where(revoked_at: nil) }
+  scope :effective, lambda {
+    now = Time.current
+    not_revoked
+      .where("effective_at <= ?", now)
+      .where("expires_at IS NULL OR expires_at > ?", now)
+  }
+  scope :global, -> { where(store_id: nil) }
+  scope :for_store, ->(store_id) { where(store_id: store_id) }
+
+  def global?
+    store_id.nil?
+  end
+
+  def revoked?
+    revoked_at.present?
+  end
+
+  def effective?(at: Time.current)
+    !revoked? &&
+      effective_at <= at &&
+      (expires_at.nil? || expires_at > at) &&
+      user.active? &&
+      role.active? &&
+      (store.nil? || store.active?)
+  end
+
+  private
+
+  def set_effective_at
+    self.effective_at ||= Time.current
+  end
+
+  def assignment_scope_matches_role
+    return if role.blank?
+
+    if global? && !role.allows_global_assignment?
+      errors.add(:store_id, "must be present for #{role.key} assignments")
+    elsif !global? && !role.allows_store_assignment?
+      errors.add(:store_id, "must be blank for #{role.key} assignments")
+    end
+  end
+
+  def user_must_be_assignable
+    return if user.blank?
+    return unless user.system_actor?
+
+    errors.add(:user_id, "system actor cannot receive role assignments")
+  end
+
+  def expiration_after_effective
+    return if expires_at.blank? || effective_at.blank?
+    return if expires_at > effective_at
+
+    errors.add(:expires_at, "must be later than effective_at")
+  end
+
+  def revocation_consistency
+    if revoked_at.present? && revoked_by_id.blank?
+      errors.add(:revoked_by_id, "is required when revoked")
+    end
+  end
+end

--- a/app/models/role_permission.rb
+++ b/app/models/role_permission.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class RolePermission < ApplicationRecord
+  belongs_to :role
+  belongs_to :permission
+  belongs_to :granted_by, class_name: "User"
+
+  validates :role_id, uniqueness: { scope: :permission_id }
+
+  after_create :bump_role_lock_version
+  after_destroy :bump_role_lock_version
+
+  private
+
+  def bump_role_lock_version
+    role.update!(updated_at: Time.current)
+  end
+end

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Store < ApplicationRecord
+  belongs_to :deactivated_by, class_name: "User", optional: true
+  has_many :workstations, dependent: :restrict_with_exception
+  has_many :role_assignments, dependent: :restrict_with_exception
+
+  before_validation :normalize_codes
+
+  validates :store_number, :code, :name, :country_code, :timezone, presence: true
+  validates :country_code, length: { is: 2 }
+  validates :store_number, uniqueness: { case_sensitive: false }
+  validates :code, uniqueness: { case_sensitive: false }
+
+  scope :active, -> { where(active: true) }
+
+  private
+
+  def normalize_codes
+    self.store_number = store_number.to_s.strip
+    self.code = code.to_s.strip.downcase
+    self.country_code = country_code.to_s.strip.upcase
+  end
+end

--- a/app/models/system_settings.rb
+++ b/app/models/system_settings.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class SystemSettings < ApplicationRecord
+  self.table_name = "system_settings"
+
+  validates :organization_name, :base_currency_code, :default_timezone, :default_country_code, presence: true
+  validates :base_currency_code, length: { is: 3 }
+  validates :default_country_code, length: { is: 2 }
+  validates :fiscal_year_start_month, inclusion: { in: 1..12 }
+  validates :default_supplier_cancellation_days, :default_customer_reservation_expiration_days,
+            numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validate :singleton_row
+
+  def self.current
+    record = order(:created_at).first
+    raise "System settings are not configured" if record.nil?
+    raise "Multiple system settings rows exist" if count > 1
+
+    record
+  end
+
+  def self.initialized?
+    exists?(singleton_key: true) && where.not(initialized_at: nil).exists?
+  end
+
+  def initialized?
+    initialized_at.present?
+  end
+
+  private
+
+  def singleton_row
+    errors.add(:singleton_key, "must be true") unless singleton_key == true
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+class User < ApplicationRecord
+  ACTOR_TYPES = %w[human system integration scheduled_job].freeze
+  SYSTEM_USERNAME = "system"
+
+  has_secure_password validations: false
+
+  belongs_to :deactivated_by, class_name: "User", optional: true
+  has_many :role_assignments, dependent: :restrict_with_exception
+  has_many :assigned_role_assignments, class_name: "RoleAssignment", foreign_key: :assigned_by_id, inverse_of: :assigned_by, dependent: :restrict_with_exception
+  has_many :user_sessions, dependent: :restrict_with_exception
+
+  before_validation :normalize_identity
+
+  validates :username, :display_name, :actor_type, presence: true
+  validates :actor_type, inclusion: { in: ACTOR_TYPES }
+  validates :username, uniqueness: { case_sensitive: false }
+  validates :email, uniqueness: { case_sensitive: false, allow_nil: true }
+  validates :password, length: { minimum: 12 }, allow_nil: true
+  validate :password_required_for_interactive_humans
+  validate :system_actor_constraints
+
+  scope :active, -> { where(active: true) }
+  scope :human, -> { where(actor_type: "human") }
+
+  def system_actor?
+    actor_type == "system"
+  end
+
+  def interactive?
+    actor_type == "human"
+  end
+
+  def authenticatable?
+    interactive? && active? && locked_at.nil? && password_digest.present?
+  end
+
+  private
+
+  def normalize_identity
+    self.username = username.to_s.strip
+    self.email = email.to_s.strip.presence
+    self.display_name = display_name.to_s.strip
+  end
+
+  def password_required_for_interactive_humans
+    return unless interactive?
+    return if password_digest.present? || password.present?
+
+    errors.add(:password, "can't be blank")
+  end
+
+  def system_actor_constraints
+    return unless system_actor?
+
+    errors.add(:username, "must be reserved system username") unless username == SYSTEM_USERNAME
+    errors.add(:base, "system actor cannot be deactivated") if !active? || deactivated_at.present?
+  end
+end

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class UserSession < ApplicationRecord
+  IDLE_TTL = 12.hours
+  ABSOLUTE_TTL = 14.days
+
+  belongs_to :user
+  belongs_to :revoked_by, class_name: "User", optional: true
+
+  validates :token_digest, :last_seen_at, :expires_at, presence: true
+  validates :token_digest, uniqueness: true
+
+  scope :active, lambda {
+    where(revoked_at: nil).where("expires_at > ?", Time.current)
+  }
+
+  def self.digest(token)
+    Digest::SHA256.hexdigest(token)
+  end
+
+  def self.issue!(user:, ip_address: nil, user_agent: nil)
+    raise ArgumentError, "user is not authenticatable" unless user.authenticatable?
+
+    raw_token = SecureRandom.urlsafe_base64(32)
+    session = create!(
+      user: user,
+      token_digest: digest(raw_token),
+      last_seen_at: Time.current,
+      expires_at: ABSOLUTE_TTL.from_now,
+      ip_address: ip_address,
+      user_agent: user_agent
+    )
+    [ session, raw_token ]
+  end
+
+  def active?
+    revoked_at.nil? && expires_at > Time.current && !idle_expired?
+  end
+
+  def idle_expired?
+    last_seen_at < IDLE_TTL.ago
+  end
+
+  def touch_last_seen!
+    update!(last_seen_at: Time.current)
+  end
+
+  def revoke!(by: nil)
+    update!(revoked_at: Time.current, revoked_by: by)
+  end
+end

--- a/app/models/workstation.rb
+++ b/app/models/workstation.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Workstation < ApplicationRecord
+  belongs_to :store
+  belongs_to :deactivated_by, class_name: "User", optional: true
+
+  before_validation :normalize_code
+
+  validates :code, :name, presence: true
+  validates :code, uniqueness: { scope: :store_id, case_sensitive: false }
+  validates :receipt_sequence, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+
+  scope :active, -> { where(active: true) }
+
+  private
+
+  def normalize_code
+    self.code = code.to_s.strip.upcase
+  end
+end

--- a/app/services/audit/recorder.rb
+++ b/app/services/audit/recorder.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Audit
+  class Recorder
+    def self.record!(**attrs)
+      new.record!(**attrs)
+    end
+
+    def record!(
+      action:,
+      outcome:,
+      actor_user: nil,
+      actor_type: nil,
+      actor_label: nil,
+      store: nil,
+      workstation: nil,
+      user_session_id: nil,
+      subject: nil,
+      subject_type: nil,
+      subject_id: nil,
+      subject_label: nil,
+      reason_code: nil,
+      reason_text: nil,
+      correlation_id: nil,
+      before_values: nil,
+      after_values: nil,
+      metadata: {},
+      ip_address: nil,
+      user_agent: nil,
+      occurred_at: Time.current
+    )
+      AuditEvent.create!(
+        action: action,
+        outcome: outcome,
+        actor_user: actor_user,
+        actor_type: actor_type || (actor_user&.system_actor? ? "system" : "user"),
+        actor_label: actor_label || actor_user&.display_name || "unknown",
+        store: store,
+        workstation: workstation,
+        user_session_id: user_session_id,
+        subject_type: subject_type || subject&.class&.name,
+        subject_id: subject_id || subject&.id,
+        subject_label: subject_label || subject_label_for(subject),
+        reason_code: reason_code,
+        reason_text: reason_text,
+        correlation_id: correlation_id || SecureRandom.uuid_v7,
+        before_values: before_values,
+        after_values: after_values,
+        metadata: metadata || {},
+        ip_address: ip_address,
+        user_agent: user_agent,
+        occurred_at: occurred_at,
+        application_version: Rails.application.config.x.application_version
+      )
+    end
+
+    private
+
+    def subject_label_for(subject)
+      return if subject.nil?
+      return subject.display_name if subject.respond_to?(:display_name)
+      return subject.name if subject.respond_to?(:name)
+      return subject.key if subject.respond_to?(:key)
+
+      subject.to_s
+    end
+  end
+end

--- a/app/services/authentication/admin_password_reset.rb
+++ b/app/services/authentication/admin_password_reset.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Authentication
+  class AdminPasswordReset
+    def self.call(user:, actor:, temporary_password:)
+      raise ArgumentError, "system actor cannot reset passwords" if user.system_actor?
+
+      user.update!(
+        password: temporary_password,
+        password_confirmation: temporary_password,
+        password_changed_at: Time.current,
+        password_reset_required: true,
+        locked_at: nil,
+        failed_sign_in_count: 0
+      )
+      user.user_sessions.active.find_each { |session| session.revoke!(by: actor) }
+
+      Audit::Recorder.record!(
+        action: "authentication.admin_password_reset",
+        outcome: "succeeded",
+        actor_user: actor,
+        actor_label: actor.display_name,
+        subject: user,
+        after_values: { password_reset_required: true }
+      )
+      user
+    end
+  end
+end

--- a/app/services/authentication/password_change.rb
+++ b/app/services/authentication/password_change.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Authentication
+  class PasswordChange
+    class Error < StandardError; end
+
+    def self.call(user:, current_password:, new_password:, new_password_confirmation:)
+      raise Error, "Current password is incorrect" unless user.authenticate(current_password)
+
+      user.update!(
+        password: new_password,
+        password_confirmation: new_password_confirmation,
+        password_changed_at: Time.current,
+        password_reset_required: false
+      )
+      user.user_sessions.active.find_each(&:revoke!)
+
+      Audit::Recorder.record!(
+        action: "authentication.password_change",
+        outcome: "succeeded",
+        actor_user: user,
+        actor_label: user.display_name,
+        subject: user
+      )
+      user
+    end
+  end
+end

--- a/app/services/authentication/sign_in.rb
+++ b/app/services/authentication/sign_in.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module Authentication
+  class SignIn
+    MAX_FAILED_ATTEMPTS = 5
+
+    Result = Struct.new(:success?, :user, :session, :raw_token, :error, keyword_init: true)
+
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(username:, password:, ip_address: nil, user_agent: nil)
+      @username = username.to_s.strip
+      @password = password
+      @ip_address = ip_address
+      @user_agent = user_agent
+    end
+
+    def call
+      user = User.find_by("lower(username) = ?", @username.downcase)
+
+      if user.nil?
+        return failure("Invalid username or password")
+      end
+
+      if user.system_actor? || !user.interactive?
+        audit_failure(user, "non_interactive_actor")
+        return failure("Invalid username or password")
+      end
+
+      if !user.active? || user.locked_at.present?
+        audit_failure(user, "inactive_or_locked")
+        return failure("Invalid username or password")
+      end
+
+      unless user.authenticate(@password)
+        register_failed_attempt!(user)
+        audit_failure(user, "invalid_password")
+        return failure("Invalid username or password")
+      end
+
+      user.update!(failed_sign_in_count: 0, last_signed_in_at: Time.current)
+      session, raw_token = UserSession.issue!(user: user, ip_address: @ip_address, user_agent: @user_agent)
+
+      Audit::Recorder.record!(
+        action: "authentication.sign_in",
+        outcome: "succeeded",
+        actor_user: user,
+        actor_label: user.display_name,
+        user_session_id: session.id,
+        subject: user,
+        ip_address: @ip_address,
+        user_agent: @user_agent
+      )
+
+      Result.new(success?: true, user: user, session: session, raw_token: raw_token)
+    end
+
+    private
+
+    def failure(message)
+      Result.new(success?: false, error: message)
+    end
+
+    def register_failed_attempt!(user)
+      attrs = { failed_sign_in_count: user.failed_sign_in_count + 1 }
+      attrs[:locked_at] = Time.current if attrs[:failed_sign_in_count] >= MAX_FAILED_ATTEMPTS
+      user.update!(attrs)
+    end
+
+    def audit_failure(user, reason_code)
+      Audit::Recorder.record!(
+        action: "authentication.sign_in",
+        outcome: "failed",
+        actor_user: user,
+        actor_label: user.display_name,
+        subject: user,
+        reason_code: reason_code,
+        ip_address: @ip_address,
+        user_agent: @user_agent
+      )
+    end
+  end
+end

--- a/app/services/authentication/sign_out.rb
+++ b/app/services/authentication/sign_out.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Authentication
+  class SignOut
+    def self.call(session:, ip_address: nil, user_agent: nil)
+      return if session.nil? || session.revoked?
+
+      session.revoke!
+      Audit::Recorder.record!(
+        action: "authentication.sign_out",
+        outcome: "succeeded",
+        actor_user: session.user,
+        actor_label: session.user.display_name,
+        user_session_id: session.id,
+        subject: session.user,
+        ip_address: ip_address,
+        user_agent: user_agent
+      )
+    end
+  end
+end

--- a/app/services/authorization/last_global_administrator.rb
+++ b/app/services/authorization/last_global_administrator.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Authorization
+  class LastGlobalAdministrator
+    SYSTEM_ADMIN_KEY = "system_administrator"
+
+    class WouldRemoveLastAdministrator < StandardError; end
+
+    def self.ensure_remaining!
+      new.ensure_remaining!
+    end
+
+    def ensure_remaining!
+      RoleAssignment.transaction do
+        lock_global_system_admin_assignments!
+        raise WouldRemoveLastAdministrator, "ShelfSense must retain at least one active global system administrator" if count_effective_global_admins < 1
+      end
+    end
+
+    def with_lock
+      RoleAssignment.transaction do
+        lock_global_system_admin_assignments!
+        yield
+        ensure_remaining_without_new_transaction!
+      end
+    end
+
+    private
+
+    def lock_global_system_admin_assignments!
+      role = Role.find_by!(key: SYSTEM_ADMIN_KEY)
+      RoleAssignment.global.where(role_id: role.id).lock.to_a
+    end
+
+    def ensure_remaining_without_new_transaction!
+      raise WouldRemoveLastAdministrator, "ShelfSense must retain at least one active global system administrator" if count_effective_global_admins < 1
+    end
+
+    def count_effective_global_admins
+      role = Role.find_by!(key: SYSTEM_ADMIN_KEY)
+      RoleAssignment.effective.global.where(role_id: role.id).joins(:user).merge(User.active.human).count
+    end
+  end
+end

--- a/app/services/authorization/permission_catalog.rb
+++ b/app/services/authorization/permission_catalog.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+module Authorization
+  module PermissionCatalog
+    module_function
+
+    PERMISSIONS = [
+      { key: "system_settings.view", group_key: "system_settings", name: "View system settings", scope_type: "global" },
+      { key: "system_settings.manage", group_key: "system_settings", name: "Manage system settings", scope_type: "global" },
+      { key: "stores.view", group_key: "stores", name: "View stores", scope_type: "either" },
+      { key: "stores.create", group_key: "stores", name: "Create stores", scope_type: "global" },
+      { key: "stores.manage", group_key: "stores", name: "Manage stores", scope_type: "either" },
+      { key: "stores.deactivate", group_key: "stores", name: "Deactivate stores", scope_type: "global" },
+      { key: "users.view", group_key: "users", name: "View users", scope_type: "global" },
+      { key: "users.create", group_key: "users", name: "Create users", scope_type: "global" },
+      { key: "users.manage", group_key: "users", name: "Manage users", scope_type: "global" },
+      { key: "users.deactivate", group_key: "users", name: "Deactivate users", scope_type: "global" },
+      { key: "users.assign_roles", group_key: "users", name: "Assign roles", scope_type: "global" },
+      { key: "users.revoke_sessions", group_key: "users", name: "Revoke sessions", scope_type: "global" },
+      { key: "roles.view", group_key: "roles", name: "View roles", scope_type: "global" },
+      { key: "roles.create", group_key: "roles", name: "Create roles", scope_type: "global" },
+      { key: "roles.manage", group_key: "roles", name: "Manage roles", scope_type: "global" },
+      { key: "roles.deactivate", group_key: "roles", name: "Deactivate roles", scope_type: "global" },
+      { key: "workstations.view", group_key: "workstations", name: "View workstations", scope_type: "either" },
+      { key: "workstations.create", group_key: "workstations", name: "Create workstations", scope_type: "either" },
+      { key: "workstations.manage", group_key: "workstations", name: "Manage workstations", scope_type: "either" },
+      { key: "workstations.deactivate", group_key: "workstations", name: "Deactivate workstations", scope_type: "either" },
+      { key: "workstations.revoke", group_key: "workstations", name: "Revoke workstations", scope_type: "either" },
+      { key: "audit_events.view", group_key: "audit_events", name: "View audit events", scope_type: "either" }
+    ].freeze
+
+    ROLES = [
+      {
+        key: "system_administrator",
+        name: "System administrator",
+        assignment_scope: "global",
+        permission_keys: PERMISSIONS.map { |p| p[:key] }
+      },
+      {
+        key: "store_manager",
+        name: "Store manager",
+        assignment_scope: "store",
+        permission_keys: %w[
+          stores.view
+          stores.manage
+          workstations.view
+          workstations.create
+          workstations.manage
+          workstations.deactivate
+          workstations.revoke
+          audit_events.view
+        ]
+      },
+      {
+        key: "associate",
+        name: "Associate",
+        assignment_scope: "store",
+        permission_keys: %w[stores.view]
+      }
+    ].freeze
+
+    def seed!(granted_by:)
+      PERMISSIONS.each do |attrs|
+        Permission.find_or_initialize_by(key: attrs[:key]).tap do |permission|
+          permission.assign_attributes(attrs.merge(active: true))
+          permission.save!
+        end
+      end
+
+      ROLES.each do |role_attrs|
+        role = Role.find_or_initialize_by(key: role_attrs[:key])
+        role.assign_attributes(
+          name: role_attrs[:name],
+          assignment_scope: role_attrs[:assignment_scope],
+          system_role: true,
+          active: true
+        )
+        role.save!
+
+        desired = role_attrs[:permission_keys]
+        current = role.permissions.pluck(:key)
+        (desired - current).each do |key|
+          role.role_permissions.create!(permission: Permission.find_by!(key: key), granted_by: granted_by)
+        end
+        (current - desired).each do |key|
+          role.role_permissions.joins(:permission).where(permissions: { key: key }).find_each(&:destroy!)
+        end
+      end
+    end
+  end
+end

--- a/app/services/authorization/permission_evaluator.rb
+++ b/app/services/authorization/permission_evaluator.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Authorization
+  class PermissionEvaluator
+    def self.permissions_for(user:, store:)
+      new(user: user, store: store).permission_keys
+    end
+
+    def self.allowed?(user:, permission_key:, store: nil)
+      new(user: user, store: store).allowed?(permission_key)
+    end
+
+    def initialize(user:, store:)
+      @user = user
+      @store = store
+    end
+
+    def permission_keys
+      return Set.new if @user.nil? || !@user.active?
+
+      keys = Set.new
+      effective_assignments.find_each do |assignment|
+        assignment.role.permissions.active.find_each do |permission|
+          next unless permission_applies?(permission, assignment)
+
+          keys << permission.key
+        end
+      end
+      keys
+    end
+
+    def allowed?(permission_key)
+      permission_keys.include?(permission_key)
+    end
+
+    private
+
+    def effective_assignments
+      scope = RoleAssignment.effective.where(user_id: @user.id).joins(:role).merge(Role.active).includes(role: :permissions)
+      if @store
+        scope.where("store_id IS NULL OR store_id = ?", @store.id)
+      else
+        scope.global
+      end
+    end
+
+    def permission_applies?(permission, assignment)
+      case permission.scope_type
+      when "global"
+        assignment.global?
+      when "store"
+        @store.present? && (assignment.global? || assignment.store_id == @store.id)
+      when "either"
+        assignment.global? || (@store.present? && assignment.store_id == @store.id)
+      else
+        false
+      end
+    end
+  end
+end

--- a/app/services/authorization/store_access.rb
+++ b/app/services/authorization/store_access.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Authorization
+  class StoreAccess
+    def self.accessible_stores_for(user)
+      return Store.none if user.nil? || !user.active?
+
+      global = RoleAssignment.effective.global.where(user_id: user.id).joins(:role).merge(Role.active).exists?
+      return Store.active.order(:name) if global
+
+      store_ids = RoleAssignment.effective.where(user_id: user.id).where.not(store_id: nil).joins(:role).merge(Role.active).select(:store_id)
+      Store.active.where(id: store_ids).order(:name)
+    end
+  end
+end

--- a/app/services/installation/bootstrap.rb
+++ b/app/services/installation/bootstrap.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+module Installation
+  class Bootstrap
+    class AlreadyInitialized < StandardError; end
+    class InvalidInput < StandardError; end
+
+    ADVISORY_LOCK_KEY = 870_109_001
+
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(
+      organization_name:,
+      store_number:,
+      store_code:,
+      store_name:,
+      store_timezone:,
+      store_country_code:,
+      admin_username:,
+      admin_display_name:,
+      admin_password:,
+      admin_email: nil,
+      base_currency_code: "USD",
+      default_timezone: nil,
+      default_country_code: nil,
+      legal_name: nil
+    )
+      @organization_name = organization_name
+      @legal_name = legal_name
+      @store_number = store_number
+      @store_code = store_code
+      @store_name = store_name
+      @store_timezone = store_timezone
+      @store_country_code = store_country_code
+      @admin_username = admin_username
+      @admin_display_name = admin_display_name
+      @admin_password = admin_password
+      @admin_email = admin_email
+      @base_currency_code = base_currency_code
+      @default_timezone = default_timezone || store_timezone
+      @default_country_code = default_country_code || store_country_code
+    end
+
+    def call
+      validate_input!
+
+      ActiveRecord::Base.transaction do
+        acquire_advisory_lock!
+        raise AlreadyInitialized, "ShelfSense is already initialized" if SystemSettings.initialized?
+
+        correlation_id = SecureRandom.uuid_v7
+        settings = create_settings!
+        system_user = create_system_user!
+        Authorization::PermissionCatalog.seed!(granted_by: system_user)
+
+        Audit::Recorder.record!(
+          action: "installation.started",
+          outcome: "succeeded",
+          actor_user: system_user,
+          actor_type: "system",
+          actor_label: system_user.display_name,
+          correlation_id: correlation_id,
+          subject: settings,
+          after_values: { organization_name: settings.organization_name }
+        )
+
+        store = create_store!
+        Audit::Recorder.record!(
+          action: "stores.create",
+          outcome: "succeeded",
+          actor_user: system_user,
+          actor_type: "system",
+          actor_label: system_user.display_name,
+          store: store,
+          correlation_id: correlation_id,
+          subject: store,
+          after_values: { code: store.code, name: store.name }
+        )
+
+        admin = create_administrator!
+        assignment = assign_administrator!(admin: admin, system_user: system_user)
+
+        Audit::Recorder.record!(
+          action: "users.create",
+          outcome: "succeeded",
+          actor_user: system_user,
+          actor_type: "system",
+          actor_label: system_user.display_name,
+          correlation_id: correlation_id,
+          subject: admin,
+          after_values: { username: admin.username, display_name: admin.display_name }
+        )
+        Audit::Recorder.record!(
+          action: "role_assignments.create",
+          outcome: "succeeded",
+          actor_user: system_user,
+          actor_type: "system",
+          actor_label: system_user.display_name,
+          correlation_id: correlation_id,
+          subject: assignment,
+          after_values: { user_id: admin.id, role_key: "system_administrator", store_id: nil }
+        )
+
+        settings.update!(initialized_at: Time.current)
+        Audit::Recorder.record!(
+          action: "installation.completed",
+          outcome: "succeeded",
+          actor_user: system_user,
+          actor_type: "system",
+          actor_label: system_user.display_name,
+          correlation_id: correlation_id,
+          subject: settings,
+          after_values: { initialized_at: settings.initialized_at.iso8601 }
+        )
+
+        { settings: settings, store: store, system_user: system_user, administrator: admin, assignment: assignment }
+      end
+    end
+
+    private
+
+    attr_reader :organization_name, :legal_name, :store_number, :store_code, :store_name,
+                :store_timezone, :store_country_code, :admin_username, :admin_display_name,
+                :admin_password, :admin_email, :base_currency_code, :default_timezone, :default_country_code
+
+    def validate_input!
+      raise InvalidInput, "admin password is required" if admin_password.blank?
+      raise InvalidInput, "organization name is required" if organization_name.blank?
+    end
+
+    def acquire_advisory_lock!
+      locked = ActiveRecord::Base.connection.select_value(
+        ActiveRecord::Base.sanitize_sql_array([ "SELECT pg_try_advisory_xact_lock(?)", ADVISORY_LOCK_KEY ])
+      )
+      raise AlreadyInitialized, "Bootstrap is already in progress or completed" unless locked
+    end
+
+    def create_settings!
+      SystemSettings.create!(
+        singleton_key: true,
+        organization_name: organization_name,
+        legal_name: legal_name,
+        base_currency_code: base_currency_code,
+        default_timezone: default_timezone,
+        default_country_code: default_country_code
+      )
+    end
+
+    def create_system_user!
+      User.create!(
+        username: User::SYSTEM_USERNAME,
+        display_name: "System",
+        actor_type: "system",
+        active: true
+      )
+    end
+
+    def create_store!
+      Store.create!(
+        store_number: store_number,
+        code: store_code,
+        name: store_name,
+        timezone: store_timezone,
+        country_code: store_country_code
+      )
+    end
+
+    def create_administrator!
+      User.create!(
+        username: admin_username,
+        email: admin_email,
+        display_name: admin_display_name,
+        actor_type: "human",
+        password: admin_password,
+        password_confirmation: admin_password,
+        password_changed_at: Time.current,
+        active: true
+      )
+    end
+
+    def assign_administrator!(admin:, system_user:)
+      role = Role.find_by!(key: "system_administrator")
+      RoleAssignment.create!(
+        user: admin,
+        role: role,
+        store: nil,
+        assigned_by: system_user,
+        effective_at: Time.current
+      )
+    end
+  end
+end

--- a/app/services/users/deactivate.rb
+++ b/app/services/users/deactivate.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Users
+  class Deactivate
+    def self.call(user:, actor:)
+      raise ArgumentError, "system actor cannot be deactivated" if user.system_actor?
+
+      Authorization::LastGlobalAdministrator.new.with_lock do
+        user.update!(
+          active: false,
+          deactivated_at: Time.current,
+          deactivated_by: actor
+        )
+        user.user_sessions.active.find_each { |session| session.revoke!(by: actor) }
+
+        Audit::Recorder.record!(
+          action: "users.deactivate",
+          outcome: "succeeded",
+          actor_user: actor,
+          actor_label: actor.display_name,
+          subject: user,
+          after_values: { active: false }
+        )
+      end
+      user
+    end
+  end
+end

--- a/app/views/admin/audit_events/index.html.erb
+++ b/app/views/admin/audit_events/index.html.erb
@@ -1,0 +1,20 @@
+<% content_for :title, "Audit events" %>
+<h1>Audit events</h1>
+<%= form_with url: admin_audit_events_path, method: :get do %>
+  <p>
+    <%= label_tag :action_key, "Action" %><%= text_field_tag :action_key, params[:action_key] %>
+    <%= label_tag :outcome, "Outcome" %><%= select_tag :outcome, options_for_select([ "", "succeeded", "failed", "denied" ], params[:outcome]) %>
+    <%= label_tag :from, "From" %><%= text_field_tag :from, params[:from] %>
+    <%= label_tag :to, "To" %><%= text_field_tag :to, params[:to] %>
+    <%= submit_tag "Filter" %>
+  </p>
+<% end %>
+<ul>
+  <% @audit_events.each do |event| %>
+    <li>
+      <%= link_to event.occurred_at.iso8601, admin_audit_event_path(event) %>
+      <%= event.action %> · <%= event.outcome %> · <%= event.actor_label %>
+      <%= event.store&.code %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/admin/audit_events/show.html.erb
+++ b/app/views/admin/audit_events/show.html.erb
@@ -1,0 +1,10 @@
+<% content_for :title, "Audit event" %>
+<h1><%= @audit_event.action %></h1>
+<p>Outcome: <%= @audit_event.outcome %></p>
+<p>Actor: <%= @audit_event.actor_label %> (<%= @audit_event.actor_type %>)</p>
+<p>Occurred: <%= @audit_event.occurred_at %></p>
+<p>Store: <%= @audit_event.store&.name || "none" %></p>
+<p>Subject: <%= @audit_event.subject_type %> <%= @audit_event.subject_label %></p>
+<pre><%= JSON.pretty_generate(@audit_event.before_values || {}) %></pre>
+<pre><%= JSON.pretty_generate(@audit_event.after_values || {}) %></pre>
+<pre><%= JSON.pretty_generate(@audit_event.metadata || {}) %></pre>

--- a/app/views/admin/role_assignments/index.html.erb
+++ b/app/views/admin/role_assignments/index.html.erb
@@ -1,0 +1,15 @@
+<% content_for :title, "Role assignments" %>
+<h1>Role assignments</h1>
+<p><%= link_to "Assign role", new_admin_role_assignment_path %></p>
+<ul>
+  <% @role_assignments.each do |assignment| %>
+    <li>
+      <%= assignment.user.username %> → <%= assignment.role.key %>
+      <%= assignment.store ? " @ #{assignment.store.code}" : " (global)" %>
+      <%= "revoked" if assignment.revoked? %>
+      <% unless assignment.revoked? %>
+        <%= button_to "Revoke", admin_role_assignment_path(assignment), method: :delete %>
+      <% end %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/admin/role_assignments/new.html.erb
+++ b/app/views/admin/role_assignments/new.html.erb
@@ -1,0 +1,9 @@
+<% content_for :title, "Assign role" %>
+<h1>Assign role</h1>
+<%= form_with model: [:admin, @role_assignment] do |form| %>
+  <% if @role_assignment.errors.any? %><ul><% @role_assignment.errors.full_messages.each do |m| %><li><%= m %></li><% end %></ul><% end %>
+  <p><%= form.label :user_id %><%= form.collection_select :user_id, @users, :id, :username %></p>
+  <p><%= form.label :role_id %><%= form.collection_select :role_id, @roles, :id, :name %></p>
+  <p><%= form.label :store_id %><%= form.collection_select :store_id, @stores, :id, :name, include_blank: "Global" %></p>
+  <p><%= form.submit "Assign" %></p>
+<% end %>

--- a/app/views/admin/roles/_form.html.erb
+++ b/app/views/admin/roles/_form.html.erb
@@ -1,0 +1,18 @@
+<%= form_with model: [:admin, role] do |form| %>
+  <% if role.errors.any? %><ul><% role.errors.full_messages.each do |m| %><li><%= m %></li><% end %></ul><% end %>
+  <%= form.hidden_field :lock_version %>
+  <p><%= form.label :key %><%= form.text_field :key %></p>
+  <p><%= form.label :name %><%= form.text_field :name %></p>
+  <p><%= form.label :description %><%= form.text_area :description %></p>
+  <p><%= form.label :assignment_scope %><%= form.select :assignment_scope, Role::ASSIGNMENT_SCOPES %></p>
+  <fieldset>
+    <legend>Permissions</legend>
+    <% permissions.each do |permission| %>
+      <label>
+        <%= check_box_tag "role[permission_ids][]", permission.id, role.permission_ids.include?(permission.id) %>
+        <%= permission.key %>
+      </label><br>
+    <% end %>
+  </fieldset>
+  <p><%= form.submit %></p>
+<% end %>

--- a/app/views/admin/roles/edit.html.erb
+++ b/app/views/admin/roles/edit.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "Edit role" %>
+<h1>Edit role</h1>
+<%= render "form", role: @role, permissions: @permissions %>

--- a/app/views/admin/roles/index.html.erb
+++ b/app/views/admin/roles/index.html.erb
@@ -1,0 +1,8 @@
+<% content_for :title, "Roles" %>
+<h1>Roles</h1>
+<% if effective_permissions.include?("roles.create") %><p><%= link_to "New role", new_admin_role_path %></p><% end %>
+<ul>
+  <% @roles.each do |role| %>
+    <li><%= link_to role.name, admin_role_path(role) %> (<%= role.key %>, <%= role.assignment_scope %>)</li>
+  <% end %>
+</ul>

--- a/app/views/admin/roles/new.html.erb
+++ b/app/views/admin/roles/new.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "New role" %>
+<h1>New role</h1>
+<%= render "form", role: @role, permissions: @permissions %>

--- a/app/views/admin/roles/show.html.erb
+++ b/app/views/admin/roles/show.html.erb
@@ -1,0 +1,9 @@
+<% content_for :title, @role.name %>
+<h1><%= @role.name %></h1>
+<p>Key: <%= @role.key %> · Scope: <%= @role.assignment_scope %></p>
+<ul>
+  <% @role.permissions.order(:key).each do |permission| %>
+    <li><%= permission.key %></li>
+  <% end %>
+</ul>
+<%= link_to "Edit", edit_admin_role_path(@role) if !@role.system_role? && effective_permissions.include?("roles.manage") %>

--- a/app/views/admin/stores/_form.html.erb
+++ b/app/views/admin/stores/_form.html.erb
@@ -1,0 +1,12 @@
+<%= form_with model: [:admin, store] do |form| %>
+  <% if store.errors.any? %><ul><% store.errors.full_messages.each do |m| %><li><%= m %></li><% end %></ul><% end %>
+  <%= form.hidden_field :lock_version %>
+  <p><%= form.label :store_number %><%= form.text_field :store_number %></p>
+  <p><%= form.label :code %><%= form.text_field :code %></p>
+  <p><%= form.label :name %><%= form.text_field :name %></p>
+  <p><%= form.label :country_code %><%= form.text_field :country_code %></p>
+  <p><%= form.label :timezone %><%= form.text_field :timezone %></p>
+  <p><%= form.label :receipt_header %><%= form.text_area :receipt_header %></p>
+  <p><%= form.label :receipt_footer %><%= form.text_area :receipt_footer %></p>
+  <p><%= form.submit %></p>
+<% end %>

--- a/app/views/admin/stores/edit.html.erb
+++ b/app/views/admin/stores/edit.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "Edit store" %>
+<h1>Edit store</h1>
+<%= render "form", store: @store %>

--- a/app/views/admin/stores/index.html.erb
+++ b/app/views/admin/stores/index.html.erb
@@ -1,0 +1,8 @@
+<% content_for :title, "Stores" %>
+<h1>Stores</h1>
+<% if effective_permissions.include?("stores.create") %><p><%= link_to "New store", new_admin_store_path %></p><% end %>
+<ul>
+  <% @stores.each do |store| %>
+    <li><%= link_to "#{store.name} (#{store.code})", admin_store_path(store) %> <%= "inactive" unless store.active? %></li>
+  <% end %>
+</ul>

--- a/app/views/admin/stores/new.html.erb
+++ b/app/views/admin/stores/new.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "New store" %>
+<h1>New store</h1>
+<%= render "form", store: @store %>

--- a/app/views/admin/stores/show.html.erb
+++ b/app/views/admin/stores/show.html.erb
@@ -1,0 +1,9 @@
+<% content_for :title, @store.name %>
+<h1><%= @store.name %></h1>
+<p>Code: <%= @store.code %> · Number: <%= @store.store_number %> · <%= @store.timezone %></p>
+<p>
+  <%= link_to "Edit", edit_admin_store_path(@store) if effective_permissions.include?("stores.manage") %>
+  <% if effective_permissions.include?("stores.deactivate") && @store.active? %>
+    <%= button_to "Deactivate", admin_store_path(@store), method: :delete, form: { data: { turbo_confirm: "Deactivate this store?" } } %>
+  <% end %>
+</p>

--- a/app/views/admin/system_settings/edit.html.erb
+++ b/app/views/admin/system_settings/edit.html.erb
@@ -1,0 +1,15 @@
+<% content_for :title, "Edit settings" %>
+<h1>Edit system settings</h1>
+<%= form_with model: @settings, url: admin_system_settings_path, method: :patch do |form| %>
+  <%= form.hidden_field :lock_version %>
+  <p><%= form.label :organization_name %><%= form.text_field :organization_name %></p>
+  <p><%= form.label :legal_name %><%= form.text_field :legal_name %></p>
+  <p><%= form.label :base_currency_code %><%= form.text_field :base_currency_code %></p>
+  <p><%= form.label :default_timezone %><%= form.text_field :default_timezone %></p>
+  <p><%= form.label :default_country_code %><%= form.text_field :default_country_code %></p>
+  <p><%= form.label :default_region_code %><%= form.text_field :default_region_code %></p>
+  <p><%= form.label :fiscal_year_start_month %><%= form.number_field :fiscal_year_start_month %></p>
+  <p><%= form.label :default_receipt_header %><%= form.text_area :default_receipt_header %></p>
+  <p><%= form.label :default_receipt_footer %><%= form.text_area :default_receipt_footer %></p>
+  <p><%= form.submit "Save" %></p>
+<% end %>

--- a/app/views/admin/system_settings/show.html.erb
+++ b/app/views/admin/system_settings/show.html.erb
@@ -1,0 +1,10 @@
+<% content_for :title, "System settings" %>
+<h1>System settings</h1>
+<dl>
+  <dt>Organization</dt><dd><%= @settings.organization_name %></dd>
+  <dt>Legal name</dt><dd><%= @settings.legal_name %></dd>
+  <dt>Currency</dt><dd><%= @settings.base_currency_code %></dd>
+  <dt>Timezone</dt><dd><%= @settings.default_timezone %></dd>
+  <dt>Country</dt><dd><%= @settings.default_country_code %></dd>
+</dl>
+<%= link_to "Edit", edit_admin_system_settings_path if effective_permissions.include?("system_settings.manage") %>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,0 +1,10 @@
+<%= form_with model: [:admin, user] do |form| %>
+  <% if user.errors.any? %><ul><% user.errors.full_messages.each do |m| %><li><%= m %></li><% end %></ul><% end %>
+  <%= form.hidden_field :lock_version %>
+  <p><%= form.label :username %><%= form.text_field :username %></p>
+  <p><%= form.label :display_name %><%= form.text_field :display_name %></p>
+  <p><%= form.label :email %><%= form.email_field :email %></p>
+  <p><%= form.label :password %><%= form.password_field :password %></p>
+  <p><%= form.label :password_confirmation %><%= form.password_field :password_confirmation %></p>
+  <p><%= form.submit %></p>
+<% end %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "Edit user" %>
+<h1>Edit user</h1>
+<%= render "form", user: @user %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,8 @@
+<% content_for :title, "Users" %>
+<h1>Users</h1>
+<% if effective_permissions.include?("users.create") %><p><%= link_to "New user", new_admin_user_path %></p><% end %>
+<ul>
+  <% @users.each do |user| %>
+    <li><%= link_to user.username, admin_user_path(user) %> — <%= user.display_name %><%= " (inactive)" unless user.active? %></li>
+  <% end %>
+</ul>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "New user" %>
+<h1>New user</h1>
+<%= render "form", user: @user %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, @user.username %>
+<h1><%= @user.display_name %></h1>
+<p>Username: <%= @user.username %></p>
+<p>Email: <%= @user.email %></p>
+<p>
+  <%= link_to "Edit", edit_admin_user_path(@user) if effective_permissions.include?("users.manage") %>
+  <% if effective_permissions.include?("users.manage") && @user.active? %>
+    <%= button_to "Reset password", reset_password_admin_user_path(@user), method: :post %>
+  <% end %>
+  <% if effective_permissions.include?("users.deactivate") && @user.active? && !@user.system_actor? %>
+    <%= button_to "Deactivate", deactivate_admin_user_path(@user), method: :post %>
+  <% end %>
+</p>

--- a/app/views/admin/workstations/_form.html.erb
+++ b/app/views/admin/workstations/_form.html.erb
@@ -1,0 +1,8 @@
+<%= form_with model: [:admin, workstation] do |form| %>
+  <% if workstation.errors.any? %><ul><% workstation.errors.full_messages.each do |m| %><li><%= m %></li><% end %></ul><% end %>
+  <%= form.hidden_field :lock_version %>
+  <p><%= form.label :code %><%= form.text_field :code %></p>
+  <p><%= form.label :name %><%= form.text_field :name %></p>
+  <p><%= form.label :description %><%= form.text_area :description %></p>
+  <p><%= form.submit %></p>
+<% end %>

--- a/app/views/admin/workstations/edit.html.erb
+++ b/app/views/admin/workstations/edit.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "Edit workstation" %>
+<h1>Edit workstation</h1>
+<%= render "form", workstation: @workstation %>

--- a/app/views/admin/workstations/index.html.erb
+++ b/app/views/admin/workstations/index.html.erb
@@ -1,0 +1,8 @@
+<% content_for :title, "Workstations" %>
+<h1>Workstations</h1>
+<% if effective_permissions.include?("workstations.create") %><p><%= link_to "New workstation", new_admin_workstation_path %></p><% end %>
+<ul>
+  <% @workstations.each do |workstation| %>
+    <li><%= link_to "#{workstation.code} — #{workstation.name}", admin_workstation_path(workstation) %> (<%= workstation.store.code %>)</li>
+  <% end %>
+</ul>

--- a/app/views/admin/workstations/new.html.erb
+++ b/app/views/admin/workstations/new.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "New workstation" %>
+<h1>New workstation</h1>
+<%= render "form", workstation: @workstation %>

--- a/app/views/admin/workstations/show.html.erb
+++ b/app/views/admin/workstations/show.html.erb
@@ -1,0 +1,7 @@
+<% content_for :title, @workstation.name %>
+<h1><%= @workstation.name %></h1>
+<p><%= @workstation.code %> · <%= @workstation.store.name %></p>
+<%= link_to "Edit", edit_admin_workstation_path(@workstation) if effective_permissions.include?("workstations.manage") %>
+<% if effective_permissions.include?("workstations.deactivate") && @workstation.active? %>
+  <%= button_to "Deactivate", admin_workstation_path(@workstation), method: :delete %>
+<% end %>

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -1,0 +1,16 @@
+<% content_for :title, "Home" %>
+
+<section>
+  <h1>ShelfSense</h1>
+  <% if current_user %>
+    <p>Signed in as <%= current_user.display_name %>.</p>
+    <% if current_store %>
+      <p>Current store: <%= current_store.name %> (<%= current_store.code %>).</p>
+    <% elsif accessible_stores.exists? %>
+      <p><%= link_to "Select a store", new_store_selection_path %></p>
+    <% else %>
+      <p>No accessible store is available for your account.</p>
+    <% end %>
+    <p><%= button_to "Sign out", session_path, method: :delete %></p>
+  <% end %>
+</section>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,28 +1,46 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "App" %></title>
+    <title><%= content_for(:title) || "ShelfSense" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="application-name" content="App">
-    <meta name="mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-
     <%= yield :head %>
-
-    <%# Enable PWA manifest for installable apps (make sure to enable in config/routes.rb too!) %>
-    <%#= tag.link rel: "manifest", href: pwa_manifest_path(format: :json) %>
-
-    <link rel="icon" href="/icon.png" type="image/png">
-    <link rel="icon" href="/icon.svg" type="image/svg+xml">
-    <link rel="apple-touch-icon" href="/icon.png">
-
-    <%# Includes all stylesheet files in app/assets/stylesheets %>
-    <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
   </head>
-
   <body>
+    <% if notice.present? %><p class="notice"><%= notice %></p><% end %>
+    <% if alert.present? %><p class="alert"><%= alert %></p><% end %>
+    <% if signed_in? %>
+      <nav>
+        <%= link_to "Home", root_path %>
+        <% if effective_permissions.include?("system_settings.view") %>
+          <%= link_to "Settings", admin_system_settings_path %>
+        <% end %>
+        <% if effective_permissions.include?("stores.view") || effective_permissions.include?("stores.create") %>
+          <%= link_to "Stores", admin_stores_path %>
+        <% end %>
+        <% if effective_permissions.include?("users.view") %>
+          <%= link_to "Users", admin_users_path %>
+        <% end %>
+        <% if effective_permissions.include?("roles.view") %>
+          <%= link_to "Roles", admin_roles_path %>
+        <% end %>
+        <% if effective_permissions.include?("users.assign_roles") %>
+          <%= link_to "Role assignments", admin_role_assignments_path %>
+        <% end %>
+        <% if effective_permissions.include?("workstations.view") %>
+          <%= link_to "Workstations", admin_workstations_path %>
+        <% end %>
+        <% if effective_permissions.include?("audit_events.view") %>
+          <%= link_to "Audit", admin_audit_events_path %>
+        <% end %>
+        <% if accessible_stores.many? %>
+          <%= link_to "Switch store", new_store_selection_path %>
+        <% end %>
+        <%= button_to "Sign out", session_path, method: :delete %>
+      </nav>
+    <% end %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title, "Sign in" %>
+
+<section class="auth">
+  <h1>Sign in</h1>
+
+  <%= form_with url: session_path, scope: :session do |form| %>
+    <p>
+      <%= form.label :username %>
+      <%= form.text_field :username, autocomplete: "username", required: true %>
+    </p>
+    <p>
+      <%= form.label :password %>
+      <%= form.password_field :password, autocomplete: "current-password", required: true %>
+    </p>
+    <p><%= form.submit "Sign in" %></p>
+  <% end %>
+</section>

--- a/app/views/store_selections/new.html.erb
+++ b/app/views/store_selections/new.html.erb
@@ -1,0 +1,12 @@
+<% content_for :title, "Select store" %>
+
+<section>
+  <h1>Select a store</h1>
+  <%= form_with url: store_selection_path do |form| %>
+    <p>
+      <%= form.label :store_id, "Store" %>
+      <%= form.collection_select :store_id, @stores, :id, :name, { prompt: "Choose a store" }, required: true %>
+    </p>
+    <p><%= form.submit "Continue" %></p>
+  <% end %>
+</section>

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,7 @@ module App
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    config.x.application_version = ENV.fetch("APPLICATION_VERSION", "0.1.0")
   end
 end

--- a/config/initializers/shelfsense_migration.rb
+++ b/config/initializers/shelfsense_migration.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "shelfsense/migration"
+
+ActiveSupport.on_load(:active_record) do
+  ActiveRecord::Migration.include(Shelfsense::Migration)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,25 @@
-Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+# frozen_string_literal: true
 
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
+Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
 
-  # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
-  # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
-  # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
+  resource :session, only: %i[new create destroy]
+  resource :store_selection, only: %i[new create]
 
-  # Defines the root path route ("/")
-  # root "posts#index"
+  namespace :admin do
+    resource :system_settings, only: %i[show edit update]
+    resources :stores
+    resources :users do
+      member do
+        post :deactivate
+        post :reset_password
+      end
+    end
+    resources :roles
+    resources :role_assignments, only: %i[index new create destroy]
+    resources :workstations
+    resources :audit_events, only: %i[index show]
+  end
+
+  root "home#show"
 end

--- a/db/migrate/20260809220000_create_phase1_foundation.rb
+++ b/db/migrate/20260809220000_create_phase1_foundation.rb
@@ -1,0 +1,216 @@
+# frozen_string_literal: true
+
+class CreatePhase1Foundation < ActiveRecord::Migration[8.1]
+  def change
+    create_uuid_table :users do |t|
+      t.string :username, null: false
+      t.string :email
+      t.string :display_name, null: false
+      t.string :actor_type, null: false, default: "human"
+      t.string :password_digest
+      t.boolean :active, null: false, default: true
+      t.timestamptz :password_changed_at
+      t.boolean :password_reset_required, null: false, default: false
+      t.timestamptz :last_signed_in_at
+      t.integer :failed_sign_in_count, null: false, default: 0
+      t.timestamptz :locked_at
+      t.timestamptz :deactivated_at
+      t.uuid :deactivated_by_id
+      t.integer :lock_version, null: false, default: 0
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+
+    add_index :users, "lower(username)", unique: true, name: "index_users_on_lower_username"
+    add_index :users, "lower(email)", unique: true, where: "email IS NOT NULL", name: "index_users_on_lower_email"
+    add_check_constraint :users, "failed_sign_in_count >= 0", name: "users_failed_sign_in_count_nonnegative"
+    add_check_constraint :users, "actor_type IN ('human', 'system', 'integration', 'scheduled_job')", name: "users_actor_type_valid"
+    add_foreign_key :users, :users, column: :deactivated_by_id
+
+    create_uuid_table :system_settings do |t|
+      t.boolean :singleton_key, null: false, default: true
+      t.string :organization_name, null: false
+      t.string :legal_name
+      t.string :base_currency_code, limit: 3, null: false
+      t.string :default_timezone, null: false
+      t.string :default_country_code, limit: 2, null: false
+      t.string :default_region_code
+      t.integer :fiscal_year_start_month, limit: 2, null: false, default: 1
+      t.integer :default_supplier_cancellation_days, limit: 2, null: false, default: 20
+      t.integer :default_customer_reservation_expiration_days, limit: 2, null: false, default: 7
+      t.text :default_receipt_header
+      t.text :default_receipt_footer
+      t.timestamptz :initialized_at
+      t.integer :lock_version, null: false, default: 0
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+
+    add_index :system_settings, :singleton_key, unique: true
+    add_check_constraint :system_settings, "singleton_key = true", name: "system_settings_singleton_key_true"
+    add_check_constraint :system_settings, "fiscal_year_start_month BETWEEN 1 AND 12", name: "system_settings_fiscal_year_start_month_range"
+    add_check_constraint :system_settings, "default_supplier_cancellation_days >= 0", name: "system_settings_supplier_cancellation_days_nonnegative"
+    add_check_constraint :system_settings, "default_customer_reservation_expiration_days >= 0", name: "system_settings_reservation_days_nonnegative"
+
+    create_uuid_table :stores do |t|
+      t.string :store_number, null: false
+      t.string :code, null: false
+      t.string :name, null: false
+      t.string :legal_name
+      t.string :street_address_1
+      t.string :street_address_2
+      t.string :city
+      t.string :region_code
+      t.string :postal_code
+      t.string :country_code, limit: 2, null: false
+      t.string :phone
+      t.string :san
+      t.string :timezone, null: false
+      t.text :receipt_header
+      t.text :receipt_footer
+      t.boolean :active, null: false, default: true
+      t.timestamptz :deactivated_at
+      t.uuid :deactivated_by_id
+      t.integer :lock_version, null: false, default: 0
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+
+    add_index :stores, "lower(store_number)", unique: true, name: "index_stores_on_lower_store_number"
+    add_index :stores, "lower(code)", unique: true, name: "index_stores_on_lower_code"
+    add_foreign_key :stores, :users, column: :deactivated_by_id
+
+    create_uuid_table :permissions do |t|
+      t.string :key, null: false
+      t.string :group_key, null: false
+      t.string :name, null: false
+      t.text :description
+      t.string :scope_type, null: false
+      t.boolean :active, null: false, default: true
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+
+    add_index :permissions, :key, unique: true
+    add_check_constraint :permissions, "scope_type IN ('global', 'store', 'either')", name: "permissions_scope_type_valid"
+
+    create_uuid_table :roles do |t|
+      t.string :key, null: false
+      t.string :name, null: false
+      t.text :description
+      t.boolean :system_role, null: false, default: false
+      t.string :assignment_scope, null: false
+      t.boolean :active, null: false, default: true
+      t.timestamptz :deactivated_at
+      t.uuid :deactivated_by_id
+      t.integer :lock_version, null: false, default: 0
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+
+    add_index :roles, :key, unique: true
+    add_index :roles, "lower(name)", unique: true, name: "index_roles_on_lower_name"
+    add_check_constraint :roles, "assignment_scope IN ('global', 'store', 'either')", name: "roles_assignment_scope_valid"
+    add_foreign_key :roles, :users, column: :deactivated_by_id
+
+    create_uuid_table :role_permissions do |t|
+      t.uuid :role_id, null: false
+      t.uuid :permission_id, null: false
+      t.uuid :granted_by_id, null: false
+      t.timestamptz :created_at, null: false
+    end
+
+    add_index :role_permissions, [ :role_id, :permission_id ], unique: true
+    add_foreign_key :role_permissions, :roles
+    add_foreign_key :role_permissions, :permissions
+    add_foreign_key :role_permissions, :users, column: :granted_by_id
+
+    create_uuid_table :role_assignments do |t|
+      t.uuid :user_id, null: false
+      t.uuid :role_id, null: false
+      t.uuid :store_id
+      t.timestamptz :effective_at, null: false
+      t.timestamptz :expires_at
+      t.uuid :assigned_by_id, null: false
+      t.timestamptz :revoked_at
+      t.uuid :revoked_by_id
+      t.text :revocation_reason
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+
+    add_index :role_assignments, [ :user_id, :role_id ],
+              unique: true,
+              where: "store_id IS NULL AND revoked_at IS NULL",
+              name: "index_role_assignments_unique_global_active"
+    add_index :role_assignments, [ :user_id, :role_id, :store_id ],
+              unique: true,
+              where: "store_id IS NOT NULL AND revoked_at IS NULL",
+              name: "index_role_assignments_unique_store_active"
+    add_foreign_key :role_assignments, :users
+    add_foreign_key :role_assignments, :roles
+    add_foreign_key :role_assignments, :stores
+    add_foreign_key :role_assignments, :users, column: :assigned_by_id
+    add_foreign_key :role_assignments, :users, column: :revoked_by_id
+
+    create_uuid_table :workstations do |t|
+      t.uuid :store_id, null: false
+      t.string :code, null: false
+      t.string :name, null: false
+      t.text :description
+      t.boolean :active, null: false, default: true
+      t.bigint :receipt_sequence, null: false, default: 0
+      t.timestamptz :activated_at
+      t.timestamptz :revoked_at
+      t.timestamptz :deactivated_at
+      t.uuid :deactivated_by_id
+      t.timestamptz :last_seen_at
+      t.integer :lock_version, null: false, default: 0
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+
+    add_index :workstations, [ :store_id, :code ], unique: true
+    add_check_constraint :workstations, "receipt_sequence >= 0", name: "workstations_receipt_sequence_nonnegative"
+    add_foreign_key :workstations, :stores
+    add_foreign_key :workstations, :users, column: :deactivated_by_id
+
+    create_uuid_table :audit_events do |t|
+      t.timestamptz :occurred_at, null: false
+      t.timestamptz :recorded_at, null: false
+      t.string :actor_type, null: false
+      t.uuid :actor_user_id
+      t.string :actor_label, null: false
+      t.uuid :store_id
+      t.uuid :workstation_id
+      t.uuid :user_session_id
+      t.string :action, null: false
+      t.string :outcome, null: false
+      t.string :subject_type
+      t.uuid :subject_id
+      t.string :subject_label
+      t.string :reason_code
+      t.text :reason_text
+      t.uuid :correlation_id, null: false
+      t.jsonb :before_values
+      t.jsonb :after_values
+      t.jsonb :metadata, null: false, default: {}
+      t.inet :ip_address
+      t.text :user_agent
+      t.string :application_version
+      t.timestamptz :created_at, null: false
+    end
+
+    add_index :audit_events, :occurred_at
+    add_index :audit_events, [ :actor_user_id, :occurred_at ]
+    add_index :audit_events, [ :store_id, :occurred_at ]
+    add_index :audit_events, [ :action, :occurred_at ]
+    add_index :audit_events, [ :subject_type, :subject_id ]
+    add_index :audit_events, :correlation_id
+    add_index :audit_events, [ :outcome, :occurred_at ]
+    add_check_constraint :audit_events, "outcome IN ('succeeded', 'failed', 'denied')", name: "audit_events_outcome_valid"
+    add_foreign_key :audit_events, :users, column: :actor_user_id
+    add_foreign_key :audit_events, :stores
+    add_foreign_key :audit_events, :workstations
+  end
+end

--- a/db/migrate/20260809221000_create_user_sessions.rb
+++ b/db/migrate/20260809221000_create_user_sessions.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class CreateUserSessions < ActiveRecord::Migration[8.1]
+  def change
+    create_uuid_table :user_sessions do |t|
+      t.uuid :user_id, null: false
+      t.string :token_digest, null: false
+      t.timestamptz :last_seen_at, null: false
+      t.timestamptz :expires_at, null: false
+      t.timestamptz :revoked_at
+      t.uuid :revoked_by_id
+      t.inet :ip_address
+      t.text :user_agent
+      t.timestamptz :created_at, null: false
+    end
+
+    add_index :user_sessions, :token_digest, unique: true
+    add_index :user_sessions, [ :user_id, :revoked_at ]
+    add_index :user_sessions, :expires_at
+    add_foreign_key :user_sessions, :users
+    add_foreign_key :user_sessions, :users, column: :revoked_by_id
+    add_foreign_key :audit_events, :user_sessions
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,222 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 0) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_09_221000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
+  create_table "audit_events", id: :uuid, default: nil, force: :cascade do |t|
+    t.string "action", null: false
+    t.string "actor_label", null: false
+    t.string "actor_type", null: false
+    t.uuid "actor_user_id"
+    t.jsonb "after_values"
+    t.string "application_version"
+    t.jsonb "before_values"
+    t.uuid "correlation_id", null: false
+    t.timestamptz "created_at", null: false
+    t.inet "ip_address"
+    t.jsonb "metadata", default: {}, null: false
+    t.timestamptz "occurred_at", null: false
+    t.string "outcome", null: false
+    t.string "reason_code"
+    t.text "reason_text"
+    t.timestamptz "recorded_at", null: false
+    t.uuid "store_id"
+    t.uuid "subject_id"
+    t.string "subject_label"
+    t.string "subject_type"
+    t.text "user_agent"
+    t.uuid "user_session_id"
+    t.uuid "workstation_id"
+    t.index ["action", "occurred_at"], name: "index_audit_events_on_action_and_occurred_at"
+    t.index ["actor_user_id", "occurred_at"], name: "index_audit_events_on_actor_user_id_and_occurred_at"
+    t.index ["correlation_id"], name: "index_audit_events_on_correlation_id"
+    t.index ["occurred_at"], name: "index_audit_events_on_occurred_at"
+    t.index ["outcome", "occurred_at"], name: "index_audit_events_on_outcome_and_occurred_at"
+    t.index ["store_id", "occurred_at"], name: "index_audit_events_on_store_id_and_occurred_at"
+    t.index ["subject_type", "subject_id"], name: "index_audit_events_on_subject_type_and_subject_id"
+    t.check_constraint "outcome::text = ANY (ARRAY['succeeded'::character varying, 'failed'::character varying, 'denied'::character varying]::text[])", name: "audit_events_outcome_valid"
+  end
+
+  create_table "permissions", id: :uuid, default: nil, force: :cascade do |t|
+    t.boolean "active", default: true, null: false
+    t.timestamptz "created_at", null: false
+    t.text "description"
+    t.string "group_key", null: false
+    t.string "key", null: false
+    t.string "name", null: false
+    t.string "scope_type", null: false
+    t.timestamptz "updated_at", null: false
+    t.index ["key"], name: "index_permissions_on_key", unique: true
+    t.check_constraint "scope_type::text = ANY (ARRAY['global'::character varying, 'store'::character varying, 'either'::character varying]::text[])", name: "permissions_scope_type_valid"
+  end
+
+  create_table "role_assignments", id: :uuid, default: nil, force: :cascade do |t|
+    t.uuid "assigned_by_id", null: false
+    t.timestamptz "created_at", null: false
+    t.timestamptz "effective_at", null: false
+    t.timestamptz "expires_at"
+    t.text "revocation_reason"
+    t.timestamptz "revoked_at"
+    t.uuid "revoked_by_id"
+    t.uuid "role_id", null: false
+    t.uuid "store_id"
+    t.timestamptz "updated_at", null: false
+    t.uuid "user_id", null: false
+    t.index ["user_id", "role_id", "store_id"], name: "index_role_assignments_unique_store_active", unique: true, where: "((store_id IS NOT NULL) AND (revoked_at IS NULL))"
+    t.index ["user_id", "role_id"], name: "index_role_assignments_unique_global_active", unique: true, where: "((store_id IS NULL) AND (revoked_at IS NULL))"
+  end
+
+  create_table "role_permissions", id: :uuid, default: nil, force: :cascade do |t|
+    t.timestamptz "created_at", null: false
+    t.uuid "granted_by_id", null: false
+    t.uuid "permission_id", null: false
+    t.uuid "role_id", null: false
+    t.index ["role_id", "permission_id"], name: "index_role_permissions_on_role_id_and_permission_id", unique: true
+  end
+
+  create_table "roles", id: :uuid, default: nil, force: :cascade do |t|
+    t.boolean "active", default: true, null: false
+    t.string "assignment_scope", null: false
+    t.timestamptz "created_at", null: false
+    t.timestamptz "deactivated_at"
+    t.uuid "deactivated_by_id"
+    t.text "description"
+    t.string "key", null: false
+    t.integer "lock_version", default: 0, null: false
+    t.string "name", null: false
+    t.boolean "system_role", default: false, null: false
+    t.timestamptz "updated_at", null: false
+    t.index "lower((name)::text)", name: "index_roles_on_lower_name", unique: true
+    t.index ["key"], name: "index_roles_on_key", unique: true
+    t.check_constraint "assignment_scope::text = ANY (ARRAY['global'::character varying, 'store'::character varying, 'either'::character varying]::text[])", name: "roles_assignment_scope_valid"
+  end
+
+  create_table "stores", id: :uuid, default: nil, force: :cascade do |t|
+    t.boolean "active", default: true, null: false
+    t.string "city"
+    t.string "code", null: false
+    t.string "country_code", limit: 2, null: false
+    t.timestamptz "created_at", null: false
+    t.timestamptz "deactivated_at"
+    t.uuid "deactivated_by_id"
+    t.string "legal_name"
+    t.integer "lock_version", default: 0, null: false
+    t.string "name", null: false
+    t.string "phone"
+    t.string "postal_code"
+    t.text "receipt_footer"
+    t.text "receipt_header"
+    t.string "region_code"
+    t.string "san"
+    t.string "store_number", null: false
+    t.string "street_address_1"
+    t.string "street_address_2"
+    t.string "timezone", null: false
+    t.timestamptz "updated_at", null: false
+    t.index "lower((code)::text)", name: "index_stores_on_lower_code", unique: true
+    t.index "lower((store_number)::text)", name: "index_stores_on_lower_store_number", unique: true
+  end
+
+  create_table "system_settings", id: :uuid, default: nil, force: :cascade do |t|
+    t.string "base_currency_code", limit: 3, null: false
+    t.timestamptz "created_at", null: false
+    t.string "default_country_code", limit: 2, null: false
+    t.integer "default_customer_reservation_expiration_days", limit: 2, default: 7, null: false
+    t.text "default_receipt_footer"
+    t.text "default_receipt_header"
+    t.string "default_region_code"
+    t.integer "default_supplier_cancellation_days", limit: 2, default: 20, null: false
+    t.string "default_timezone", null: false
+    t.integer "fiscal_year_start_month", limit: 2, default: 1, null: false
+    t.timestamptz "initialized_at"
+    t.string "legal_name"
+    t.integer "lock_version", default: 0, null: false
+    t.string "organization_name", null: false
+    t.boolean "singleton_key", default: true, null: false
+    t.timestamptz "updated_at", null: false
+    t.index ["singleton_key"], name: "index_system_settings_on_singleton_key", unique: true
+    t.check_constraint "default_customer_reservation_expiration_days >= 0", name: "system_settings_reservation_days_nonnegative"
+    t.check_constraint "default_supplier_cancellation_days >= 0", name: "system_settings_supplier_cancellation_days_nonnegative"
+    t.check_constraint "fiscal_year_start_month >= 1 AND fiscal_year_start_month <= 12", name: "system_settings_fiscal_year_start_month_range"
+    t.check_constraint "singleton_key = true", name: "system_settings_singleton_key_true"
+  end
+
+  create_table "user_sessions", id: :uuid, default: nil, force: :cascade do |t|
+    t.timestamptz "created_at", null: false
+    t.timestamptz "expires_at", null: false
+    t.inet "ip_address"
+    t.timestamptz "last_seen_at", null: false
+    t.timestamptz "revoked_at"
+    t.uuid "revoked_by_id"
+    t.string "token_digest", null: false
+    t.text "user_agent"
+    t.uuid "user_id", null: false
+    t.index ["expires_at"], name: "index_user_sessions_on_expires_at"
+    t.index ["token_digest"], name: "index_user_sessions_on_token_digest", unique: true
+    t.index ["user_id", "revoked_at"], name: "index_user_sessions_on_user_id_and_revoked_at"
+  end
+
+  create_table "users", id: :uuid, default: nil, force: :cascade do |t|
+    t.boolean "active", default: true, null: false
+    t.string "actor_type", default: "human", null: false
+    t.timestamptz "created_at", null: false
+    t.timestamptz "deactivated_at"
+    t.uuid "deactivated_by_id"
+    t.string "display_name", null: false
+    t.string "email"
+    t.integer "failed_sign_in_count", default: 0, null: false
+    t.timestamptz "last_signed_in_at"
+    t.integer "lock_version", default: 0, null: false
+    t.timestamptz "locked_at"
+    t.timestamptz "password_changed_at"
+    t.string "password_digest"
+    t.boolean "password_reset_required", default: false, null: false
+    t.timestamptz "updated_at", null: false
+    t.string "username", null: false
+    t.index "lower((email)::text)", name: "index_users_on_lower_email", unique: true, where: "(email IS NOT NULL)"
+    t.index "lower((username)::text)", name: "index_users_on_lower_username", unique: true
+    t.check_constraint "actor_type::text = ANY (ARRAY['human'::character varying, 'system'::character varying, 'integration'::character varying, 'scheduled_job'::character varying]::text[])", name: "users_actor_type_valid"
+    t.check_constraint "failed_sign_in_count >= 0", name: "users_failed_sign_in_count_nonnegative"
+  end
+
+  create_table "workstations", id: :uuid, default: nil, force: :cascade do |t|
+    t.timestamptz "activated_at"
+    t.boolean "active", default: true, null: false
+    t.string "code", null: false
+    t.timestamptz "created_at", null: false
+    t.timestamptz "deactivated_at"
+    t.uuid "deactivated_by_id"
+    t.text "description"
+    t.timestamptz "last_seen_at"
+    t.integer "lock_version", default: 0, null: false
+    t.string "name", null: false
+    t.bigint "receipt_sequence", default: 0, null: false
+    t.timestamptz "revoked_at"
+    t.uuid "store_id", null: false
+    t.timestamptz "updated_at", null: false
+    t.index ["store_id", "code"], name: "index_workstations_on_store_id_and_code", unique: true
+    t.check_constraint "receipt_sequence >= 0", name: "workstations_receipt_sequence_nonnegative"
+  end
+
+  add_foreign_key "audit_events", "stores"
+  add_foreign_key "audit_events", "user_sessions"
+  add_foreign_key "audit_events", "users", column: "actor_user_id"
+  add_foreign_key "audit_events", "workstations"
+  add_foreign_key "role_assignments", "roles"
+  add_foreign_key "role_assignments", "stores"
+  add_foreign_key "role_assignments", "users"
+  add_foreign_key "role_assignments", "users", column: "assigned_by_id"
+  add_foreign_key "role_assignments", "users", column: "revoked_by_id"
+  add_foreign_key "role_permissions", "permissions"
+  add_foreign_key "role_permissions", "roles"
+  add_foreign_key "role_permissions", "users", column: "granted_by_id"
+  add_foreign_key "roles", "users", column: "deactivated_by_id"
+  add_foreign_key "stores", "users", column: "deactivated_by_id"
+  add_foreign_key "user_sessions", "users"
+  add_foreign_key "user_sessions", "users", column: "revoked_by_id"
+  add_foreign_key "users", "users", column: "deactivated_by_id"
+  add_foreign_key "workstations", "stores"
+  add_foreign_key "workstations", "users", column: "deactivated_by_id"
 end

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,8 +7,12 @@ This directory contains the project’s technical authority, development guidanc
 | Document | Purpose |
 |---|---|
 | [Architecture Decision Records](adr/README.md) | Accepted and proposed cross-cutting architecture decisions |
+| [Phase 1 plan](planning/phase1-operational-foundation/phase1-plan.md) | Phase 1 scope, slices, and acceptance criteria |
+| [Phase 1 schema](planning/phase1-operational-foundation/phase1-schema.md) | Phase 1 tables, fields, and constraints |
+| [Phase 1 authorization](planning/phase1-operational-foundation/phase1-authorization.md) | Permission catalog, role grants, and evaluation rules |
 | [Development guide](development.md) | Docker-only local setup, PostgreSQL configuration, application commands, and troubleshooting |
 | [Testing and CI](testing.md) | Active GitHub Actions checks and prerequisites for deferred checks |
+| [GitHub work management](github-workflow.md) | Issues, PRs, milestones, labels, and release tagging |
 | [Project README](../README.md) | Project purpose, status, roadmap, architecture summary, and quick start |
 | [Contributor rules](../AGENTS.md) | Required practices for human contributors and coding agents |
 

--- a/docs/adr/ADR-002-identifiers.md
+++ b/docs/adr/ADR-002-identifiers.md
@@ -41,34 +41,24 @@ POS databases will use a native UUID type when reliably supported. Otherwise, UU
 
 ## Central generation
 
-Centrally created records should normally omit the `id` during insertion and allow the configured PostgreSQL default to generate it:
+### Selected implementation profile (PostgreSQL 17)
 
-```sql
-id uuid PRIMARY KEY DEFAULT uuidv7()
-```
+ShelfSense remains on PostgreSQL 17 for now and generates UUIDv7 values in Rails:
 
-An explicitly supplied identifier must be preserved:
+* Domain models assign `SecureRandom.uuid_v7` in a shared `before_validation`, `on: :create` callback when `id` is blank and the primary-key attribute type is `:uuid`.
+* Explicitly supplied identifiers are preserved.
+* Migrations declare `id: :uuid` and UUID foreign keys without a PostgreSQL `DEFAULT uuidv7()`.
+* Callback-bypassing APIs such as `insert_all`, `upsert_all`, and raw SQL must supply IDs explicitly; otherwise inserts fail with a null primary key.
+* Framework-owned tables keep framework defaults and must not inherit blind UUID assignment.
+
+Revisit native database generation (`uuidv7()`) when the project adopts PostgreSQL 18. Changing the generator implementation later does not change this ADR, provided the generated identifiers remain RFC 9562-compatible and existing IDs are preserved.
+
+An explicitly supplied identifier must be preserved on insert and synchronization:
 
 ```sql
 INSERT INTO pos_transactions (id, ...)
 VALUES ('019...', ...);
 ```
-
-A database default runs only when no value is supplied. It must not overwrite POS-generated identifiers.
-
-### PostgreSQL version requirement
-
-ShelfSense currently targets PostgreSQL 17, which does not provide PostgreSQL 18’s native `uuidv7()` function.
-
-Before the first UUID migration is committed, the project must choose and test one of these implementation profiles:
-
-1. Upgrade to PostgreSQL 18 and use its native `uuidv7()` function.
-2. Remain on PostgreSQL 17 and install a reviewed UUIDv7 extension or project-defined database function.
-3. Generate UUIDv7 values in Rails until native database support is adopted.
-
-The selected mechanism must produce RFC 9562-compatible UUIDv7 values and must be available in development, test, CI, and production.
-
-Changing the generator implementation later does not change this ADR, provided the generated identifiers remain compatible and existing IDs are preserved.
 
 ## Offline POS generation
 
@@ -147,23 +137,21 @@ Any exception for a ShelfSense domain table must be documented.
 
 ## Rails migration convention
 
-UUID-backed domain tables must declare their primary and foreign-key types explicitly:
+UUID-backed domain tables must declare their primary and foreign-key types explicitly, without a database UUID default while on PostgreSQL 17:
 
 ```ruby
-create_table :stores, id: :uuid, default: -> { "uuidv7()" } do |t|
+create_table :stores, id: :uuid, default: nil do |t|
   # ...
   t.timestamps
 end
 
-create_table :workstations, id: :uuid, default: -> { "uuidv7()" } do |t|
+create_table :workstations, id: :uuid, default: nil do |t|
   t.references :store, null: false, type: :uuid, foreign_key: true
   # ...
 end
 ```
 
-The literal default shown above is illustrative until the PostgreSQL 17/18 implementation profile is selected.
-
-The project should provide a shared migration convention or helper so individual migrations do not choose their own generator.
+Use `default: nil` so Rails does not install PostgreSQL’s `gen_random_uuid()` default. Domain models include the shared UUID assignment concern (or equivalent conditional callback). Individual migrations must not invent alternate generators.
 
 ## Validation and testing
 
@@ -199,20 +187,6 @@ The implementation must test that:
 
 ## Implementation follow-up
 
-Before Phase 1 migrations land:
-
-1. Select the PostgreSQL 17 implementation or upgrade the project to PostgreSQL 18.
-2. Configure Rails migrations to use that generator consistently.
-3. Add generator conformance tests.
-4. Document the future POS requirement without selecting its programming-language library prematurely.
-
----
-
-My preference for ShelfSense would be:
-
-* Keep the durable ADR neutral about whether PostgreSQL 17 uses an extension or Rails generation.
-* Add a short implementation decision immediately before Slice 1.
-* If remaining on PostgreSQL 17, seriously consider application-generated UUIDv7 in Rails as the initial implementation. It avoids introducing a database extension solely for ID generation and gives Rails objects permanent IDs before insertion.
-* Revisit native database generation when moving to PostgreSQL 18.
-
-That would slightly revise our earlier recommendation: creator-assigned UUIDv7 is the architectural rule; database-generated versus application-generated is an implementation profile. The offline POS always generates its own IDs.
+1. Keep Rails `SecureRandom.uuid_v7` conformance tests green in development, test, and CI.
+2. When adopting PostgreSQL 18, evaluate switching central defaults to native `uuidv7()` without changing origin-assigned ID semantics.
+3. Document the future POS language-specific UUIDv7 library when the workstation client stack is selected.

--- a/docs/adr/ADR-009-concurrency-and-idempotency.md
+++ b/docs/adr/ADR-009-concurrency-and-idempotency.md
@@ -2,6 +2,7 @@
 
 - **Status:** Accepted
 - **Date:** 2026-08-09
+- **Amended:** 2026-08-09
 
 ## Context
 
@@ -9,7 +10,9 @@ Concurrent edits and retried commands are different failure modes. A single mech
 
 ## Decision
 
-Use an integer `version` on mutable aggregate roots. Updates include the expected version and increment it atomically. A mismatch rejects the stale edit for intentional reconciliation. Child edits increment the aggregate root version. Do not use `updated_at` as a concurrency token.
+Use optimistic concurrency control on mutable aggregate roots. Updates include the expected concurrency token and increment it atomically. A mismatch rejects the stale edit for intentional reconciliation. Child edits increment the aggregate root concurrency token. Do not use `updated_at` as a concurrency token.
+
+In the Rails application, the physical column implementing this policy is `lock_version` (`integer`, `null: false`, default `0`), which Active Record recognizes for optimistic locking. Earlier drafts of this ADR referred to the conceptual field as `version`; that name is not required in the schema.
 
 Every retryable business command uses a scoped idempotency record containing an idempotency key, operation type, source identity, payload hash, processing status, stored result or response reference, and completion time. Enforce uniqueness on `(source_id, operation_type, idempotency_key)`. Reuse of a key with a different payload hash is an error.
 
@@ -18,6 +21,7 @@ Database uniqueness constraints additionally prevent duplicated business effects
 ## Consequences
 
 - Stale editors cannot silently overwrite current aggregate state.
+- Rails raises `ActiveRecord::StaleObjectError` on conflicting updates when `lock_version` is present and submitted with the edit.
 - Network retries return the original outcome rather than repeat the effect.
 - Idempotency records require retention and cleanup rules long enough to cover all possible retries.
 - Commands must define their aggregate boundary, payload canonicalization, and result semantics.

--- a/docs/development.md
+++ b/docs/development.md
@@ -88,6 +88,40 @@ The PostgreSQL image applies `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES
 
 Do not commit production credentials. Production values must come from the deployment environment. The ERB in `config/database.yml` must not use strict `ENV.fetch` calls without defaults for production-only variables, because Rails evaluates the entire file before selecting an environment; strict production lookups would also break development and CI startup.
 
+## Identifiers and migrations
+
+Phase 1 domain tables use UUID primary keys without a PostgreSQL default. Rails assigns RFC 9562 UUIDv7 values in a shared `before_validation` callback (`SecureRandom.uuid_v7`) when `id` is blank. Prefer the migration helper:
+
+```ruby
+create_uuid_table :example_records do |t|
+  t.references :store, null: false, type: :uuid, foreign_key: true
+  t.timestamptz :created_at, null: false
+  t.timestamptz :updated_at, null: false
+end
+```
+
+Callback-bypassing APIs such as `insert_all` must supply IDs explicitly.
+
+## Bootstrap a development installation
+
+After `db:prepare` / `db:migrate`, initialize once:
+
+```sh
+./dev/rails-docker env \
+  ORGANIZATION_NAME="Example Books" \
+  STORE_NUMBER=1 \
+  STORE_CODE=main \
+  STORE_NAME="Main Store" \
+  STORE_TIMEZONE=America/New_York \
+  STORE_COUNTRY_CODE=US \
+  ADMIN_USERNAME=admin \
+  ADMIN_DISPLAY_NAME="Admin User" \
+  ADMIN_PASSWORD='ChangeMe123!' \
+  bin/rails shelfsense:bootstrap
+```
+
+Do not commit real passwords. Bootstrap is concurrency-safe and sets `system_settings.initialized_at` only on success.
+
 ## Tests and validation
 
 Run the Rails test suite:

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -1,0 +1,110 @@
+# GitHub work management
+
+How ShelfSense uses GitHub for planning, review, and releases. Keep this lightweight: add process only when coordination, review, or release pain appears.
+
+## Principles
+
+1. Repository documentation is the source of truth for durable product and technical decisions (`docs/`, ADRs, phase plans).
+2. Issues track discrete outcomes; pull requests review the implementation.
+3. Milestones define phase delivery scope.
+4. Labels classify type; do not duplicate project status, phase, or priority unless automation requires it.
+5. Git tags mark stable release checkpoints, not ordinary merges.
+
+## Documentation authority
+
+Prefer linking to existing docs over copying them into issues or PRs:
+
+| Location | Purpose |
+|---|---|
+| [README.md](../README.md) | Project overview, roadmap summary, quick start |
+| [docs/adr/](adr/README.md) | Accepted and proposed architecture decisions |
+| [docs/planning/](planning/README.md) | Phase plans, schema, authorization contracts |
+| [docs/development.md](development.md) | Docker workflow and local commands |
+| [docs/testing.md](testing.md) | CI coverage and deferred checks |
+| [AGENTS.md](../AGENTS.md) | Contributor and coding-agent rules |
+
+Update applicable docs in the same PR as the behavior change (or in a prerequisite docs PR).
+
+## Lightweight defaults (current scale)
+
+Use this minimal setup until multi-person or multi-domain coordination requires more:
+
+1. **One milestone per active phase** (e.g. `Phase 1 — Operational Foundation`).
+2. **One GitHub Project** with Status only: Backlog, Ready, In progress, In review, Done.
+3. **Type labels:** `type: feature`, `type: bug`, `type: documentation`, `type: refactor`, `type: maintenance`, `type: test`, `type: decision`.
+4. **Special labels when needed:** `needs-decision`, `security`, `breaking-change`.
+5. Optional later: Project fields for Phase / Domain / Priority / Size; domain labels; parent/child issue trees.
+
+Do not create labels for status, milestone membership, priority, size, or individual tables/technologies.
+
+## Issues
+
+Implementation issues should usually be one focused PR. Structure:
+
+```markdown
+## Summary
+Outcome and why.
+
+## References
+- Phase plan / schema / ADR links
+- Parent issue, if any: #
+
+## Acceptance criteria
+- [ ] Verifiable behavior
+- [ ] Tests / checks
+- [ ] Docs updated
+
+## Exclusions
+Deferred work
+
+## Dependencies
+Blocking issues or decisions
+```
+
+Split when work spans unrelated concerns, needs independently reviewable prerequisites, or would produce an unreviewable PR. Do not split tightly coupled implementation and tests merely to create smaller tasks.
+
+Small maintenance (dependency bumps, tiny fixes) may use an issue + PR without a parent issue or Project Size field.
+
+## Branches and pull requests
+
+Branch naming: `<issue-number>-<short-description>` (lowercase, hyphenated). Merge to the primary development branch (`main`). No long-lived phase branches unless a release strategy requires them.
+
+PR structure:
+
+```markdown
+## Summary
+- Material changes and important choices
+
+## Verification
+- `./dev/rails-docker bin/rails test`
+- `./dev/rails-docker bin/rubocop`
+- `./dev/rails-docker bin/brakeman --no-pager`
+- `./dev/rails-docker bin/bundler-audit`
+- Manual checks, if any
+
+## Documentation and migrations
+- Docs touched
+- Migrations / rollback notes
+
+Closes #N
+```
+
+PRs must stay focused, include appropriate tests, update docs, pass CI, and avoid unrelated cleanup. Record follow-up work as new issues.
+
+## Releases
+
+Create an annotated tag and GitHub Release when the repo reaches a meaningful checkpoint (completed phase in a known-good state, internal test release, RC, or production readiness)—not for ordinary merges.
+
+Pre-1.0 versions mark capability checkpoints (e.g. `v0.1.0` after Phase 1 verification). Closing a milestone and tagging a release are related but distinct.
+
+## Phase completion
+
+1. Review milestone issues; move deferred work to the backlog or a later milestone.
+2. Verify phase acceptance criteria and CI on the release commit.
+3. Ensure docs match the implemented system.
+4. Close the milestone.
+5. Tag a release only if the result is a stable checkpoint.
+
+## Policy maintenance
+
+Revise this document when the team repeatedly works around it. Do not add fields, labels, views, or steps solely because GitHub supports them.

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -85,6 +85,12 @@ For offline POS, explicitly distinguish:
 
 ### Phase 1 — Operable foundation
 
+Authoritative Phase 1 documents:
+
+* [phase1-plan.md](phase1-operational-foundation/phase1-plan.md) — scope, slices, acceptance criteria  
+* [phase1-schema.md](phase1-operational-foundation/phase1-schema.md) — tables, fields, constraints  
+* [phase1-authorization.md](phase1-operational-foundation/phase1-authorization.md) — permission catalog, role grants, evaluation rules  
+
 Implement only what is necessary to run and administer one store:
 
 * `system_settings`  
@@ -93,12 +99,14 @@ Implement only what is necessary to run and administer one store:
 * `roles`  
 * `permissions`  
 * `role_permissions`  
-* `user_roles`  
-* `registers`  
+* `role_assignments`  
+* `workstations`  
+* `user_sessions`  
+* `audit_events`  
 * authentication and authorization  
-* audit-event recording
+* audit-event recording  
 
-Deliverable: a user can sign in, access an authorized store, and manage essential system configuration.
+Deliverable: a user can sign in, access an authorized store, and manage essential system configuration according to globally or store-scoped permissions, with material actions recorded in the audit log.
 
 ### Phase 2 — Minimal merchandise catalog
 

--- a/docs/planning/phase1-operational-foundation/phase1-authorization.md
+++ b/docs/planning/phase1-operational-foundation/phase1-authorization.md
@@ -1,0 +1,112 @@
+# Phase 1 Authorization Contract
+
+This document is the authoritative Phase 1 permission catalog, role grants, assignment-scope rules, and evaluation sequence. Schema field details live in [phase1-schema.md](phase1-schema.md). Phase scope and acceptance criteria live in [phase1-plan.md](phase1-plan.md).
+
+## Concepts
+
+| Concept | Meaning |
+|---|---|
+| `permissions.scope_type` | Where a permission may take effect: `global`, `store`, or `either`. |
+| `roles.assignment_scope` | Where a role may be assigned: `global`, `store`, or `either`. |
+| Global role assignment | `role_assignments.store_id IS NULL` — organization-wide authority. |
+| Store-scoped role assignment | `role_assignments.store_id` populated — authority only in that store. |
+
+Permission `scope_type` alone cannot prevent an inappropriate global role assignment. Role `assignment_scope` must also be enforced when creating assignments.
+
+## Permission catalog
+
+| Permission | scope_type | group_key |
+|---|---|---|
+| `system_settings.view` | global | system_settings |
+| `system_settings.manage` | global | system_settings |
+| `stores.view` | either | stores |
+| `stores.create` | global | stores |
+| `stores.manage` | either | stores |
+| `stores.deactivate` | global | stores |
+| `users.view` | global | users |
+| `users.create` | global | users |
+| `users.manage` | global | users |
+| `users.deactivate` | global | users |
+| `users.assign_roles` | global | users |
+| `users.revoke_sessions` | global | users |
+| `roles.view` | global | roles |
+| `roles.create` | global | roles |
+| `roles.manage` | global | roles |
+| `roles.deactivate` | global | roles |
+| `workstations.view` | either | workstations |
+| `workstations.create` | either | workstations |
+| `workstations.manage` | either | workstations |
+| `workstations.deactivate` | either | workstations |
+| `workstations.revoke` | either | workstations |
+| `audit_events.view` | either | audit_events |
+
+Permission keys are seeded by application code. The UI must not invent new permission semantics.
+
+## Meaning of `scope_type`
+
+### `global`
+
+Meaningful only through a global role assignment. Example: `users.manage`, `system_settings.manage`.
+
+### `store`
+
+Evaluated only in a store context through a store-scoped assignment (or a global assignment that contributes store-context authority when the contract allows). Phase 1 seeded catalog does not currently use pure `store` keys; reserved for later domains.
+
+### `either`
+
+- A **global** grant permits the action organization-wide (any store, or org-wide subjects).
+- A **store-scoped** grant permits the action only for the current assigned store.
+
+Examples:
+
+- Global `stores.manage` → manage any store.
+- Store-scoped `stores.manage` → manage only the current store.
+- Global `audit_events.view` → organization-wide audit visibility, including events with `store_id IS NULL`.
+- Store-scoped `audit_events.view` → only events for that store. Events with `store_id IS NULL` must not leak to store-scoped viewers.
+
+## Seeded roles
+
+| Role | assignment_scope | Permissions |
+|---|---|---|
+| `system_administrator` | global | Entire catalog |
+| `store_manager` | store | `stores.view`, `stores.manage`, `workstations.view`, `workstations.create`, `workstations.manage`, `workstations.deactivate`, `workstations.revoke`, `audit_events.view` |
+| `associate` | store | `stores.view` |
+
+`system_administrator` is a normal role populated through `role_permissions`. It is not an authorization bypass.
+
+Future custom roles may set `assignment_scope` to `global`, `store`, or `either`. Seeded system roles keep the scopes above.
+
+## Role-assignment authority
+
+- Granting or revoking any role requires effective `users.assign_roles` from a **global** assignment.
+- `system_administrator` may only be assigned with `store_id IS NULL`.
+- `store_manager` and `associate` may only be assigned with a populated `store_id`.
+- System roles cannot be deleted. Their permission membership is code-seeded.
+
+## Store selection and permission evaluation
+
+Do not use `stores.view` to discover accessible stores. That creates a circular dependency.
+
+Required sequence:
+
+1. Derive accessible active stores from effective **role assignments**:
+   - A global assignment contributes every active store.
+   - A store-scoped assignment contributes that store when active.
+2. Select or validate `current_store` (auto-select when exactly one; selector when several; deny when none).
+3. Compute `effective_permissions` as the union of permissions from:
+   - effective global assignments, and
+   - effective assignments for `current_store`,
+   respecting each permission’s `scope_type` and each role’s `assignment_scope`.
+4. Authorize the requested action against `effective_permissions` (and subject-store rules for `either` permissions).
+
+Organization-wide administration pages may not require an active store, but they still require the relevant permission through a global assignment.
+
+## Last global administrator
+
+ShelfSense must always retain at least one active, sign-in-capable human user with an effective global `system_administrator` assignment.
+
+Granting, revoking, or otherwise removing protected assignments (including deactivating the user or role) must occur through a transactional service that locks the relevant global `system_administrator` assignments before checking the invariant. Model validations may provide friendly feedback but are not sufficient under concurrency.
+
+## System actor
+
+The protected system user (`actor_type = system`) cannot authenticate, cannot receive interactive sessions or role assignments, and is exempt from password-presence validation. Authentication must reject system actors even if a password digest exists.

--- a/docs/planning/phase1-operational-foundation/phase1-plan.md
+++ b/docs/planning/phase1-operational-foundation/phase1-plan.md
@@ -1,5 +1,7 @@
 # Phase 1 \- Operational Foundation
 
+**Authority:** Field-level schema is defined in [phase1-schema.md](phase1-schema.md). Permission catalog, role grants, and evaluation rules are defined in [phase1-authorization.md](phase1-authorization.md). Where this plan’s earlier draft tables conflict (for example historical `user_roles` / `registers` / conceptual `version` wording), prefer the schema, authorization contract, and the settled decisions at the end of this document. Mutable aggregate concurrency uses Rails `lock_version`.
+
 Phase 1 is appropriately scoped, but I would make three structural adjustments before implementation:
 
 1. Treat `user_roles` as scoped role assignments, with an optional `store_id`.  
@@ -44,7 +46,7 @@ The central application should be usable at the end of Phase 1, but the workstat
 | `roles` | Reusable permission bundles |
 | `permissions` | System-defined authorization capabilities |
 | `role_permissions` | Permissions included in each role |
-| `user_roles` | Global or store-scoped role assignments |
+| `role_assignments` | Global or store-scoped role assignments |
 | `workstations` | Durable store-assigned POS workstation identities |
 | `audit_events` | Append-only record of material actions |
 | Authentication/session storage | Credential recovery, sessions, and related authentication state |
@@ -61,7 +63,7 @@ erDiagram
     STORES ||--o{ WORKSTATIONS : contains
 ```
 
-A null `user_roles.store_id` means the assignment is organization-wide. A populated `store_id` means it applies only while operating in that store.
+A null `role_assignments.store_id` means the assignment is organization-wide. A populated `store_id` means it applies only while operating in that store.
 
 This gives us explicit store access without a separate `user_stores` table: a user can access a store only if they have at least one active role assignment applicable to it.
 
@@ -87,7 +89,7 @@ This should be a true singleton representing the organization using this ShelfSe
 | `default_customer_reservation_expiration_days` | smallint | null: false; default 7 |
 | `default_receipt_header` | text |  |
 | `default_receipt_footer` | text |  |
-| `version` | integer | null: false; default 1 |
+| `lock_version` | integer | null: false; default 1 |
 | `created_at` | timestamp | null: false |
 | `updated_at` | timestamp | null: false |
 
@@ -149,7 +151,7 @@ A store is an operational and reporting boundary. Even though Phase 1 initially 
 | `receipt_header` | text | optional override |
 | `receipt_footer` | text | optional override |
 | `active` | boolean | null: false; default true |
-| `version` | integer | null: false; default 1 |
+| `lock_version` | integer | null: false; default 1 |
 | `created_at` | timestamp | null: false |
 | `updated_at` | timestamp | null: false |
 
@@ -192,7 +194,7 @@ A user is a durable actor identity. Shared cashier accounts should not be permit
 | `last_signed_in_at` | timestamp |  |
 | `failed_sign_in_count` | integer | null: false; default 0 |
 | `locked_at` | timestamp |  |
-| `version` | integer | null: false; default 1 |
+| `lock_version` | integer | null: false; default 1 |
 | `created_at` | timestamp | null: false |
 | `updated_at` | timestamp | null: false |
 
@@ -249,7 +251,7 @@ The application must prevent an administrator from removing the final usable glo
 | `description` | text |  |
 | `system_role` | boolean | null: false; default false |
 | `active` | boolean | null: false; default true |
-| `version` | integer | null: false; default 1 |
+| `lock_version` | integer | null: false; default 1 |
 | `created_at` | timestamp | null: false |
 | `updated_at` | timestamp | null: false |
 
@@ -308,7 +310,7 @@ Primary or unique constraint:
 unique(role_id, permission_id)
 ```
 
-Changes to the set should increment `roles.version`.
+Changes to the set should increment `roles.lock_version`.
 
 ---
 
@@ -375,7 +377,7 @@ We previously settled on **Workstation** as the durable configured identity. A f
 | `activated_at` | timestamp | future provisioning support |
 | `revoked_at` | timestamp |  |
 | `last_seen_at` | timestamp | later synchronization use |
-| `version` | integer | null: false; default 1 |
+| `lock_version` | integer | null: false; default 1 |
 | `created_at` | timestamp | null: false |
 | `updated_at` | timestamp | null: false |
 
@@ -636,7 +638,7 @@ Bootstrap credentials should come from an explicit installation workflow or depl
 
 * Audit-event browser  
 * Filters by actor, store, action, subject, outcome, and date  
-* Concurrency checks using `version`  
+* Concurrency checks using `lock_version`  
 * Protected-record invariants  
 * Security and authorization tests
 

--- a/docs/planning/phase1-operational-foundation/phase1-schema.md
+++ b/docs/planning/phase1-operational-foundation/phase1-schema.md
@@ -7,7 +7,8 @@
 * All primary business identifiers use UUIDv7  
 * Lifecycle records are deactivated or revoked rather than deleted  
 * Timestamps are `timestamptz`  
-* Mutable configuration records use optimistic-concurrency versions
+* Mutable configuration records use optimistic-concurrency `lock_version`
+* Authorization contract: [phase1-authorization.md](phase1-authorization.md)
 
 ## 1\. `system_settings`
 
@@ -28,13 +29,14 @@ One row representing installation-wide configuration.
 | `default_customer_reservation_expiration_days` | smallint | null: false; default `7`; check `>= 0` | Default for customer reservations |
 | `default_receipt_header` | text |  |  |
 | `default_receipt_footer` | text |  |  |
+| `initialized_at` | timestamptz |  | Set only as the final successful bootstrap step; null means install incomplete / retryable |
 | `lock_version` | integer | null: false; default `0` | Optimistic concurrency |
 | `created_at` | timestamptz | null: false |  |
 | `updated_at` | timestamptz | null: false |  |
 
 `singleton_key` gives PostgreSQL a simple way to prevent a second settings row without relying on a magic integer ID.
 
-There should be no normal create or delete operation after bootstrap.
+There should be no normal create or delete operation after bootstrap. Bootstrap uses a transactional service with an advisory lock (and/or locking the singleton row). Concurrent bootstrap attempts must fail cleanly. A rolled-back failure leaves `initialized_at` null so installation remains retryable. Phase 1 does not provide an ordinary administrative reopen of bootstrap.
 
 ---
 
@@ -87,7 +89,7 @@ A durable human or system actor identity.
 | `email` | varchar |  | Case-insensitive unique when present |
 | `display_name` | varchar | null: false | Historical audit records also snapshot this |
 | `actor_type` | varchar | null: false; default `human` | `human`, `system`, `integration`, `scheduled_job` |
-| `password_digest` | varchar |  | Required for interactive human users |
+| `password_digest` | varchar |  | Required for interactive human users; omitted for the protected system actor |
 | `active` | boolean | null: false; default `true` |  |
 | `password_changed_at` | timestamptz |  |  |
 | `password_reset_required` | boolean | null: false; default `false` | Useful for administrator-initiated resets |
@@ -109,13 +111,14 @@ unique(lower(email)) where email is not null
 
 Recommended invariants:
 
-* `actor_type = 'human'` requires `password_digest` for interactive accounts.  
+* Interactive `actor_type = 'human'` accounts require `password_digest` (`has_secure_password` + `bcrypt`).  
+* The protected system actor (`actor_type = 'system'`) cannot authenticate, cannot receive interactive sessions or role assignments, and is exempt from password-presence validation. Authentication must reject system actors even if a digest exists.  
 * Non-human actors cannot sign in interactively.  
 * The protected system actor cannot be deactivated or deleted.  
 * Deactivation revokes all active `user_sessions`.  
-* ShelfSense must retain at least one active human with a current global `system_administrator` role assignment.
+* ShelfSense must retain at least one active human with a current global `system_administrator` role assignment (enforced with transactional locking; see authorization contract).
 
-I would not retain an `administrator` user type. Administrator status comes entirely from roles and permissions.
+Administrator status comes entirely from roles and permissions. There is no separate administrator user type.
 
 ---
 
@@ -130,6 +133,7 @@ Reusable permission bundles.
 | `name` | varchar | null: false | Human-facing name |
 | `description` | text |  |  |
 | `system_role` | boolean | null: false; default `false` | Seeded/protected role |
+| `assignment_scope` | varchar | null: false | `global`, `store`, or `either` — where the role may be assigned |
 | `active` | boolean | null: false; default `true` |  |
 | `deactivated_at` | timestamptz |  |  |
 | `deactivated_by_id` | uuid | FK: `users`; nullable |  |
@@ -150,7 +154,8 @@ Recommended rules:
 * System roles cannot be deleted.  
 * Deactivated roles grant no permissions.  
 * The `system_administrator` role does not bypass authorization; it receives its capabilities through `role_permissions`.  
-* Any change to `role_permissions` increments `roles.lock_version`.
+* Any change to `role_permissions` increments `roles.lock_version`.  
+* Seeded assignment scopes: `system_administrator` → `global`; `store_manager` / `associate` → `store`. See [phase1-authorization.md](phase1-authorization.md).
 
 Initial roles:
 
@@ -431,38 +436,6 @@ erDiagram
     WORKSTATIONS o|--o{ AUDIT_EVENTS : originates
 ```
 
-## Phase 1 permission catalog
+## Phase 1 permission catalog and role matrix
 
-A practical initial catalog would be:
-
-```
-system_settings.view
-system_settings.manage
-
-stores.view
-stores.create
-stores.manage
-stores.deactivate
-
-users.view
-users.create
-users.manage
-users.deactivate
-users.assign_roles
-users.revoke_sessions
-
-roles.view
-roles.create
-roles.manage
-roles.deactivate
-
-workstations.view
-workstations.create
-workstations.manage
-workstations.deactivate
-workstations.revoke
-
-audit_events.view
-```
-
-The next useful step would be to define the exact permission-to-role matrix for `system_administrator`, `store_manager`, and `associate`, because that will expose any ambiguity in how global versus store-scoped administration should behave.  
+The authoritative permission catalog, role grants, assignment scopes, evaluation sequence, and last-administrator rules are defined in [phase1-authorization.md](phase1-authorization.md).  

--- a/lib/shelfsense/migration.rb
+++ b/lib/shelfsense/migration.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Shelfsense
+  module Migration
+    # UUID primary keys without a database default. Rails assigns UUIDv7 in models.
+    def create_uuid_table(name, **options, &block)
+      create_table(name, id: :uuid, default: nil, **options, &block)
+    end
+  end
+end

--- a/lib/tasks/shelfsense.rake
+++ b/lib/tasks/shelfsense.rake
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+namespace :shelfsense do
+  desc "Bootstrap a fresh ShelfSense installation"
+  task bootstrap: :environment do
+    required = %w[
+      ORGANIZATION_NAME
+      STORE_NUMBER
+      STORE_CODE
+      STORE_NAME
+      STORE_TIMEZONE
+      STORE_COUNTRY_CODE
+      ADMIN_USERNAME
+      ADMIN_DISPLAY_NAME
+      ADMIN_PASSWORD
+    ]
+    missing = required.select { |key| ENV[key].to_s.strip.empty? }
+    abort "Missing required environment variables: #{missing.join(', ')}" if missing.any?
+
+    result = Installation::Bootstrap.call(
+      organization_name: ENV.fetch("ORGANIZATION_NAME"),
+      legal_name: ENV["LEGAL_NAME"],
+      store_number: ENV.fetch("STORE_NUMBER"),
+      store_code: ENV.fetch("STORE_CODE"),
+      store_name: ENV.fetch("STORE_NAME"),
+      store_timezone: ENV.fetch("STORE_TIMEZONE"),
+      store_country_code: ENV.fetch("STORE_COUNTRY_CODE"),
+      admin_username: ENV.fetch("ADMIN_USERNAME"),
+      admin_display_name: ENV.fetch("ADMIN_DISPLAY_NAME"),
+      admin_password: ENV.fetch("ADMIN_PASSWORD"),
+      admin_email: ENV["ADMIN_EMAIL"],
+      base_currency_code: ENV.fetch("BASE_CURRENCY_CODE", "USD")
+    )
+
+    puts "Bootstrap complete."
+    puts "Organization: #{result[:settings].organization_name}"
+    puts "Store: #{result[:store].code} (#{result[:store].name})"
+    puts "Administrator: #{result[:administrator].username}"
+  end
+end

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Bootstrap the application
+./dev/rails-docker env \
+  ORGANIZATION_NAME="Example Books" \
+  STORE_NUMBER=1 \
+  STORE_CODE=main \
+  STORE_NAME="Main Store" \
+  STORE_TIMEZONE=America/New_York \
+  STORE_COUNTRY_CODE=US \
+  ADMIN_USERNAME=admin \
+  ADMIN_DISPLAY_NAME="Admin User" \
+  ADMIN_PASSWORD='ChangeMe123!' \
+  bin/rails shelfsense:bootstrap

--- a/test/integration/phase1_flow_test.rb
+++ b/test/integration/phase1_flow_test.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Phase1FlowTest < ActionDispatch::IntegrationTest
+  setup do
+    Installation::Bootstrap.call(
+      organization_name: "Example Books",
+      store_number: "1",
+      store_code: "main",
+      store_name: "Main Store",
+      store_timezone: "America/New_York",
+      store_country_code: "US",
+      admin_username: "admin",
+      admin_display_name: "Admin User",
+      admin_password: "correct-horse-battery"
+    )
+  end
+
+  test "sign in administer settings and browse audit" do
+    get new_session_path
+    assert_response :success
+
+    post session_path, params: { session: { username: "admin", password: "correct-horse-battery" } }
+    assert_redirected_to root_path
+    follow_redirect!
+    assert_response :success
+
+    get admin_system_settings_path
+    assert_response :success
+
+    settings = SystemSettings.current
+    patch admin_system_settings_path, params: {
+      system_settings: {
+        organization_name: "Example Books Updated",
+        legal_name: settings.legal_name,
+        base_currency_code: settings.base_currency_code,
+        default_timezone: settings.default_timezone,
+        default_country_code: settings.default_country_code,
+        default_region_code: settings.default_region_code,
+        fiscal_year_start_month: settings.fiscal_year_start_month,
+        default_supplier_cancellation_days: settings.default_supplier_cancellation_days,
+        default_customer_reservation_expiration_days: settings.default_customer_reservation_expiration_days,
+        default_receipt_header: settings.default_receipt_header,
+        default_receipt_footer: settings.default_receipt_footer,
+        lock_version: settings.lock_version
+      }
+    }
+    assert_redirected_to admin_system_settings_path
+    assert_equal "Example Books Updated", SystemSettings.current.organization_name
+
+    get admin_audit_events_path
+    assert_response :success
+    assert_match "system_settings.update", response.body
+  end
+
+  test "direct unauthorized access is denied" do
+    manager = User.create!(
+      username: "manager",
+      display_name: "Manager",
+      password: "correct-horse-battery",
+      password_confirmation: "correct-horse-battery"
+    )
+    RoleAssignment.create!(
+      user: manager,
+      role: Role.find_by!(key: "store_manager"),
+      store: Store.first,
+      assigned_by: User.find_by!(username: "admin"),
+      effective_at: Time.current
+    )
+
+    post session_path, params: { session: { username: "manager", password: "correct-horse-battery" } }
+    get admin_users_path
+    assert_redirected_to root_path
+    assert_equal "denied", AuditEvent.where(action: "authorization.denied").order(:created_at).last.outcome
+  end
+
+  test "stale lock_version surfaces a conflict" do
+    post session_path, params: { session: { username: "admin", password: "correct-horse-battery" } }
+    settings = SystemSettings.current
+    stale = settings.lock_version
+    settings.update!(organization_name: "Concurrent Edit")
+
+    patch admin_system_settings_path, params: {
+      system_settings: {
+        organization_name: "Stale Edit",
+        base_currency_code: settings.base_currency_code,
+        default_timezone: settings.default_timezone,
+        default_country_code: settings.default_country_code,
+        fiscal_year_start_month: settings.fiscal_year_start_month,
+        default_supplier_cancellation_days: settings.default_supplier_cancellation_days,
+        default_customer_reservation_expiration_days: settings.default_customer_reservation_expiration_days,
+        lock_version: stale
+      }
+    }
+    assert_response :redirect
+    follow_redirect!
+    assert_match(/changed by someone else|try again/i, flash[:alert].to_s + response.body)
+    assert_equal "Concurrent Edit", SystemSettings.current.organization_name
+  end
+end

--- a/test/models/concerns/uuid_v7_primary_key_test.rb
+++ b/test/models/concerns/uuid_v7_primary_key_test.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class UuidV7PrimaryKeyTest < ActiveSupport::TestCase
+  setup do
+    @connection = ActiveRecord::Base.connection
+    @connection.create_table :uuid_v7_test_records, id: :uuid, default: nil, force: true do |t|
+      t.string :name, null: false
+      t.uuid :parent_id
+      t.timestamps
+    end
+
+    @model = Class.new(ApplicationRecord) do
+      self.table_name = "uuid_v7_test_records"
+
+      validates :name, presence: true
+      belongs_to :parent, class_name: name, optional: true
+      has_many :children, class_name: name, foreign_key: :parent_id, inverse_of: :parent, dependent: :nullify
+
+      def self.name
+        "UuidV7TestRecord"
+      end
+    end
+  end
+
+  teardown do
+    @connection.drop_table :uuid_v7_test_records, if_exists: true
+  end
+
+  test "assigns uuid v7 before validation completes" do
+    record = @model.new(name: "alpha")
+    assert_nil record.id
+
+    record.valid?
+
+    assert record.id.present?
+    assert_equal 7, uuid_version(record.id)
+    assert_equal 0b10, uuid_variant(record.id)
+  end
+
+  test "preserves an explicitly supplied uuid v7" do
+    explicit = SecureRandom.uuid_v7
+    record = @model.new(id: explicit, name: "beta")
+    record.valid?
+
+    assert_equal explicit, record.id
+  end
+
+  test "rejects invalid uuid text" do
+    assert_raises(ActiveRecord::StatementInvalid) do
+      @model.transaction(requires_new: true) do
+        @model.insert_all([ { id: "not-a-uuid", name: "bad", created_at: Time.current, updated_at: Time.current } ])
+      end
+    end
+  end
+
+  test "callback-bypassing insertion without id fails clearly" do
+    error = assert_raises(ActiveRecord::NotNullViolation, ActiveRecord::StatementInvalid) do
+      @model.transaction(requires_new: true) do
+        @model.insert_all([ { name: "missing-id", created_at: Time.current, updated_at: Time.current } ])
+      end
+    end
+
+    assert_match(/null value in column "id"|NotNullViolation/i, "#{error.class}: #{error.message}")
+  end
+
+  test "insert_all succeeds when given an explicit uuid v7" do
+    id = SecureRandom.uuid_v7
+    assert_nothing_raised do
+      @model.insert_all([ { id: id, name: "bulk", created_at: Time.current, updated_at: Time.current } ])
+    end
+
+    assert_equal "bulk", @model.find(id).name
+    assert_equal 7, uuid_version(id)
+  end
+
+  test "parent and child uuid relationships work before saving" do
+    parent = @model.new(name: "parent")
+    parent.valid?
+    child = @model.new(name: "child", parent_id: parent.id)
+    child.valid?
+
+    assert parent.id.present?
+    assert_equal parent.id, child.parent_id
+  end
+
+  private
+
+  def uuid_version(uuid)
+    uuid.to_s.delete("-")[12].to_i(16)
+  end
+
+  def uuid_variant(uuid)
+    (uuid.to_s.delete("-")[16].to_i(16) & 0b1100) >> 2
+  end
+end

--- a/test/services/authentication/sign_in_test.rb
+++ b/test/services/authentication/sign_in_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Authentication::SignInTest < ActiveSupport::TestCase
+  setup do
+    @bootstrap = Installation::Bootstrap.call(
+      organization_name: "Example Books",
+      store_number: "1",
+      store_code: "main",
+      store_name: "Main Store",
+      store_timezone: "America/New_York",
+      store_country_code: "US",
+      admin_username: "admin",
+      admin_display_name: "Admin User",
+      admin_password: "correct-horse-battery"
+    )
+  end
+
+  test "signs in an active human user" do
+    result = Authentication::SignIn.call(username: "admin", password: "correct-horse-battery")
+
+    assert result.success?
+    assert_equal @bootstrap[:administrator].id, result.user.id
+    assert result.session.persisted?
+    assert result.raw_token.present?
+    assert_equal "succeeded", AuditEvent.where(action: "authentication.sign_in").order(:created_at).last.outcome
+  end
+
+  test "rejects invalid password" do
+    result = Authentication::SignIn.call(username: "admin", password: "wrong-password-value")
+
+    assert_not result.success?
+    assert_equal 1, @bootstrap[:administrator].reload.failed_sign_in_count
+    assert_equal "failed", AuditEvent.where(action: "authentication.sign_in").order(:created_at).last.outcome
+  end
+
+  test "rejects system actor" do
+    result = Authentication::SignIn.call(username: "system", password: "anything-at-all")
+
+    assert_not result.success?
+  end
+
+  test "rejects inactive users" do
+    user = @bootstrap[:administrator]
+    second = User.create!(
+      username: "other",
+      display_name: "Other",
+      password: "correct-horse-battery",
+      password_confirmation: "correct-horse-battery"
+    )
+    RoleAssignment.create!(
+      user: second,
+      role: Role.find_by!(key: "system_administrator"),
+      assigned_by: user,
+      effective_at: Time.current
+    )
+    Users::Deactivate.call(user: user, actor: second)
+
+    result = Authentication::SignIn.call(username: "admin", password: "correct-horse-battery")
+    assert_not result.success?
+    assert_equal 0, user.user_sessions.active.count
+  end
+end

--- a/test/services/authorization/permission_evaluator_test.rb
+++ b/test/services/authorization/permission_evaluator_test.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Authorization::PermissionEvaluatorTest < ActiveSupport::TestCase
+  setup do
+    @bootstrap = Installation::Bootstrap.call(
+      organization_name: "Example Books",
+      store_number: "1",
+      store_code: "main",
+      store_name: "Main Store",
+      store_timezone: "America/New_York",
+      store_country_code: "US",
+      admin_username: "admin",
+      admin_display_name: "Admin User",
+      admin_password: "correct-horse-battery"
+    )
+    @store = @bootstrap[:store]
+    @second_store = Store.create!(
+      store_number: "2",
+      code: "east",
+      name: "East Store",
+      timezone: "America/New_York",
+      country_code: "US"
+    )
+    @manager = User.create!(
+      username: "manager",
+      display_name: "Manager",
+      password: "correct-horse-battery",
+      password_confirmation: "correct-horse-battery"
+    )
+    RoleAssignment.create!(
+      user: @manager,
+      role: Role.find_by!(key: "store_manager"),
+      store: @store,
+      assigned_by: @bootstrap[:administrator],
+      effective_at: Time.current
+    )
+  end
+
+  test "accessible stores come from role assignments not stores.view" do
+    stores = Authorization::StoreAccess.accessible_stores_for(@manager)
+    assert_equal [ @store.id ], stores.map(&:id)
+
+    admin_stores = Authorization::StoreAccess.accessible_stores_for(@bootstrap[:administrator])
+    assert_includes admin_stores.map(&:id), @store.id
+    assert_includes admin_stores.map(&:id), @second_store.id
+  end
+
+  test "store manager permissions apply only in assigned store" do
+    at_store = Authorization::PermissionEvaluator.permissions_for(user: @manager, store: @store)
+    assert_includes at_store, "workstations.manage"
+    assert_includes at_store, "stores.manage"
+    assert_not_includes at_store, "users.manage"
+
+    other = Authorization::PermissionEvaluator.permissions_for(user: @manager, store: @second_store)
+    assert_empty other
+  end
+
+  test "global admin has organization-wide permissions" do
+    keys = Authorization::PermissionEvaluator.permissions_for(user: @bootstrap[:administrator], store: @store)
+    assert_includes keys, "system_settings.manage"
+    assert_includes keys, "users.assign_roles"
+    assert_includes keys, "workstations.manage"
+  end
+
+  test "store-scoped audit viewers cannot see null-store events" do
+    org_event = AuditEvent.create!(
+      occurred_at: Time.current,
+      recorded_at: Time.current,
+      created_at: Time.current,
+      actor_type: "system",
+      actor_label: "System",
+      action: "installation.completed",
+      outcome: "succeeded",
+      correlation_id: SecureRandom.uuid_v7,
+      metadata: {},
+      store_id: nil
+    )
+    store_event = AuditEvent.create!(
+      occurred_at: Time.current,
+      recorded_at: Time.current,
+      created_at: Time.current,
+      actor_type: "user",
+      actor_user: @manager,
+      actor_label: @manager.display_name,
+      action: "workstations.create",
+      outcome: "succeeded",
+      correlation_id: SecureRandom.uuid_v7,
+      metadata: {},
+      store: @store
+    )
+
+    visible_ids = AuditEvent.where(store_id: Authorization::StoreAccess.accessible_stores_for(@manager).select(:id)).pluck(:id)
+    assert_includes visible_ids, store_event.id
+    assert_not_includes visible_ids, org_event.id
+  end
+end

--- a/test/services/installation/bootstrap_test.rb
+++ b/test/services/installation/bootstrap_test.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Installation::BootstrapTest < ActiveSupport::TestCase
+  setup do
+    @attrs = {
+      organization_name: "Example Books",
+      store_number: "1",
+      store_code: "main",
+      store_name: "Main Store",
+      store_timezone: "America/New_York",
+      store_country_code: "US",
+      admin_username: "admin",
+      admin_display_name: "Admin User",
+      admin_password: "correct-horse-battery",
+      admin_email: "admin@example.com"
+    }
+  end
+
+  test "bootstraps organization store system actor admin and audit events" do
+    result = Installation::Bootstrap.call(**@attrs)
+
+    assert SystemSettings.initialized?
+    assert_equal "Example Books", result[:settings].organization_name
+    assert_equal "main", result[:store].code
+    assert result[:system_user].system_actor?
+    assert_nil result[:system_user].password_digest
+    assert result[:administrator].authenticate("correct-horse-battery")
+    assert_equal "system_administrator", result[:assignment].role.key
+    assert_nil result[:assignment].store_id
+
+    assert_equal 22, Permission.count
+    assert_equal 3, Role.count
+    assert Role.find_by!(key: "store_manager").assignment_scope == "store"
+
+    actions = AuditEvent.order(:occurred_at).pluck(:action)
+    assert_includes actions, "installation.started"
+    assert_includes actions, "installation.completed"
+    assert AuditEvent.where(actor_type: "system").exists?
+  end
+
+  test "rejects a second bootstrap after initialization" do
+    Installation::Bootstrap.call(**@attrs)
+
+    assert_raises(Installation::Bootstrap::AlreadyInitialized) do
+      Installation::Bootstrap.call(**@attrs.merge(admin_username: "admin2", store_code: "two", store_number: "2"))
+    end
+  end
+
+  test "failed bootstrap leaves installation retryable" do
+    assert_raises(ActiveRecord::RecordInvalid) do
+      Installation::Bootstrap.call(**@attrs.merge(admin_password: "short"))
+    end
+
+    assert_not SystemSettings.initialized?
+    assert_equal 0, User.count
+    assert_equal 0, AuditEvent.count
+
+    result = Installation::Bootstrap.call(**@attrs)
+    assert SystemSettings.initialized?
+    assert result[:administrator].persisted?
+  end
+
+  test "system actor cannot authenticate and cannot receive roles" do
+    result = Installation::Bootstrap.call(**@attrs)
+    system_user = result[:system_user]
+
+    assert_not system_user.authenticatable?
+    assignment = RoleAssignment.new(
+      user: system_user,
+      role: Role.find_by!(key: "associate"),
+      store: result[:store],
+      assigned_by: result[:administrator]
+    )
+    assert_not assignment.valid?
+    assert_includes assignment.errors[:user_id], "system actor cannot receive role assignments"
+  end
+
+  test "store-only roles cannot be assigned globally" do
+    result = Installation::Bootstrap.call(**@attrs)
+    assignment = RoleAssignment.new(
+      user: result[:administrator],
+      role: Role.find_by!(key: "store_manager"),
+      store: nil,
+      assigned_by: result[:administrator]
+    )
+    assert_not assignment.valid?
+  end
+
+  test "last global administrator protection locks and rejects removal" do
+    result = Installation::Bootstrap.call(**@attrs)
+    assignment = result[:assignment]
+
+    error = assert_raises(Authorization::LastGlobalAdministrator::WouldRemoveLastAdministrator) do
+      Authorization::LastGlobalAdministrator.new.with_lock do
+        assignment.update!(revoked_at: Time.current, revoked_by: result[:administrator], revocation_reason: "test")
+      end
+    end
+
+    assert_match(/at least one active global system administrator/, error.message)
+    assert_nil assignment.reload.revoked_at
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,8 +7,8 @@ module ActiveSupport
     # Run tests in parallel with specified workers
     parallelize(workers: :number_of_processors)
 
-    # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
-    fixtures :all
+    # Fixtures are opt-in per test case until a stable fixture set exists.
+    # fixtures :all
 
     # Add more helper methods to be used by all tests here...
   end


### PR DESCRIPTION
## Summary
- Deliver Phase 1 operable foundation: UUIDv7 identity, bootstrap, auth sessions, store-scoped authorization, admin UI, and append-only audit events.
- Align ADRs/planning docs (`lock_version`, Rails UUIDv7 on PostgreSQL 17, `role_assignments`/`workstations`) and add the Phase 1 authorization contract.
- Add lightweight GitHub work-management guidance for issues, PRs, milestones, and releases.

## Test plan
- [x] `./dev/rails-docker bin/rails db:prepare`
- [x] Bootstrap via `scripts/bootstrap.sh` or `bin/rails shelfsense:bootstrap` with required env vars
- [x] Sign in as the bootstrap admin; confirm store context and admin navigation
- [x] `./dev/rails-docker bin/rails test`
- [x] `./dev/rails-docker bin/rubocop`
- [x] `./dev/rails-docker bin/brakeman --no-pager`
- [x] `./dev/rails-docker bin/bundler-audit`
- [x] Confirm CI jobs pass on the PR


Made with [Cursor](https://cursor.com)