### PR TITLE
Phase 2: financial classification and merchandise foundation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ gem "jbuilder"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 gem "bcrypt", "~> 3.1.7"
+gem "csv", "~> 3.3"
+
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,7 @@ GEM
     concurrent-ruby (1.3.8)
     connection_pool (3.0.2)
     crass (1.0.7)
+    csv (3.3.6)
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
@@ -388,6 +389,7 @@ DEPENDENCIES
   brakeman
   bundler-audit
   capybara
+  csv (~> 3.3)
   debug
   image_processing (~> 1.2)
   importmap-rails

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Phase 2 extends Phase 1 patterns for organization-wide catalog master data:
 
 The Phase 2 deliverable is:
 
-> An authorized user can configure financial classifications, create a product with one or more sellable variants (each with an immutable `221` SKU), assign department/tax/class/condition/price, and retrieve by product identifier, variant SKU, or variant industry identifier.
+> An authorized user can configure financial classifications, create a product with one or more sellable standard or used variants (each with an immutable `221` SKU), assign department/tax/class/price (and condition for used variants), and retrieve by product identifier, variant SKU, or variant industry identifier.
 
 Phase 2 does not include inventory, journal posting, tax calculation, suppliers/purchasing, POS, buyback, promotions, or bibliographic enrichment.
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,23 @@ The Phase 1 deliverable is:
 
 Phase 1 does not include business days, POS sessions, cash drawers, transactions, inventory, merchandise, customers, suppliers, offline workstation synchronization, or purchasing workflows.
 
+### Phase 2: Financial classification and merchandise foundation
+
+Status: implemented (GL/tax/departments, merchandise reference data, products with mandatory primary identifiers, variants with immutable `221` SKUs, identifier registry tombstones, lookup, and CSV import).
+
+Phase 2 extends Phase 1 patterns for organization-wide catalog master data:
+
+- Financial classifications: `gl_accounts`, `tax_classes`, `departments`
+- Merchandise reference: `merchandise_classes`, `merchandise_categories`, `merchandise_conditions`
+- Catalog: `products` (mandatory `primary_identifier`, enter-external or generate-`222` at create), `product_variants` (immutable generated `221` SKU), `identifier_registry`
+- Unified identifier lookup (`merchandise.lookup`) and minimal CSV import (`merchandise.import`)
+
+The Phase 2 deliverable is:
+
+> An authorized user can configure financial classifications, create a product with one or more sellable variants (each with an immutable `221` SKU), assign department/tax/class/condition/price, and retrieve by product identifier, variant SKU, or variant industry identifier.
+
+Phase 2 does not include inventory, journal posting, tax calculation, suppliers/purchasing, POS, buyback, promotions, or bibliographic enrichment.
+
 ## Phase 1 authorization model
 
 Permissions are additive and supplied by roles:
@@ -170,6 +187,7 @@ Start with the [documentation index](docs/README.md). Key references include:
 
 - [Architecture Decision Records](docs/adr/README.md)
 - [Phase 1 plan](docs/planning/phase1-operational-foundation/phase1-plan.md), [schema](docs/planning/phase1-operational-foundation/phase1-schema.md), and [authorization contract](docs/planning/phase1-operational-foundation/phase1-authorization.md)
+- [Phase 2 plan](docs/planning/phase2-financial-classification-and-merchandise-foundation/phase2-plan.md), [schema](docs/planning/phase2-financial-classification-and-merchandise-foundation/phase-2-database-schema.md), and [authorization contract](docs/planning/phase2-financial-classification-and-merchandise-foundation/phase2-authorization.md)
 - [Development guide](docs/development.md)
 - [Testing and CI](docs/testing.md)
 - [GitHub work management](docs/github-workflow.md)

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -28,5 +28,57 @@ module Admin
     rescue ActiveRecord::StaleObjectError
       redirect_back fallback_location: root_path, alert: "This record was changed by someone else. Reload and try again."
     end
+
+    def create_and_audit!(record, action:, after_values: nil)
+      record.class.transaction do
+        return false unless record.save
+
+        Audit::Recorder.record!(
+          action: action,
+          outcome: "succeeded",
+          actor_user: current_user,
+          actor_label: current_user.display_name,
+          store: current_store,
+          subject: record,
+          after_values: after_values
+        )
+      end
+      true
+    end
+
+    def save_and_audit!(record, attrs:, action:, before_keys:)
+      record.class.transaction do
+        before = record.attributes.slice(*before_keys)
+        return false unless record.update(attrs)
+
+        Audit::Recorder.record!(
+          action: action,
+          outcome: "succeeded",
+          actor_user: current_user,
+          actor_label: current_user.display_name,
+          store: current_store,
+          subject: record,
+          before_values: before,
+          after_values: record.attributes.slice(*before.keys)
+        )
+      end
+      true
+    end
+
+    def mutate_and_audit!(record, action:, before_values: nil, after_values: nil)
+      record.class.transaction do
+        yield
+        Audit::Recorder.record!(
+          action: action,
+          outcome: "succeeded",
+          actor_user: current_user,
+          actor_label: current_user.display_name,
+          store: current_store,
+          subject: record,
+          before_values: before_values,
+          after_values: after_values
+        )
+      end
+    end
   end
 end

--- a/app/controllers/admin/departments_controller.rb
+++ b/app/controllers/admin/departments_controller.rb
@@ -21,16 +21,11 @@ module Admin
 
     def create
       @department = Department.new(department_params.except(:lock_version))
-      if @department.save
-        Audit::Recorder.record!(
-          action: "departments.create",
-          outcome: "succeeded",
-          actor_user: current_user,
-          actor_label: current_user.display_name,
-          store: current_store,
-          subject: @department,
-          after_values: { code: @department.code, name: @department.name }
-        )
+      if create_and_audit!(
+        @department,
+        action: "departments.create",
+        after_values: { code: @department.code, name: @department.name }
+      )
         redirect_to admin_department_path(@department), notice: "Department created."
       else
         load_form_options
@@ -44,18 +39,12 @@ module Admin
 
     def update
       rescue_stale do
-        before = @department.attributes.slice(*audit_attribute_keys)
-        if @department.update(department_params)
-          Audit::Recorder.record!(
-            action: "departments.update",
-            outcome: "succeeded",
-            actor_user: current_user,
-            actor_label: current_user.display_name,
-            store: current_store,
-            subject: @department,
-            before_values: before,
-            after_values: @department.attributes.slice(*before.keys)
-          )
+        if save_and_audit!(
+          @department,
+          attrs: department_params,
+          action: "departments.update",
+          before_keys: audit_attribute_keys
+        )
           redirect_to admin_department_path(@department), notice: "Department updated."
         else
           load_form_options
@@ -65,15 +54,7 @@ module Admin
     end
 
     def destroy
-      @department.update!(active: false)
-      Audit::Recorder.record!(
-        action: "departments.deactivate",
-        outcome: "succeeded",
-        actor_user: current_user,
-        actor_label: current_user.display_name,
-        store: current_store,
-        subject: @department
-      )
+      mutate_and_audit!(@department, action: "departments.deactivate") { @department.update!(active: false) }
       redirect_to admin_departments_path, notice: "Department deactivated."
     end
 

--- a/app/controllers/admin/departments_controller.rb
+++ b/app/controllers/admin/departments_controller.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+module Admin
+  class DepartmentsController < BaseController
+    before_action -> { require_permission!("departments.view") }, only: %i[index show]
+    before_action -> { require_permission!("departments.create") }, only: %i[new create]
+    before_action -> { require_permission!("departments.update") }, only: %i[edit update]
+    before_action -> { require_permission!("departments.deactivate") }, only: :destroy
+    before_action :set_department, only: %i[show edit update destroy]
+
+    def index
+      @departments = Department.order(:display_order, :code)
+    end
+
+    def show; end
+
+    def new
+      @department = Department.new(display_order: 0)
+      load_form_options
+    end
+
+    def create
+      @department = Department.new(department_params.except(:lock_version))
+      if @department.save
+        Audit::Recorder.record!(
+          action: "departments.create",
+          outcome: "succeeded",
+          actor_user: current_user,
+          actor_label: current_user.display_name,
+          store: current_store,
+          subject: @department,
+          after_values: { code: @department.code, name: @department.name }
+        )
+        redirect_to admin_department_path(@department), notice: "Department created."
+      else
+        load_form_options
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def edit
+      load_form_options
+    end
+
+    def update
+      rescue_stale do
+        before = @department.attributes.slice(*audit_attribute_keys)
+        if @department.update(department_params)
+          Audit::Recorder.record!(
+            action: "departments.update",
+            outcome: "succeeded",
+            actor_user: current_user,
+            actor_label: current_user.display_name,
+            store: current_store,
+            subject: @department,
+            before_values: before,
+            after_values: @department.attributes.slice(*before.keys)
+          )
+          redirect_to admin_department_path(@department), notice: "Department updated."
+        else
+          load_form_options
+          render :edit, status: :unprocessable_entity
+        end
+      end
+    end
+
+    def destroy
+      @department.update!(active: false)
+      Audit::Recorder.record!(
+        action: "departments.deactivate",
+        outcome: "succeeded",
+        actor_user: current_user,
+        actor_label: current_user.display_name,
+        store: current_store,
+        subject: @department
+      )
+      redirect_to admin_departments_path, notice: "Department deactivated."
+    end
+
+    private
+
+    def set_department
+      @department = Department.find(params[:id])
+    end
+
+    def load_form_options
+      @tax_classes = TaxClass.assignable.order(:display_order, :code)
+      @gl_accounts = GlAccount.assignable.order(:account_number)
+    end
+
+    def audit_attribute_keys
+      %w[
+        code department_number name description default_tax_class_id default_target_margin_bps
+        inventory_asset_gl_account_id cost_of_goods_sold_gl_account_id sales_revenue_gl_account_id
+        sales_returns_gl_account_id receiving_clearing_gl_account_id freight_in_gl_account_id
+        inventory_shrinkage_gl_account_id inventory_adjustment_gain_gl_account_id
+        inventory_adjustment_loss_gl_account_id inventory_write_down_gl_account_id display_order
+      ]
+    end
+
+    def department_params
+      permitted = params.require(:department).permit(
+        :code, :department_number, :name, :description, :default_tax_class_id,
+        :default_target_margin_bps, :inventory_asset_gl_account_id, :cost_of_goods_sold_gl_account_id,
+        :sales_revenue_gl_account_id, :sales_returns_gl_account_id, :receiving_clearing_gl_account_id,
+        :freight_in_gl_account_id, :inventory_shrinkage_gl_account_id,
+        :inventory_adjustment_gain_gl_account_id, :inventory_adjustment_loss_gl_account_id,
+        :inventory_write_down_gl_account_id, :display_order, :lock_version
+      )
+      blankable = %i[
+        department_number default_target_margin_bps inventory_asset_gl_account_id
+        cost_of_goods_sold_gl_account_id sales_revenue_gl_account_id sales_returns_gl_account_id
+        receiving_clearing_gl_account_id freight_in_gl_account_id inventory_shrinkage_gl_account_id
+        inventory_adjustment_gain_gl_account_id inventory_adjustment_loss_gl_account_id
+        inventory_write_down_gl_account_id
+      ]
+      blankable.each { |key| permitted[key] = nil if permitted[key].blank? }
+      permitted
+    end
+  end
+end

--- a/app/controllers/admin/gl_accounts_controller.rb
+++ b/app/controllers/admin/gl_accounts_controller.rb
@@ -21,20 +21,15 @@ module Admin
 
     def create
       @gl_account = GlAccount.new(gl_account_params.except(:lock_version))
-      if @gl_account.save
-        Audit::Recorder.record!(
-          action: "gl_accounts.create",
-          outcome: "succeeded",
-          actor_user: current_user,
-          actor_label: current_user.display_name,
-          store: current_store,
-          subject: @gl_account,
-          after_values: {
-            account_number: @gl_account.account_number,
-            name: @gl_account.name,
-            account_type: @gl_account.account_type
-          }
-        )
+      if create_and_audit!(
+        @gl_account,
+        action: "gl_accounts.create",
+        after_values: {
+          account_number: @gl_account.account_number,
+          name: @gl_account.name,
+          account_type: @gl_account.account_type
+        }
+      )
         redirect_to admin_gl_account_path(@gl_account), notice: "GL account created."
       else
         load_parent_options
@@ -48,21 +43,15 @@ module Admin
 
     def update
       rescue_stale do
-        before = @gl_account.attributes.slice(
-          "account_number", "name", "description", "account_type", "account_category",
-          "parent_id", "posting_allowed", "display_order"
+        if save_and_audit!(
+          @gl_account,
+          attrs: gl_account_params,
+          action: "gl_accounts.update",
+          before_keys: %w[
+            account_number name description account_type account_category
+            parent_id posting_allowed display_order
+          ]
         )
-        if @gl_account.update(gl_account_params)
-          Audit::Recorder.record!(
-            action: "gl_accounts.update",
-            outcome: "succeeded",
-            actor_user: current_user,
-            actor_label: current_user.display_name,
-            store: current_store,
-            subject: @gl_account,
-            before_values: before,
-            after_values: @gl_account.attributes.slice(*before.keys)
-          )
           redirect_to admin_gl_account_path(@gl_account), notice: "GL account updated."
         else
           load_parent_options
@@ -72,15 +61,7 @@ module Admin
     end
 
     def destroy
-      @gl_account.update!(active: false)
-      Audit::Recorder.record!(
-        action: "gl_accounts.deactivate",
-        outcome: "succeeded",
-        actor_user: current_user,
-        actor_label: current_user.display_name,
-        store: current_store,
-        subject: @gl_account
-      )
+      mutate_and_audit!(@gl_account, action: "gl_accounts.deactivate") { @gl_account.update!(active: false) }
       redirect_to admin_gl_accounts_path, notice: "GL account deactivated."
     end
 

--- a/app/controllers/admin/gl_accounts_controller.rb
+++ b/app/controllers/admin/gl_accounts_controller.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+module Admin
+  class GlAccountsController < BaseController
+    before_action -> { require_permission!("gl_accounts.view") }, only: %i[index show]
+    before_action -> { require_permission!("gl_accounts.create") }, only: %i[new create]
+    before_action -> { require_permission!("gl_accounts.update") }, only: %i[edit update]
+    before_action -> { require_permission!("gl_accounts.deactivate") }, only: :destroy
+    before_action :set_gl_account, only: %i[show edit update destroy]
+
+    def index
+      @gl_accounts = GlAccount.order(:display_order, :account_number)
+    end
+
+    def show; end
+
+    def new
+      @gl_account = GlAccount.new(posting_allowed: true, display_order: 0)
+      load_parent_options
+    end
+
+    def create
+      @gl_account = GlAccount.new(gl_account_params.except(:lock_version))
+      if @gl_account.save
+        Audit::Recorder.record!(
+          action: "gl_accounts.create",
+          outcome: "succeeded",
+          actor_user: current_user,
+          actor_label: current_user.display_name,
+          store: current_store,
+          subject: @gl_account,
+          after_values: {
+            account_number: @gl_account.account_number,
+            name: @gl_account.name,
+            account_type: @gl_account.account_type
+          }
+        )
+        redirect_to admin_gl_account_path(@gl_account), notice: "GL account created."
+      else
+        load_parent_options
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def edit
+      load_parent_options
+    end
+
+    def update
+      rescue_stale do
+        before = @gl_account.attributes.slice(
+          "account_number", "name", "description", "account_type", "account_category",
+          "parent_id", "posting_allowed", "display_order"
+        )
+        if @gl_account.update(gl_account_params)
+          Audit::Recorder.record!(
+            action: "gl_accounts.update",
+            outcome: "succeeded",
+            actor_user: current_user,
+            actor_label: current_user.display_name,
+            store: current_store,
+            subject: @gl_account,
+            before_values: before,
+            after_values: @gl_account.attributes.slice(*before.keys)
+          )
+          redirect_to admin_gl_account_path(@gl_account), notice: "GL account updated."
+        else
+          load_parent_options
+          render :edit, status: :unprocessable_entity
+        end
+      end
+    end
+
+    def destroy
+      @gl_account.update!(active: false)
+      Audit::Recorder.record!(
+        action: "gl_accounts.deactivate",
+        outcome: "succeeded",
+        actor_user: current_user,
+        actor_label: current_user.display_name,
+        store: current_store,
+        subject: @gl_account
+      )
+      redirect_to admin_gl_accounts_path, notice: "GL account deactivated."
+    end
+
+    private
+
+    def set_gl_account
+      @gl_account = GlAccount.find(params[:id])
+    end
+
+    def load_parent_options
+      scope = GlAccount.order(:account_number)
+      scope = scope.where.not(id: @gl_account.id) if @gl_account&.persisted?
+      @parent_options = scope
+    end
+
+    def gl_account_params
+      permitted = params.require(:gl_account).permit(
+        :account_number, :name, :description, :account_type, :account_category,
+        :parent_id, :posting_allowed, :display_order, :lock_version
+      )
+      permitted[:parent_id] = nil if permitted[:parent_id].blank?
+      permitted
+    end
+  end
+end

--- a/app/controllers/admin/merchandise_categories_controller.rb
+++ b/app/controllers/admin/merchandise_categories_controller.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module Admin
+  class MerchandiseCategoriesController < BaseController
+    before_action -> { require_permission!("merchandise_categories.view") }, only: %i[index show]
+    before_action -> { require_permission!("merchandise_categories.create") }, only: %i[new create]
+    before_action -> { require_permission!("merchandise_categories.update") }, only: %i[edit update]
+    before_action -> { require_permission!("merchandise_categories.deactivate") }, only: :destroy
+    before_action :set_merchandise_category, only: %i[show edit update destroy]
+
+    def index
+      @merchandise_categories = MerchandiseCategory.order(:display_order, :name)
+    end
+
+    def show; end
+
+    def new
+      @merchandise_category = MerchandiseCategory.new(display_order: 0)
+      load_form_options
+    end
+
+    def create
+      @merchandise_category = MerchandiseCategory.new(merchandise_category_params.except(:lock_version))
+      if @merchandise_category.save
+        Audit::Recorder.record!(
+          action: "merchandise_categories.create",
+          outcome: "succeeded",
+          actor_user: current_user,
+          actor_label: current_user.display_name,
+          store: current_store,
+          subject: @merchandise_category,
+          after_values: { code: @merchandise_category.code, name: @merchandise_category.name }
+        )
+        redirect_to admin_merchandise_category_path(@merchandise_category), notice: "Merchandise category created."
+      else
+        load_form_options
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def edit
+      load_form_options
+    end
+
+    def update
+      rescue_stale do
+        before = @merchandise_category.attributes.slice(
+          "code", "name", "description", "parent_id", "default_merchandise_class_id", "display_order"
+        )
+        if @merchandise_category.update(merchandise_category_params)
+          Audit::Recorder.record!(
+            action: "merchandise_categories.update",
+            outcome: "succeeded",
+            actor_user: current_user,
+            actor_label: current_user.display_name,
+            store: current_store,
+            subject: @merchandise_category,
+            before_values: before,
+            after_values: @merchandise_category.attributes.slice(*before.keys)
+          )
+          redirect_to admin_merchandise_category_path(@merchandise_category), notice: "Merchandise category updated."
+        else
+          load_form_options
+          render :edit, status: :unprocessable_entity
+        end
+      end
+    end
+
+    def destroy
+      @merchandise_category.update!(active: false)
+      Audit::Recorder.record!(
+        action: "merchandise_categories.deactivate",
+        outcome: "succeeded",
+        actor_user: current_user,
+        actor_label: current_user.display_name,
+        store: current_store,
+        subject: @merchandise_category
+      )
+      redirect_to admin_merchandise_categories_path, notice: "Merchandise category deactivated."
+    end
+
+    private
+
+    def set_merchandise_category
+      @merchandise_category = MerchandiseCategory.find(params[:id])
+    end
+
+    def load_form_options
+      scope = MerchandiseCategory.order(:display_order, :name)
+      scope = scope.where.not(id: @merchandise_category.id) if @merchandise_category&.persisted?
+      @parent_options = scope
+      @merchandise_classes = MerchandiseClass.assignable.order(:display_order, :code)
+    end
+
+    def merchandise_category_params
+      permitted = params.require(:merchandise_category).permit(
+        :code, :name, :description, :parent_id, :default_merchandise_class_id,
+        :display_order, :lock_version
+      )
+      %i[code parent_id default_merchandise_class_id].each do |key|
+        permitted[key] = nil if permitted[key].blank?
+      end
+      permitted
+    end
+  end
+end

--- a/app/controllers/admin/merchandise_categories_controller.rb
+++ b/app/controllers/admin/merchandise_categories_controller.rb
@@ -21,16 +21,11 @@ module Admin
 
     def create
       @merchandise_category = MerchandiseCategory.new(merchandise_category_params.except(:lock_version))
-      if @merchandise_category.save
-        Audit::Recorder.record!(
-          action: "merchandise_categories.create",
-          outcome: "succeeded",
-          actor_user: current_user,
-          actor_label: current_user.display_name,
-          store: current_store,
-          subject: @merchandise_category,
-          after_values: { code: @merchandise_category.code, name: @merchandise_category.name }
-        )
+      if create_and_audit!(
+        @merchandise_category,
+        action: "merchandise_categories.create",
+        after_values: { code: @merchandise_category.code, name: @merchandise_category.name }
+      )
         redirect_to admin_merchandise_category_path(@merchandise_category), notice: "Merchandise category created."
       else
         load_form_options
@@ -44,20 +39,12 @@ module Admin
 
     def update
       rescue_stale do
-        before = @merchandise_category.attributes.slice(
-          "code", "name", "description", "parent_id", "default_merchandise_class_id", "display_order"
+        if save_and_audit!(
+          @merchandise_category,
+          attrs: merchandise_category_params,
+          action: "merchandise_categories.update",
+          before_keys: %w[code name description parent_id default_merchandise_class_id display_order]
         )
-        if @merchandise_category.update(merchandise_category_params)
-          Audit::Recorder.record!(
-            action: "merchandise_categories.update",
-            outcome: "succeeded",
-            actor_user: current_user,
-            actor_label: current_user.display_name,
-            store: current_store,
-            subject: @merchandise_category,
-            before_values: before,
-            after_values: @merchandise_category.attributes.slice(*before.keys)
-          )
           redirect_to admin_merchandise_category_path(@merchandise_category), notice: "Merchandise category updated."
         else
           load_form_options
@@ -67,15 +54,9 @@ module Admin
     end
 
     def destroy
-      @merchandise_category.update!(active: false)
-      Audit::Recorder.record!(
-        action: "merchandise_categories.deactivate",
-        outcome: "succeeded",
-        actor_user: current_user,
-        actor_label: current_user.display_name,
-        store: current_store,
-        subject: @merchandise_category
-      )
+      mutate_and_audit!(@merchandise_category, action: "merchandise_categories.deactivate") do
+        @merchandise_category.update!(active: false)
+      end
       redirect_to admin_merchandise_categories_path, notice: "Merchandise category deactivated."
     end
 

--- a/app/controllers/admin/merchandise_classes_controller.rb
+++ b/app/controllers/admin/merchandise_classes_controller.rb
@@ -25,16 +25,11 @@ module Admin
 
     def create
       @merchandise_class = MerchandiseClass.new(merchandise_class_params.except(:lock_version))
-      if @merchandise_class.save
-        Audit::Recorder.record!(
-          action: "merchandise_classes.create",
-          outcome: "succeeded",
-          actor_user: current_user,
-          actor_label: current_user.display_name,
-          store: current_store,
-          subject: @merchandise_class,
-          after_values: { code: @merchandise_class.code, name: @merchandise_class.name }
-        )
+      if create_and_audit!(
+        @merchandise_class,
+        action: "merchandise_classes.create",
+        after_values: { code: @merchandise_class.code, name: @merchandise_class.name }
+      )
         redirect_to admin_merchandise_class_path(@merchandise_class), notice: "Merchandise class created."
       else
         load_form_options
@@ -48,22 +43,16 @@ module Admin
 
     def update
       rescue_stale do
-        before = @merchandise_class.attributes.slice(
-          "code", "name", "description", "inventory_mode", "pricing_method",
-          "default_standard_department_id", "default_used_department_id",
-          "used_merchandise_allowed", "buyback_allowed", "default_returnable", "display_order"
+        if save_and_audit!(
+          @merchandise_class,
+          attrs: merchandise_class_params,
+          action: "merchandise_classes.update",
+          before_keys: %w[
+            code name description inventory_mode pricing_method
+            default_standard_department_id default_used_department_id
+            used_merchandise_allowed buyback_allowed default_returnable display_order
+          ]
         )
-        if @merchandise_class.update(merchandise_class_params)
-          Audit::Recorder.record!(
-            action: "merchandise_classes.update",
-            outcome: "succeeded",
-            actor_user: current_user,
-            actor_label: current_user.display_name,
-            store: current_store,
-            subject: @merchandise_class,
-            before_values: before,
-            after_values: @merchandise_class.attributes.slice(*before.keys)
-          )
           redirect_to admin_merchandise_class_path(@merchandise_class), notice: "Merchandise class updated."
         else
           load_form_options
@@ -73,15 +62,9 @@ module Admin
     end
 
     def destroy
-      @merchandise_class.update!(active: false)
-      Audit::Recorder.record!(
-        action: "merchandise_classes.deactivate",
-        outcome: "succeeded",
-        actor_user: current_user,
-        actor_label: current_user.display_name,
-        store: current_store,
-        subject: @merchandise_class
-      )
+      mutate_and_audit!(@merchandise_class, action: "merchandise_classes.deactivate") do
+        @merchandise_class.update!(active: false)
+      end
       redirect_to admin_merchandise_classes_path, notice: "Merchandise class deactivated."
     end
 

--- a/app/controllers/admin/merchandise_classes_controller.rb
+++ b/app/controllers/admin/merchandise_classes_controller.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module Admin
+  class MerchandiseClassesController < BaseController
+    before_action -> { require_permission!("merchandise_classes.view") }, only: %i[index show]
+    before_action -> { require_permission!("merchandise_classes.create") }, only: %i[new create]
+    before_action -> { require_permission!("merchandise_classes.update") }, only: %i[edit update]
+    before_action -> { require_permission!("merchandise_classes.deactivate") }, only: :destroy
+    before_action :set_merchandise_class, only: %i[show edit update destroy]
+
+    def index
+      @merchandise_classes = MerchandiseClass.order(:display_order, :code)
+    end
+
+    def show; end
+
+    def new
+      @merchandise_class = MerchandiseClass.new(
+        inventory_tracking_mode: "quantity",
+        pricing_method: "fixed",
+        display_order: 0
+      )
+      load_form_options
+    end
+
+    def create
+      @merchandise_class = MerchandiseClass.new(merchandise_class_params.except(:lock_version))
+      if @merchandise_class.save
+        Audit::Recorder.record!(
+          action: "merchandise_classes.create",
+          outcome: "succeeded",
+          actor_user: current_user,
+          actor_label: current_user.display_name,
+          store: current_store,
+          subject: @merchandise_class,
+          after_values: { code: @merchandise_class.code, name: @merchandise_class.name }
+        )
+        redirect_to admin_merchandise_class_path(@merchandise_class), notice: "Merchandise class created."
+      else
+        load_form_options
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def edit
+      load_form_options
+    end
+
+    def update
+      rescue_stale do
+        before = @merchandise_class.attributes.slice(
+          "code", "name", "description", "inventory_tracking_mode", "pricing_method",
+          "default_standard_department_id", "default_used_department_id",
+          "used_merchandise_allowed", "buyback_allowed", "default_returnable", "display_order"
+        )
+        if @merchandise_class.update(merchandise_class_params)
+          Audit::Recorder.record!(
+            action: "merchandise_classes.update",
+            outcome: "succeeded",
+            actor_user: current_user,
+            actor_label: current_user.display_name,
+            store: current_store,
+            subject: @merchandise_class,
+            before_values: before,
+            after_values: @merchandise_class.attributes.slice(*before.keys)
+          )
+          redirect_to admin_merchandise_class_path(@merchandise_class), notice: "Merchandise class updated."
+        else
+          load_form_options
+          render :edit, status: :unprocessable_entity
+        end
+      end
+    end
+
+    def destroy
+      @merchandise_class.update!(active: false)
+      Audit::Recorder.record!(
+        action: "merchandise_classes.deactivate",
+        outcome: "succeeded",
+        actor_user: current_user,
+        actor_label: current_user.display_name,
+        store: current_store,
+        subject: @merchandise_class
+      )
+      redirect_to admin_merchandise_classes_path, notice: "Merchandise class deactivated."
+    end
+
+    private
+
+    def set_merchandise_class
+      @merchandise_class = MerchandiseClass.find(params[:id])
+    end
+
+    def load_form_options
+      @departments = Department.assignable.order(:display_order, :code)
+    end
+
+    def merchandise_class_params
+      permitted = params.require(:merchandise_class).permit(
+        :code, :name, :description, :inventory_tracking_mode, :pricing_method,
+        :default_standard_department_id, :default_used_department_id,
+        :used_merchandise_allowed, :buyback_allowed, :default_returnable,
+        :display_order, :lock_version
+      )
+      %i[default_standard_department_id default_used_department_id].each do |key|
+        permitted[key] = nil if permitted[key].blank?
+      end
+      permitted
+    end
+  end
+end

--- a/app/controllers/admin/merchandise_classes_controller.rb
+++ b/app/controllers/admin/merchandise_classes_controller.rb
@@ -16,7 +16,7 @@ module Admin
 
     def new
       @merchandise_class = MerchandiseClass.new(
-        inventory_tracking_mode: "quantity",
+        inventory_mode: "inventory",
         pricing_method: "fixed",
         display_order: 0
       )
@@ -49,7 +49,7 @@ module Admin
     def update
       rescue_stale do
         before = @merchandise_class.attributes.slice(
-          "code", "name", "description", "inventory_tracking_mode", "pricing_method",
+          "code", "name", "description", "inventory_mode", "pricing_method",
           "default_standard_department_id", "default_used_department_id",
           "used_merchandise_allowed", "buyback_allowed", "default_returnable", "display_order"
         )
@@ -97,7 +97,7 @@ module Admin
 
     def merchandise_class_params
       permitted = params.require(:merchandise_class).permit(
-        :code, :name, :description, :inventory_tracking_mode, :pricing_method,
+        :code, :name, :description, :inventory_mode, :pricing_method,
         :default_standard_department_id, :default_used_department_id,
         :used_merchandise_allowed, :buyback_allowed, :default_returnable,
         :display_order, :lock_version

--- a/app/controllers/admin/merchandise_conditions_controller.rb
+++ b/app/controllers/admin/merchandise_conditions_controller.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module Admin
+  class MerchandiseConditionsController < BaseController
+    before_action -> { require_permission!("merchandise_conditions.view") }, only: %i[index show]
+    before_action -> { require_permission!("merchandise_conditions.create") }, only: %i[new create]
+    before_action -> { require_permission!("merchandise_conditions.update") }, only: %i[edit update]
+    before_action -> { require_permission!("merchandise_conditions.deactivate") }, only: :destroy
+    before_action :set_merchandise_condition, only: %i[show edit update destroy]
+
+    def index
+      @merchandise_conditions = MerchandiseCondition.order(:display_order, :code)
+    end
+
+    def show; end
+
+    def new
+      @merchandise_condition = MerchandiseCondition.new(
+        department_basis: "standard",
+        price_adjustment_bps: 10_000,
+        display_order: 0
+      )
+    end
+
+    def create
+      @merchandise_condition = MerchandiseCondition.new(merchandise_condition_params.except(:lock_version))
+      if @merchandise_condition.save
+        Audit::Recorder.record!(
+          action: "merchandise_conditions.create",
+          outcome: "succeeded",
+          actor_user: current_user,
+          actor_label: current_user.display_name,
+          store: current_store,
+          subject: @merchandise_condition,
+          after_values: { code: @merchandise_condition.code, name: @merchandise_condition.name }
+        )
+        redirect_to admin_merchandise_condition_path(@merchandise_condition), notice: "Merchandise condition created."
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def edit; end
+
+    def update
+      rescue_stale do
+        before = @merchandise_condition.attributes.slice(
+          "code", "name", "description", "department_basis", "price_adjustment_bps", "display_order"
+        )
+        if @merchandise_condition.update(merchandise_condition_params)
+          Audit::Recorder.record!(
+            action: "merchandise_conditions.update",
+            outcome: "succeeded",
+            actor_user: current_user,
+            actor_label: current_user.display_name,
+            store: current_store,
+            subject: @merchandise_condition,
+            before_values: before,
+            after_values: @merchandise_condition.attributes.slice(*before.keys)
+          )
+          redirect_to admin_merchandise_condition_path(@merchandise_condition), notice: "Merchandise condition updated."
+        else
+          render :edit, status: :unprocessable_entity
+        end
+      end
+    end
+
+    def destroy
+      @merchandise_condition.update!(active: false)
+      Audit::Recorder.record!(
+        action: "merchandise_conditions.deactivate",
+        outcome: "succeeded",
+        actor_user: current_user,
+        actor_label: current_user.display_name,
+        store: current_store,
+        subject: @merchandise_condition
+      )
+      redirect_to admin_merchandise_conditions_path, notice: "Merchandise condition deactivated."
+    end
+
+    private
+
+    def set_merchandise_condition
+      @merchandise_condition = MerchandiseCondition.find(params[:id])
+    end
+
+    def merchandise_condition_params
+      params.require(:merchandise_condition).permit(
+        :code, :name, :description, :department_basis, :price_adjustment_bps,
+        :display_order, :lock_version
+      )
+    end
+  end
+end

--- a/app/controllers/admin/merchandise_conditions_controller.rb
+++ b/app/controllers/admin/merchandise_conditions_controller.rb
@@ -23,16 +23,11 @@ module Admin
 
     def create
       @merchandise_condition = MerchandiseCondition.new(merchandise_condition_params.except(:lock_version))
-      if @merchandise_condition.save
-        Audit::Recorder.record!(
-          action: "merchandise_conditions.create",
-          outcome: "succeeded",
-          actor_user: current_user,
-          actor_label: current_user.display_name,
-          store: current_store,
-          subject: @merchandise_condition,
-          after_values: { code: @merchandise_condition.code, name: @merchandise_condition.name }
-        )
+      if create_and_audit!(
+        @merchandise_condition,
+        action: "merchandise_conditions.create",
+        after_values: { code: @merchandise_condition.code, name: @merchandise_condition.name }
+      )
         redirect_to admin_merchandise_condition_path(@merchandise_condition), notice: "Merchandise condition created."
       else
         render :new, status: :unprocessable_entity
@@ -43,20 +38,12 @@ module Admin
 
     def update
       rescue_stale do
-        before = @merchandise_condition.attributes.slice(
-          "code", "name", "description", "price_adjustment_bps", "display_order"
+        if save_and_audit!(
+          @merchandise_condition,
+          attrs: merchandise_condition_params,
+          action: "merchandise_conditions.update",
+          before_keys: %w[code name description price_adjustment_bps display_order]
         )
-        if @merchandise_condition.update(merchandise_condition_params)
-          Audit::Recorder.record!(
-            action: "merchandise_conditions.update",
-            outcome: "succeeded",
-            actor_user: current_user,
-            actor_label: current_user.display_name,
-            store: current_store,
-            subject: @merchandise_condition,
-            before_values: before,
-            after_values: @merchandise_condition.attributes.slice(*before.keys)
-          )
           redirect_to admin_merchandise_condition_path(@merchandise_condition), notice: "Merchandise condition updated."
         else
           render :edit, status: :unprocessable_entity
@@ -65,15 +52,9 @@ module Admin
     end
 
     def destroy
-      @merchandise_condition.update!(active: false)
-      Audit::Recorder.record!(
-        action: "merchandise_conditions.deactivate",
-        outcome: "succeeded",
-        actor_user: current_user,
-        actor_label: current_user.display_name,
-        store: current_store,
-        subject: @merchandise_condition
-      )
+      mutate_and_audit!(@merchandise_condition, action: "merchandise_conditions.deactivate") do
+        @merchandise_condition.update!(active: false)
+      end
       redirect_to admin_merchandise_conditions_path, notice: "Merchandise condition deactivated."
     end
 

--- a/app/controllers/admin/merchandise_conditions_controller.rb
+++ b/app/controllers/admin/merchandise_conditions_controller.rb
@@ -16,7 +16,6 @@ module Admin
 
     def new
       @merchandise_condition = MerchandiseCondition.new(
-        department_basis: "standard",
         price_adjustment_bps: 10_000,
         display_order: 0
       )
@@ -45,7 +44,7 @@ module Admin
     def update
       rescue_stale do
         before = @merchandise_condition.attributes.slice(
-          "code", "name", "description", "department_basis", "price_adjustment_bps", "display_order"
+          "code", "name", "description", "price_adjustment_bps", "display_order"
         )
         if @merchandise_condition.update(merchandise_condition_params)
           Audit::Recorder.record!(
@@ -86,7 +85,7 @@ module Admin
 
     def merchandise_condition_params
       params.require(:merchandise_condition).permit(
-        :code, :name, :description, :department_basis, :price_adjustment_bps,
+        :code, :name, :description, :price_adjustment_bps,
         :display_order, :lock_version
       )
     end

--- a/app/controllers/admin/merchandise_imports_controller.rb
+++ b/app/controllers/admin/merchandise_imports_controller.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Admin
+  class MerchandiseImportsController < BaseController
+    before_action -> { require_permission!("merchandise.import") }
+
+    def new; end
+
+    def create
+      upload = params.require(:import).permit(:file)[:file]
+      if upload.blank?
+        flash.now[:alert] = "CSV file is required."
+        render :new, status: :unprocessable_entity
+        return
+      end
+
+      result = Merchandise::CsvImporter.call(io: upload, actor: current_user)
+      Audit::Recorder.record!(
+        action: "merchandise.import",
+        outcome: result.errors.any? ? "succeeded_with_errors" : "succeeded",
+        actor_user: current_user,
+        actor_label: current_user.display_name,
+        store: current_store,
+        after_values: {
+          created_products: result.created_products,
+          updated_products: result.updated_products,
+          created_variants: result.created_variants,
+          updated_variants: result.updated_variants,
+          error_count: result.errors.size
+        }
+      )
+      @result = result
+      render :new
+    rescue ActionController::ParameterMissing
+      flash.now[:alert] = "CSV file is required."
+      render :new, status: :unprocessable_entity
+    rescue Merchandise::CsvImporter::Error => e
+      flash.now[:alert] = e.message
+      render :new, status: :unprocessable_entity
+    end
+  end
+end

--- a/app/controllers/admin/merchandise_lookups_controller.rb
+++ b/app/controllers/admin/merchandise_lookups_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Admin
+  class MerchandiseLookupsController < BaseController
+    before_action -> { require_permission!("merchandise.lookup") }
+
+    def new
+      @raw = nil
+      @result = nil
+    end
+
+    def create
+      @raw = params.require(:lookup).permit(:raw)[:raw]
+      @result = Identifiers::Lookup.call(@raw)
+      render :new
+    rescue ActionController::ParameterMissing
+      @raw = nil
+      @result = Identifiers::Lookup::Result.new(status: :invalid, message: "Identifier is required")
+      render :new, status: :unprocessable_entity
+    end
+  end
+end

--- a/app/controllers/admin/product_variants_controller.rb
+++ b/app/controllers/admin/product_variants_controller.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+module Admin
+  class ProductVariantsController < BaseController
+    before_action -> { require_permission!("product_variants.view") }, only: %i[index show]
+    before_action -> { require_permission!("product_variants.create") }, only: %i[new create]
+    before_action -> { require_permission!("product_variants.update") }, only: %i[edit update]
+    before_action -> { require_permission!("product_variants.discontinue") }, only: :discontinue
+    before_action -> { require_permission!("product_variants.update") }, only: :destroy
+    before_action :set_product, only: %i[index new create]
+    before_action :set_product_variant, only: %i[show edit update destroy discontinue]
+
+    def index
+      @product_variants = @product.product_variants.order(:sku)
+    end
+
+    def show; end
+
+    def new
+      @product_variant = @product.product_variants.build(status: "draft")
+      load_form_options
+    end
+
+    def create
+      @product_variant = ProductVariants::Create.call(
+        product: @product,
+        attributes: variant_attributes,
+        actor: current_user
+      )
+      redirect_to admin_product_variant_path(@product_variant), notice: "Product variant created."
+    rescue ProductVariants::Create::Error => e
+      @product_variant = @product.product_variants.build(variant_attributes)
+      @product_variant.errors.add(:base, e.message)
+      load_form_options
+      render :new, status: :unprocessable_entity
+    end
+
+    def edit
+      @product = @product_variant.product
+      load_form_options
+    end
+
+    def update
+      rescue_stale do
+        attrs = product_variant_params
+        if attrs[:status] == "discontinued"
+          @product_variant.errors.add(:status, "use Discontinue instead")
+          @product = @product_variant.product
+          load_form_options
+          render :edit, status: :unprocessable_entity
+          return
+        end
+
+        before = @product_variant.attributes.slice(*audit_attribute_keys)
+        if @product_variant.update(attrs.except(:sku))
+          Audit::Recorder.record!(
+            action: "product_variants.update",
+            outcome: "succeeded",
+            actor_user: current_user,
+            actor_label: current_user.display_name,
+            store: current_store,
+            subject: @product_variant,
+            before_values: before,
+            after_values: @product_variant.attributes.slice(*before.keys)
+          )
+          redirect_to admin_product_variant_path(@product_variant), notice: "Product variant updated."
+        else
+          @product = @product_variant.product
+          load_form_options
+          render :edit, status: :unprocessable_entity
+        end
+      end
+    end
+
+    def discontinue
+      rescue_stale do
+        before_status = @product_variant.status
+        @product_variant.update!(status: "discontinued")
+        Audit::Recorder.record!(
+          action: "product_variants.discontinue",
+          outcome: "succeeded",
+          actor_user: current_user,
+          actor_label: current_user.display_name,
+          store: current_store,
+          subject: @product_variant,
+          before_values: { status: before_status },
+          after_values: { status: @product_variant.status }
+        )
+        redirect_to admin_product_variant_path(@product_variant), notice: "Product variant discontinued."
+      end
+    end
+
+    def destroy
+      unless @product_variant.draft?
+        redirect_to admin_product_variant_path(@product_variant), alert: "Only draft variants can be deleted."
+        return
+      end
+
+      product = @product_variant.product
+      ProductVariant.transaction do
+        Identifiers::Registry.retire!(value: @product_variant.sku)
+        if @product_variant.industry_identifier.present?
+          Identifiers::Registry.retire!(value: @product_variant.industry_identifier)
+        end
+        sku = @product_variant.sku
+        @product_variant.destroy!
+        Audit::Recorder.record!(
+          action: "product_variants.destroy",
+          outcome: "succeeded",
+          actor_user: current_user,
+          actor_label: current_user.display_name,
+          store: current_store,
+          after_values: { sku: sku, product_id: product.id }
+        )
+      end
+      redirect_to admin_product_path(product), notice: "Draft variant deleted."
+    rescue ActiveRecord::RecordNotFound => e
+      redirect_to admin_products_path, alert: e.message
+    end
+
+    private
+
+    def set_product
+      @product = Product.find(params[:product_id])
+    end
+
+    def set_product_variant
+      @product_variant = ProductVariant.find(params[:id])
+    end
+
+    def load_form_options
+      @merchandise_conditions = MerchandiseCondition.assignable.order(:display_order, :code)
+      @merchandise_classes = MerchandiseClass.assignable.order(:display_order, :code)
+      @departments = Department.assignable.order(:display_order, :code)
+      @tax_classes = TaxClass.assignable.order(:display_order, :code)
+    end
+
+    def audit_attribute_keys
+      %w[
+        name option_value_1 option_value_2 merchandise_condition_id merchandise_class_id
+        department_id tax_class_id regular_price_cents status industry_identifier
+      ]
+    end
+
+    def variant_attributes
+      product_variant_params.except(:lock_version, :sku).to_h.symbolize_keys
+    end
+
+    def product_variant_params
+      permitted = params.require(:product_variant).permit(
+        :name, :option_value_1, :option_value_2, :merchandise_condition_id,
+        :merchandise_class_id, :department_id, :tax_class_id, :regular_price_cents,
+        :industry_identifier, :status, :lock_version
+      )
+      %i[name option_value_1 option_value_2 merchandise_class_id department_id tax_class_id
+         regular_price_cents industry_identifier].each do |key|
+        permitted[key] = nil if permitted[key].blank?
+      end
+      permitted
+    end
+  end
+end

--- a/app/controllers/admin/product_variants_controller.rb
+++ b/app/controllers/admin/product_variants_controller.rb
@@ -51,41 +51,30 @@ module Admin
           return
         end
 
-        before = @product_variant.attributes.slice(*audit_attribute_keys)
-        if @product_variant.update(attrs.except(:sku))
-          Audit::Recorder.record!(
-            action: "product_variants.update",
-            outcome: "succeeded",
-            actor_user: current_user,
-            actor_label: current_user.display_name,
-            store: current_store,
-            subject: @product_variant,
-            before_values: before,
-            after_values: @product_variant.attributes.slice(*before.keys)
-          )
-          redirect_to admin_product_variant_path(@product_variant), notice: "Product variant updated."
-        else
-          @product = @product_variant.product
-          load_form_options
-          render :edit, status: :unprocessable_entity
-        end
+        ProductVariants::Update.call(
+          variant: @product_variant,
+          attributes: attrs.except(:sku).to_h.symbolize_keys,
+          actor: current_user,
+          store: current_store
+        )
+        redirect_to admin_product_variant_path(@product_variant), notice: "Product variant updated."
+      rescue ProductVariants::Update::Error => e
+        @product_variant.errors.add(:base, e.message)
+        @product = @product_variant.product
+        load_form_options
+        render :edit, status: :unprocessable_entity
       end
     end
 
     def discontinue
       rescue_stale do
         before_status = @product_variant.status
-        @product_variant.update!(status: "discontinued")
-        Audit::Recorder.record!(
+        mutate_and_audit!(
+          @product_variant,
           action: "product_variants.discontinue",
-          outcome: "succeeded",
-          actor_user: current_user,
-          actor_label: current_user.display_name,
-          store: current_store,
-          subject: @product_variant,
           before_values: { status: before_status },
-          after_values: { status: @product_variant.status }
-        )
+          after_values: { status: "discontinued" }
+        ) { @product_variant.update!(status: "discontinued") }
         redirect_to admin_product_variant_path(@product_variant), notice: "Product variant discontinued."
       end
     end

--- a/app/controllers/admin/product_variants_controller.rb
+++ b/app/controllers/admin/product_variants_controller.rb
@@ -17,7 +17,7 @@ module Admin
     def show; end
 
     def new
-      @product_variant = @product.product_variants.build(status: "draft")
+      @product_variant = @product.product_variants.build(status: "draft", variant_type: "standard")
       load_form_options
     end
 
@@ -137,7 +137,7 @@ module Admin
 
     def audit_attribute_keys
       %w[
-        name option_value_1 option_value_2 merchandise_condition_id merchandise_class_id
+        variant_type name option_value_1 option_value_2 merchandise_condition_id merchandise_class_id
         department_id tax_class_id regular_price_cents status industry_identifier
       ]
     end
@@ -148,11 +148,11 @@ module Admin
 
     def product_variant_params
       permitted = params.require(:product_variant).permit(
-        :name, :option_value_1, :option_value_2, :merchandise_condition_id,
+        :variant_type, :name, :option_value_1, :option_value_2, :merchandise_condition_id,
         :merchandise_class_id, :department_id, :tax_class_id, :regular_price_cents,
         :industry_identifier, :status, :lock_version
       )
-      %i[name option_value_1 option_value_2 merchandise_class_id department_id tax_class_id
+      %i[name option_value_1 option_value_2 merchandise_condition_id merchandise_class_id department_id tax_class_id
          regular_price_cents industry_identifier].each do |key|
         permitted[key] = nil if permitted[key].blank?
       end

--- a/app/controllers/admin/products_controller.rb
+++ b/app/controllers/admin/products_controller.rb
@@ -51,20 +51,16 @@ module Admin
           return
         end
 
-        before = @product.attributes.slice(*audit_attribute_keys)
-        if @product.update(attrs)
-          Audit::Recorder.record!(
-            action: "products.update",
-            outcome: "succeeded",
-            actor_user: current_user,
-            actor_label: current_user.display_name,
-            store: current_store,
-            subject: @product,
-            before_values: before,
-            after_values: @product.attributes.slice(*before.keys)
+        begin
+          Products::Update.call(
+            product: @product,
+            attributes: attrs.to_h.symbolize_keys,
+            actor: current_user,
+            store: current_store
           )
           redirect_to admin_product_path(@product), notice: "Product updated."
-        else
+        rescue Products::Update::Error => e
+          @product.errors.add(:base, e.message)
           load_form_options
           render :edit, status: :unprocessable_entity
         end
@@ -74,17 +70,12 @@ module Admin
     def discontinue
       rescue_stale do
         before_status = @product.status
-        @product.update!(status: "discontinued")
-        Audit::Recorder.record!(
+        mutate_and_audit!(
+          @product,
           action: "products.discontinue",
-          outcome: "succeeded",
-          actor_user: current_user,
-          actor_label: current_user.display_name,
-          store: current_store,
-          subject: @product,
           before_values: { status: before_status },
-          after_values: { status: @product.status }
-        )
+          after_values: { status: "discontinued" }
+        ) { @product.update!(status: "discontinued") }
         redirect_to admin_product_path(@product), notice: "Product discontinued."
       end
     end

--- a/app/controllers/admin/products_controller.rb
+++ b/app/controllers/admin/products_controller.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+module Admin
+  class ProductsController < BaseController
+    before_action -> { require_permission!("products.view") }, only: %i[index show]
+    before_action -> { require_permission!("products.create") }, only: %i[new create]
+    before_action -> { require_permission!("products.update") }, only: %i[edit update]
+    before_action -> { require_permission!("products.discontinue") }, only: :discontinue
+    before_action -> { require_permission!("products.update") }, only: :destroy
+    before_action :set_product, only: %i[show edit update destroy discontinue]
+
+    def index
+      @products = Product.order(:name)
+    end
+
+    def show
+      @product_variants = @product.product_variants.order(:sku)
+    end
+
+    def new
+      @product = Product.new(status: "draft")
+      load_form_options
+    end
+
+    def create
+      @product = Products::Create.call(
+        attributes: product_attributes,
+        actor: current_user,
+        identifier_mode: identifier_mode,
+        external_identifier: external_identifier.presence
+      )
+      redirect_to admin_product_path(@product), notice: "Product created."
+    rescue Products::Create::Error => e
+      @product = Product.new(product_attributes)
+      @product.errors.add(:base, e.message)
+      load_form_options
+      render :new, status: :unprocessable_entity
+    end
+
+    def edit
+      load_form_options
+    end
+
+    def update
+      rescue_stale do
+        attrs = product_params
+        if attrs[:status] == "discontinued"
+          @product.errors.add(:status, "use Discontinue instead")
+          load_form_options
+          render :edit, status: :unprocessable_entity
+          return
+        end
+
+        before = @product.attributes.slice(*audit_attribute_keys)
+        if @product.update(attrs)
+          Audit::Recorder.record!(
+            action: "products.update",
+            outcome: "succeeded",
+            actor_user: current_user,
+            actor_label: current_user.display_name,
+            store: current_store,
+            subject: @product,
+            before_values: before,
+            after_values: @product.attributes.slice(*before.keys)
+          )
+          redirect_to admin_product_path(@product), notice: "Product updated."
+        else
+          load_form_options
+          render :edit, status: :unprocessable_entity
+        end
+      end
+    end
+
+    def discontinue
+      rescue_stale do
+        before_status = @product.status
+        @product.update!(status: "discontinued")
+        Audit::Recorder.record!(
+          action: "products.discontinue",
+          outcome: "succeeded",
+          actor_user: current_user,
+          actor_label: current_user.display_name,
+          store: current_store,
+          subject: @product,
+          before_values: { status: before_status },
+          after_values: { status: @product.status }
+        )
+        redirect_to admin_product_path(@product), notice: "Product discontinued."
+      end
+    end
+
+    def destroy
+      unless @product.draft?
+        redirect_to admin_product_path(@product), alert: "Only draft products can be deleted."
+        return
+      end
+
+      primary_identifier = @product.primary_identifier
+      name = @product.name
+      Product.transaction do
+        Identifiers::Registry.retire!(value: primary_identifier)
+        @product.destroy!
+        Audit::Recorder.record!(
+          action: "products.destroy",
+          outcome: "succeeded",
+          actor_user: current_user,
+          actor_label: current_user.display_name,
+          store: current_store,
+          after_values: { primary_identifier: primary_identifier, name: name }
+        )
+      end
+      redirect_to admin_products_path, notice: "Draft product deleted."
+    rescue ActiveRecord::DeleteRestrictionError, ActiveRecord::InvalidForeignKey, ActiveRecord::RecordNotFound => e
+      redirect_to admin_product_path(@product), alert: e.message
+    end
+
+    private
+
+    def set_product
+      @product = Product.find(params[:id])
+    end
+
+    def load_form_options
+      @merchandise_categories = MerchandiseCategory.assignable.order(:display_order, :name)
+    end
+
+    def audit_attribute_keys
+      %w[
+        name subtitle description brand_name product_model merchandise_category_id
+        list_price_cents release_date status variant_option_name_1 variant_option_name_2
+      ]
+    end
+
+    def identifier_mode
+      params.dig(:product, :identifier_mode).presence || params[:identifier_mode].presence || "enter"
+    end
+
+    def external_identifier
+      params.dig(:product, :external_identifier).presence || params[:external_identifier]
+    end
+
+    def product_attributes
+      attrs = product_params.except(:lock_version).to_h.symbolize_keys
+      attrs[:status] = "draft" if attrs[:status].blank?
+      attrs
+    end
+
+    def product_params
+      permitted = params.require(:product).permit(
+        :name, :subtitle, :description, :brand_name, :product_model, :merchandise_category_id,
+        :list_price_cents, :release_date, :status, :variant_option_name_1, :variant_option_name_2,
+        :lock_version
+      )
+      %i[merchandise_category_id list_price_cents release_date subtitle description brand_name
+         product_model variant_option_name_1 variant_option_name_2].each do |key|
+        permitted[key] = nil if permitted[key].blank?
+      end
+      permitted
+    end
+  end
+end

--- a/app/controllers/admin/tax_classes_controller.rb
+++ b/app/controllers/admin/tax_classes_controller.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module Admin
+  class TaxClassesController < BaseController
+    before_action -> { require_permission!("tax_classes.view") }, only: %i[index show]
+    before_action -> { require_permission!("tax_classes.create") }, only: %i[new create]
+    before_action -> { require_permission!("tax_classes.update") }, only: %i[edit update]
+    before_action -> { require_permission!("tax_classes.deactivate") }, only: :destroy
+    before_action :set_tax_class, only: %i[show edit update destroy]
+
+    def index
+      @tax_classes = TaxClass.order(:display_order, :code)
+    end
+
+    def show; end
+
+    def new
+      @tax_class = TaxClass.new(display_order: 0)
+    end
+
+    def create
+      @tax_class = TaxClass.new(tax_class_params.except(:lock_version))
+      if @tax_class.save
+        Audit::Recorder.record!(
+          action: "tax_classes.create",
+          outcome: "succeeded",
+          actor_user: current_user,
+          actor_label: current_user.display_name,
+          store: current_store,
+          subject: @tax_class,
+          after_values: { code: @tax_class.code, name: @tax_class.name }
+        )
+        redirect_to admin_tax_class_path(@tax_class), notice: "Tax class created."
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def edit; end
+
+    def update
+      rescue_stale do
+        before = @tax_class.attributes.slice("code", "name", "description", "display_order")
+        if @tax_class.update(tax_class_params)
+          Audit::Recorder.record!(
+            action: "tax_classes.update",
+            outcome: "succeeded",
+            actor_user: current_user,
+            actor_label: current_user.display_name,
+            store: current_store,
+            subject: @tax_class,
+            before_values: before,
+            after_values: @tax_class.attributes.slice(*before.keys)
+          )
+          redirect_to admin_tax_class_path(@tax_class), notice: "Tax class updated."
+        else
+          render :edit, status: :unprocessable_entity
+        end
+      end
+    end
+
+    def destroy
+      @tax_class.update!(active: false)
+      Audit::Recorder.record!(
+        action: "tax_classes.deactivate",
+        outcome: "succeeded",
+        actor_user: current_user,
+        actor_label: current_user.display_name,
+        store: current_store,
+        subject: @tax_class
+      )
+      redirect_to admin_tax_classes_path, notice: "Tax class deactivated."
+    end
+
+    private
+
+    def set_tax_class
+      @tax_class = TaxClass.find(params[:id])
+    end
+
+    def tax_class_params
+      params.require(:tax_class).permit(:code, :name, :description, :display_order, :lock_version)
+    end
+  end
+end

--- a/app/controllers/admin/tax_classes_controller.rb
+++ b/app/controllers/admin/tax_classes_controller.rb
@@ -20,16 +20,11 @@ module Admin
 
     def create
       @tax_class = TaxClass.new(tax_class_params.except(:lock_version))
-      if @tax_class.save
-        Audit::Recorder.record!(
-          action: "tax_classes.create",
-          outcome: "succeeded",
-          actor_user: current_user,
-          actor_label: current_user.display_name,
-          store: current_store,
-          subject: @tax_class,
-          after_values: { code: @tax_class.code, name: @tax_class.name }
-        )
+      if create_and_audit!(
+        @tax_class,
+        action: "tax_classes.create",
+        after_values: { code: @tax_class.code, name: @tax_class.name }
+      )
         redirect_to admin_tax_class_path(@tax_class), notice: "Tax class created."
       else
         render :new, status: :unprocessable_entity
@@ -40,18 +35,12 @@ module Admin
 
     def update
       rescue_stale do
-        before = @tax_class.attributes.slice("code", "name", "description", "display_order")
-        if @tax_class.update(tax_class_params)
-          Audit::Recorder.record!(
-            action: "tax_classes.update",
-            outcome: "succeeded",
-            actor_user: current_user,
-            actor_label: current_user.display_name,
-            store: current_store,
-            subject: @tax_class,
-            before_values: before,
-            after_values: @tax_class.attributes.slice(*before.keys)
-          )
+        if save_and_audit!(
+          @tax_class,
+          attrs: tax_class_params,
+          action: "tax_classes.update",
+          before_keys: %w[code name description display_order]
+        )
           redirect_to admin_tax_class_path(@tax_class), notice: "Tax class updated."
         else
           render :edit, status: :unprocessable_entity
@@ -60,15 +49,7 @@ module Admin
     end
 
     def destroy
-      @tax_class.update!(active: false)
-      Audit::Recorder.record!(
-        action: "tax_classes.deactivate",
-        outcome: "succeeded",
-        actor_user: current_user,
-        actor_label: current_user.display_name,
-        store: current_store,
-        subject: @tax_class
-      )
+      mutate_and_audit!(@tax_class, action: "tax_classes.deactivate") { @tax_class.update!(active: false) }
       redirect_to admin_tax_classes_path, notice: "Tax class deactivated."
     end
 

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+class Department < ApplicationRecord
+  GL_MAPPING_EXPECTATIONS = {
+    inventory_asset_gl_account_id: { account_type: "asset", account_category: "inventory" },
+    cost_of_goods_sold_gl_account_id: { account_type: "expense", account_category: "cost_of_goods_sold" },
+    sales_revenue_gl_account_id: { account_type: "revenue", account_category: "sales" },
+    sales_returns_gl_account_id: { account_type: "revenue", account_category: "sales_returns" },
+    inventory_shrinkage_gl_account_id: { account_type: "expense", account_category: "inventory_shrinkage" },
+    inventory_adjustment_loss_gl_account_id: { account_type: "expense", account_category: "inventory_adjustment" },
+    inventory_write_down_gl_account_id: { account_type: "expense", account_category: "inventory_write_down" }
+  }.freeze
+
+  FLEXIBLE_GL_FIELDS = %w[
+    receiving_clearing_gl_account_id
+    freight_in_gl_account_id
+    inventory_adjustment_gain_gl_account_id
+  ].freeze
+
+  belongs_to :default_tax_class, class_name: "TaxClass"
+  belongs_to :inventory_asset_gl_account, class_name: "GlAccount", optional: true
+  belongs_to :cost_of_goods_sold_gl_account, class_name: "GlAccount", optional: true
+  belongs_to :sales_revenue_gl_account, class_name: "GlAccount", optional: true
+  belongs_to :sales_returns_gl_account, class_name: "GlAccount", optional: true
+  belongs_to :receiving_clearing_gl_account, class_name: "GlAccount", optional: true
+  belongs_to :freight_in_gl_account, class_name: "GlAccount", optional: true
+  belongs_to :inventory_shrinkage_gl_account, class_name: "GlAccount", optional: true
+  belongs_to :inventory_adjustment_gain_gl_account, class_name: "GlAccount", optional: true
+  belongs_to :inventory_adjustment_loss_gl_account, class_name: "GlAccount", optional: true
+  belongs_to :inventory_write_down_gl_account, class_name: "GlAccount", optional: true
+
+  before_validation :normalize_code
+
+  validates :code, :name, :default_tax_class_id, presence: true
+  validates :code, uniqueness: true
+  validates :default_target_margin_bps,
+            numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than: 10_000 },
+            allow_nil: true
+  validate :validate_changed_gl_mappings
+  validate :validate_changed_tax_class
+
+  scope :active, -> { where(active: true) }
+  scope :assignable, -> { active }
+
+  def assignable?
+    active?
+  end
+
+  private
+
+  def normalize_code
+    self.code = code.to_s.strip.downcase.tr(" ", "_")
+    self.department_number = department_number.to_s.strip.presence
+  end
+
+  def validate_changed_tax_class
+    return unless default_tax_class_id_changed?
+    return if default_tax_class.blank?
+
+    errors.add(:default_tax_class_id, "must be an active tax class") unless default_tax_class.assignable?
+  end
+
+  def validate_changed_gl_mappings
+    GL_MAPPING_EXPECTATIONS.each do |field, expectation|
+      next unless public_send("#{field}_changed?")
+
+      account = public_send(field.to_s.delete_suffix("_id"))
+      next if account.nil?
+
+      validate_gl_account_assignment(field, account, expectation)
+    end
+
+    FLEXIBLE_GL_FIELDS.each do |field|
+      next unless public_send("#{field}_changed?")
+
+      account = public_send(field.delete_suffix("_id"))
+      next if account.nil?
+
+      errors.add(field, "must be an active posting account") unless account.assignable?
+    end
+  end
+
+  def validate_gl_account_assignment(field, account, expectation)
+    unless account.assignable?
+      errors.add(field, "must be an active posting account")
+      return
+    end
+
+    if account.account_type != expectation[:account_type] || account.account_category != expectation[:account_category]
+      errors.add(field, "must be #{expectation[:account_type]}/#{expectation[:account_category]}")
+    end
+  end
+end

--- a/app/models/gl_account.rb
+++ b/app/models/gl_account.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+class GlAccount < ApplicationRecord
+  ACCOUNT_TYPES = %w[asset liability equity revenue expense].freeze
+  ACCOUNT_CATEGORIES = %w[
+    cash accounts_receivable inventory other_current_asset fixed_asset
+    accounts_payable other_current_liability long_term_liability equity
+    sales sales_returns cost_of_goods_sold freight_in inventory_shrinkage
+    inventory_adjustment inventory_write_down other_revenue other_expense
+  ].freeze
+
+  belongs_to :parent, class_name: "GlAccount", optional: true
+  has_many :children, class_name: "GlAccount", foreign_key: :parent_id, inverse_of: :parent, dependent: :restrict_with_exception
+
+  before_validation :normalize_account_number
+
+  validates :account_number, :name, :account_type, :account_category, presence: true
+  validates :account_number, uniqueness: true
+  validates :account_type, inclusion: { in: ACCOUNT_TYPES }
+  validates :account_category, inclusion: { in: ACCOUNT_CATEGORIES }
+  validate :parent_not_self
+  validate :parent_same_account_type
+  validate :no_parent_cycle
+
+  scope :active, -> { where(active: true) }
+  scope :posting, -> { where(posting_allowed: true) }
+  scope :assignable, -> { active.posting }
+
+  def assignable?
+    active? && posting_allowed?
+  end
+
+  private
+
+  def normalize_account_number
+    self.account_number = account_number.to_s.strip
+  end
+
+  def parent_not_self
+    return if parent_id.blank? || id.blank?
+    errors.add(:parent_id, "cannot reference itself") if parent_id == id
+  end
+
+  def parent_same_account_type
+    return if parent.blank?
+    errors.add(:parent_id, "must have the same account type") if parent.account_type != account_type
+  end
+
+  def no_parent_cycle
+    return if parent.blank?
+
+    seen = Set.new
+    current = parent
+    while current
+      if current.id == id || seen.include?(current.id)
+        errors.add(:parent_id, "would create a hierarchy cycle")
+        break
+      end
+      seen << current.id
+      current = current.parent
+    end
+  end
+end

--- a/app/models/identifier_registry.rb
+++ b/app/models/identifier_registry.rb
@@ -23,6 +23,9 @@ class IdentifierRegistry < ApplicationRecord
   private
 
   def ownership_rules
+    owner_count = [ product_id, product_variant_id ].count(&:present?)
+    errors.add(:base, "registry rows may have at most one owner") if owner_count > 1
+
     if active?
       case identifier_kind
       when "product_primary"
@@ -32,7 +35,7 @@ class IdentifierRegistry < ApplicationRecord
         errors.add(:product_variant_id, "is required for active #{identifier_kind} rows") if product_variant_id.blank?
         errors.add(:product_id, "must be blank for #{identifier_kind} rows") if product_id.present?
       end
-    elsif product_id.blank? && product_variant_id.blank? && retired_at.blank?
+    elsif owner_count.zero? && retired_at.blank?
       errors.add(:retired_at, "must be set when unowned")
     end
   end

--- a/app/models/identifier_registry.rb
+++ b/app/models/identifier_registry.rb
@@ -23,10 +23,16 @@ class IdentifierRegistry < ApplicationRecord
   private
 
   def ownership_rules
-    owners = [ product_id, product_variant_id ].compact
     if active?
-      errors.add(:base, "active registry rows require exactly one owner") unless owners.size == 1
-    elsif owners.empty? && retired_at.blank?
+      case identifier_kind
+      when "product_primary"
+        errors.add(:product_id, "is required for active product_primary rows") if product_id.blank?
+        errors.add(:product_variant_id, "must be blank for product_primary rows") if product_variant_id.present?
+      when "variant_sku", "variant_industry"
+        errors.add(:product_variant_id, "is required for active #{identifier_kind} rows") if product_variant_id.blank?
+        errors.add(:product_id, "must be blank for #{identifier_kind} rows") if product_id.present?
+      end
+    elsif product_id.blank? && product_variant_id.blank? && retired_at.blank?
       errors.add(:retired_at, "must be set when unowned")
     end
   end

--- a/app/models/identifier_registry.rb
+++ b/app/models/identifier_registry.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class IdentifierRegistry < ApplicationRecord
+  self.table_name = "identifier_registry"
+
+  KINDS = %w[product_primary variant_sku variant_industry].freeze
+
+  belongs_to :product, optional: true
+  belongs_to :product_variant, optional: true
+
+  validates :value, :identifier_kind, presence: true
+  validates :value, uniqueness: true
+  validates :identifier_kind, inclusion: { in: KINDS }
+  validate :ownership_rules
+
+  scope :active, -> { where(retired_at: nil) }
+  scope :retired, -> { where.not(retired_at: nil) }
+
+  def active?
+    retired_at.nil?
+  end
+
+  private
+
+  def ownership_rules
+    owners = [ product_id, product_variant_id ].compact
+    if active?
+      errors.add(:base, "active registry rows require exactly one owner") unless owners.size == 1
+    elsif owners.empty? && retired_at.blank?
+      errors.add(:retired_at, "must be set when unowned")
+    end
+  end
+end

--- a/app/models/merchandise_category.rb
+++ b/app/models/merchandise_category.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class MerchandiseCategory < ApplicationRecord
+  belongs_to :parent, class_name: "MerchandiseCategory", optional: true
+  belongs_to :default_merchandise_class, class_name: "MerchandiseClass", optional: true
+  has_many :children, class_name: "MerchandiseCategory", foreign_key: :parent_id, inverse_of: :parent, dependent: :restrict_with_exception
+
+  before_validation :normalize_code
+
+  validates :name, presence: true
+  validate :parent_not_self
+  validate :no_parent_cycle
+  validate :validate_changed_default_class
+
+  scope :active, -> { where(active: true) }
+  scope :assignable, -> { active }
+
+  def assignable?
+    active?
+  end
+
+  private
+
+  def normalize_code
+    self.code = code.to_s.strip.downcase.tr(" ", "_").presence
+  end
+
+  def parent_not_self
+    return if parent_id.blank? || id.blank?
+    errors.add(:parent_id, "cannot reference itself") if parent_id == id
+  end
+
+  def no_parent_cycle
+    return if parent.blank?
+
+    seen = Set.new
+    current = parent
+    while current
+      if current.id == id || seen.include?(current.id)
+        errors.add(:parent_id, "would create a hierarchy cycle")
+        break
+      end
+      seen << current.id
+      current = current.parent
+    end
+  end
+
+  def validate_changed_default_class
+    return unless default_merchandise_class_id_changed?
+    return if default_merchandise_class.blank?
+
+    errors.add(:default_merchandise_class_id, "must be an active merchandise class") unless default_merchandise_class.assignable?
+  end
+end

--- a/app/models/merchandise_class.rb
+++ b/app/models/merchandise_class.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class MerchandiseClass < ApplicationRecord
+  TRACKING_MODES = %w[quantity individual non_inventory].freeze
+  PRICING_METHODS = %w[fixed list_price cost_based open_price].freeze
+
+  belongs_to :default_standard_department, class_name: "Department", optional: true
+  belongs_to :default_used_department, class_name: "Department", optional: true
+
+  before_validation :normalize_code
+
+  validates :code, :name, :inventory_tracking_mode, :pricing_method, presence: true
+  validates :code, uniqueness: true
+  validates :inventory_tracking_mode, inclusion: { in: TRACKING_MODES }
+  validates :pricing_method, inclusion: { in: PRICING_METHODS }
+  validate :validate_changed_departments
+
+  scope :active, -> { where(active: true) }
+  scope :assignable, -> { active }
+
+  def assignable?
+    active?
+  end
+
+  private
+
+  def normalize_code
+    self.code = code.to_s.strip.downcase.tr(" ", "_")
+  end
+
+  def validate_changed_departments
+    if default_standard_department_id_changed? && default_standard_department.present? && !default_standard_department.assignable?
+      errors.add(:default_standard_department_id, "must be an active department")
+    end
+    if default_used_department_id_changed? && default_used_department.present? && !default_used_department.assignable?
+      errors.add(:default_used_department_id, "must be an active department")
+    end
+  end
+end

--- a/app/models/merchandise_class.rb
+++ b/app/models/merchandise_class.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class MerchandiseClass < ApplicationRecord
-  TRACKING_MODES = %w[quantity individual non_inventory].freeze
+  INVENTORY_MODES = %w[inventory non_inventory].freeze
   PRICING_METHODS = %w[fixed list_price cost_based open_price].freeze
 
   belongs_to :default_standard_department, class_name: "Department", optional: true
@@ -9,9 +9,9 @@ class MerchandiseClass < ApplicationRecord
 
   before_validation :normalize_code
 
-  validates :code, :name, :inventory_tracking_mode, :pricing_method, presence: true
+  validates :code, :name, :inventory_mode, :pricing_method, presence: true
   validates :code, uniqueness: true
-  validates :inventory_tracking_mode, inclusion: { in: TRACKING_MODES }
+  validates :inventory_mode, inclusion: { in: INVENTORY_MODES }
   validates :pricing_method, inclusion: { in: PRICING_METHODS }
   validate :validate_changed_departments
 
@@ -20,6 +20,14 @@ class MerchandiseClass < ApplicationRecord
 
   def assignable?
     active?
+  end
+
+  def inventory?
+    inventory_mode == "inventory"
+  end
+
+  def non_inventory?
+    inventory_mode == "non_inventory"
   end
 
   private

--- a/app/models/merchandise_condition.rb
+++ b/app/models/merchandise_condition.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
 class MerchandiseCondition < ApplicationRecord
-  DEPARTMENT_BASES = %w[standard used].freeze
-
   before_validation :normalize_code
 
-  validates :code, :name, :department_basis, presence: true
+  validates :code, :name, presence: true
   validates :code, uniqueness: true
-  validates :department_basis, inclusion: { in: DEPARTMENT_BASES }
   validates :price_adjustment_bps, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
   scope :active, -> { where(active: true) }
@@ -15,10 +12,6 @@ class MerchandiseCondition < ApplicationRecord
 
   def assignable?
     active?
-  end
-
-  def used_basis?
-    department_basis == "used"
   end
 
   private

--- a/app/models/merchandise_condition.rb
+++ b/app/models/merchandise_condition.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class MerchandiseCondition < ApplicationRecord
+  DEPARTMENT_BASES = %w[standard used].freeze
+
+  before_validation :normalize_code
+
+  validates :code, :name, :department_basis, presence: true
+  validates :code, uniqueness: true
+  validates :department_basis, inclusion: { in: DEPARTMENT_BASES }
+  validates :price_adjustment_bps, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+
+  scope :active, -> { where(active: true) }
+  scope :assignable, -> { active }
+
+  def assignable?
+    active?
+  end
+
+  def used_basis?
+    department_basis == "used"
+  end
+
+  private
+
+  def normalize_code
+    self.code = code.to_s.strip.downcase.tr(" ", "_")
+  end
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class Product < ApplicationRecord
+  STATUSES = %w[draft active discontinued].freeze
+
+  belongs_to :merchandise_category, optional: true
+  has_many :product_variants, dependent: :restrict_with_exception
+  has_many :identifier_registry_entries, class_name: "IdentifierRegistry", dependent: :nullify
+
+  validates :name, :primary_identifier, :status, presence: true
+  validates :primary_identifier, uniqueness: true, format: { with: /\A\d{13}\z/ }
+  validates :status, inclusion: { in: STATUSES }
+  validates :list_price_cents, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
+  validate :validate_changed_category
+
+  scope :active, -> { where(status: "active") }
+  scope :draft, -> { where(status: "draft") }
+
+  def draft?
+    status == "draft"
+  end
+
+  def active_status?
+    status == "active"
+  end
+
+  private
+
+  def validate_changed_category
+    return unless merchandise_category_id_changed?
+    return if merchandise_category.blank?
+
+    errors.add(:merchandise_category_id, "must be an active category") unless merchandise_category.assignable?
+  end
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -3,6 +3,8 @@
 class Product < ApplicationRecord
   STATUSES = %w[draft active discontinued].freeze
 
+  attr_accessor :identifier_writes_enabled
+
   belongs_to :merchandise_category, optional: true
   has_many :product_variants, dependent: :restrict_with_exception
   has_many :identifier_registry_entries, class_name: "IdentifierRegistry", dependent: :nullify
@@ -12,6 +14,8 @@ class Product < ApplicationRecord
   validates :status, inclusion: { in: STATUSES }
   validates :list_price_cents, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
   validate :validate_changed_category
+  validate :primary_identifier_write_rules
+  after_save { self.identifier_writes_enabled = false }
 
   scope :active, -> { where(status: "active") }
   scope :draft, -> { where(status: "draft") }
@@ -31,5 +35,15 @@ class Product < ApplicationRecord
     return if merchandise_category.blank?
 
     errors.add(:merchandise_category_id, "must be an active category") unless merchandise_category.assignable?
+  end
+
+  def primary_identifier_write_rules
+    if new_record?
+      unless identifier_writes_enabled
+        errors.add(:primary_identifier, "must be assigned through Products::Create")
+      end
+    elsif primary_identifier_changed?
+      errors.add(:primary_identifier, "cannot be changed")
+    end
   end
 end

--- a/app/models/product_variant.rb
+++ b/app/models/product_variant.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+class ProductVariant < ApplicationRecord
+  STATUSES = %w[draft active discontinued].freeze
+
+  belongs_to :product
+  belongs_to :merchandise_condition
+  belongs_to :merchandise_class, optional: true
+  belongs_to :department, optional: true
+  belongs_to :tax_class, optional: true
+
+  validates :sku, :status, :merchandise_condition_id, presence: true
+  validates :sku, uniqueness: true, format: { with: /\A\d{13}\z/ }
+  validates :industry_identifier, uniqueness: true, allow_nil: true, format: { with: /\A\d{13}\z/ }
+  validates :status, inclusion: { in: STATUSES }
+  validates :regular_price_cents, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
+  validate :validate_changed_references
+  validate :sku_immutable, on: :update
+  validate :activation_requirements, if: -> { status_changed? && status == "active" }
+
+  scope :active, -> { where(status: "active") }
+  scope :draft, -> { where(status: "draft") }
+
+  def draft?
+    status == "draft"
+  end
+
+  def sellable?
+    status == "active" &&
+      product.active_status? &&
+      sku.present? &&
+      merchandise_class&.assignable? &&
+      merchandise_condition&.assignable? &&
+      department&.assignable? &&
+      tax_class&.assignable? &&
+      condition_allowed_by_class? &&
+      price_satisfies_pricing_method?
+  end
+
+  def condition_allowed_by_class?
+    return false if merchandise_class.blank? || merchandise_condition.blank?
+    return true unless merchandise_condition.used_basis?
+
+    merchandise_class.used_merchandise_allowed?
+  end
+
+  def price_satisfies_pricing_method?
+    return false if merchandise_class.blank?
+
+    case merchandise_class.pricing_method
+    when "open_price"
+      true
+    when "fixed", "list_price", "cost_based"
+      regular_price_cents.present? && regular_price_cents >= 0
+    else
+      false
+    end
+  end
+
+  private
+
+  def sku_immutable
+    errors.add(:sku, "cannot be changed") if sku_changed?
+  end
+
+  def validate_changed_references
+    if merchandise_condition_id_changed? && merchandise_condition.present? && !merchandise_condition.assignable?
+      errors.add(:merchandise_condition_id, "must be an active condition")
+    end
+    if merchandise_class_id_changed? && merchandise_class.present? && !merchandise_class.assignable?
+      errors.add(:merchandise_class_id, "must be an active merchandise class")
+    end
+    if department_id_changed? && department.present? && !department.assignable?
+      errors.add(:department_id, "must be an active department")
+    end
+    if tax_class_id_changed? && tax_class.present? && !tax_class.assignable?
+      errors.add(:tax_class_id, "must be an active tax class")
+    end
+  end
+
+  def activation_requirements
+    errors.add(:merchandise_class_id, "is required to activate") if merchandise_class_id.blank?
+    errors.add(:department_id, "is required to activate") if department_id.blank?
+    errors.add(:tax_class_id, "is required to activate") if tax_class_id.blank?
+    errors.add(:base, "condition is not allowed for this merchandise class") unless condition_allowed_by_class?
+    errors.add(:regular_price_cents, "is required for this pricing method") unless price_satisfies_pricing_method?
+    errors.add(:product_id, "product must be active") unless product.active_status?
+  end
+end

--- a/app/models/product_variant.rb
+++ b/app/models/product_variant.rb
@@ -4,6 +4,8 @@ class ProductVariant < ApplicationRecord
   STATUSES = %w[draft active discontinued].freeze
   VARIANT_TYPES = %w[standard used].freeze
 
+  attr_accessor :identifier_writes_enabled
+
   belongs_to :product
   belongs_to :merchandise_condition, optional: true
   belongs_to :merchandise_class, optional: true
@@ -18,8 +20,9 @@ class ProductVariant < ApplicationRecord
   validates :regular_price_cents, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
   validate :condition_matches_variant_type
   validate :validate_changed_references
-  validate :sku_immutable, on: :update
+  validate :identifier_write_rules
   validate :activation_requirements, if: -> { status == "active" }
+  after_save { self.identifier_writes_enabled = false }
 
   scope :active, -> { where(status: "active") }
   scope :draft, -> { where(status: "draft") }
@@ -57,17 +60,23 @@ class ProductVariant < ApplicationRecord
       merchandise_class&.assignable? &&
       department&.assignable? &&
       tax_class&.assignable? &&
-      type_and_condition_valid_for_class? &&
+      type_and_condition_valid_for_class?(require_assignable_condition: true) &&
       price_satisfies_pricing_method?
   end
 
-  def type_and_condition_valid_for_class?
+  def type_and_condition_valid_for_class?(require_assignable_condition: true)
     return false if merchandise_class.blank?
 
     if standard?
       merchandise_condition_id.blank?
     elsif used?
-      merchandise_condition&.assignable? &&
+      condition_ok =
+        if require_assignable_condition
+          merchandise_condition&.assignable?
+        else
+          merchandise_condition.present?
+        end
+      condition_ok &&
         merchandise_class.used_merchandise_allowed? &&
         merchandise_class.inventory?
     else
@@ -90,8 +99,19 @@ class ProductVariant < ApplicationRecord
 
   private
 
-  def sku_immutable
+  def identifier_write_rules
+    if new_record?
+      unless identifier_writes_enabled
+        errors.add(:base, "identifiers must be assigned through ProductVariants::Create")
+      end
+      return
+    end
+
     errors.add(:sku, "cannot be changed") if sku_changed?
+
+    if industry_identifier_changed? && !identifier_writes_enabled
+      errors.add(:industry_identifier, "must be changed through Identifiers::AssignIndustry")
+    end
   end
 
   def condition_matches_variant_type
@@ -121,13 +141,17 @@ class ProductVariant < ApplicationRecord
     errors.add(:merchandise_class_id, "is required to activate") if merchandise_class_id.blank?
     errors.add(:department_id, "is required to activate") if department_id.blank?
     errors.add(:tax_class_id, "is required to activate") if tax_class_id.blank?
-    unless type_and_condition_valid_for_class?
+
+    require_assignable_condition = status_changed? || merchandise_condition_id_changed?
+    unless type_and_condition_valid_for_class?(require_assignable_condition: require_assignable_condition)
       if used? && merchandise_class.present? && merchandise_class.non_inventory?
         errors.add(:merchandise_class_id, "used variants cannot use a non-inventory merchandise class")
       elsif used? && merchandise_class.present? && !merchandise_class.used_merchandise_allowed?
         errors.add(:base, "used variants require a merchandise class that allows used merchandise")
       elsif used? && merchandise_condition.blank?
         errors.add(:merchandise_condition_id, "is required for used variants")
+      elsif used? && require_assignable_condition && merchandise_condition.present? && !merchandise_condition.assignable?
+        errors.add(:merchandise_condition_id, "must be an active condition")
       elsif standard? && merchandise_condition_id.present?
         errors.add(:merchandise_condition_id, "must be blank for standard variants")
       else

--- a/app/models/product_variant.rb
+++ b/app/models/product_variant.rb
@@ -2,27 +2,52 @@
 
 class ProductVariant < ApplicationRecord
   STATUSES = %w[draft active discontinued].freeze
+  VARIANT_TYPES = %w[standard used].freeze
 
   belongs_to :product
-  belongs_to :merchandise_condition
+  belongs_to :merchandise_condition, optional: true
   belongs_to :merchandise_class, optional: true
   belongs_to :department, optional: true
   belongs_to :tax_class, optional: true
 
-  validates :sku, :status, :merchandise_condition_id, presence: true
+  validates :sku, :status, :variant_type, presence: true
   validates :sku, uniqueness: true, format: { with: /\A\d{13}\z/ }
   validates :industry_identifier, uniqueness: true, allow_nil: true, format: { with: /\A\d{13}\z/ }
   validates :status, inclusion: { in: STATUSES }
+  validates :variant_type, inclusion: { in: VARIANT_TYPES }
   validates :regular_price_cents, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
+  validate :condition_matches_variant_type
   validate :validate_changed_references
   validate :sku_immutable, on: :update
   validate :activation_requirements, if: -> { status_changed? && status == "active" }
 
   scope :active, -> { where(status: "active") }
   scope :draft, -> { where(status: "draft") }
+  scope :standard, -> { where(variant_type: "standard") }
+  scope :used, -> { where(variant_type: "used") }
 
   def draft?
     status == "draft"
+  end
+
+  def standard?
+    variant_type == "standard"
+  end
+
+  def used?
+    variant_type == "used"
+  end
+
+  def derived_inventory_tracking
+    return nil if merchandise_class.blank?
+
+    case [ merchandise_class.inventory_mode, variant_type ]
+    when %w[inventory standard] then "quantity"
+    when %w[inventory used] then "individual"
+    when %w[non_inventory standard] then "non_inventory"
+    else
+      nil
+    end
   end
 
   def sellable?
@@ -30,18 +55,24 @@ class ProductVariant < ApplicationRecord
       product.active_status? &&
       sku.present? &&
       merchandise_class&.assignable? &&
-      merchandise_condition&.assignable? &&
       department&.assignable? &&
       tax_class&.assignable? &&
-      condition_allowed_by_class? &&
+      type_and_condition_valid_for_class? &&
       price_satisfies_pricing_method?
   end
 
-  def condition_allowed_by_class?
-    return false if merchandise_class.blank? || merchandise_condition.blank?
-    return true unless merchandise_condition.used_basis?
+  def type_and_condition_valid_for_class?
+    return false if merchandise_class.blank?
 
-    merchandise_class.used_merchandise_allowed?
+    if standard?
+      merchandise_condition_id.blank?
+    elsif used?
+      merchandise_condition&.assignable? &&
+        merchandise_class.used_merchandise_allowed? &&
+        merchandise_class.inventory?
+    else
+      false
+    end
   end
 
   def price_satisfies_pricing_method?
@@ -63,6 +94,14 @@ class ProductVariant < ApplicationRecord
     errors.add(:sku, "cannot be changed") if sku_changed?
   end
 
+  def condition_matches_variant_type
+    if standard? && merchandise_condition_id.present?
+      errors.add(:merchandise_condition_id, "must be blank for standard variants")
+    elsif used? && merchandise_condition_id.blank?
+      errors.add(:merchandise_condition_id, "is required for used variants")
+    end
+  end
+
   def validate_changed_references
     if merchandise_condition_id_changed? && merchandise_condition.present? && !merchandise_condition.assignable?
       errors.add(:merchandise_condition_id, "must be an active condition")
@@ -82,7 +121,19 @@ class ProductVariant < ApplicationRecord
     errors.add(:merchandise_class_id, "is required to activate") if merchandise_class_id.blank?
     errors.add(:department_id, "is required to activate") if department_id.blank?
     errors.add(:tax_class_id, "is required to activate") if tax_class_id.blank?
-    errors.add(:base, "condition is not allowed for this merchandise class") unless condition_allowed_by_class?
+    unless type_and_condition_valid_for_class?
+      if used? && merchandise_class.present? && merchandise_class.non_inventory?
+        errors.add(:merchandise_class_id, "used variants cannot use a non-inventory merchandise class")
+      elsif used? && merchandise_class.present? && !merchandise_class.used_merchandise_allowed?
+        errors.add(:base, "used variants require a merchandise class that allows used merchandise")
+      elsif used? && merchandise_condition.blank?
+        errors.add(:merchandise_condition_id, "is required for used variants")
+      elsif standard? && merchandise_condition_id.present?
+        errors.add(:merchandise_condition_id, "must be blank for standard variants")
+      else
+        errors.add(:base, "variant type, condition, and merchandise class combination is invalid")
+      end
+    end
     errors.add(:regular_price_cents, "is required for this pricing method") unless price_satisfies_pricing_method?
     errors.add(:product_id, "product must be active") unless product.active_status?
   end

--- a/app/models/product_variant.rb
+++ b/app/models/product_variant.rb
@@ -19,7 +19,7 @@ class ProductVariant < ApplicationRecord
   validate :condition_matches_variant_type
   validate :validate_changed_references
   validate :sku_immutable, on: :update
-  validate :activation_requirements, if: -> { status_changed? && status == "active" }
+  validate :activation_requirements, if: -> { status == "active" }
 
   scope :active, -> { where(status: "active") }
   scope :draft, -> { where(status: "draft") }

--- a/app/models/tax_class.rb
+++ b/app/models/tax_class.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class TaxClass < ApplicationRecord
+  before_validation :normalize_code
+
+  validates :code, :name, presence: true
+  validates :code, uniqueness: true
+
+  scope :active, -> { where(active: true) }
+  scope :assignable, -> { active }
+
+  def assignable?
+    active?
+  end
+
+  private
+
+  def normalize_code
+    self.code = code.to_s.strip.downcase.tr(" ", "_")
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,7 @@ class User < ApplicationRecord
 
   scope :active, -> { where(active: true) }
   scope :human, -> { where(actor_type: "human") }
+  scope :system_actors, -> { where(actor_type: "system") }
 
   def system_actor?
     actor_type == "system"

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -48,4 +48,8 @@ class UserSession < ApplicationRecord
   def revoke!(by: nil)
     update!(revoked_at: Time.current, revoked_by: by)
   end
+
+  def revoked?
+    revoked_at.present?
+  end
 end

--- a/app/services/authorization/permission_catalog.rb
+++ b/app/services/authorization/permission_catalog.rb
@@ -4,7 +4,7 @@ module Authorization
   module PermissionCatalog
     module_function
 
-    PERMISSIONS = [
+    PHASE1_PERMISSIONS = [
       { key: "system_settings.view", group_key: "system_settings", name: "View system settings", scope_type: "global" },
       { key: "system_settings.manage", group_key: "system_settings", name: "Manage system settings", scope_type: "global" },
       { key: "stores.view", group_key: "stores", name: "View stores", scope_type: "either" },
@@ -29,6 +29,60 @@ module Authorization
       { key: "audit_events.view", group_key: "audit_events", name: "View audit events", scope_type: "either" }
     ].freeze
 
+    # View/lookup keys use scope_type "either" so store-scoped roles (associate,
+    # store_manager) can read organization-wide catalog data in an active store.
+    # Create/update/lifecycle keys remain "global" and require a global assignment.
+    PHASE2_PERMISSIONS = [
+      { key: "gl_accounts.view", group_key: "gl_accounts", name: "View GL accounts", scope_type: "either" },
+      { key: "gl_accounts.create", group_key: "gl_accounts", name: "Create GL accounts", scope_type: "global" },
+      { key: "gl_accounts.update", group_key: "gl_accounts", name: "Update GL accounts", scope_type: "global" },
+      { key: "gl_accounts.deactivate", group_key: "gl_accounts", name: "Deactivate GL accounts", scope_type: "global" },
+      { key: "tax_classes.view", group_key: "tax_classes", name: "View tax classes", scope_type: "either" },
+      { key: "tax_classes.create", group_key: "tax_classes", name: "Create tax classes", scope_type: "global" },
+      { key: "tax_classes.update", group_key: "tax_classes", name: "Update tax classes", scope_type: "global" },
+      { key: "tax_classes.deactivate", group_key: "tax_classes", name: "Deactivate tax classes", scope_type: "global" },
+      { key: "departments.view", group_key: "departments", name: "View departments", scope_type: "either" },
+      { key: "departments.create", group_key: "departments", name: "Create departments", scope_type: "global" },
+      { key: "departments.update", group_key: "departments", name: "Update departments", scope_type: "global" },
+      { key: "departments.deactivate", group_key: "departments", name: "Deactivate departments", scope_type: "global" },
+      { key: "merchandise_classes.view", group_key: "merchandise_classes", name: "View merchandise classes", scope_type: "either" },
+      { key: "merchandise_classes.create", group_key: "merchandise_classes", name: "Create merchandise classes", scope_type: "global" },
+      { key: "merchandise_classes.update", group_key: "merchandise_classes", name: "Update merchandise classes", scope_type: "global" },
+      { key: "merchandise_classes.deactivate", group_key: "merchandise_classes", name: "Deactivate merchandise classes", scope_type: "global" },
+      { key: "merchandise_categories.view", group_key: "merchandise_categories", name: "View merchandise categories", scope_type: "either" },
+      { key: "merchandise_categories.create", group_key: "merchandise_categories", name: "Create merchandise categories", scope_type: "global" },
+      { key: "merchandise_categories.update", group_key: "merchandise_categories", name: "Update merchandise categories", scope_type: "global" },
+      { key: "merchandise_categories.deactivate", group_key: "merchandise_categories", name: "Deactivate merchandise categories", scope_type: "global" },
+      { key: "merchandise_conditions.view", group_key: "merchandise_conditions", name: "View merchandise conditions", scope_type: "either" },
+      { key: "merchandise_conditions.create", group_key: "merchandise_conditions", name: "Create merchandise conditions", scope_type: "global" },
+      { key: "merchandise_conditions.update", group_key: "merchandise_conditions", name: "Update merchandise conditions", scope_type: "global" },
+      { key: "merchandise_conditions.deactivate", group_key: "merchandise_conditions", name: "Deactivate merchandise conditions", scope_type: "global" },
+      { key: "products.view", group_key: "products", name: "View products", scope_type: "either" },
+      { key: "products.create", group_key: "products", name: "Create products", scope_type: "global" },
+      { key: "products.update", group_key: "products", name: "Update products", scope_type: "global" },
+      { key: "products.discontinue", group_key: "products", name: "Discontinue products", scope_type: "global" },
+      { key: "product_variants.view", group_key: "product_variants", name: "View product variants", scope_type: "either" },
+      { key: "product_variants.create", group_key: "product_variants", name: "Create product variants", scope_type: "global" },
+      { key: "product_variants.update", group_key: "product_variants", name: "Update product variants", scope_type: "global" },
+      { key: "product_variants.discontinue", group_key: "product_variants", name: "Discontinue product variants", scope_type: "global" },
+      { key: "merchandise.lookup", group_key: "merchandise", name: "Look up merchandise by identifier", scope_type: "either" },
+      { key: "merchandise.import", group_key: "merchandise", name: "Import merchandise", scope_type: "global" }
+    ].freeze
+
+    PERMISSIONS = (PHASE1_PERMISSIONS + PHASE2_PERMISSIONS).freeze
+
+    STORE_MANAGER_PHASE2_VIEWS = %w[
+      gl_accounts.view
+      tax_classes.view
+      departments.view
+      merchandise_classes.view
+      merchandise_categories.view
+      merchandise_conditions.view
+      products.view
+      product_variants.view
+      merchandise.lookup
+    ].freeze
+
     ROLES = [
       {
         key: "system_administrator",
@@ -49,13 +103,18 @@ module Authorization
           workstations.deactivate
           workstations.revoke
           audit_events.view
-        ]
+        ] + STORE_MANAGER_PHASE2_VIEWS
       },
       {
         key: "associate",
         name: "Associate",
         assignment_scope: "store",
-        permission_keys: %w[stores.view]
+        permission_keys: %w[
+          stores.view
+          merchandise.lookup
+          products.view
+          product_variants.view
+        ]
       }
     ].freeze
 

--- a/app/services/identifiers/assign_industry.rb
+++ b/app/services/identifiers/assign_industry.rb
@@ -8,11 +8,12 @@ module Identifiers
       new(**attrs).call
     end
 
-    def initialize(variant:, raw_value:, actor: nil, source: "ui")
+    def initialize(variant:, raw_value:, actor: nil, source: "ui", persist: true)
       @variant = variant
       @raw_value = raw_value
       @actor = actor
       @source = source
+      @persist = persist
     end
 
     def call
@@ -20,20 +21,19 @@ module Identifiers
         previous = @variant.industry_identifier
 
         if @raw_value.blank?
-          clear!(previous)
+          apply_clear!(previous)
         else
           normalized = Normalizer.normalize(@raw_value, allow_shelfsense_222: false)
           raise Error, "industry identifier cannot equal SKU" if normalized == @variant.sku
-          if normalized == previous
-            @variant
-          else
-            # Retire first so the active variant_industry unique owner index allows the new row.
-            Registry.retire!(value: previous) if previous.present?
-            Registry.reserve!(value: normalized, kind: "variant_industry", product_variant: @variant)
-            @variant.update!(industry_identifier: normalized)
-            @variant
-          end
+          apply_replace!(previous, normalized) unless normalized == previous
         end
+
+        if @persist
+          @variant.identifier_writes_enabled = true
+          @variant.save!
+        end
+
+        @variant
       end
     rescue NormalizationError, Registry::ConflictError, ActiveRecord::RecordInvalid => e
       raise Error, e.message
@@ -41,12 +41,20 @@ module Identifiers
 
     private
 
-    def clear!(previous)
-      return @variant if previous.blank?
+    def apply_clear!(previous)
+      return if previous.blank?
 
       Registry.retire!(value: previous)
-      @variant.update!(industry_identifier: nil)
-      @variant
+      @variant.identifier_writes_enabled = true
+      @variant.industry_identifier = nil
+    end
+
+    def apply_replace!(previous, normalized)
+      # Retire first so the active variant_industry unique owner index allows the new row.
+      Registry.retire!(value: previous) if previous.present?
+      Registry.reserve!(value: normalized, kind: "variant_industry", product_variant: @variant)
+      @variant.identifier_writes_enabled = true
+      @variant.industry_identifier = normalized
     end
   end
 end

--- a/app/services/identifiers/assign_industry.rb
+++ b/app/services/identifiers/assign_industry.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Identifiers
+  class AssignIndustry
+    class Error < StandardError; end
+
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(variant:, raw_value:, actor: nil, source: "ui")
+      @variant = variant
+      @raw_value = raw_value
+      @actor = actor
+      @source = source
+    end
+
+    def call
+      ProductVariant.transaction do
+        previous = @variant.industry_identifier
+
+        if @raw_value.blank?
+          clear!(previous)
+        else
+          normalized = Normalizer.normalize(@raw_value, allow_shelfsense_222: false)
+          raise Error, "industry identifier cannot equal SKU" if normalized == @variant.sku
+          if normalized == previous
+            @variant
+          else
+            # Retire first so the active variant_industry unique owner index allows the new row.
+            Registry.retire!(value: previous) if previous.present?
+            Registry.reserve!(value: normalized, kind: "variant_industry", product_variant: @variant)
+            @variant.update!(industry_identifier: normalized)
+            @variant
+          end
+        end
+      end
+    rescue NormalizationError, Registry::ConflictError, ActiveRecord::RecordInvalid => e
+      raise Error, e.message
+    end
+
+    private
+
+    def clear!(previous)
+      return @variant if previous.blank?
+
+      Registry.retire!(value: previous)
+      @variant.update!(industry_identifier: nil)
+      @variant
+    end
+  end
+end

--- a/app/services/identifiers/ean13.rb
+++ b/app/services/identifiers/ean13.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Identifiers
+  module Ean13
+    module_function
+
+    def check_digit(twelve_digits)
+      digits = twelve_digits.to_s.chars.map(&:to_i)
+      raise ArgumentError, "EAN-13 body must be 12 digits" unless digits.length == 12
+
+      sum = digits.each_with_index.sum { |d, i| d * (i.even? ? 1 : 3) }
+      (10 - (sum % 10)) % 10
+    end
+
+    def valid?(value)
+      return false unless value.to_s.match?(/\A\d{13}\z/)
+
+      body = value.to_s[0, 12]
+      value.to_s[-1].to_i == check_digit(body)
+    end
+
+    def complete(prefix3, payload9)
+      body = "#{prefix3}#{payload9}"
+      raise ArgumentError, "body must be 12 digits" unless body.match?(/\A\d{12}\z/)
+
+      "#{body}#{check_digit(body)}"
+    end
+  end
+end

--- a/app/services/identifiers/generator.rb
+++ b/app/services/identifiers/generator.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Identifiers
+  class Generator
+    class ExhaustedError < StandardError; end
+
+    SEQUENCE_BY_PREFIX = {
+      "221" => "shelfsense_sku_221_seq",
+      "222" => "shelfsense_product_222_seq"
+    }.freeze
+
+    def self.next_ean13!(prefix)
+      new.next_ean13!(prefix)
+    end
+
+    def next_ean13!(prefix)
+      sequence = SEQUENCE_BY_PREFIX.fetch(prefix) { raise ArgumentError, "unsupported prefix #{prefix}" }
+      connection = ActiveRecord::Base.connection
+
+      payload =
+        begin
+          connection.create_savepoint("shelfsense_id_seq")
+          value = connection.select_value("SELECT nextval(#{connection.quote(sequence)})")
+          connection.release_savepoint("shelfsense_id_seq")
+          value
+        rescue ActiveRecord::StatementInvalid => e
+          connection.rollback_to_savepoint("shelfsense_id_seq")
+          raise ExhaustedError, "identifier sequence #{sequence} is exhausted" if e.message.match?(/sequence.*maxvalue|reached maximum/i)
+
+          raise
+        end
+
+      raise ExhaustedError, "identifier sequence #{sequence} is exhausted" if payload.nil? || payload.to_i > 999_999_999
+
+      Ean13.complete(prefix, format("%09d", payload.to_i))
+    end
+  end
+end

--- a/app/services/identifiers/lookup.rb
+++ b/app/services/identifiers/lookup.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Identifiers
+  class Lookup
+    Result = Struct.new(:status, :product, :variant, :variants, :message, keyword_init: true)
+
+    def self.call(raw)
+      new(raw).call
+    end
+
+    def initialize(raw)
+      @raw = raw
+    end
+
+    def call
+      normalized = Normalizer.normalize(@raw, allow_shelfsense_222: true)
+      row = Registry.find_any(normalized)
+      return Result.new(status: :not_found, message: "No match") if row.nil?
+      return Result.new(status: :retired, message: "Identifier is retired") if row.retired_at.present?
+
+      case row.identifier_kind
+      when "variant_sku", "variant_industry"
+        variant = row.product_variant
+        return Result.new(status: :not_found, message: "Variant missing") if variant.nil?
+
+        Result.new(status: :variant, variant: variant, product: variant.product)
+      when "product_primary"
+        product = row.product
+        return Result.new(status: :not_found, message: "Product missing") if product.nil?
+
+        eligible = product.product_variants.select(&:sellable?)
+        if eligible.one?
+          Result.new(status: :variant, variant: eligible.first, product: product)
+        elsif eligible.many?
+          Result.new(status: :multi_variant, product: product, variants: eligible)
+        else
+          Result.new(status: :product, product: product)
+        end
+      else
+        Result.new(status: :invalid, message: "Unknown identifier kind")
+      end
+    rescue NormalizationError => e
+      Result.new(status: :invalid, message: e.message)
+    end
+  end
+end

--- a/app/services/identifiers/normalization_error.rb
+++ b/app/services/identifiers/normalization_error.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Identifiers
+  class NormalizationError < StandardError; end
+end

--- a/app/services/identifiers/normalizer.rb
+++ b/app/services/identifiers/normalizer.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Identifiers
+  module Normalizer
+    module_function
+
+    def normalize(raw, allow_shelfsense_222: false)
+      cleaned = raw.to_s.gsub(/[\s-]/, "")
+      raise NormalizationError, "identifier is blank" if cleaned.blank?
+
+      if cleaned.match?(/\A\d{10}\z/) || cleaned.match?(/\A\d{9}[\dXx]\z/)
+        cleaned = isbn10_to_isbn13(cleaned)
+      elsif cleaned.match?(/\A\d{12}\z/)
+        cleaned = "0#{cleaned}"
+      end
+
+      raise NormalizationError, "identifier must be 13 digits" unless cleaned.match?(/\A\d{13}\z/)
+      raise NormalizationError, "invalid check digit" unless Ean13.valid?(cleaned)
+
+      if cleaned.start_with?("222") && !allow_shelfsense_222
+        raise NormalizationError, "entered identifiers may not use the reserved 222 namespace"
+      end
+
+      cleaned
+    end
+
+    def isbn10_to_isbn13(isbn10)
+      body = isbn10.to_s.upcase
+      raise NormalizationError, "invalid ISBN-10" unless body.match?(/\A\d{9}[\dX]\z/)
+
+      core = "978#{body[0, 9]}"
+      "#{core}#{Ean13.check_digit(core)}"
+    end
+  end
+end

--- a/app/services/identifiers/normalizer.rb
+++ b/app/services/identifiers/normalizer.rb
@@ -27,9 +27,20 @@ module Identifiers
     def isbn10_to_isbn13(isbn10)
       body = isbn10.to_s.upcase
       raise NormalizationError, "invalid ISBN-10" unless body.match?(/\A\d{9}[\dX]\z/)
+      raise NormalizationError, "invalid ISBN-10 check digit" unless isbn10_valid?(body)
 
       core = "978#{body[0, 9]}"
       "#{core}#{Ean13.check_digit(core)}"
+    end
+
+    def isbn10_valid?(isbn10)
+      body = isbn10.to_s.upcase
+      return false unless body.match?(/\A\d{9}[\dX]\z/)
+
+      digits = body[0, 9].chars.map(&:to_i)
+      check = body[9] == "X" ? 10 : body[9].to_i
+      sum = digits.each_with_index.sum { |digit, index| digit * (10 - index) } + check
+      (sum % 11).zero?
     end
   end
 end

--- a/app/services/identifiers/registry.rb
+++ b/app/services/identifiers/registry.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Identifiers
+  class Registry
+    class ConflictError < StandardError; end
+
+    def self.reserve!(value:, kind:, product: nil, product_variant: nil)
+      new.reserve!(value: value, kind: kind, product: product, product_variant: product_variant)
+    end
+
+    def self.retire!(value:)
+      new.retire!(value: value)
+    end
+
+    def self.find_active(value)
+      IdentifierRegistry.find_by(value: value, retired_at: nil)
+    end
+
+    def self.find_any(value)
+      IdentifierRegistry.find_by(value: value)
+    end
+
+    def reserve!(value:, kind:, product: nil, product_variant: nil)
+      if IdentifierRegistry.exists?(value: value)
+        raise ConflictError, "identifier #{value} is already reserved"
+      end
+
+      IdentifierRegistry.create!(
+        value: value,
+        identifier_kind: kind,
+        product: product,
+        product_variant: product_variant,
+        retired_at: nil
+      )
+    rescue ActiveRecord::RecordNotUnique
+      raise ConflictError, "identifier #{value} is already reserved"
+    end
+
+    def retire!(value:)
+      row = IdentifierRegistry.find_by!(value: value)
+      row.update!(retired_at: Time.current)
+      row
+    end
+  end
+end

--- a/app/services/merchandise/csv_importer.rb
+++ b/app/services/merchandise/csv_importer.rb
@@ -24,22 +24,35 @@ module Merchandise
       updated_variants = 0
       errors = []
 
-      rows = CSV.parse(@io.read, headers: true)
-      rows.each_with_index do |row, index|
-        begin
-          ActiveRecord::Base.transaction do
-            product, product_status = upsert_product!(row)
-            created_products += 1 if product_status == :created
-            updated_products += 1 if product_status == :updated
+      groups = group_rows(CSV.parse(@io.read, headers: true))
+      groups.each do |group|
+        if group[:error]
+          errors << { row: group[:rows].map { |e| e[:line] }.join(","), message: group[:error] }
+          next
+        end
 
-            if row["variant_type"].present? || row["variant_condition_code"].present? || row["sku"].present? || row["industry_identifier"].present?
-              _, variant_status = upsert_variant!(product, row)
-              created_variants += 1 if variant_status == :created
-              updated_variants += 1 if variant_status == :updated
+        begin
+          product_statuses = []
+          variant_statuses = []
+
+          ActiveRecord::Base.transaction do
+            product = nil
+            group[:rows].each do |entry|
+              product, product_status = upsert_product!(entry[:row], generate_only: group[:generate_only])
+              product_statuses << product_status
+              next unless variant_requested?(entry[:row])
+
+              _, variant_status = upsert_variant!(product, entry[:row])
+              variant_statuses << variant_status
             end
           end
+
+          created_products += 1 if product_statuses.include?(:created)
+          updated_products += 1 if product_statuses.include?(:updated) && !product_statuses.include?(:created)
+          created_variants += variant_statuses.count(:created)
+          updated_variants += variant_statuses.count(:updated)
         rescue StandardError => e
-          errors << { row: index + 2, message: e.message }
+          errors << { row: group[:rows].map { |e| e[:line] }.join(","), message: e.message }
         end
       end
 
@@ -54,38 +67,75 @@ module Merchandise
 
     private
 
-    def upsert_product!(row)
-      generate = ActiveModel::Type::Boolean.new.cast(row["generate_primary_identifier"])
-      raw_id = row["primary_identifier"].presence
+    def group_rows(rows)
+      indexed = rows.each_with_index.map { |row, index| { row: row, line: index + 2 } }
+      groups = []
+      by_primary = Hash.new { |h, k| h[k] = [] }
 
-      if raw_id.blank? && !generate
-        raise Error, "primary_identifier is required or generate_primary_identifier must be true"
-      end
+      indexed.each do |entry|
+        row = entry[:row]
+        generate = ActiveModel::Type::Boolean.new.cast(row["generate_primary_identifier"])
+        raw_id = row["primary_identifier"].presence
 
-      if raw_id.present?
-        normalized = Identifiers::Normalizer.normalize(raw_id, allow_shelfsense_222: true)
-        if (existing = Product.find_by(primary_identifier: normalized))
-          existing.update!(name: row["name"].presence || existing.name)
-          return [ existing, :updated ]
+        if raw_id.blank? && generate
+          groups << { generate_only: true, rows: [ entry ] }
+          next
         end
 
-        product = Products::Create.call(
-          attributes: { name: row.fetch("name"), status: row["status"].presence || "draft" },
-          actor: @actor,
-          identifier_mode: "enter",
-          external_identifier: raw_id,
-          source: @source
-        )
-        [ product, :created ]
-      else
+        if raw_id.blank?
+          groups << { generate_only: false, rows: [ entry ], error: "primary_identifier is required or generate_primary_identifier must be true" }
+          next
+        end
+
+        begin
+          key = Identifiers::Normalizer.normalize(raw_id, allow_shelfsense_222: true)
+          by_primary[key] << entry
+        rescue Identifiers::NormalizationError => e
+          groups << { generate_only: false, rows: [ entry ], error: e.message }
+        end
+      end
+
+      by_primary.each_value { |entries| groups << { generate_only: false, rows: entries } }
+      groups
+    end
+
+    def variant_requested?(row)
+      row["variant_type"].present? || row["variant_condition_code"].present? || row["sku"].present? || row["industry_identifier"].present?
+    end
+
+    def upsert_product!(row, generate_only:)
+      if generate_only
         product = Products::Create.call(
           attributes: { name: row.fetch("name"), status: row["status"].presence || "draft" },
           actor: @actor,
           identifier_mode: "generate",
           source: @source
         )
-        [ product, :created ]
+        return [ product, :created ]
       end
+
+      raw_id = row["primary_identifier"].presence
+      raise Error, "primary_identifier is required or generate_primary_identifier must be true" if raw_id.blank?
+
+      normalized = Identifiers::Normalizer.normalize(raw_id, allow_shelfsense_222: true)
+      if (existing = Product.find_by(primary_identifier: normalized))
+        Products::Update.call(
+          product: existing,
+          actor: @actor,
+          source: @source,
+          attributes: { name: row["name"].presence || existing.name }
+        )
+        return [ existing, :updated ]
+      end
+
+      product = Products::Create.call(
+        attributes: { name: row.fetch("name"), status: row["status"].presence || "draft" },
+        actor: @actor,
+        identifier_mode: "enter",
+        external_identifier: raw_id,
+        source: @source
+      )
+      [ product, :created ]
     end
 
     def upsert_variant!(product, row)
@@ -94,7 +144,12 @@ module Merchandise
         raise Error, "caller-assigned SKU is not accepted for new variants; SKU not found for update" unless variant
         raise Error, "SKU belongs to a different product" unless variant.product_id == product.id
 
-        variant.update!(name: row["variant_name"].presence || variant.name)
+        ProductVariants::Update.call(
+          variant: variant,
+          actor: @actor,
+          source: @source,
+          attributes: { name: row["variant_name"].presence || variant.name }
+        )
         return [ variant, :updated ]
       end
 
@@ -103,7 +158,14 @@ module Merchandise
         if (variant = ProductVariant.find_by(industry_identifier: normalized))
           raise Error, "industry identifier belongs to a different product" unless variant.product_id == product.id
 
-          variant.update!(name: row["variant_name"].presence || variant.name) if row["variant_name"].present?
+          if row["variant_name"].present?
+            ProductVariants::Update.call(
+              variant: variant,
+              actor: @actor,
+              source: @source,
+              attributes: { name: row["variant_name"] }
+            )
+          end
           return [ variant, :updated ]
         end
       end
@@ -115,16 +177,16 @@ module Merchandise
         variant_type: variant_type,
         name: row["variant_name"],
         industry_identifier: row["industry_identifier"],
-        regular_price_cents: row["regular_price_cents"].presence&.to_i,
-        merchandise_class_id: MerchandiseClass.find_by(code: row["merchandise_class_code"])&.id,
-        department_id: Department.find_by(code: row["department_code"])&.id,
-        tax_class_id: TaxClass.find_by(code: row["tax_class_code"])&.id
+        regular_price_cents: row["regular_price_cents"].presence&.to_i
       }
+      attributes.merge!(resolve_reference_ids!(row))
 
       if variant_type == "used"
         raise Error, "variant_condition_code is required for used variants" if row["variant_condition_code"].blank?
 
-        condition = MerchandiseCondition.find_by!(code: row["variant_condition_code"])
+        condition = MerchandiseCondition.find_by(code: row["variant_condition_code"])
+        raise Error, "unknown variant_condition_code: #{row["variant_condition_code"]}" if condition.nil?
+
         attributes[:merchandise_condition_id] = condition.id
       elsif row["variant_condition_code"].present?
         raise Error, "variant_condition_code must be blank for standard variants"
@@ -137,6 +199,35 @@ module Merchandise
         attributes: attributes.compact
       )
       [ variant, :created ]
+    end
+
+    def resolve_reference_ids!(row)
+      ids = {}
+      code = row["merchandise_class_code"].presence
+      if code
+        klass = MerchandiseClass.find_by(code: code)
+        raise Error, "unknown merchandise_class_code: #{code}" if klass.nil?
+
+        ids[:merchandise_class_id] = klass.id
+      end
+
+      code = row["department_code"].presence
+      if code
+        dept = Department.find_by(code: code)
+        raise Error, "unknown department_code: #{code}" if dept.nil?
+
+        ids[:department_id] = dept.id
+      end
+
+      code = row["tax_class_code"].presence
+      if code
+        tax = TaxClass.find_by(code: code)
+        raise Error, "unknown tax_class_code: #{code}" if tax.nil?
+
+        ids[:tax_class_id] = tax.id
+      end
+
+      ids
     end
   end
 end

--- a/app/services/merchandise/csv_importer.rb
+++ b/app/services/merchandise/csv_importer.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require "csv"
+
+module Merchandise
+  class CsvImporter
+    class Error < StandardError; end
+    Result = Struct.new(:created_products, :updated_products, :created_variants, :updated_variants, :errors, keyword_init: true)
+
+    def self.call(io:, actor:, source: "csv_import")
+      new(io: io, actor: actor, source: source).call
+    end
+
+    def initialize(io:, actor:, source:)
+      @io = io
+      @actor = actor
+      @source = source
+    end
+
+    def call
+      created_products = 0
+      updated_products = 0
+      created_variants = 0
+      updated_variants = 0
+      errors = []
+
+      rows = CSV.parse(@io.read, headers: true)
+      rows.each_with_index do |row, index|
+        begin
+          ActiveRecord::Base.transaction do
+            product, product_status = upsert_product!(row)
+            created_products += 1 if product_status == :created
+            updated_products += 1 if product_status == :updated
+
+            if row["variant_condition_code"].present? || row["sku"].present? || row["industry_identifier"].present?
+              _, variant_status = upsert_variant!(product, row)
+              created_variants += 1 if variant_status == :created
+              updated_variants += 1 if variant_status == :updated
+            end
+          end
+        rescue StandardError => e
+          errors << { row: index + 2, message: e.message }
+        end
+      end
+
+      Result.new(
+        created_products: created_products,
+        updated_products: updated_products,
+        created_variants: created_variants,
+        updated_variants: updated_variants,
+        errors: errors
+      )
+    end
+
+    private
+
+    def upsert_product!(row)
+      generate = ActiveModel::Type::Boolean.new.cast(row["generate_primary_identifier"])
+      raw_id = row["primary_identifier"].presence
+
+      if raw_id.blank? && !generate
+        raise Error, "primary_identifier is required or generate_primary_identifier must be true"
+      end
+
+      if raw_id.present?
+        normalized = Identifiers::Normalizer.normalize(raw_id, allow_shelfsense_222: true)
+        if (existing = Product.find_by(primary_identifier: normalized))
+          existing.update!(name: row["name"].presence || existing.name)
+          return [ existing, :updated ]
+        end
+
+        product = Products::Create.call(
+          attributes: { name: row.fetch("name"), status: row["status"].presence || "draft" },
+          actor: @actor,
+          identifier_mode: "enter",
+          external_identifier: raw_id,
+          source: @source
+        )
+        [ product, :created ]
+      else
+        product = Products::Create.call(
+          attributes: { name: row.fetch("name"), status: row["status"].presence || "draft" },
+          actor: @actor,
+          identifier_mode: "generate",
+          source: @source
+        )
+        [ product, :created ]
+      end
+    end
+
+    def upsert_variant!(product, row)
+      if row["sku"].present?
+        variant = ProductVariant.find_by(sku: row["sku"])
+        raise Error, "caller-assigned SKU is not accepted for new variants; SKU not found for update" unless variant
+        raise Error, "SKU belongs to a different product" unless variant.product_id == product.id
+
+        variant.update!(name: row["variant_name"].presence || variant.name)
+        return [ variant, :updated ]
+      end
+
+      if row["industry_identifier"].present?
+        normalized = Identifiers::Normalizer.normalize(row["industry_identifier"], allow_shelfsense_222: false)
+        if (variant = ProductVariant.find_by(industry_identifier: normalized))
+          raise Error, "industry identifier belongs to a different product" unless variant.product_id == product.id
+
+          variant.update!(name: row["variant_name"].presence || variant.name) if row["variant_name"].present?
+          return [ variant, :updated ]
+        end
+      end
+
+      if row["variant_condition_code"].blank?
+        raise Error, "insufficient identity to create or update variant"
+      end
+
+      condition = MerchandiseCondition.find_by!(code: row["variant_condition_code"])
+      variant = ProductVariants::Create.call(
+        product: product,
+        actor: @actor,
+        source: @source,
+        attributes: {
+          merchandise_condition_id: condition.id,
+          name: row["variant_name"],
+          industry_identifier: row["industry_identifier"],
+          regular_price_cents: row["regular_price_cents"].presence&.to_i,
+          merchandise_class_id: MerchandiseClass.find_by(code: row["merchandise_class_code"])&.id,
+          department_id: Department.find_by(code: row["department_code"])&.id,
+          tax_class_id: TaxClass.find_by(code: row["tax_class_code"])&.id
+        }.compact
+      )
+      [ variant, :created ]
+    end
+  end
+end

--- a/app/services/merchandise/csv_importer.rb
+++ b/app/services/merchandise/csv_importer.rb
@@ -32,7 +32,7 @@ module Merchandise
             created_products += 1 if product_status == :created
             updated_products += 1 if product_status == :updated
 
-            if row["variant_condition_code"].present? || row["sku"].present? || row["industry_identifier"].present?
+            if row["variant_type"].present? || row["variant_condition_code"].present? || row["sku"].present? || row["industry_identifier"].present?
               _, variant_status = upsert_variant!(product, row)
               created_variants += 1 if variant_status == :created
               updated_variants += 1 if variant_status == :updated
@@ -108,24 +108,33 @@ module Merchandise
         end
       end
 
-      if row["variant_condition_code"].blank?
-        raise Error, "insufficient identity to create or update variant"
+      variant_type = row["variant_type"].to_s.presence
+      raise Error, "insufficient identity to create or update variant" if variant_type.blank?
+
+      attributes = {
+        variant_type: variant_type,
+        name: row["variant_name"],
+        industry_identifier: row["industry_identifier"],
+        regular_price_cents: row["regular_price_cents"].presence&.to_i,
+        merchandise_class_id: MerchandiseClass.find_by(code: row["merchandise_class_code"])&.id,
+        department_id: Department.find_by(code: row["department_code"])&.id,
+        tax_class_id: TaxClass.find_by(code: row["tax_class_code"])&.id
+      }
+
+      if variant_type == "used"
+        raise Error, "variant_condition_code is required for used variants" if row["variant_condition_code"].blank?
+
+        condition = MerchandiseCondition.find_by!(code: row["variant_condition_code"])
+        attributes[:merchandise_condition_id] = condition.id
+      elsif row["variant_condition_code"].present?
+        raise Error, "variant_condition_code must be blank for standard variants"
       end
 
-      condition = MerchandiseCondition.find_by!(code: row["variant_condition_code"])
       variant = ProductVariants::Create.call(
         product: product,
         actor: @actor,
         source: @source,
-        attributes: {
-          merchandise_condition_id: condition.id,
-          name: row["variant_name"],
-          industry_identifier: row["industry_identifier"],
-          regular_price_cents: row["regular_price_cents"].presence&.to_i,
-          merchandise_class_id: MerchandiseClass.find_by(code: row["merchandise_class_code"])&.id,
-          department_id: Department.find_by(code: row["department_code"])&.id,
-          tax_class_id: TaxClass.find_by(code: row["tax_class_code"])&.id
-        }.compact
+        attributes: attributes.compact
       )
       [ variant, :created ]
     end

--- a/app/services/product_variants/create.rb
+++ b/app/services/product_variants/create.rb
@@ -16,19 +16,31 @@ module ProductVariants
     end
 
     def call
-      condition_id = @attributes[:merchandise_condition_id]
-      raise Error, "merchandise_condition_id is required" if condition_id.blank?
+      variant_type = @attributes[:variant_type].to_s
+      raise Error, "variant_type must be standard or used" unless ProductVariant::VARIANT_TYPES.include?(variant_type)
+
+      condition_id = @attributes[:merchandise_condition_id].presence
+      if variant_type == "used"
+        raise Error, "merchandise_condition_id is required for used variants" if condition_id.blank?
+      elsif condition_id.present?
+        raise Error, "merchandise_condition_id must be blank for standard variants"
+      end
 
       ProductVariant.transaction do
-        condition = MerchandiseCondition.find(condition_id)
+        condition = condition_id.present? ? MerchandiseCondition.find(condition_id) : nil
+        klass = find_optional(MerchandiseClass, @attributes[:merchandise_class_id])
+        validate_class_for_type!(variant_type, klass) if klass
+
         resolved = DefaultResolver.resolve(
           product: @product,
+          variant_type: variant_type,
           condition: condition,
-          merchandise_class: find_optional(MerchandiseClass, @attributes[:merchandise_class_id]),
+          merchandise_class: klass,
           department: find_optional(Department, @attributes[:department_id]),
           tax_class: find_optional(TaxClass, @attributes[:tax_class_id]),
           regular_price_cents: @attributes[:regular_price_cents]
         )
+        validate_class_for_type!(variant_type, resolved.merchandise_class) if resolved.merchandise_class
 
         sku = allocate_221!
         industry = @attributes[:industry_identifier].presence
@@ -40,6 +52,7 @@ module ProductVariants
 
         variant = @product.product_variants.new(
           @attributes.except(:industry_identifier, :sku).merge(
+            variant_type: variant_type,
             sku: sku,
             industry_identifier: normalized_industry,
             merchandise_condition: condition,
@@ -68,7 +81,12 @@ module ProductVariants
           actor_user: @actor,
           actor_label: @actor.display_name,
           subject: variant,
-          after_values: { sku: variant.sku, product_id: variant.product_id, source: @source }
+          after_values: {
+            sku: variant.sku,
+            product_id: variant.product_id,
+            variant_type: variant.variant_type,
+            source: @source
+          }
         )
 
         variant
@@ -78,6 +96,15 @@ module ProductVariants
     end
 
     private
+
+    def validate_class_for_type!(variant_type, klass)
+      return if klass.blank?
+
+      if variant_type == "used"
+        raise Error, "used variants cannot use a non-inventory merchandise class" if klass.non_inventory?
+        raise Error, "used variants require a merchandise class that allows used merchandise" unless klass.used_merchandise_allowed?
+      end
+    end
 
     def find_optional(model, id)
       return if id.blank?

--- a/app/services/product_variants/create.rb
+++ b/app/services/product_variants/create.rb
@@ -67,6 +67,7 @@ module ProductVariants
             status: @attributes[:status].presence || "draft"
           )
         )
+        variant.identifier_writes_enabled = true
         variant.save!
 
         Identifiers::Registry.reserve!(value: sku, kind: "variant_sku", product_variant: variant)

--- a/app/services/product_variants/create.rb
+++ b/app/services/product_variants/create.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+module ProductVariants
+  class Create
+    class Error < StandardError; end
+
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(product:, attributes:, actor:, source: "ui")
+      @product = product
+      @attributes = attributes.to_h.symbolize_keys
+      @actor = actor
+      @source = source
+    end
+
+    def call
+      condition_id = @attributes[:merchandise_condition_id]
+      raise Error, "merchandise_condition_id is required" if condition_id.blank?
+
+      ProductVariant.transaction do
+        condition = MerchandiseCondition.find(condition_id)
+        resolved = DefaultResolver.resolve(
+          product: @product,
+          condition: condition,
+          merchandise_class: find_optional(MerchandiseClass, @attributes[:merchandise_class_id]),
+          department: find_optional(Department, @attributes[:department_id]),
+          tax_class: find_optional(TaxClass, @attributes[:tax_class_id]),
+          regular_price_cents: @attributes[:regular_price_cents]
+        )
+
+        sku = allocate_221!
+        industry = @attributes[:industry_identifier].presence
+        normalized_industry =
+          if industry
+            Identifiers::Normalizer.normalize(industry, allow_shelfsense_222: false)
+          end
+        raise Error, "industry identifier cannot equal SKU" if normalized_industry.present? && normalized_industry == sku
+
+        variant = @product.product_variants.new(
+          @attributes.except(:industry_identifier, :sku).merge(
+            sku: sku,
+            industry_identifier: normalized_industry,
+            merchandise_condition: condition,
+            merchandise_class: resolved.merchandise_class,
+            department: resolved.department,
+            tax_class: resolved.tax_class,
+            regular_price_cents: if @attributes.key?(:regular_price_cents)
+                                   @attributes[:regular_price_cents]
+                                 else
+                                   resolved.suggested_price_cents
+                                 end,
+            status: @attributes[:status].presence || "draft"
+          )
+        )
+        variant.save!
+
+        Identifiers::Registry.reserve!(value: sku, kind: "variant_sku", product_variant: variant)
+
+        if normalized_industry.present?
+          Identifiers::Registry.reserve!(value: normalized_industry, kind: "variant_industry", product_variant: variant)
+        end
+
+        Audit::Recorder.record!(
+          action: "product_variants.create",
+          outcome: "succeeded",
+          actor_user: @actor,
+          actor_label: @actor.display_name,
+          subject: variant,
+          after_values: { sku: variant.sku, product_id: variant.product_id, source: @source }
+        )
+
+        variant
+      end
+    rescue Identifiers::NormalizationError, Identifiers::Registry::ConflictError, Identifiers::Generator::ExhaustedError, ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
+      raise Error, e.message
+    end
+
+    private
+
+    def find_optional(model, id)
+      return if id.blank?
+
+      model.find(id)
+    end
+
+    def allocate_221!
+      attempts = 0
+      begin
+        attempts += 1
+        value = Identifiers::Generator.next_ean13!("221")
+        return value unless Identifiers::Registry.find_any(value) || ProductVariant.exists?(sku: value)
+
+        raise Identifiers::Registry::ConflictError, "generated SKU collision" if attempts < 5
+
+        raise Identifiers::Registry::ConflictError, "unable to allocate unique 221 SKU"
+      rescue Identifiers::Registry::ConflictError
+        retry if attempts < 5
+        raise
+      end
+    end
+  end
+end

--- a/app/services/product_variants/default_resolver.rb
+++ b/app/services/product_variants/default_resolver.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module ProductVariants
+  class DefaultResolver
+    Result = Struct.new(:merchandise_class, :department, :tax_class, :suggested_price_cents, keyword_init: true)
+
+    def self.resolve(**attrs)
+      new(**attrs).resolve
+    end
+
+    def initialize(product:, condition:, merchandise_class: nil, department: nil, tax_class: nil, regular_price_cents: nil)
+      @product = product
+      @condition = condition
+      @merchandise_class = merchandise_class
+      @department = department
+      @tax_class = tax_class
+      @regular_price_cents = regular_price_cents
+    end
+
+    def resolve
+      klass = @merchandise_class || @product.merchandise_category&.default_merchandise_class
+      department = @department || department_from(klass)
+      tax = @tax_class || department&.default_tax_class
+      price = @regular_price_cents
+      if price.nil? && @product.list_price_cents.present? && @condition
+        price = (@product.list_price_cents * @condition.price_adjustment_bps / 10_000.0).round
+      end
+
+      Result.new(
+        merchandise_class: klass,
+        department: department,
+        tax_class: tax,
+        suggested_price_cents: price
+      )
+    end
+
+    private
+
+    def department_from(klass)
+      return if klass.blank?
+
+      if @condition&.used_basis?
+        klass.default_used_department
+      else
+        klass.default_standard_department
+      end
+    end
+  end
+end

--- a/app/services/product_variants/default_resolver.rb
+++ b/app/services/product_variants/default_resolver.rb
@@ -26,7 +26,8 @@ module ProductVariants
       if price.nil? && @product.list_price_cents.present?
         price =
           if @variant_type == "used" && @condition
-            (@product.list_price_cents * @condition.price_adjustment_bps / 10_000.0).round
+            # Half-up integer rounding: (cents * bps + 5000) / 10000
+            (@product.list_price_cents * @condition.price_adjustment_bps + 5_000) / 10_000
           else
             @product.list_price_cents
           end

--- a/app/services/product_variants/default_resolver.rb
+++ b/app/services/product_variants/default_resolver.rb
@@ -8,8 +8,9 @@ module ProductVariants
       new(**attrs).resolve
     end
 
-    def initialize(product:, condition:, merchandise_class: nil, department: nil, tax_class: nil, regular_price_cents: nil)
+    def initialize(product:, variant_type:, condition: nil, merchandise_class: nil, department: nil, tax_class: nil, regular_price_cents: nil)
       @product = product
+      @variant_type = variant_type.to_s
       @condition = condition
       @merchandise_class = merchandise_class
       @department = department
@@ -22,8 +23,13 @@ module ProductVariants
       department = @department || department_from(klass)
       tax = @tax_class || department&.default_tax_class
       price = @regular_price_cents
-      if price.nil? && @product.list_price_cents.present? && @condition
-        price = (@product.list_price_cents * @condition.price_adjustment_bps / 10_000.0).round
+      if price.nil? && @product.list_price_cents.present?
+        price =
+          if @variant_type == "used" && @condition
+            (@product.list_price_cents * @condition.price_adjustment_bps / 10_000.0).round
+          else
+            @product.list_price_cents
+          end
       end
 
       Result.new(
@@ -39,7 +45,7 @@ module ProductVariants
     def department_from(klass)
       return if klass.blank?
 
-      if @condition&.used_basis?
+      if @variant_type == "used"
         klass.default_used_department
       else
         klass.default_standard_department

--- a/app/services/product_variants/update.rb
+++ b/app/services/product_variants/update.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module ProductVariants
+  class Update
+    class Error < StandardError; end
+
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(variant:, attributes:, actor:, source: "ui", store: nil)
+      @variant = variant
+      attrs = attributes.to_h.symbolize_keys
+      @lock_version = attrs[:lock_version]
+      @attributes = attrs.except(:sku, :lock_version)
+      @actor = actor
+      @source = source
+      @store = store
+    end
+
+    def call
+      ProductVariant.transaction do
+        before = @variant.attributes.slice(*audit_keys)
+
+        if @attributes.key?(:industry_identifier)
+          Identifiers::AssignIndustry.call(
+            variant: @variant,
+            raw_value: @attributes[:industry_identifier],
+            actor: @actor,
+            source: @source
+          )
+        end
+
+        non_id_attrs = @attributes.except(:industry_identifier)
+        @variant.assign_attributes(non_id_attrs) if non_id_attrs.any?
+        @variant.lock_version = @lock_version unless @lock_version.nil?
+        @variant.save!
+
+        Audit::Recorder.record!(
+          action: "product_variants.update",
+          outcome: "succeeded",
+          actor_user: @actor,
+          actor_label: @actor.display_name,
+          store: @store,
+          subject: @variant,
+          before_values: before,
+          after_values: @variant.attributes.slice(*before.keys).merge(source: @source)
+        )
+
+        @variant
+      end
+    rescue Identifiers::AssignIndustry::Error, ActiveRecord::RecordInvalid => e
+      raise Error, e.message
+    end
+
+    private
+
+    def audit_keys
+      %w[
+        variant_type name option_value_1 option_value_2 merchandise_condition_id merchandise_class_id
+        department_id tax_class_id regular_price_cents status industry_identifier
+      ]
+    end
+  end
+end

--- a/app/services/product_variants/update.rb
+++ b/app/services/product_variants/update.rb
@@ -21,19 +21,20 @@ module ProductVariants
     def call
       ProductVariant.transaction do
         before = @variant.attributes.slice(*audit_keys)
+        @variant.lock_version = @lock_version unless @lock_version.nil?
 
         if @attributes.key?(:industry_identifier)
           Identifiers::AssignIndustry.call(
             variant: @variant,
             raw_value: @attributes[:industry_identifier],
             actor: @actor,
-            source: @source
+            source: @source,
+            persist: false
           )
         end
 
         non_id_attrs = @attributes.except(:industry_identifier)
         @variant.assign_attributes(non_id_attrs) if non_id_attrs.any?
-        @variant.lock_version = @lock_version unless @lock_version.nil?
         @variant.save!
 
         Audit::Recorder.record!(

--- a/app/services/products/create.rb
+++ b/app/services/products/create.rb
@@ -30,6 +30,7 @@ module Products
           end
 
         product = Product.new(@attributes.merge(primary_identifier: primary))
+        product.identifier_writes_enabled = true
         product.save!
 
         Identifiers::Registry.reserve!(value: primary, kind: "product_primary", product: product)

--- a/app/services/products/create.rb
+++ b/app/services/products/create.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module Products
+  class Create
+    class Error < StandardError; end
+
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(attributes:, actor:, identifier_mode:, external_identifier: nil, source: "ui")
+      @attributes = attributes
+      @actor = actor
+      @identifier_mode = identifier_mode.to_s
+      @external_identifier = external_identifier
+      @source = source
+    end
+
+    def call
+      raise Error, "identifier mode must be enter or generate" unless %w[enter generate].include?(@identifier_mode)
+      raise Error, "external identifier is required" if @identifier_mode == "enter" && @external_identifier.blank?
+      raise Error, "external identifier must be blank when generating" if @identifier_mode == "generate" && @external_identifier.present?
+
+      Product.transaction do
+        primary =
+          if @identifier_mode == "generate"
+            allocate_222!
+          else
+            Identifiers::Normalizer.normalize(@external_identifier, allow_shelfsense_222: false)
+          end
+
+        product = Product.new(@attributes.merge(primary_identifier: primary))
+        product.save!
+
+        Identifiers::Registry.reserve!(value: primary, kind: "product_primary", product: product)
+
+        Audit::Recorder.record!(
+          action: "products.create",
+          outcome: "succeeded",
+          actor_user: @actor,
+          actor_label: @actor.display_name,
+          subject: product,
+          after_values: {
+            name: product.name,
+            primary_identifier: product.primary_identifier,
+            identifier_source: @identifier_mode,
+            source: @source
+          }
+        )
+
+        product
+      end
+    rescue Identifiers::NormalizationError, Identifiers::Registry::ConflictError, Identifiers::Generator::ExhaustedError, ActiveRecord::RecordInvalid => e
+      raise Error, e.message
+    end
+
+    private
+
+    def allocate_222!
+      attempts = 0
+      begin
+        attempts += 1
+        value = Identifiers::Generator.next_ean13!("222")
+        return value unless Identifiers::Registry.find_any(value) || Product.exists?(primary_identifier: value)
+
+        raise Identifiers::Registry::ConflictError, "generated identifier collision" if attempts < 5
+
+        raise Identifiers::Registry::ConflictError, "unable to allocate unique 222 identifier"
+      rescue Identifiers::Registry::ConflictError
+        retry if attempts < 5
+        raise
+      end
+    end
+  end
+end

--- a/app/services/products/update.rb
+++ b/app/services/products/update.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Products
+  class Update
+    class Error < StandardError; end
+
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(product:, attributes:, actor:, source: "ui", store: nil)
+      @product = product
+      attrs = attributes.to_h.symbolize_keys
+      @lock_version = attrs[:lock_version]
+      @attributes = attrs.except(:primary_identifier, :lock_version)
+      @actor = actor
+      @source = source
+      @store = store
+    end
+
+    def call
+      Product.transaction do
+        before = @product.attributes.slice(*audit_keys)
+        update_attrs = @attributes.dup
+        update_attrs[:lock_version] = @lock_version unless @lock_version.nil?
+        @product.update!(update_attrs)
+        Audit::Recorder.record!(
+          action: "products.update",
+          outcome: "succeeded",
+          actor_user: @actor,
+          actor_label: @actor.display_name,
+          store: @store,
+          subject: @product,
+          before_values: before,
+          after_values: @product.attributes.slice(*before.keys).merge(source: @source)
+        )
+        @product
+      end
+    rescue ActiveRecord::RecordInvalid => e
+      raise Error, e.message
+    end
+
+    private
+
+    def audit_keys
+      %w[
+        name subtitle description brand_name product_model merchandise_category_id
+        list_price_cents release_date status variant_option_name_1 variant_option_name_2
+      ]
+    end
+  end
+end

--- a/app/views/admin/departments/_form.html.erb
+++ b/app/views/admin/departments/_form.html.erb
@@ -1,0 +1,32 @@
+<%= form_with model: [:admin, department] do |form| %>
+  <% if department.errors.any? %><ul><% department.errors.full_messages.each do |m| %><li><%= m %></li><% end %></ul><% end %>
+  <%= form.hidden_field :lock_version %>
+  <p><%= form.label :code %><%= form.text_field :code %></p>
+  <p><%= form.label :department_number %><%= form.text_field :department_number %></p>
+  <p><%= form.label :name %><%= form.text_field :name %></p>
+  <p><%= form.label :description %><%= form.text_area :description %></p>
+  <p>
+    <%= form.label :default_tax_class_id, "Default tax class" %>
+    <%= form.select :default_tax_class_id, @tax_classes.map { |t| ["#{t.code} — #{t.name}", t.id] }, include_blank: true %>
+  </p>
+  <p><%= form.label :default_target_margin_bps %><%= form.number_field :default_target_margin_bps %></p>
+  <% [
+    [:inventory_asset_gl_account_id, "Inventory asset GL"],
+    [:cost_of_goods_sold_gl_account_id, "COGS GL"],
+    [:sales_revenue_gl_account_id, "Sales revenue GL"],
+    [:sales_returns_gl_account_id, "Sales returns GL"],
+    [:receiving_clearing_gl_account_id, "Receiving clearing GL"],
+    [:freight_in_gl_account_id, "Freight in GL"],
+    [:inventory_shrinkage_gl_account_id, "Shrinkage GL"],
+    [:inventory_adjustment_gain_gl_account_id, "Adjustment gain GL"],
+    [:inventory_adjustment_loss_gl_account_id, "Adjustment loss GL"],
+    [:inventory_write_down_gl_account_id, "Write-down GL"]
+  ].each do |field, label| %>
+    <p>
+      <%= form.label field, label %>
+      <%= form.select field, @gl_accounts.map { |a| ["#{a.account_number} — #{a.name}", a.id] }, include_blank: "None" %>
+    </p>
+  <% end %>
+  <p><%= form.label :display_order %><%= form.number_field :display_order %></p>
+  <p><%= form.submit %></p>
+<% end %>

--- a/app/views/admin/departments/edit.html.erb
+++ b/app/views/admin/departments/edit.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "Edit department" %>
+<h1>Edit department</h1>
+<%= render "form", department: @department %>

--- a/app/views/admin/departments/index.html.erb
+++ b/app/views/admin/departments/index.html.erb
@@ -1,0 +1,11 @@
+<% content_for :title, "Departments" %>
+<h1>Departments</h1>
+<% if effective_permissions.include?("departments.create") %><p><%= link_to "New department", new_admin_department_path %></p><% end %>
+<ul>
+  <% @departments.each do |department| %>
+    <li>
+      <%= link_to "#{department.code} — #{department.name}", admin_department_path(department) %>
+      <%= "inactive" unless department.active? %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/admin/departments/new.html.erb
+++ b/app/views/admin/departments/new.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "New department" %>
+<h1>New department</h1>
+<%= render "form", department: @department %>

--- a/app/views/admin/departments/show.html.erb
+++ b/app/views/admin/departments/show.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title, @department.name %>
+<h1><%= @department.code %> — <%= @department.name %></h1>
+<p>
+  Number: <%= @department.department_number.presence || "—" %> ·
+  Tax class: <%= @department.default_tax_class.code %> ·
+  Margin bps: <%= @department.default_target_margin_bps.presence || "—" %> ·
+  Order: <%= @department.display_order %> ·
+  <%= @department.active? ? "active" : "inactive" %>
+</p>
+<% if @department.description.present? %><p><%= @department.description %></p><% end %>
+<p>
+  <%= link_to "Edit", edit_admin_department_path(@department) if effective_permissions.include?("departments.update") %>
+  <% if effective_permissions.include?("departments.deactivate") && @department.active? %>
+    <%= button_to "Deactivate", admin_department_path(@department), method: :delete, form: { data: { turbo_confirm: "Deactivate this department?" } } %>
+  <% end %>
+</p>
+<p><%= link_to "Back to departments", admin_departments_path %></p>

--- a/app/views/admin/gl_accounts/_form.html.erb
+++ b/app/views/admin/gl_accounts/_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_with model: [:admin, gl_account] do |form| %>
+  <% if gl_account.errors.any? %><ul><% gl_account.errors.full_messages.each do |m| %><li><%= m %></li><% end %></ul><% end %>
+  <%= form.hidden_field :lock_version %>
+  <p><%= form.label :account_number %><%= form.text_field :account_number %></p>
+  <p><%= form.label :name %><%= form.text_field :name %></p>
+  <p><%= form.label :description %><%= form.text_area :description %></p>
+  <p>
+    <%= form.label :account_type %>
+    <%= form.select :account_type, GlAccount::ACCOUNT_TYPES.map { |t| [t.humanize, t] }, include_blank: true %>
+  </p>
+  <p>
+    <%= form.label :account_category %>
+    <%= form.select :account_category, GlAccount::ACCOUNT_CATEGORIES.map { |c| [c.humanize, c] }, include_blank: true %>
+  </p>
+  <p>
+    <%= form.label :parent_id, "Parent" %>
+    <%= form.select :parent_id, @parent_options.map { |a| ["#{a.account_number} — #{a.name}", a.id] }, include_blank: "None" %>
+  </p>
+  <p><%= form.check_box :posting_allowed %><%= form.label :posting_allowed %></p>
+  <p><%= form.label :display_order %><%= form.number_field :display_order %></p>
+  <p><%= form.submit %></p>
+<% end %>

--- a/app/views/admin/gl_accounts/edit.html.erb
+++ b/app/views/admin/gl_accounts/edit.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "Edit GL account" %>
+<h1>Edit GL account</h1>
+<%= render "form", gl_account: @gl_account %>

--- a/app/views/admin/gl_accounts/index.html.erb
+++ b/app/views/admin/gl_accounts/index.html.erb
@@ -1,0 +1,11 @@
+<% content_for :title, "GL Accounts" %>
+<h1>GL Accounts</h1>
+<% if effective_permissions.include?("gl_accounts.create") %><p><%= link_to "New GL account", new_admin_gl_account_path %></p><% end %>
+<ul>
+  <% @gl_accounts.each do |gl_account| %>
+    <li>
+      <%= link_to "#{gl_account.account_number} — #{gl_account.name}", admin_gl_account_path(gl_account) %>
+      <%= "inactive" unless gl_account.active? %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/admin/gl_accounts/new.html.erb
+++ b/app/views/admin/gl_accounts/new.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "New GL account" %>
+<h1>New GL account</h1>
+<%= render "form", gl_account: @gl_account %>

--- a/app/views/admin/gl_accounts/show.html.erb
+++ b/app/views/admin/gl_accounts/show.html.erb
@@ -1,0 +1,19 @@
+<% content_for :title, @gl_account.name %>
+<h1><%= @gl_account.account_number %> — <%= @gl_account.name %></h1>
+<p>
+  Type: <%= @gl_account.account_type %> · Category: <%= @gl_account.account_category %> ·
+  Posting: <%= @gl_account.posting_allowed? ? "allowed" : "not allowed" %> ·
+  Order: <%= @gl_account.display_order %> ·
+  <%= @gl_account.active? ? "active" : "inactive" %>
+</p>
+<% if @gl_account.description.present? %><p><%= @gl_account.description %></p><% end %>
+<% if @gl_account.parent.present? %>
+  <p>Parent: <%= link_to "#{@gl_account.parent.account_number} — #{@gl_account.parent.name}", admin_gl_account_path(@gl_account.parent) %></p>
+<% end %>
+<p>
+  <%= link_to "Edit", edit_admin_gl_account_path(@gl_account) if effective_permissions.include?("gl_accounts.update") %>
+  <% if effective_permissions.include?("gl_accounts.deactivate") && @gl_account.active? %>
+    <%= button_to "Deactivate", admin_gl_account_path(@gl_account), method: :delete, form: { data: { turbo_confirm: "Deactivate this GL account?" } } %>
+  <% end %>
+</p>
+<p><%= link_to "Back to GL accounts", admin_gl_accounts_path %></p>

--- a/app/views/admin/merchandise_categories/_form.html.erb
+++ b/app/views/admin/merchandise_categories/_form.html.erb
@@ -1,0 +1,17 @@
+<%= form_with model: [:admin, merchandise_category] do |form| %>
+  <% if merchandise_category.errors.any? %><ul><% merchandise_category.errors.full_messages.each do |m| %><li><%= m %></li><% end %></ul><% end %>
+  <%= form.hidden_field :lock_version %>
+  <p><%= form.label :code %><%= form.text_field :code %></p>
+  <p><%= form.label :name %><%= form.text_field :name %></p>
+  <p><%= form.label :description %><%= form.text_area :description %></p>
+  <p>
+    <%= form.label :parent_id, "Parent" %>
+    <%= form.select :parent_id, @parent_options.map { |c| [c.name, c.id] }, include_blank: "None" %>
+  </p>
+  <p>
+    <%= form.label :default_merchandise_class_id, "Default merchandise class" %>
+    <%= form.select :default_merchandise_class_id, @merchandise_classes.map { |c| ["#{c.code} — #{c.name}", c.id] }, include_blank: "None" %>
+  </p>
+  <p><%= form.label :display_order %><%= form.number_field :display_order %></p>
+  <p><%= form.submit %></p>
+<% end %>

--- a/app/views/admin/merchandise_categories/edit.html.erb
+++ b/app/views/admin/merchandise_categories/edit.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "Edit merchandise category" %>
+<h1>Edit merchandise category</h1>
+<%= render "form", merchandise_category: @merchandise_category %>

--- a/app/views/admin/merchandise_categories/index.html.erb
+++ b/app/views/admin/merchandise_categories/index.html.erb
@@ -1,0 +1,11 @@
+<% content_for :title, "Merchandise Categories" %>
+<h1>Merchandise Categories</h1>
+<% if effective_permissions.include?("merchandise_categories.create") %><p><%= link_to "New category", new_admin_merchandise_category_path %></p><% end %>
+<ul>
+  <% @merchandise_categories.each do |category| %>
+    <li>
+      <%= link_to "#{category.code.presence || "—"} — #{category.name}", admin_merchandise_category_path(category) %>
+      <%= "inactive" unless category.active? %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/admin/merchandise_categories/new.html.erb
+++ b/app/views/admin/merchandise_categories/new.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "New merchandise category" %>
+<h1>New merchandise category</h1>
+<%= render "form", merchandise_category: @merchandise_category %>

--- a/app/views/admin/merchandise_categories/show.html.erb
+++ b/app/views/admin/merchandise_categories/show.html.erb
@@ -1,0 +1,16 @@
+<% content_for :title, @merchandise_category.name %>
+<h1><%= @merchandise_category.code.presence || "—" %> — <%= @merchandise_category.name %></h1>
+<p>
+  Parent: <%= @merchandise_category.parent&.name || "—" %> ·
+  Default class: <%= @merchandise_category.default_merchandise_class&.code || "—" %> ·
+  Order: <%= @merchandise_category.display_order %> ·
+  <%= @merchandise_category.active? ? "active" : "inactive" %>
+</p>
+<% if @merchandise_category.description.present? %><p><%= @merchandise_category.description %></p><% end %>
+<p>
+  <%= link_to "Edit", edit_admin_merchandise_category_path(@merchandise_category) if effective_permissions.include?("merchandise_categories.update") %>
+  <% if effective_permissions.include?("merchandise_categories.deactivate") && @merchandise_category.active? %>
+    <%= button_to "Deactivate", admin_merchandise_category_path(@merchandise_category), method: :delete, form: { data: { turbo_confirm: "Deactivate this category?" } } %>
+  <% end %>
+</p>
+<p><%= link_to "Back to categories", admin_merchandise_categories_path %></p>

--- a/app/views/admin/merchandise_classes/_form.html.erb
+++ b/app/views/admin/merchandise_classes/_form.html.erb
@@ -1,0 +1,28 @@
+<%= form_with model: [:admin, merchandise_class] do |form| %>
+  <% if merchandise_class.errors.any? %><ul><% merchandise_class.errors.full_messages.each do |m| %><li><%= m %></li><% end %></ul><% end %>
+  <%= form.hidden_field :lock_version %>
+  <p><%= form.label :code %><%= form.text_field :code %></p>
+  <p><%= form.label :name %><%= form.text_field :name %></p>
+  <p><%= form.label :description %><%= form.text_area :description %></p>
+  <p>
+    <%= form.label :inventory_tracking_mode %>
+    <%= form.select :inventory_tracking_mode, MerchandiseClass::TRACKING_MODES.map { |m| [m.humanize, m] } %>
+  </p>
+  <p>
+    <%= form.label :pricing_method %>
+    <%= form.select :pricing_method, MerchandiseClass::PRICING_METHODS.map { |m| [m.humanize, m] } %>
+  </p>
+  <p>
+    <%= form.label :default_standard_department_id, "Default standard department" %>
+    <%= form.select :default_standard_department_id, @departments.map { |d| ["#{d.code} — #{d.name}", d.id] }, include_blank: "None" %>
+  </p>
+  <p>
+    <%= form.label :default_used_department_id, "Default used department" %>
+    <%= form.select :default_used_department_id, @departments.map { |d| ["#{d.code} — #{d.name}", d.id] }, include_blank: "None" %>
+  </p>
+  <p><%= form.check_box :used_merchandise_allowed %><%= form.label :used_merchandise_allowed %></p>
+  <p><%= form.check_box :buyback_allowed %><%= form.label :buyback_allowed %></p>
+  <p><%= form.check_box :default_returnable %><%= form.label :default_returnable %></p>
+  <p><%= form.label :display_order %><%= form.number_field :display_order %></p>
+  <p><%= form.submit %></p>
+<% end %>

--- a/app/views/admin/merchandise_classes/_form.html.erb
+++ b/app/views/admin/merchandise_classes/_form.html.erb
@@ -5,8 +5,8 @@
   <p><%= form.label :name %><%= form.text_field :name %></p>
   <p><%= form.label :description %><%= form.text_area :description %></p>
   <p>
-    <%= form.label :inventory_tracking_mode %>
-    <%= form.select :inventory_tracking_mode, MerchandiseClass::TRACKING_MODES.map { |m| [m.humanize, m] } %>
+    <%= form.label :inventory_mode %>
+    <%= form.select :inventory_mode, MerchandiseClass::INVENTORY_MODES.map { |m| [m.humanize, m] } %>
   </p>
   <p>
     <%= form.label :pricing_method %>

--- a/app/views/admin/merchandise_classes/edit.html.erb
+++ b/app/views/admin/merchandise_classes/edit.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "Edit merchandise class" %>
+<h1>Edit merchandise class</h1>
+<%= render "form", merchandise_class: @merchandise_class %>

--- a/app/views/admin/merchandise_classes/index.html.erb
+++ b/app/views/admin/merchandise_classes/index.html.erb
@@ -1,0 +1,11 @@
+<% content_for :title, "Merchandise Classes" %>
+<h1>Merchandise Classes</h1>
+<% if effective_permissions.include?("merchandise_classes.create") %><p><%= link_to "New merchandise class", new_admin_merchandise_class_path %></p><% end %>
+<ul>
+  <% @merchandise_classes.each do |merchandise_class| %>
+    <li>
+      <%= link_to "#{merchandise_class.code} — #{merchandise_class.name}", admin_merchandise_class_path(merchandise_class) %>
+      <%= "inactive" unless merchandise_class.active? %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/admin/merchandise_classes/new.html.erb
+++ b/app/views/admin/merchandise_classes/new.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "New merchandise class" %>
+<h1>New merchandise class</h1>
+<%= render "form", merchandise_class: @merchandise_class %>

--- a/app/views/admin/merchandise_classes/show.html.erb
+++ b/app/views/admin/merchandise_classes/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, @merchandise_class.name %>
 <h1><%= @merchandise_class.code %> — <%= @merchandise_class.name %></h1>
 <p>
-  Tracking: <%= @merchandise_class.inventory_tracking_mode %> ·
+  Inventory: <%= @merchandise_class.inventory_mode %> ·
   Pricing: <%= @merchandise_class.pricing_method %> ·
   Order: <%= @merchandise_class.display_order %> ·
   <%= @merchandise_class.active? ? "active" : "inactive" %>

--- a/app/views/admin/merchandise_classes/show.html.erb
+++ b/app/views/admin/merchandise_classes/show.html.erb
@@ -1,0 +1,16 @@
+<% content_for :title, @merchandise_class.name %>
+<h1><%= @merchandise_class.code %> — <%= @merchandise_class.name %></h1>
+<p>
+  Tracking: <%= @merchandise_class.inventory_tracking_mode %> ·
+  Pricing: <%= @merchandise_class.pricing_method %> ·
+  Order: <%= @merchandise_class.display_order %> ·
+  <%= @merchandise_class.active? ? "active" : "inactive" %>
+</p>
+<% if @merchandise_class.description.present? %><p><%= @merchandise_class.description %></p><% end %>
+<p>
+  <%= link_to "Edit", edit_admin_merchandise_class_path(@merchandise_class) if effective_permissions.include?("merchandise_classes.update") %>
+  <% if effective_permissions.include?("merchandise_classes.deactivate") && @merchandise_class.active? %>
+    <%= button_to "Deactivate", admin_merchandise_class_path(@merchandise_class), method: :delete, form: { data: { turbo_confirm: "Deactivate this merchandise class?" } } %>
+  <% end %>
+</p>
+<p><%= link_to "Back to merchandise classes", admin_merchandise_classes_path %></p>

--- a/app/views/admin/merchandise_conditions/_form.html.erb
+++ b/app/views/admin/merchandise_conditions/_form.html.erb
@@ -1,0 +1,14 @@
+<%= form_with model: [:admin, merchandise_condition] do |form| %>
+  <% if merchandise_condition.errors.any? %><ul><% merchandise_condition.errors.full_messages.each do |m| %><li><%= m %></li><% end %></ul><% end %>
+  <%= form.hidden_field :lock_version %>
+  <p><%= form.label :code %><%= form.text_field :code %></p>
+  <p><%= form.label :name %><%= form.text_field :name %></p>
+  <p><%= form.label :description %><%= form.text_area :description %></p>
+  <p>
+    <%= form.label :department_basis %>
+    <%= form.select :department_basis, MerchandiseCondition::DEPARTMENT_BASES.map { |b| [b.humanize, b] } %>
+  </p>
+  <p><%= form.label :price_adjustment_bps %><%= form.number_field :price_adjustment_bps %></p>
+  <p><%= form.label :display_order %><%= form.number_field :display_order %></p>
+  <p><%= form.submit %></p>
+<% end %>

--- a/app/views/admin/merchandise_conditions/_form.html.erb
+++ b/app/views/admin/merchandise_conditions/_form.html.erb
@@ -4,10 +4,6 @@
   <p><%= form.label :code %><%= form.text_field :code %></p>
   <p><%= form.label :name %><%= form.text_field :name %></p>
   <p><%= form.label :description %><%= form.text_area :description %></p>
-  <p>
-    <%= form.label :department_basis %>
-    <%= form.select :department_basis, MerchandiseCondition::DEPARTMENT_BASES.map { |b| [b.humanize, b] } %>
-  </p>
   <p><%= form.label :price_adjustment_bps %><%= form.number_field :price_adjustment_bps %></p>
   <p><%= form.label :display_order %><%= form.number_field :display_order %></p>
   <p><%= form.submit %></p>

--- a/app/views/admin/merchandise_conditions/edit.html.erb
+++ b/app/views/admin/merchandise_conditions/edit.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "Edit merchandise condition" %>
+<h1>Edit merchandise condition</h1>
+<%= render "form", merchandise_condition: @merchandise_condition %>

--- a/app/views/admin/merchandise_conditions/index.html.erb
+++ b/app/views/admin/merchandise_conditions/index.html.erb
@@ -1,0 +1,11 @@
+<% content_for :title, "Merchandise Conditions" %>
+<h1>Merchandise Conditions</h1>
+<% if effective_permissions.include?("merchandise_conditions.create") %><p><%= link_to "New condition", new_admin_merchandise_condition_path %></p><% end %>
+<ul>
+  <% @merchandise_conditions.each do |condition| %>
+    <li>
+      <%= link_to "#{condition.code} — #{condition.name}", admin_merchandise_condition_path(condition) %>
+      <%= "inactive" unless condition.active? %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/admin/merchandise_conditions/new.html.erb
+++ b/app/views/admin/merchandise_conditions/new.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "New merchandise condition" %>
+<h1>New merchandise condition</h1>
+<%= render "form", merchandise_condition: @merchandise_condition %>

--- a/app/views/admin/merchandise_conditions/show.html.erb
+++ b/app/views/admin/merchandise_conditions/show.html.erb
@@ -1,0 +1,16 @@
+<% content_for :title, @merchandise_condition.name %>
+<h1><%= @merchandise_condition.code %> — <%= @merchandise_condition.name %></h1>
+<p>
+  Basis: <%= @merchandise_condition.department_basis %> ·
+  Price adjustment bps: <%= @merchandise_condition.price_adjustment_bps %> ·
+  Order: <%= @merchandise_condition.display_order %> ·
+  <%= @merchandise_condition.active? ? "active" : "inactive" %>
+</p>
+<% if @merchandise_condition.description.present? %><p><%= @merchandise_condition.description %></p><% end %>
+<p>
+  <%= link_to "Edit", edit_admin_merchandise_condition_path(@merchandise_condition) if effective_permissions.include?("merchandise_conditions.update") %>
+  <% if effective_permissions.include?("merchandise_conditions.deactivate") && @merchandise_condition.active? %>
+    <%= button_to "Deactivate", admin_merchandise_condition_path(@merchandise_condition), method: :delete, form: { data: { turbo_confirm: "Deactivate this condition?" } } %>
+  <% end %>
+</p>
+<p><%= link_to "Back to conditions", admin_merchandise_conditions_path %></p>

--- a/app/views/admin/merchandise_conditions/show.html.erb
+++ b/app/views/admin/merchandise_conditions/show.html.erb
@@ -1,7 +1,6 @@
 <% content_for :title, @merchandise_condition.name %>
 <h1><%= @merchandise_condition.code %> — <%= @merchandise_condition.name %></h1>
 <p>
-  Basis: <%= @merchandise_condition.department_basis %> ·
   Price adjustment bps: <%= @merchandise_condition.price_adjustment_bps %> ·
   Order: <%= @merchandise_condition.display_order %> ·
   <%= @merchandise_condition.active? ? "active" : "inactive" %>

--- a/app/views/admin/merchandise_imports/new.html.erb
+++ b/app/views/admin/merchandise_imports/new.html.erb
@@ -1,0 +1,24 @@
+<% content_for :title, "Merchandise import" %>
+<h1>Merchandise CSV import</h1>
+<%= form_with url: admin_merchandise_imports_path, scope: :import, html: { multipart: true } do |form| %>
+  <p><%= form.label :file, "CSV file" %><%= form.file_field :file, accept: ".csv,text/csv" %></p>
+  <p><%= form.submit "Import" %></p>
+<% end %>
+
+<% if @result %>
+  <h2>Import result</h2>
+  <ul>
+    <li>Products created: <%= @result.created_products %></li>
+    <li>Products updated: <%= @result.updated_products %></li>
+    <li>Variants created: <%= @result.created_variants %></li>
+    <li>Variants updated: <%= @result.updated_variants %></li>
+  </ul>
+  <% if @result.errors.any? %>
+    <h3>Row errors</h3>
+    <ul>
+      <% @result.errors.each do |error| %>
+        <li>Row <%= error[:row] %>: <%= error[:message] %></li>
+      <% end %>
+    </ul>
+  <% end %>
+<% end %>

--- a/app/views/admin/merchandise_lookups/new.html.erb
+++ b/app/views/admin/merchandise_lookups/new.html.erb
@@ -1,0 +1,25 @@
+<% content_for :title, "Merchandise lookup" %>
+<h1>Merchandise lookup</h1>
+<%= form_with url: admin_merchandise_lookups_path, scope: :lookup do |form| %>
+  <p><%= form.label :raw, "Identifier" %><%= form.text_field :raw, value: @raw %></p>
+  <p><%= form.submit "Look up" %></p>
+<% end %>
+
+<% if @result %>
+  <h2>Result</h2>
+  <p>Status: <%= @result.status %></p>
+  <% if @result.message.present? %><p><%= @result.message %></p><% end %>
+  <% if @result.product %>
+    <p>Product: <%= link_to "#{@result.product.primary_identifier} — #{@result.product.name}", admin_product_path(@result.product) %></p>
+  <% end %>
+  <% if @result.variant %>
+    <p>Variant: <%= link_to "#{@result.variant.sku} — #{@result.variant.name.presence || "unnamed"}", admin_product_variant_path(@result.variant) %></p>
+  <% end %>
+  <% if @result.variants.present? %>
+    <ul>
+      <% @result.variants.each do |variant| %>
+        <li><%= link_to "#{variant.sku} — #{variant.name.presence || "unnamed"}", admin_product_variant_path(variant) %></li>
+      <% end %>
+    </ul>
+  <% end %>
+<% end %>

--- a/app/views/admin/product_variants/_form.html.erb
+++ b/app/views/admin/product_variants/_form.html.erb
@@ -1,0 +1,33 @@
+<%= form_with model: product_variant.persisted? ? [:admin, product_variant] : [:admin, product, product_variant] do |form| %>
+  <% if product_variant.errors.any? %><ul><% product_variant.errors.full_messages.each do |m| %><li><%= m %></li><% end %></ul><% end %>
+  <%= form.hidden_field :lock_version %>
+  <% if product_variant.persisted? %>
+    <p>SKU: <%= product_variant.sku %></p>
+  <% end %>
+  <p><%= form.label :name %><%= form.text_field :name %></p>
+  <p><%= form.label :option_value_1 %><%= form.text_field :option_value_1 %></p>
+  <p><%= form.label :option_value_2 %><%= form.text_field :option_value_2 %></p>
+  <p>
+    <%= form.label :merchandise_condition_id, "Condition" %>
+    <%= form.select :merchandise_condition_id, @merchandise_conditions.map { |c| ["#{c.code} — #{c.name}", c.id] }, include_blank: true %>
+  </p>
+  <p>
+    <%= form.label :merchandise_class_id, "Merchandise class" %>
+    <%= form.select :merchandise_class_id, @merchandise_classes.map { |c| ["#{c.code} — #{c.name}", c.id] }, include_blank: "Resolve default" %>
+  </p>
+  <p>
+    <%= form.label :department_id, "Department" %>
+    <%= form.select :department_id, @departments.map { |d| ["#{d.code} — #{d.name}", d.id] }, include_blank: "Resolve default" %>
+  </p>
+  <p>
+    <%= form.label :tax_class_id, "Tax class" %>
+    <%= form.select :tax_class_id, @tax_classes.map { |t| ["#{t.code} — #{t.name}", t.id] }, include_blank: "Resolve default" %>
+  </p>
+  <p><%= form.label :regular_price_cents %><%= form.number_field :regular_price_cents %></p>
+  <p><%= form.label :industry_identifier %><%= form.text_field :industry_identifier %></p>
+  <p>
+    <%= form.label :status %>
+    <%= form.select :status, ProductVariant::STATUSES.reject { |s| s == "discontinued" }.map { |s| [s.humanize, s] } %>
+  </p>
+  <p><%= form.submit %></p>
+<% end %>

--- a/app/views/admin/product_variants/_form.html.erb
+++ b/app/views/admin/product_variants/_form.html.erb
@@ -3,12 +3,18 @@
   <%= form.hidden_field :lock_version %>
   <% if product_variant.persisted? %>
     <p>SKU: <%= product_variant.sku %></p>
+    <p>Type: <%= product_variant.variant_type %></p>
+  <% else %>
+    <p>
+      <%= form.label :variant_type %>
+      <%= form.select :variant_type, ProductVariant::VARIANT_TYPES.map { |t| [t.humanize, t] } %>
+    </p>
   <% end %>
   <p><%= form.label :name %><%= form.text_field :name %></p>
   <p><%= form.label :option_value_1 %><%= form.text_field :option_value_1 %></p>
   <p><%= form.label :option_value_2 %><%= form.text_field :option_value_2 %></p>
   <p>
-    <%= form.label :merchandise_condition_id, "Condition" %>
+    <%= form.label :merchandise_condition_id, "Condition (used variants only)" %>
     <%= form.select :merchandise_condition_id, @merchandise_conditions.map { |c| ["#{c.code} — #{c.name}", c.id] }, include_blank: true %>
   </p>
   <p>

--- a/app/views/admin/product_variants/edit.html.erb
+++ b/app/views/admin/product_variants/edit.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "Edit product variant" %>
+<h1>Edit variant <%= @product_variant.sku %></h1>
+<%= render "form", product_variant: @product_variant, product: @product %>

--- a/app/views/admin/product_variants/index.html.erb
+++ b/app/views/admin/product_variants/index.html.erb
@@ -1,0 +1,14 @@
+<% content_for :title, "Variants" %>
+<h1>Variants for <%= @product.name %></h1>
+<% if effective_permissions.include?("product_variants.create") %>
+  <p><%= link_to "New variant", new_admin_product_product_variant_path(@product) %></p>
+<% end %>
+<ul>
+  <% @product_variants.each do |variant| %>
+    <li>
+      <%= link_to "#{variant.sku} — #{variant.name.presence || "unnamed"}", admin_product_variant_path(variant) %>
+      (<%= variant.status %>)
+    </li>
+  <% end %>
+</ul>
+<p><%= link_to "Back to product", admin_product_path(@product) %></p>

--- a/app/views/admin/product_variants/new.html.erb
+++ b/app/views/admin/product_variants/new.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "New product variant" %>
+<h1>New variant for <%= @product.name %></h1>
+<%= render "form", product_variant: @product_variant, product: @product %>

--- a/app/views/admin/product_variants/show.html.erb
+++ b/app/views/admin/product_variants/show.html.erb
@@ -1,0 +1,24 @@
+<% content_for :title, @product_variant.sku %>
+<h1><%= @product_variant.sku %></h1>
+<p>
+  Product: <%= link_to @product_variant.product.name, admin_product_path(@product_variant.product) %> ·
+  Status: <%= @product_variant.status %> ·
+  Condition: <%= @product_variant.merchandise_condition.code %> ·
+  Price cents: <%= @product_variant.regular_price_cents.presence || "—" %>
+</p>
+<p>
+  Class: <%= @product_variant.merchandise_class&.code || "—" %> ·
+  Department: <%= @product_variant.department&.code || "—" %> ·
+  Tax class: <%= @product_variant.tax_class&.code || "—" %> ·
+  Industry ID: <%= @product_variant.industry_identifier.presence || "—" %>
+</p>
+<p>
+  <%= link_to "Edit", edit_admin_product_variant_path(@product_variant) if effective_permissions.include?("product_variants.update") %>
+  <% if effective_permissions.include?("product_variants.discontinue") && @product_variant.status != "discontinued" %>
+    <%= button_to "Discontinue", discontinue_admin_product_variant_path(@product_variant), method: :post, form: { data: { turbo_confirm: "Discontinue this variant?" } } %>
+  <% end %>
+  <% if effective_permissions.include?("product_variants.update") && @product_variant.draft? %>
+    <%= button_to "Delete draft", admin_product_variant_path(@product_variant), method: :delete, form: { data: { turbo_confirm: "Delete this draft variant and retire its identifiers?" } } %>
+  <% end %>
+</p>
+<p><%= link_to "Back to product", admin_product_path(@product_variant.product) %></p>

--- a/app/views/admin/product_variants/show.html.erb
+++ b/app/views/admin/product_variants/show.html.erb
@@ -2,8 +2,9 @@
 <h1><%= @product_variant.sku %></h1>
 <p>
   Product: <%= link_to @product_variant.product.name, admin_product_path(@product_variant.product) %> ·
+  Type: <%= @product_variant.variant_type %> ·
   Status: <%= @product_variant.status %> ·
-  Condition: <%= @product_variant.merchandise_condition.code %> ·
+  Condition: <%= @product_variant.merchandise_condition&.code || "—" %> ·
   Price cents: <%= @product_variant.regular_price_cents.presence || "—" %>
 </p>
 <p>

--- a/app/views/admin/products/_form.html.erb
+++ b/app/views/admin/products/_form.html.erb
@@ -1,0 +1,34 @@
+<%= form_with model: [:admin, product] do |form| %>
+  <% if product.errors.any? %><ul><% product.errors.full_messages.each do |m| %><li><%= m %></li><% end %></ul><% end %>
+  <%= form.hidden_field :lock_version %>
+  <% if creating %>
+    <p>
+      <%= form.label :identifier_mode, "Identifier mode" %>
+      <%= select_tag "product[identifier_mode]", options_for_select([["Enter external", "enter"], ["Generate ShelfSense (222)", "generate"]], params.dig(:product, :identifier_mode) || "enter") %>
+    </p>
+    <p>
+      <%= form.label :external_identifier, "External identifier" %>
+      <%= text_field_tag "product[external_identifier]", params.dig(:product, :external_identifier) %>
+    </p>
+  <% else %>
+    <p>Primary identifier: <%= product.primary_identifier %></p>
+  <% end %>
+  <p><%= form.label :name %><%= form.text_field :name %></p>
+  <p><%= form.label :subtitle %><%= form.text_field :subtitle %></p>
+  <p><%= form.label :description %><%= form.text_area :description %></p>
+  <p><%= form.label :brand_name %><%= form.text_field :brand_name %></p>
+  <p><%= form.label :product_model, "Model" %><%= form.text_field :product_model %></p>
+  <p>
+    <%= form.label :merchandise_category_id, "Category" %>
+    <%= form.select :merchandise_category_id, @merchandise_categories.map { |c| [c.name, c.id] }, include_blank: "None" %>
+  </p>
+  <p><%= form.label :list_price_cents %><%= form.number_field :list_price_cents %></p>
+  <p><%= form.label :release_date %><%= form.date_field :release_date %></p>
+  <p>
+    <%= form.label :status %>
+    <%= form.select :status, Product::STATUSES.reject { |s| s == "discontinued" }.map { |s| [s.humanize, s] } %>
+  </p>
+  <p><%= form.label :variant_option_name_1 %><%= form.text_field :variant_option_name_1 %></p>
+  <p><%= form.label :variant_option_name_2 %><%= form.text_field :variant_option_name_2 %></p>
+  <p><%= form.submit %></p>
+<% end %>

--- a/app/views/admin/products/edit.html.erb
+++ b/app/views/admin/products/edit.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "Edit product" %>
+<h1>Edit product</h1>
+<%= render "form", product: @product, creating: false %>

--- a/app/views/admin/products/index.html.erb
+++ b/app/views/admin/products/index.html.erb
@@ -1,0 +1,11 @@
+<% content_for :title, "Products" %>
+<h1>Products</h1>
+<% if effective_permissions.include?("products.create") %><p><%= link_to "New product", new_admin_product_path %></p><% end %>
+<ul>
+  <% @products.each do |product| %>
+    <li>
+      <%= link_to "#{product.primary_identifier} — #{product.name}", admin_product_path(product) %>
+      (<%= product.status %>)
+    </li>
+  <% end %>
+</ul>

--- a/app/views/admin/products/new.html.erb
+++ b/app/views/admin/products/new.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "New product" %>
+<h1>New product</h1>
+<%= render "form", product: @product, creating: true %>

--- a/app/views/admin/products/show.html.erb
+++ b/app/views/admin/products/show.html.erb
@@ -1,0 +1,32 @@
+<% content_for :title, @product.name %>
+<h1><%= @product.name %></h1>
+<p>
+  Identifier: <%= @product.primary_identifier %> ·
+  Status: <%= @product.status %> ·
+  Category: <%= @product.merchandise_category&.name || "—" %>
+</p>
+<% if @product.description.present? %><p><%= @product.description %></p><% end %>
+
+<h2>Variants</h2>
+<% if effective_permissions.include?("product_variants.create") %>
+  <p><%= link_to "New variant", new_admin_product_product_variant_path(@product) %></p>
+<% end %>
+<ul>
+  <% @product_variants.each do |variant| %>
+    <li>
+      <%= link_to "#{variant.sku} — #{variant.name.presence || "unnamed"}", admin_product_variant_path(variant) %>
+      (<%= variant.status %>)
+    </li>
+  <% end %>
+</ul>
+
+<p>
+  <%= link_to "Edit", edit_admin_product_path(@product) if effective_permissions.include?("products.update") %>
+  <% if effective_permissions.include?("products.discontinue") && @product.status != "discontinued" %>
+    <%= button_to "Discontinue", discontinue_admin_product_path(@product), method: :post, form: { data: { turbo_confirm: "Discontinue this product?" } } %>
+  <% end %>
+  <% if effective_permissions.include?("products.update") && @product.draft? %>
+    <%= button_to "Delete draft", admin_product_path(@product), method: :delete, form: { data: { turbo_confirm: "Delete this draft product and retire its identifier?" } } %>
+  <% end %>
+</p>
+<p><%= link_to "Back to products", admin_products_path %></p>

--- a/app/views/admin/tax_classes/_form.html.erb
+++ b/app/views/admin/tax_classes/_form.html.erb
@@ -1,0 +1,9 @@
+<%= form_with model: [:admin, tax_class] do |form| %>
+  <% if tax_class.errors.any? %><ul><% tax_class.errors.full_messages.each do |m| %><li><%= m %></li><% end %></ul><% end %>
+  <%= form.hidden_field :lock_version %>
+  <p><%= form.label :code %><%= form.text_field :code %></p>
+  <p><%= form.label :name %><%= form.text_field :name %></p>
+  <p><%= form.label :description %><%= form.text_area :description %></p>
+  <p><%= form.label :display_order %><%= form.number_field :display_order %></p>
+  <p><%= form.submit %></p>
+<% end %>

--- a/app/views/admin/tax_classes/edit.html.erb
+++ b/app/views/admin/tax_classes/edit.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "Edit tax class" %>
+<h1>Edit tax class</h1>
+<%= render "form", tax_class: @tax_class %>

--- a/app/views/admin/tax_classes/index.html.erb
+++ b/app/views/admin/tax_classes/index.html.erb
@@ -1,0 +1,11 @@
+<% content_for :title, "Tax Classes" %>
+<h1>Tax Classes</h1>
+<% if effective_permissions.include?("tax_classes.create") %><p><%= link_to "New tax class", new_admin_tax_class_path %></p><% end %>
+<ul>
+  <% @tax_classes.each do |tax_class| %>
+    <li>
+      <%= link_to "#{tax_class.code} — #{tax_class.name}", admin_tax_class_path(tax_class) %>
+      <%= "inactive" unless tax_class.active? %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/admin/tax_classes/new.html.erb
+++ b/app/views/admin/tax_classes/new.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "New tax class" %>
+<h1>New tax class</h1>
+<%= render "form", tax_class: @tax_class %>

--- a/app/views/admin/tax_classes/show.html.erb
+++ b/app/views/admin/tax_classes/show.html.erb
@@ -1,0 +1,11 @@
+<% content_for :title, @tax_class.name %>
+<h1><%= @tax_class.code %> — <%= @tax_class.name %></h1>
+<p>Order: <%= @tax_class.display_order %> · <%= @tax_class.active? ? "active" : "inactive" %></p>
+<% if @tax_class.description.present? %><p><%= @tax_class.description %></p><% end %>
+<p>
+  <%= link_to "Edit", edit_admin_tax_class_path(@tax_class) if effective_permissions.include?("tax_classes.update") %>
+  <% if effective_permissions.include?("tax_classes.deactivate") && @tax_class.active? %>
+    <%= button_to "Deactivate", admin_tax_class_path(@tax_class), method: :delete, form: { data: { turbo_confirm: "Deactivate this tax class?" } } %>
+  <% end %>
+</p>
+<p><%= link_to "Back to tax classes", admin_tax_classes_path %></p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,9 +20,37 @@
         <% if effective_permissions.include?("stores.view") || effective_permissions.include?("stores.create") %>
           <%= link_to "Stores", admin_stores_path %>
         <% end %>
+        <% if effective_permissions.include?("gl_accounts.view") %>
+          <%= link_to "GL Accounts", admin_gl_accounts_path %>
+        <% end %>
+        <% if effective_permissions.include?("tax_classes.view") %>
+          <%= link_to "Tax Classes", admin_tax_classes_path %>
+        <% end %>
+        <% if effective_permissions.include?("departments.view") %>
+          <%= link_to "Departments", admin_departments_path %>
+        <% end %>
+        <% if effective_permissions.include?("merchandise_classes.view") %>
+          <%= link_to "Merchandise classes", admin_merchandise_classes_path %>
+        <% end %>
+        <% if effective_permissions.include?("merchandise_categories.view") %>
+          <%= link_to "Categories", admin_merchandise_categories_path %>
+        <% end %>
+        <% if effective_permissions.include?("merchandise_conditions.view") %>
+          <%= link_to "Conditions", admin_merchandise_conditions_path %>
+        <% end %>
+        <% if effective_permissions.include?("products.view") %>
+          <%= link_to "Products", admin_products_path %>
+        <% end %>
+        <% if effective_permissions.include?("merchandise.lookup") %>
+          <%= link_to "Lookup", new_admin_merchandise_lookup_path %>
+        <% end %>
+        <% if effective_permissions.include?("merchandise.import") %>
+          <%= link_to "Import", new_admin_merchandise_import_path %>
+        <% end %>
         <% if effective_permissions.include?("users.view") %>
           <%= link_to "Users", admin_users_path %>
         <% end %>
+
         <% if effective_permissions.include?("roles.view") %>
           <%= link_to "Roles", admin_roles_path %>
         <% end %>

--- a/config/initializers/schema_dump_identifier_sequences.rb
+++ b/config/initializers/schema_dump_identifier_sequences.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Shelfsense
+  module SchemaDumpIdentifierSequences
+    SEQUENCE_SQL = [
+      "CREATE SEQUENCE IF NOT EXISTS shelfsense_sku_221_seq AS bigint MINVALUE 0 MAXVALUE 999999999 START WITH 0 INCREMENT BY 1 NO CYCLE",
+      "CREATE SEQUENCE IF NOT EXISTS shelfsense_product_222_seq AS bigint MINVALUE 0 MAXVALUE 999999999 START WITH 0 INCREMENT BY 1 NO CYCLE"
+    ].freeze
+
+    def tables(stream)
+      stream.puts "  # ShelfSense identifier allocation sequences (not owned by a table column)."
+      SEQUENCE_SQL.each do |sql|
+        stream.puts "  execute #{sql.inspect}"
+      end
+      stream.puts
+      super
+    end
+  end
+end
+
+ActiveSupport.on_load(:active_record) do
+  ActiveRecord::SchemaDumper.prepend(Shelfsense::SchemaDumpIdentifierSequences)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,24 @@ Rails.application.routes.draw do
   namespace :admin do
     resource :system_settings, only: %i[show edit update]
     resources :stores
+    resources :gl_accounts
+    resources :tax_classes
+    resources :departments
+    resources :merchandise_classes
+    resources :merchandise_categories
+    resources :merchandise_conditions
+    resources :products do
+      member do
+        post :discontinue
+      end
+      resources :product_variants, shallow: true do
+        member do
+          post :discontinue
+        end
+      end
+    end
+    resources :merchandise_lookups, only: %i[new create]
+    resources :merchandise_imports, only: %i[new create]
     resources :users do
       member do
         post :deactivate

--- a/db/migrate/20260810140000_create_phase2_financial_classifications.rb
+++ b/db/migrate/20260810140000_create_phase2_financial_classifications.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class CreatePhase2FinancialClassifications < ActiveRecord::Migration[8.1]
+  def change
+    create_uuid_table :gl_accounts do |t|
+      t.string :account_number, null: false
+      t.string :name, null: false
+      t.text :description
+      t.string :account_type, null: false
+      t.string :account_category, null: false
+      t.uuid :parent_id
+      t.boolean :posting_allowed, null: false, default: true
+      t.boolean :active, null: false, default: true
+      t.integer :display_order, null: false, default: 0
+      t.integer :lock_version, null: false, default: 0
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+
+    add_index :gl_accounts, :account_number, unique: true
+    add_index :gl_accounts, :parent_id
+    add_index :gl_accounts, [ :active, :account_number ]
+    add_foreign_key :gl_accounts, :gl_accounts, column: :parent_id
+    add_check_constraint :gl_accounts, "parent_id IS NULL OR parent_id <> id", name: "gl_accounts_parent_not_self"
+    add_check_constraint :gl_accounts,
+                         "account_type IN ('asset', 'liability', 'equity', 'revenue', 'expense')",
+                         name: "gl_accounts_account_type_valid"
+
+    create_uuid_table :tax_classes do |t|
+      t.string :code, null: false
+      t.string :name, null: false
+      t.text :description
+      t.boolean :active, null: false, default: true
+      t.integer :display_order, null: false, default: 0
+      t.integer :lock_version, null: false, default: 0
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+
+    add_index :tax_classes, :code, unique: true
+  end
+end

--- a/db/migrate/20260810141000_create_phase2_departments.rb
+++ b/db/migrate/20260810141000_create_phase2_departments.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class CreatePhase2Departments < ActiveRecord::Migration[8.1]
+  def change
+    create_uuid_table :departments do |t|
+      t.string :code, null: false
+      t.string :department_number
+      t.string :name, null: false
+      t.text :description
+      t.uuid :default_tax_class_id, null: false
+      t.integer :default_target_margin_bps
+      t.uuid :inventory_asset_gl_account_id
+      t.uuid :cost_of_goods_sold_gl_account_id
+      t.uuid :sales_revenue_gl_account_id
+      t.uuid :sales_returns_gl_account_id
+      t.uuid :receiving_clearing_gl_account_id
+      t.uuid :freight_in_gl_account_id
+      t.uuid :inventory_shrinkage_gl_account_id
+      t.uuid :inventory_adjustment_gain_gl_account_id
+      t.uuid :inventory_adjustment_loss_gl_account_id
+      t.uuid :inventory_write_down_gl_account_id
+      t.boolean :active, null: false, default: true
+      t.integer :display_order, null: false, default: 0
+      t.integer :lock_version, null: false, default: 0
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+
+    add_index :departments, :code, unique: true
+    add_index :departments, :department_number, unique: true, where: "department_number IS NOT NULL"
+    add_foreign_key :departments, :tax_classes, column: :default_tax_class_id
+    %w[
+      inventory_asset_gl_account_id
+      cost_of_goods_sold_gl_account_id
+      sales_revenue_gl_account_id
+      sales_returns_gl_account_id
+      receiving_clearing_gl_account_id
+      freight_in_gl_account_id
+      inventory_shrinkage_gl_account_id
+      inventory_adjustment_gain_gl_account_id
+      inventory_adjustment_loss_gl_account_id
+      inventory_write_down_gl_account_id
+    ].each do |column|
+      add_foreign_key :departments, :gl_accounts, column: column
+      add_index :departments, column
+    end
+    add_check_constraint :departments,
+                         "default_target_margin_bps IS NULL OR (default_target_margin_bps >= 0 AND default_target_margin_bps < 10000)",
+                         name: "departments_margin_bps_range"
+  end
+end

--- a/db/migrate/20260810142000_create_phase2_merchandise_reference.rb
+++ b/db/migrate/20260810142000_create_phase2_merchandise_reference.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+class CreatePhase2MerchandiseReference < ActiveRecord::Migration[8.1]
+  def change
+    create_uuid_table :merchandise_classes do |t|
+      t.string :code, null: false
+      t.string :name, null: false
+      t.text :description
+      t.string :inventory_tracking_mode, null: false
+      t.string :pricing_method, null: false
+      t.uuid :default_standard_department_id
+      t.uuid :default_used_department_id
+      t.boolean :used_merchandise_allowed, null: false, default: false
+      t.boolean :buyback_allowed, null: false, default: false
+      t.boolean :default_returnable, null: false, default: true
+      t.boolean :active, null: false, default: true
+      t.integer :display_order, null: false, default: 0
+      t.integer :lock_version, null: false, default: 0
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+
+    add_index :merchandise_classes, :code, unique: true
+    add_foreign_key :merchandise_classes, :departments, column: :default_standard_department_id
+    add_foreign_key :merchandise_classes, :departments, column: :default_used_department_id
+    add_check_constraint :merchandise_classes,
+                         "inventory_tracking_mode IN ('quantity', 'individual', 'non_inventory')",
+                         name: "merchandise_classes_tracking_mode_valid"
+    add_check_constraint :merchandise_classes,
+                         "pricing_method IN ('fixed', 'list_price', 'cost_based', 'open_price')",
+                         name: "merchandise_classes_pricing_method_valid"
+
+    create_uuid_table :merchandise_categories do |t|
+      t.string :code
+      t.string :name, null: false
+      t.text :description
+      t.uuid :parent_id
+      t.uuid :default_merchandise_class_id
+      t.boolean :active, null: false, default: true
+      t.integer :display_order, null: false, default: 0
+      t.integer :lock_version, null: false, default: 0
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+
+    add_index :merchandise_categories, :code, unique: true, where: "code IS NOT NULL"
+    add_index :merchandise_categories, "lower(name)", unique: true, where: "parent_id IS NULL", name: "index_merchandise_categories_root_name"
+    add_index :merchandise_categories, "parent_id, lower(name)", unique: true, where: "parent_id IS NOT NULL", name: "index_merchandise_categories_sibling_name"
+    add_foreign_key :merchandise_categories, :merchandise_categories, column: :parent_id
+    add_foreign_key :merchandise_categories, :merchandise_classes, column: :default_merchandise_class_id
+    add_check_constraint :merchandise_categories, "parent_id IS NULL OR parent_id <> id", name: "merchandise_categories_parent_not_self"
+
+    create_uuid_table :merchandise_conditions do |t|
+      t.string :code, null: false
+      t.string :name, null: false
+      t.text :description
+      t.string :department_basis, null: false
+      t.integer :price_adjustment_bps, null: false, default: 10_000
+      t.boolean :active, null: false, default: true
+      t.integer :display_order, null: false, default: 0
+      t.integer :lock_version, null: false, default: 0
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+
+    add_index :merchandise_conditions, :code, unique: true
+    add_check_constraint :merchandise_conditions,
+                         "department_basis IN ('standard', 'used')",
+                         name: "merchandise_conditions_department_basis_valid"
+    add_check_constraint :merchandise_conditions,
+                         "price_adjustment_bps >= 0",
+                         name: "merchandise_conditions_price_adjustment_nonnegative"
+  end
+end

--- a/db/migrate/20260810143000_create_phase2_products_and_registry.rb
+++ b/db/migrate/20260810143000_create_phase2_products_and_registry.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+class CreatePhase2ProductsAndRegistry < ActiveRecord::Migration[8.1]
+  def up
+    execute <<~SQL.squish
+      CREATE SEQUENCE shelfsense_sku_221_seq
+        AS bigint
+        MINVALUE 0
+        MAXVALUE 999999999
+        START WITH 0
+        INCREMENT BY 1
+        NO CYCLE
+    SQL
+    execute <<~SQL.squish
+      CREATE SEQUENCE shelfsense_product_222_seq
+        AS bigint
+        MINVALUE 0
+        MAXVALUE 999999999
+        START WITH 0
+        INCREMENT BY 1
+        NO CYCLE
+    SQL
+
+    create_uuid_table :products do |t|
+      t.string :primary_identifier, limit: 13, null: false
+      t.string :name, null: false
+      t.string :subtitle
+      t.text :description
+      t.string :brand_name
+      t.string :product_model
+      t.uuid :merchandise_category_id
+      t.bigint :list_price_cents
+      t.date :release_date
+      t.string :status, null: false, default: "draft"
+      t.string :variant_option_name_1
+      t.string :variant_option_name_2
+      t.integer :lock_version, null: false, default: 0
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+
+    add_index :products, :primary_identifier, unique: true
+    add_index :products, :merchandise_category_id
+    add_index :products, [ :status, :name ]
+    add_foreign_key :products, :merchandise_categories
+    add_check_constraint :products, "status IN ('draft', 'active', 'discontinued')", name: "products_status_valid"
+    add_check_constraint :products, "list_price_cents IS NULL OR list_price_cents >= 0", name: "products_list_price_nonnegative"
+    add_check_constraint :products, "primary_identifier ~ '^[0-9]{13}$'", name: "products_primary_identifier_shape"
+
+    create_uuid_table :identifier_registry do |t|
+      t.string :value, limit: 13, null: false
+      t.string :identifier_kind, null: false
+      t.uuid :product_id
+      t.timestamptz :retired_at
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+
+    add_index :identifier_registry, :value, unique: true
+    add_index :identifier_registry, :product_id, unique: true,
+              where: "identifier_kind = 'product_primary' AND retired_at IS NULL",
+              name: "index_identifier_registry_active_product_primary"
+    add_foreign_key :identifier_registry, :products, on_delete: :nullify
+    add_check_constraint :identifier_registry,
+                         "identifier_kind IN ('product_primary', 'variant_sku', 'variant_industry')",
+                         name: "identifier_registry_kind_valid"
+    add_check_constraint :identifier_registry,
+                         "value ~ '^[0-9]{13}$'",
+                         name: "identifier_registry_value_shape"
+    add_check_constraint :identifier_registry,
+                         "(retired_at IS NOT NULL) OR (product_id IS NOT NULL)",
+                         name: "identifier_registry_active_requires_owner"
+    add_check_constraint :identifier_registry,
+                         "identifier_kind <> 'product_primary' OR product_id IS NOT NULL OR retired_at IS NOT NULL",
+                         name: "identifier_registry_product_primary_owner"
+  end
+
+  def down
+    drop_table :identifier_registry
+    drop_table :products
+    execute "DROP SEQUENCE IF EXISTS shelfsense_product_222_seq"
+    execute "DROP SEQUENCE IF EXISTS shelfsense_sku_221_seq"
+  end
+end

--- a/db/migrate/20260810144000_create_phase2_product_variants.rb
+++ b/db/migrate/20260810144000_create_phase2_product_variants.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+class CreatePhase2ProductVariants < ActiveRecord::Migration[8.1]
+  def change
+    create_uuid_table :product_variants do |t|
+      t.uuid :product_id, null: false
+      t.string :sku, limit: 13, null: false
+      t.string :industry_identifier, limit: 13
+      t.string :name
+      t.string :option_value_1
+      t.string :option_value_2
+      t.uuid :merchandise_condition_id, null: false
+      t.uuid :merchandise_class_id
+      t.uuid :department_id
+      t.uuid :tax_class_id
+      t.bigint :regular_price_cents
+      t.string :status, null: false, default: "draft"
+      t.integer :lock_version, null: false, default: 0
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+
+    add_index :product_variants, :sku, unique: true
+    add_index :product_variants, :industry_identifier, unique: true, where: "industry_identifier IS NOT NULL"
+    add_index :product_variants, [ :product_id, :status ]
+    add_index :product_variants, :merchandise_class_id
+    add_index :product_variants, :merchandise_condition_id
+    add_index :product_variants, :department_id
+    add_index :product_variants, :tax_class_id
+    add_foreign_key :product_variants, :products
+    add_foreign_key :product_variants, :merchandise_conditions
+    add_foreign_key :product_variants, :merchandise_classes
+    add_foreign_key :product_variants, :departments
+    add_foreign_key :product_variants, :tax_classes
+    add_check_constraint :product_variants, "status IN ('draft', 'active', 'discontinued')", name: "product_variants_status_valid"
+    add_check_constraint :product_variants, "sku ~ '^[0-9]{13}$'", name: "product_variants_sku_shape"
+    add_check_constraint :product_variants,
+                         "industry_identifier IS NULL OR industry_identifier ~ '^[0-9]{13}$'",
+                         name: "product_variants_industry_identifier_shape"
+    add_check_constraint :product_variants,
+                         "regular_price_cents IS NULL OR regular_price_cents >= 0",
+                         name: "product_variants_regular_price_nonnegative"
+
+    add_column :identifier_registry, :product_variant_id, :uuid
+    add_foreign_key :identifier_registry, :product_variants, column: :product_variant_id, on_delete: :nullify
+    add_index :identifier_registry, :product_variant_id, unique: true,
+              where: "identifier_kind = 'variant_sku'",
+              name: "index_identifier_registry_variant_sku"
+    add_index :identifier_registry, :product_variant_id, unique: true,
+              where: "identifier_kind = 'variant_industry' AND retired_at IS NULL",
+              name: "index_identifier_registry_active_variant_industry"
+
+    remove_check_constraint :identifier_registry, name: "identifier_registry_active_requires_owner"
+    add_check_constraint :identifier_registry,
+                         "(retired_at IS NOT NULL) OR ((product_id IS NOT NULL)::int + (product_variant_id IS NOT NULL)::int = 1)",
+                         name: "identifier_registry_active_requires_one_owner"
+  end
+end

--- a/db/migrate/20260810145000_rename_products_model_name_and_ensure_sequences.rb
+++ b/db/migrate/20260810145000_rename_products_model_name_and_ensure_sequences.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class RenameProductsModelNameAndEnsureSequences < ActiveRecord::Migration[8.1]
+  def up
+    rename_column :products, :model_name, :product_model if column_exists?(:products, :model_name)
+
+    execute <<~SQL.squish
+      CREATE SEQUENCE IF NOT EXISTS shelfsense_sku_221_seq
+        AS bigint
+        MINVALUE 0
+        MAXVALUE 999999999
+        START WITH 0
+        INCREMENT BY 1
+        NO CYCLE
+    SQL
+    execute <<~SQL.squish
+      CREATE SEQUENCE IF NOT EXISTS shelfsense_product_222_seq
+        AS bigint
+        MINVALUE 0
+        MAXVALUE 999999999
+        START WITH 0
+        INCREMENT BY 1
+        NO CYCLE
+    SQL
+  end
+
+  def down
+    rename_column :products, :product_model, :model_name if column_exists?(:products, :product_model)
+  end
+end

--- a/db/migrate/20260810200000_clarify_standard_and_used_variants.rb
+++ b/db/migrate/20260810200000_clarify_standard_and_used_variants.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+class ClarifyStandardAndUsedVariants < ActiveRecord::Migration[8.1]
+  def up
+    add_column :merchandise_classes, :inventory_mode, :string
+    execute <<~SQL.squish
+      UPDATE merchandise_classes
+      SET inventory_mode = CASE
+        WHEN inventory_tracking_mode = 'non_inventory' THEN 'non_inventory'
+        ELSE 'inventory'
+      END
+    SQL
+    change_column_null :merchandise_classes, :inventory_mode, false
+    remove_check_constraint :merchandise_classes, name: "merchandise_classes_tracking_mode_valid"
+    remove_column :merchandise_classes, :inventory_tracking_mode
+    add_check_constraint :merchandise_classes,
+                         "inventory_mode IN ('inventory', 'non_inventory')",
+                         name: "merchandise_classes_inventory_mode_valid"
+
+    remove_check_constraint :merchandise_conditions, name: "merchandise_conditions_department_basis_valid"
+    remove_column :merchandise_conditions, :department_basis
+
+    add_column :product_variants, :variant_type, :string
+    execute <<~SQL.squish
+      UPDATE product_variants
+      SET variant_type = CASE
+        WHEN merchandise_condition_id IS NULL THEN 'standard'
+        ELSE 'used'
+      END
+    SQL
+    change_column_null :product_variants, :variant_type, false
+    change_column_null :product_variants, :merchandise_condition_id, true
+    add_check_constraint :product_variants,
+                         "variant_type IN ('standard', 'used')",
+                         name: "product_variants_variant_type_valid"
+    add_check_constraint :product_variants,
+                         "(variant_type = 'standard' AND merchandise_condition_id IS NULL) OR (variant_type = 'used' AND merchandise_condition_id IS NOT NULL)",
+                         name: "product_variants_condition_matches_type"
+    add_index :product_variants, [ :product_id, :variant_type ]
+  end
+
+  def down
+    remove_index :product_variants, [ :product_id, :variant_type ]
+    remove_check_constraint :product_variants, name: "product_variants_condition_matches_type"
+    remove_check_constraint :product_variants, name: "product_variants_variant_type_valid"
+
+    execute <<~SQL.squish
+      UPDATE product_variants
+      SET merchandise_condition_id = (
+        SELECT id FROM merchandise_conditions ORDER BY created_at ASC LIMIT 1
+      )
+      WHERE merchandise_condition_id IS NULL
+    SQL
+    change_column_null :product_variants, :merchandise_condition_id, false
+    remove_column :product_variants, :variant_type
+
+    add_column :merchandise_conditions, :department_basis, :string
+    execute "UPDATE merchandise_conditions SET department_basis = 'used'"
+    change_column_null :merchandise_conditions, :department_basis, false
+    add_check_constraint :merchandise_conditions,
+                         "department_basis IN ('standard', 'used')",
+                         name: "merchandise_conditions_department_basis_valid"
+
+    add_column :merchandise_classes, :inventory_tracking_mode, :string
+    execute <<~SQL.squish
+      UPDATE merchandise_classes
+      SET inventory_tracking_mode = CASE
+        WHEN inventory_mode = 'non_inventory' THEN 'non_inventory'
+        ELSE 'quantity'
+      END
+    SQL
+    change_column_null :merchandise_classes, :inventory_tracking_mode, false
+    remove_check_constraint :merchandise_classes, name: "merchandise_classes_inventory_mode_valid"
+    remove_column :merchandise_classes, :inventory_mode
+    add_check_constraint :merchandise_classes,
+                         "inventory_tracking_mode IN ('quantity', 'individual', 'non_inventory')",
+                         name: "merchandise_classes_tracking_mode_valid"
+  end
+end

--- a/db/migrate/20260810210000_strengthen_identifier_registry_ownership.rb
+++ b/db/migrate/20260810210000_strengthen_identifier_registry_ownership.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class StrengthenIdentifierRegistryOwnership < ActiveRecord::Migration[8.1]
+  def up
+    remove_check_constraint :identifier_registry, name: "identifier_registry_active_requires_one_owner", if_exists: true
+    remove_check_constraint :identifier_registry, name: "identifier_registry_product_primary_owner", if_exists: true
+
+    add_check_constraint :identifier_registry,
+                         <<~SQL.squish,
+                           retired_at IS NOT NULL
+                           OR (
+                             identifier_kind = 'product_primary'
+                             AND product_id IS NOT NULL
+                             AND product_variant_id IS NULL
+                           )
+                           OR (
+                             identifier_kind IN ('variant_sku', 'variant_industry')
+                             AND product_variant_id IS NOT NULL
+                             AND product_id IS NULL
+                           )
+                         SQL
+                         name: "identifier_registry_owner_matches_kind"
+  end
+
+  def down
+    remove_check_constraint :identifier_registry, name: "identifier_registry_owner_matches_kind"
+
+    add_check_constraint :identifier_registry,
+                         "(retired_at IS NOT NULL) OR ((product_id IS NOT NULL)::int + (product_variant_id IS NOT NULL)::int = 1)",
+                         name: "identifier_registry_active_requires_one_owner"
+    add_check_constraint :identifier_registry,
+                         "identifier_kind <> 'product_primary' OR product_id IS NOT NULL OR retired_at IS NOT NULL",
+                         name: "identifier_registry_product_primary_owner"
+  end
+end

--- a/db/migrate/20260810220000_tighten_identifier_registry_retired_ownership.rb
+++ b/db/migrate/20260810220000_tighten_identifier_registry_retired_ownership.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class TightenIdentifierRegistryRetiredOwnership < ActiveRecord::Migration[8.1]
+  def up
+    remove_check_constraint :identifier_registry, name: "identifier_registry_owner_matches_kind", if_exists: true
+
+    add_check_constraint :identifier_registry,
+                         <<~SQL.squish,
+                           ((product_id IS NOT NULL)::int + (product_variant_id IS NOT NULL)::int) <= 1
+                           AND (
+                             retired_at IS NOT NULL
+                             OR (
+                               identifier_kind = 'product_primary'
+                               AND product_id IS NOT NULL
+                               AND product_variant_id IS NULL
+                             )
+                             OR (
+                               identifier_kind IN ('variant_sku', 'variant_industry')
+                               AND product_variant_id IS NOT NULL
+                               AND product_id IS NULL
+                             )
+                           )
+                         SQL
+                         name: "identifier_registry_owner_matches_kind"
+  end
+
+  def down
+    remove_check_constraint :identifier_registry, name: "identifier_registry_owner_matches_kind"
+
+    add_check_constraint :identifier_registry,
+                         <<~SQL.squish,
+                           retired_at IS NOT NULL
+                           OR (
+                             identifier_kind = 'product_primary'
+                             AND product_id IS NOT NULL
+                             AND product_variant_id IS NULL
+                           )
+                           OR (
+                             identifier_kind IN ('variant_sku', 'variant_industry')
+                             AND product_variant_id IS NOT NULL
+                             AND product_id IS NULL
+                           )
+                         SQL
+                         name: "identifier_registry_owner_matches_kind"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_10_145000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_10_200000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -154,14 +154,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_145000) do
     t.uuid "default_used_department_id"
     t.text "description"
     t.integer "display_order", default: 0, null: false
-    t.string "inventory_tracking_mode", null: false
+    t.string "inventory_mode", null: false
     t.integer "lock_version", default: 0, null: false
     t.string "name", null: false
     t.string "pricing_method", null: false
     t.timestamptz "updated_at", null: false
     t.boolean "used_merchandise_allowed", default: false, null: false
     t.index ["code"], name: "index_merchandise_classes_on_code", unique: true
-    t.check_constraint "inventory_tracking_mode::text = ANY (ARRAY['quantity'::character varying, 'individual'::character varying, 'non_inventory'::character varying]::text[])", name: "merchandise_classes_tracking_mode_valid"
+    t.check_constraint "inventory_mode::text = ANY (ARRAY['inventory'::character varying, 'non_inventory'::character varying]::text[])", name: "merchandise_classes_inventory_mode_valid"
     t.check_constraint "pricing_method::text = ANY (ARRAY['fixed'::character varying, 'list_price'::character varying, 'cost_based'::character varying, 'open_price'::character varying]::text[])", name: "merchandise_classes_pricing_method_valid"
   end
 
@@ -169,7 +169,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_145000) do
     t.boolean "active", default: true, null: false
     t.string "code", null: false
     t.timestamptz "created_at", null: false
-    t.string "department_basis", null: false
     t.text "description"
     t.integer "display_order", default: 0, null: false
     t.integer "lock_version", default: 0, null: false
@@ -177,7 +176,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_145000) do
     t.integer "price_adjustment_bps", default: 10000, null: false
     t.timestamptz "updated_at", null: false
     t.index ["code"], name: "index_merchandise_conditions_on_code", unique: true
-    t.check_constraint "department_basis::text = ANY (ARRAY['standard'::character varying, 'used'::character varying]::text[])", name: "merchandise_conditions_department_basis_valid"
     t.check_constraint "price_adjustment_bps >= 0", name: "merchandise_conditions_price_adjustment_nonnegative"
   end
 
@@ -200,7 +198,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_145000) do
     t.string "industry_identifier", limit: 13
     t.integer "lock_version", default: 0, null: false
     t.uuid "merchandise_class_id"
-    t.uuid "merchandise_condition_id", null: false
+    t.uuid "merchandise_condition_id"
     t.string "name"
     t.string "option_value_1"
     t.string "option_value_2"
@@ -210,17 +208,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_145000) do
     t.string "status", default: "draft", null: false
     t.uuid "tax_class_id"
     t.timestamptz "updated_at", null: false
+    t.string "variant_type", null: false
     t.index ["department_id"], name: "index_product_variants_on_department_id"
     t.index ["industry_identifier"], name: "index_product_variants_on_industry_identifier", unique: true, where: "(industry_identifier IS NOT NULL)"
     t.index ["merchandise_class_id"], name: "index_product_variants_on_merchandise_class_id"
     t.index ["merchandise_condition_id"], name: "index_product_variants_on_merchandise_condition_id"
     t.index ["product_id", "status"], name: "index_product_variants_on_product_id_and_status"
+    t.index ["product_id", "variant_type"], name: "index_product_variants_on_product_id_and_variant_type"
     t.index ["sku"], name: "index_product_variants_on_sku", unique: true
     t.index ["tax_class_id"], name: "index_product_variants_on_tax_class_id"
     t.check_constraint "industry_identifier IS NULL OR industry_identifier::text ~ '^[0-9]{13}$'::text", name: "product_variants_industry_identifier_shape"
     t.check_constraint "regular_price_cents IS NULL OR regular_price_cents >= 0", name: "product_variants_regular_price_nonnegative"
     t.check_constraint "sku::text ~ '^[0-9]{13}$'::text", name: "product_variants_sku_shape"
     t.check_constraint "status::text = ANY (ARRAY['draft'::character varying, 'active'::character varying, 'discontinued'::character varying]::text[])", name: "product_variants_status_valid"
+    t.check_constraint "variant_type::text = 'standard'::text AND merchandise_condition_id IS NULL OR variant_type::text = 'used'::text AND merchandise_condition_id IS NOT NULL", name: "product_variants_condition_matches_type"
+    t.check_constraint "variant_type::text = ANY (ARRAY['standard'::character varying, 'used'::character varying]::text[])", name: "product_variants_variant_type_valid"
   end
 
   create_table "products", id: :uuid, default: nil, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_09_221000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_10_145000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  # ShelfSense identifier allocation sequences (not owned by a table column).
+  execute "CREATE SEQUENCE IF NOT EXISTS shelfsense_sku_221_seq AS bigint MINVALUE 0 MAXVALUE 999999999 START WITH 0 INCREMENT BY 1 NO CYCLE"
+  execute "CREATE SEQUENCE IF NOT EXISTS shelfsense_product_222_seq AS bigint MINVALUE 0 MAXVALUE 999999999 START WITH 0 INCREMENT BY 1 NO CYCLE"
 
   create_table "audit_events", id: :uuid, default: nil, force: :cascade do |t|
     t.string "action", null: false
@@ -48,6 +52,135 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_09_221000) do
     t.check_constraint "outcome::text = ANY (ARRAY['succeeded'::character varying, 'failed'::character varying, 'denied'::character varying]::text[])", name: "audit_events_outcome_valid"
   end
 
+  create_table "departments", id: :uuid, default: nil, force: :cascade do |t|
+    t.boolean "active", default: true, null: false
+    t.string "code", null: false
+    t.uuid "cost_of_goods_sold_gl_account_id"
+    t.timestamptz "created_at", null: false
+    t.integer "default_target_margin_bps"
+    t.uuid "default_tax_class_id", null: false
+    t.string "department_number"
+    t.text "description"
+    t.integer "display_order", default: 0, null: false
+    t.uuid "freight_in_gl_account_id"
+    t.uuid "inventory_adjustment_gain_gl_account_id"
+    t.uuid "inventory_adjustment_loss_gl_account_id"
+    t.uuid "inventory_asset_gl_account_id"
+    t.uuid "inventory_shrinkage_gl_account_id"
+    t.uuid "inventory_write_down_gl_account_id"
+    t.integer "lock_version", default: 0, null: false
+    t.string "name", null: false
+    t.uuid "receiving_clearing_gl_account_id"
+    t.uuid "sales_returns_gl_account_id"
+    t.uuid "sales_revenue_gl_account_id"
+    t.timestamptz "updated_at", null: false
+    t.index ["code"], name: "index_departments_on_code", unique: true
+    t.index ["cost_of_goods_sold_gl_account_id"], name: "index_departments_on_cost_of_goods_sold_gl_account_id"
+    t.index ["department_number"], name: "index_departments_on_department_number", unique: true, where: "(department_number IS NOT NULL)"
+    t.index ["freight_in_gl_account_id"], name: "index_departments_on_freight_in_gl_account_id"
+    t.index ["inventory_adjustment_gain_gl_account_id"], name: "index_departments_on_inventory_adjustment_gain_gl_account_id"
+    t.index ["inventory_adjustment_loss_gl_account_id"], name: "index_departments_on_inventory_adjustment_loss_gl_account_id"
+    t.index ["inventory_asset_gl_account_id"], name: "index_departments_on_inventory_asset_gl_account_id"
+    t.index ["inventory_shrinkage_gl_account_id"], name: "index_departments_on_inventory_shrinkage_gl_account_id"
+    t.index ["inventory_write_down_gl_account_id"], name: "index_departments_on_inventory_write_down_gl_account_id"
+    t.index ["receiving_clearing_gl_account_id"], name: "index_departments_on_receiving_clearing_gl_account_id"
+    t.index ["sales_returns_gl_account_id"], name: "index_departments_on_sales_returns_gl_account_id"
+    t.index ["sales_revenue_gl_account_id"], name: "index_departments_on_sales_revenue_gl_account_id"
+    t.check_constraint "default_target_margin_bps IS NULL OR default_target_margin_bps >= 0 AND default_target_margin_bps < 10000", name: "departments_margin_bps_range"
+  end
+
+  create_table "gl_accounts", id: :uuid, default: nil, force: :cascade do |t|
+    t.string "account_category", null: false
+    t.string "account_number", null: false
+    t.string "account_type", null: false
+    t.boolean "active", default: true, null: false
+    t.timestamptz "created_at", null: false
+    t.text "description"
+    t.integer "display_order", default: 0, null: false
+    t.integer "lock_version", default: 0, null: false
+    t.string "name", null: false
+    t.uuid "parent_id"
+    t.boolean "posting_allowed", default: true, null: false
+    t.timestamptz "updated_at", null: false
+    t.index ["account_number"], name: "index_gl_accounts_on_account_number", unique: true
+    t.index ["active", "account_number"], name: "index_gl_accounts_on_active_and_account_number"
+    t.index ["parent_id"], name: "index_gl_accounts_on_parent_id"
+    t.check_constraint "account_type::text = ANY (ARRAY['asset'::character varying, 'liability'::character varying, 'equity'::character varying, 'revenue'::character varying, 'expense'::character varying]::text[])", name: "gl_accounts_account_type_valid"
+    t.check_constraint "parent_id IS NULL OR parent_id <> id", name: "gl_accounts_parent_not_self"
+  end
+
+  create_table "identifier_registry", id: :uuid, default: nil, force: :cascade do |t|
+    t.timestamptz "created_at", null: false
+    t.string "identifier_kind", null: false
+    t.uuid "product_id"
+    t.uuid "product_variant_id"
+    t.timestamptz "retired_at"
+    t.timestamptz "updated_at", null: false
+    t.string "value", limit: 13, null: false
+    t.index ["product_id"], name: "index_identifier_registry_active_product_primary", unique: true, where: "(((identifier_kind)::text = 'product_primary'::text) AND (retired_at IS NULL))"
+    t.index ["product_variant_id"], name: "index_identifier_registry_active_variant_industry", unique: true, where: "(((identifier_kind)::text = 'variant_industry'::text) AND (retired_at IS NULL))"
+    t.index ["product_variant_id"], name: "index_identifier_registry_variant_sku", unique: true, where: "((identifier_kind)::text = 'variant_sku'::text)"
+    t.index ["value"], name: "index_identifier_registry_on_value", unique: true
+    t.check_constraint "identifier_kind::text <> 'product_primary'::text OR product_id IS NOT NULL OR retired_at IS NOT NULL", name: "identifier_registry_product_primary_owner"
+    t.check_constraint "identifier_kind::text = ANY (ARRAY['product_primary'::character varying, 'variant_sku'::character varying, 'variant_industry'::character varying]::text[])", name: "identifier_registry_kind_valid"
+    t.check_constraint "retired_at IS NOT NULL OR ((product_id IS NOT NULL)::integer + (product_variant_id IS NOT NULL)::integer) = 1", name: "identifier_registry_active_requires_one_owner"
+    t.check_constraint "value::text ~ '^[0-9]{13}$'::text", name: "identifier_registry_value_shape"
+  end
+
+  create_table "merchandise_categories", id: :uuid, default: nil, force: :cascade do |t|
+    t.boolean "active", default: true, null: false
+    t.string "code"
+    t.timestamptz "created_at", null: false
+    t.uuid "default_merchandise_class_id"
+    t.text "description"
+    t.integer "display_order", default: 0, null: false
+    t.integer "lock_version", default: 0, null: false
+    t.string "name", null: false
+    t.uuid "parent_id"
+    t.timestamptz "updated_at", null: false
+    t.index "lower((name)::text)", name: "index_merchandise_categories_root_name", unique: true, where: "(parent_id IS NULL)"
+    t.index "parent_id, lower((name)::text)", name: "index_merchandise_categories_sibling_name", unique: true, where: "(parent_id IS NOT NULL)"
+    t.index ["code"], name: "index_merchandise_categories_on_code", unique: true, where: "(code IS NOT NULL)"
+    t.check_constraint "parent_id IS NULL OR parent_id <> id", name: "merchandise_categories_parent_not_self"
+  end
+
+  create_table "merchandise_classes", id: :uuid, default: nil, force: :cascade do |t|
+    t.boolean "active", default: true, null: false
+    t.boolean "buyback_allowed", default: false, null: false
+    t.string "code", null: false
+    t.timestamptz "created_at", null: false
+    t.boolean "default_returnable", default: true, null: false
+    t.uuid "default_standard_department_id"
+    t.uuid "default_used_department_id"
+    t.text "description"
+    t.integer "display_order", default: 0, null: false
+    t.string "inventory_tracking_mode", null: false
+    t.integer "lock_version", default: 0, null: false
+    t.string "name", null: false
+    t.string "pricing_method", null: false
+    t.timestamptz "updated_at", null: false
+    t.boolean "used_merchandise_allowed", default: false, null: false
+    t.index ["code"], name: "index_merchandise_classes_on_code", unique: true
+    t.check_constraint "inventory_tracking_mode::text = ANY (ARRAY['quantity'::character varying, 'individual'::character varying, 'non_inventory'::character varying]::text[])", name: "merchandise_classes_tracking_mode_valid"
+    t.check_constraint "pricing_method::text = ANY (ARRAY['fixed'::character varying, 'list_price'::character varying, 'cost_based'::character varying, 'open_price'::character varying]::text[])", name: "merchandise_classes_pricing_method_valid"
+  end
+
+  create_table "merchandise_conditions", id: :uuid, default: nil, force: :cascade do |t|
+    t.boolean "active", default: true, null: false
+    t.string "code", null: false
+    t.timestamptz "created_at", null: false
+    t.string "department_basis", null: false
+    t.text "description"
+    t.integer "display_order", default: 0, null: false
+    t.integer "lock_version", default: 0, null: false
+    t.string "name", null: false
+    t.integer "price_adjustment_bps", default: 10000, null: false
+    t.timestamptz "updated_at", null: false
+    t.index ["code"], name: "index_merchandise_conditions_on_code", unique: true
+    t.check_constraint "department_basis::text = ANY (ARRAY['standard'::character varying, 'used'::character varying]::text[])", name: "merchandise_conditions_department_basis_valid"
+    t.check_constraint "price_adjustment_bps >= 0", name: "merchandise_conditions_price_adjustment_nonnegative"
+  end
+
   create_table "permissions", id: :uuid, default: nil, force: :cascade do |t|
     t.boolean "active", default: true, null: false
     t.timestamptz "created_at", null: false
@@ -59,6 +192,59 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_09_221000) do
     t.timestamptz "updated_at", null: false
     t.index ["key"], name: "index_permissions_on_key", unique: true
     t.check_constraint "scope_type::text = ANY (ARRAY['global'::character varying, 'store'::character varying, 'either'::character varying]::text[])", name: "permissions_scope_type_valid"
+  end
+
+  create_table "product_variants", id: :uuid, default: nil, force: :cascade do |t|
+    t.timestamptz "created_at", null: false
+    t.uuid "department_id"
+    t.string "industry_identifier", limit: 13
+    t.integer "lock_version", default: 0, null: false
+    t.uuid "merchandise_class_id"
+    t.uuid "merchandise_condition_id", null: false
+    t.string "name"
+    t.string "option_value_1"
+    t.string "option_value_2"
+    t.uuid "product_id", null: false
+    t.bigint "regular_price_cents"
+    t.string "sku", limit: 13, null: false
+    t.string "status", default: "draft", null: false
+    t.uuid "tax_class_id"
+    t.timestamptz "updated_at", null: false
+    t.index ["department_id"], name: "index_product_variants_on_department_id"
+    t.index ["industry_identifier"], name: "index_product_variants_on_industry_identifier", unique: true, where: "(industry_identifier IS NOT NULL)"
+    t.index ["merchandise_class_id"], name: "index_product_variants_on_merchandise_class_id"
+    t.index ["merchandise_condition_id"], name: "index_product_variants_on_merchandise_condition_id"
+    t.index ["product_id", "status"], name: "index_product_variants_on_product_id_and_status"
+    t.index ["sku"], name: "index_product_variants_on_sku", unique: true
+    t.index ["tax_class_id"], name: "index_product_variants_on_tax_class_id"
+    t.check_constraint "industry_identifier IS NULL OR industry_identifier::text ~ '^[0-9]{13}$'::text", name: "product_variants_industry_identifier_shape"
+    t.check_constraint "regular_price_cents IS NULL OR regular_price_cents >= 0", name: "product_variants_regular_price_nonnegative"
+    t.check_constraint "sku::text ~ '^[0-9]{13}$'::text", name: "product_variants_sku_shape"
+    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying, 'active'::character varying, 'discontinued'::character varying]::text[])", name: "product_variants_status_valid"
+  end
+
+  create_table "products", id: :uuid, default: nil, force: :cascade do |t|
+    t.string "brand_name"
+    t.timestamptz "created_at", null: false
+    t.text "description"
+    t.bigint "list_price_cents"
+    t.integer "lock_version", default: 0, null: false
+    t.uuid "merchandise_category_id"
+    t.string "name", null: false
+    t.string "primary_identifier", limit: 13, null: false
+    t.string "product_model"
+    t.date "release_date"
+    t.string "status", default: "draft", null: false
+    t.string "subtitle"
+    t.timestamptz "updated_at", null: false
+    t.string "variant_option_name_1"
+    t.string "variant_option_name_2"
+    t.index ["merchandise_category_id"], name: "index_products_on_merchandise_category_id"
+    t.index ["primary_identifier"], name: "index_products_on_primary_identifier", unique: true
+    t.index ["status", "name"], name: "index_products_on_status_and_name"
+    t.check_constraint "list_price_cents IS NULL OR list_price_cents >= 0", name: "products_list_price_nonnegative"
+    t.check_constraint "primary_identifier::text ~ '^[0-9]{13}$'::text", name: "products_primary_identifier_shape"
+    t.check_constraint "status::text = ANY (ARRAY['draft'::character varying, 'active'::character varying, 'discontinued'::character varying]::text[])", name: "products_status_valid"
   end
 
   create_table "role_assignments", id: :uuid, default: nil, force: :cascade do |t|
@@ -152,6 +338,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_09_221000) do
     t.check_constraint "singleton_key = true", name: "system_settings_singleton_key_true"
   end
 
+  create_table "tax_classes", id: :uuid, default: nil, force: :cascade do |t|
+    t.boolean "active", default: true, null: false
+    t.string "code", null: false
+    t.timestamptz "created_at", null: false
+    t.text "description"
+    t.integer "display_order", default: 0, null: false
+    t.integer "lock_version", default: 0, null: false
+    t.string "name", null: false
+    t.timestamptz "updated_at", null: false
+    t.index ["code"], name: "index_tax_classes_on_code", unique: true
+  end
+
   create_table "user_sessions", id: :uuid, default: nil, force: :cascade do |t|
     t.timestamptz "created_at", null: false
     t.timestamptz "expires_at", null: false
@@ -213,6 +411,30 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_09_221000) do
   add_foreign_key "audit_events", "user_sessions"
   add_foreign_key "audit_events", "users", column: "actor_user_id"
   add_foreign_key "audit_events", "workstations"
+  add_foreign_key "departments", "gl_accounts", column: "cost_of_goods_sold_gl_account_id"
+  add_foreign_key "departments", "gl_accounts", column: "freight_in_gl_account_id"
+  add_foreign_key "departments", "gl_accounts", column: "inventory_adjustment_gain_gl_account_id"
+  add_foreign_key "departments", "gl_accounts", column: "inventory_adjustment_loss_gl_account_id"
+  add_foreign_key "departments", "gl_accounts", column: "inventory_asset_gl_account_id"
+  add_foreign_key "departments", "gl_accounts", column: "inventory_shrinkage_gl_account_id"
+  add_foreign_key "departments", "gl_accounts", column: "inventory_write_down_gl_account_id"
+  add_foreign_key "departments", "gl_accounts", column: "receiving_clearing_gl_account_id"
+  add_foreign_key "departments", "gl_accounts", column: "sales_returns_gl_account_id"
+  add_foreign_key "departments", "gl_accounts", column: "sales_revenue_gl_account_id"
+  add_foreign_key "departments", "tax_classes", column: "default_tax_class_id"
+  add_foreign_key "gl_accounts", "gl_accounts", column: "parent_id"
+  add_foreign_key "identifier_registry", "product_variants", on_delete: :nullify
+  add_foreign_key "identifier_registry", "products", on_delete: :nullify
+  add_foreign_key "merchandise_categories", "merchandise_categories", column: "parent_id"
+  add_foreign_key "merchandise_categories", "merchandise_classes", column: "default_merchandise_class_id"
+  add_foreign_key "merchandise_classes", "departments", column: "default_standard_department_id"
+  add_foreign_key "merchandise_classes", "departments", column: "default_used_department_id"
+  add_foreign_key "product_variants", "departments"
+  add_foreign_key "product_variants", "merchandise_classes"
+  add_foreign_key "product_variants", "merchandise_conditions"
+  add_foreign_key "product_variants", "products"
+  add_foreign_key "product_variants", "tax_classes"
+  add_foreign_key "products", "merchandise_categories"
   add_foreign_key "role_assignments", "roles"
   add_foreign_key "role_assignments", "stores"
   add_foreign_key "role_assignments", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_10_210000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_10_220000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -121,8 +121,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_210000) do
     t.index ["product_variant_id"], name: "index_identifier_registry_active_variant_industry", unique: true, where: "(((identifier_kind)::text = 'variant_industry'::text) AND (retired_at IS NULL))"
     t.index ["product_variant_id"], name: "index_identifier_registry_variant_sku", unique: true, where: "((identifier_kind)::text = 'variant_sku'::text)"
     t.index ["value"], name: "index_identifier_registry_on_value", unique: true
+    t.check_constraint "((product_id IS NOT NULL)::integer + (product_variant_id IS NOT NULL)::integer) <= 1 AND (retired_at IS NOT NULL OR identifier_kind::text = 'product_primary'::text AND product_id IS NOT NULL AND product_variant_id IS NULL OR (identifier_kind::text = ANY (ARRAY['variant_sku'::character varying, 'variant_industry'::character varying]::text[])) AND product_variant_id IS NOT NULL AND product_id IS NULL)", name: "identifier_registry_owner_matches_kind"
     t.check_constraint "identifier_kind::text = ANY (ARRAY['product_primary'::character varying, 'variant_sku'::character varying, 'variant_industry'::character varying]::text[])", name: "identifier_registry_kind_valid"
-    t.check_constraint "retired_at IS NOT NULL OR identifier_kind::text = 'product_primary'::text AND product_id IS NOT NULL AND product_variant_id IS NULL OR (identifier_kind::text = ANY (ARRAY['variant_sku'::character varying, 'variant_industry'::character varying]::text[])) AND product_variant_id IS NOT NULL AND product_id IS NULL", name: "identifier_registry_owner_matches_kind"
     t.check_constraint "value::text ~ '^[0-9]{13}$'::text", name: "identifier_registry_value_shape"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_10_200000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_10_210000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -121,9 +121,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_200000) do
     t.index ["product_variant_id"], name: "index_identifier_registry_active_variant_industry", unique: true, where: "(((identifier_kind)::text = 'variant_industry'::text) AND (retired_at IS NULL))"
     t.index ["product_variant_id"], name: "index_identifier_registry_variant_sku", unique: true, where: "((identifier_kind)::text = 'variant_sku'::text)"
     t.index ["value"], name: "index_identifier_registry_on_value", unique: true
-    t.check_constraint "identifier_kind::text <> 'product_primary'::text OR product_id IS NOT NULL OR retired_at IS NOT NULL", name: "identifier_registry_product_primary_owner"
     t.check_constraint "identifier_kind::text = ANY (ARRAY['product_primary'::character varying, 'variant_sku'::character varying, 'variant_industry'::character varying]::text[])", name: "identifier_registry_kind_valid"
-    t.check_constraint "retired_at IS NOT NULL OR ((product_id IS NOT NULL)::integer + (product_variant_id IS NOT NULL)::integer) = 1", name: "identifier_registry_active_requires_one_owner"
+    t.check_constraint "retired_at IS NOT NULL OR identifier_kind::text = 'product_primary'::text AND product_id IS NOT NULL AND product_variant_id IS NULL OR (identifier_kind::text = ANY (ARRAY['variant_sku'::character varying, 'variant_industry'::character varying]::text[])) AND product_variant_id IS NOT NULL AND product_id IS NULL", name: "identifier_registry_owner_matches_kind"
     t.check_constraint "value::text ~ '^[0-9]{13}$'::text", name: "identifier_registry_value_shape"
   end
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,9 @@ This directory contains the project’s technical authority, development guidanc
 | [Phase 1 plan](planning/phase1-operational-foundation/phase1-plan.md) | Phase 1 scope, slices, and acceptance criteria |
 | [Phase 1 schema](planning/phase1-operational-foundation/phase1-schema.md) | Phase 1 tables, fields, and constraints |
 | [Phase 1 authorization](planning/phase1-operational-foundation/phase1-authorization.md) | Permission catalog, role grants, and evaluation rules |
+| [Phase 2 plan](planning/phase2-financial-classification-and-merchandise-foundation/phase2-plan.md) | Phase 2 scope, slices, and completion criteria |
+| [Phase 2 schema](planning/phase2-financial-classification-and-merchandise-foundation/phase-2-database-schema.md) | Phase 2 tables, fields, and constraints |
+| [Phase 2 authorization](planning/phase2-financial-classification-and-merchandise-foundation/phase2-authorization.md) | Phase 2 permission catalog and role grants |
 | [Development guide](development.md) | Docker-only local setup, PostgreSQL configuration, application commands, and troubleshooting |
 | [Testing and CI](testing.md) | Active GitHub Actions checks and prerequisites for deferred checks |
 | [GitHub work management](github-workflow.md) | Issues, PRs, milestones, labels, and release tagging |

--- a/docs/development.md
+++ b/docs/development.md
@@ -122,6 +122,12 @@ After `db:prepare` / `db:migrate`, initialize once:
 
 Do not commit real passwords. Bootstrap is concurrency-safe and sets `system_settings.initialized_at` only on success.
 
+After pulling catalog changes (for example Phase 2 permission keys), re-seed permissions and system role grants on an already-initialized database:
+
+```sh
+./dev/rails-docker bin/rails shelfsense:seed_permissions
+```
+
 ## Tests and validation
 
 Run the Rails test suite:

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -108,22 +108,26 @@ Implement only what is necessary to run and administer one store:
 
 Deliverable: a user can sign in, access an authorized store, and manage essential system configuration according to globally or store-scoped permissions, with material actions recorded in the audit log.
 
-### Phase 2 — Minimal merchandise catalog
+### Phase 2 — Financial classification and merchandise foundation
+
+Status: implemented.
+
+Authoritative Phase 2 documents:
+
+* [phase2-plan.md](phase2-financial-classification-and-merchandise-foundation/phase2-plan.md) — scope, slices, completion criteria  
+* [phase-2-database-schema.md](phase2-financial-classification-and-merchandise-foundation/phase-2-database-schema.md) — tables, fields, constraints  
+* [phase2-authorization.md](phase2-financial-classification-and-merchandise-foundation/phase2-authorization.md) — permissions and role grants  
 
 Implement:
 
-* merchandise classes  
-* merchandise categories  
-* merchandise conditions  
-* tax classes  
-* departments  
-* products  
-* product variants  
-* product lookup and barcode resolution
+* `gl_accounts`, `tax_classes`, `departments`  
+* `merchandise_classes`, `merchandise_categories`, `merchandise_conditions`  
+* `products` (mandatory primary identifier), `product_variants`, `identifier_registry`  
+* unified identifier lookup and minimal CSV import  
 
-Deliverable: create or import a product, create its sellable variant, assign pricing/tax/department behavior, and find it by identifier.
+Deliverable: an authorized user can configure financial classifications, create a product with one or more sellable variants (each with an immutable `221` SKU), assign department/tax/class/condition/price, and retrieve by product identifier, variant SKU, or variant industry identifier.
 
-Avoid implementing every bibliographic or external-classification feature in this phase.
+Avoid inventory, tax calculation, journal posting, and bibliographic enrichment in this phase.
 
 ### Phase 3 — Inventory foundation
 

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -125,7 +125,7 @@ Implement:
 * `products` (mandatory primary identifier), `product_variants`, `identifier_registry`  
 * unified identifier lookup and minimal CSV import  
 
-Deliverable: an authorized user can configure financial classifications, create a product with one or more sellable variants (each with an immutable `221` SKU), assign department/tax/class/condition/price, and retrieve by product identifier, variant SKU, or variant industry identifier.
+Deliverable: an authorized user can configure financial classifications, create a product with one or more sellable standard or used variants (each with an immutable `221` SKU), assign department/tax/class/price (and condition for used variants), and retrieve by product identifier, variant SKU, or variant industry identifier.
 
 Avoid inventory, tax calculation, journal posting, and bibliographic enrichment in this phase.
 

--- a/docs/planning/phase2-financial-classification-and-merchandise-foundation/phase-2-database-schema.md
+++ b/docs/planning/phase2-financial-classification-and-merchandise-foundation/phase-2-database-schema.md
@@ -7,7 +7,7 @@ Phase 2 establishes the financial classifications and merchandise records requir
 - Products contain shared catalog identity and descriptive information.
 - Product variants are the sellable records used by later inventory, purchasing, customer-request, and POS workflows.
 - Every variant receives an immutable, system-generated `221` EAN-13-compatible SKU.
-- A product may optionally use an entered trade identifier or an explicitly generated `222` EAN-13-compatible identifier.
+- Every product has exactly one mandatory `primary_identifier` (entered external GTIN/ISBN or system-generated `222` EAN-13) established at creation.
 - Defaults assist record creation; approved classifications and prices are stored on each variant and are not dynamically inherited afterward.
 - Department GL mappings are explicit nullable foreign-key columns on `departments`.
 - ShelfSense uses perpetual inventory accounting: inventory assets and cost of goods sold are separate mappings.
@@ -279,17 +279,17 @@ The approved result is stored as `product_variants.regular_price_cents`. Using `
 
 ## 7. `products`
 
-Stores shared catalog identity and descriptive information. A product may exist without a variant and without a primary identifier.
+Stores shared catalog identity and descriptive information. A product may exist without a variant, but every product—including draft—must have a primary identifier.
 
 | **Field** | **Type** | **Constraints** | **Notes** |
 |---|---|---|---|
 | id | uuid | PK; UUIDv7 | |
-| primary_identifier | char(13) | unique when present; nullable | Canonical GTIN-13/ISBN-13 or generated `222` identifier |
+| primary_identifier | char(13) | null: false; unique | Canonical manufacturer-assigned GTIN/ISBN or system-generated 222 EAN-13 |
 | name | varchar | null: false | Title or product name |
 | subtitle | varchar | | Optional subtitle or secondary name |
 | description | text | | |
 | brand_name | varchar | | Publisher, brand, manufacturer, or equivalent free-text name |
-| model_name | varchar | | Optional model, edition, series, or format designation |
+| product_model | varchar | | Optional model, edition, series, or format designation (column is `product_model` to avoid Active Record's `model_name`) |
 | merchandise_category_id | uuid | FK: `merchandise_categories`; nullable | Descriptive classification |
 | list_price_cents | bigint | nullable; check `>= 0` | Publisher or manufacturer list price |
 | release_date | date | | Publication, release, or on-sale date |
@@ -302,22 +302,23 @@ Stores shared catalog identity and descriptive information. A product may exist 
 
 ### Primary identifier rules
 
+- Product creation requires a mutually exclusive choice: enter an external identifier, or generate a ShelfSense `222` identifier. Generation is part of creation, not a later optional action.
 - Remove permitted spaces and hyphens before validation.
 - Convert a valid ISBN-10 to its equivalent ISBN-13.
 - Store ISBNs only in their canonical 13-digit form.
-- Normalize UPC-A to GTIN-13 by adding a leading zero if canonical GTIN-13 storage is adopted consistently.
+- Normalize UPC-A to GTIN-13 by adding a leading zero.
 - Validate the GTIN/EAN check digit.
-- Generate a `222` identifier only when explicitly requested.
+- Reject a user-entered value in the reserved `222` namespace.
 - A generated identifier must have exactly 13 digits, begin with `222`, have a valid check digit, remain globally unique, and never be reused.
-- Do not store identifier type or provenance.
-- Products without identifiers remain valid.
+- Do not store identifier type or provenance; audit events may record entered versus generated.
+- Reserve the value in `identifier_registry` in the same transaction as product persistence.
 
-The database should enforce the 13-digit shape and uniqueness. The shared identifier service should perform formatting removal, ISBN conversion, check-digit validation, and registry reservation.
+The database enforces the 13-digit shape and uniqueness. The shared identifier service performs formatting removal, ISBN conversion, check-digit validation, and registry reservation.
 
 Recommended indexes:
 
 ```text
-unique (primary_identifier) where primary_identifier is not null
+unique (primary_identifier)
 index (merchandise_category_id)
 index (status, name)
 ```
@@ -337,11 +338,11 @@ Represents the actual sellable SKU used by later inventory, purchasing, customer
 | name | varchar | | Optional distinguishing display name |
 | option_value_1 | varchar | | Corresponds to `products.variant_option_name_1` |
 | option_value_2 | varchar | | Corresponds to `products.variant_option_name_2` |
-| merchandise_condition_id | uuid | FK: `merchandise_conditions`; null: false | Approved condition |
-| merchandise_class_id | uuid | FK: `merchandise_classes`; null: false | Approved operational behavior |
-| department_id | uuid | FK: `departments`; null: false | Stored financial and reporting classification |
-| tax_class_id | uuid | FK: `tax_classes`; null: false | Stored tax classification |
-| regular_price_cents | bigint | nullable; check `>= 0` | Required when the pricing method requires a fixed price |
+| merchandise_condition_id | uuid | FK: `merchandise_conditions`; null: false | Approved condition; required for drafts and active variants |
+| merchandise_class_id | uuid | FK: `merchandise_classes`; nullable in draft; required when active | Approved operational behavior |
+| department_id | uuid | FK: `departments`; nullable in draft; required when active | Stored financial and reporting classification |
+| tax_class_id | uuid | FK: `tax_classes`; nullable in draft; required when active | Stored tax classification |
+| regular_price_cents | bigint | nullable; check `>= 0` | Activation requirements depend on merchandise class pricing method |
 | status | varchar | null: false; default `draft`; check enum | `draft`, `active`, `discontinued` |
 | lock_version | integer | null: false; default `0` | Optimistic concurrency |
 | created_at | timestamptz | null: false | |
@@ -415,11 +416,20 @@ Reserves operational identifiers across product and variant namespaces so that a
 | id | uuid | PK; UUIDv7 | |
 | value | char(13) | null: false; unique | Normalized lookup value |
 | identifier_kind | varchar | null: false; check enum | `product_primary`, `variant_sku`, `variant_industry` |
-| product_id | uuid | FK: `products`; nullable | Owner for `product_primary` |
-| product_variant_id | uuid | FK: `product_variants`; nullable | Owner for either variant kind |
+| product_id | uuid | FK: `products` ON DELETE SET NULL; nullable | Owner for `product_primary` when present |
+| product_variant_id | uuid | FK: `product_variants` ON DELETE SET NULL; nullable | Owner for either variant kind when present |
 | retired_at | timestamptz | nullable | Set when an identifier is removed from ordinary lookup but must remain reserved |
 | created_at | timestamptz | null: false | |
 | updated_at | timestamptz | null: false | |
+
+Registry ownership invariants:
+
+- An **active** registry row (`retired_at` null) has exactly one owner.
+- A **retired** registry row may have zero or one owner.
+- An unowned registry row must have `retired_at` populated.
+- `value` remains globally unique for both active and retired rows.
+
+Before deleting an eligible draft product or variant, retire its registry rows in the same transaction.
 
 Required checks and indexes:
 
@@ -457,13 +467,13 @@ If a product has multiple eligible variants, the user selects one. ISBN-10 input
 
 The shared generator should:
 
-1. generate or allocate the nine-digit payload following the `221` or `222` prefix;
-2. calculate the EAN-13 check digit;
+1. allocate the next nine-digit payload from a non-cycling PostgreSQL sequence (`MINVALUE 0`, `MAXVALUE 999999999`, `NO CYCLE`) for prefix `221` or `222`;
+2. zero-pad the payload to nine digits and calculate the EAN-13 check digit;
 3. attempt to reserve the complete value in `identifier_registry`;
-4. retry on a unique conflict;
+4. retry only on a unique conflict (not on sequence exhaustion);
 5. assign the identifier to the owner in the same transaction.
 
-A sequence or random payload is acceptable if uniqueness conflicts are handled transactionally and allocated values are never reused.
+Sequence exhaustion must raise a clear operational error and must not wrap.
 
 ---
 
@@ -562,8 +572,8 @@ Phase 2 is complete when:
 
 - GL accounts, tax classes, departments, merchandise classes, categories, and conditions can be securely administered.
 - Departments can hold explicit account mappings required by future perpetual-inventory and sales posting.
-- Products may exist with or without a primary identifier.
-- Users can enter a valid identifier or explicitly generate a unique `222` identifier.
+- Products always have a mandatory primary identifier (entered or generated at creation).
+- Users enter a valid external identifier or explicitly generate a unique `222` identifier during product creation.
 - Every variant automatically receives an immutable, unique `221` SKU.
 - Cross-namespace identifier collisions and reuse are prevented.
 - Variants store approved class, condition, department, tax class, and regular-price assignments.

--- a/docs/planning/phase2-financial-classification-and-merchandise-foundation/phase-2-database-schema.md
+++ b/docs/planning/phase2-financial-classification-and-merchandise-foundation/phase-2-database-schema.md
@@ -445,6 +445,7 @@ Reserves operational identifiers across product and variant namespaces so that a
 
 Registry ownership invariants:
 
+- Every registry row has at most one owner (`product_id` or `product_variant_id`, never both).
 - An **active** registry row (`retired_at` null) has exactly one owner, and that owner must match `identifier_kind`:
   - `product_primary` → `product_id` only
   - `variant_sku` / `variant_industry` → `product_variant_id` only
@@ -457,9 +458,11 @@ Before deleting an eligible draft product or variant, retire its registry rows i
 Required checks and indexes:
 
 ```text
-check exactly one of product_id or product_variant_id is present
-check product_primary requires product_id
-check variant_sku and variant_industry require product_variant_id
+check at most one of product_id or product_variant_id is present
+check active rows have a kind-matching owner
+check unowned rows are retired
+check product_primary requires product_id when active
+check variant_sku and variant_industry require product_variant_id when active
 
 unique (value)
 unique (product_id) where identifier_kind = 'product_primary' and retired_at is null
@@ -467,7 +470,7 @@ unique (product_variant_id) where identifier_kind = 'variant_sku'
 unique (product_variant_id) where identifier_kind = 'variant_industry' and retired_at is null
 ```
 
-The registry protects the namespace, while the identifier columns on `products` and `product_variants` remain the business-facing values. Assignment, replacement, retirement, and owner updates must occur in one transaction so the registry and owner cannot diverge.
+Product and variant identifier columns are writable only through the create/assignment services (`identifier_writes_enabled`). Ordinary Active Record creates/updates that change `primary_identifier`, `sku`, or `industry_identifier` are rejected so registry synchronization cannot be bypassed on those paths.
 
 - A current product or variant industry identifier has an active registry row.
 - Replacing or removing one retires the old row rather than deleting it, preventing reuse.

--- a/docs/planning/phase2-financial-classification-and-merchandise-foundation/phase-2-database-schema.md
+++ b/docs/planning/phase2-financial-classification-and-merchandise-foundation/phase-2-database-schema.md
@@ -445,7 +445,9 @@ Reserves operational identifiers across product and variant namespaces so that a
 
 Registry ownership invariants:
 
-- An **active** registry row (`retired_at` null) has exactly one owner.
+- An **active** registry row (`retired_at` null) has exactly one owner, and that owner must match `identifier_kind`:
+  - `product_primary` → `product_id` only
+  - `variant_sku` / `variant_industry` → `product_variant_id` only
 - A **retired** registry row may have zero or one owner.
 - An unowned registry row must have `retired_at` populated.
 - `value` remains globally unique for both active and retired rows.
@@ -537,11 +539,15 @@ It should:
 
 - accept products and variants;
 - normalize identifiers before matching;
+- group rows by normalized product primary identifier and persist each group atomically;
 - match products by normalized primary identifier;
 - match variants by SKU or variant industry identifier where appropriate;
 - apply ordinary creation defaults without overwriting explicit imported assignments;
-- remain idempotent when the same file is imported again;
-- report row-level errors;
+- treat blank codes as defaults, but reject explicitly supplied unknown reference codes;
+- remain idempotent when the same file is imported again for rows that include a durable product identifier;
+- treat `generate_primary_identifier=true` with a blank primary identifier as create-only (not idempotent across reimports);
+- reuse ordinary audited create/update services for product and variant writes;
+- report row-level (or group-level) errors;
 - avoid partially importing an invalid product-and-variant group.
 
 No separate staging table is required for the minimal Phase 2 importer. If later import volume, resumability, or review requirements justify persisted import jobs, those tables can be added without changing the merchandise contract.

--- a/docs/planning/phase2-financial-classification-and-merchandise-foundation/phase-2-database-schema.md
+++ b/docs/planning/phase2-financial-classification-and-merchandise-foundation/phase-2-database-schema.md
@@ -186,11 +186,11 @@ Examples include `book`, `recorded_music`, `video`, `greeting_card`, `apparel`, 
 | code | varchar | null: false; unique | Stable machine-readable code |
 | name | varchar | null: false | |
 | description | text | | |
-| inventory_tracking_mode | varchar | null: false; check enum | `quantity`, `individual`, `non_inventory` |
+| inventory_mode | varchar | null: false; check enum | `inventory` or `non_inventory` |
 | pricing_method | varchar | null: false; check enum | `fixed`, `list_price`, `cost_based`, `open_price` |
-| default_standard_department_id | uuid | FK: `departments`; nullable | Default for standard-basis conditions |
-| default_used_department_id | uuid | FK: `departments`; nullable | Default for used-basis conditions |
-| used_merchandise_allowed | boolean | null: false; default `false` | Whether used conditions may be assigned |
+| default_standard_department_id | uuid | FK: `departments`; nullable | Default for standard variants |
+| default_used_department_id | uuid | FK: `departments`; nullable | Default for used variants |
+| used_merchandise_allowed | boolean | null: false; default `false` | Whether used variants may use this class |
 | buyback_allowed | boolean | null: false; default `false` | Future behavior; buyback is deferred |
 | default_returnable | boolean | null: false; default `true` | Default used by later purchasing and return workflows |
 | active | boolean | null: false; default `true` | |
@@ -199,13 +199,21 @@ Examples include `book`, `recorded_music`, `video`, `greeting_card`, `apparel`, 
 | created_at | timestamptz | null: false | |
 | updated_at | timestamptz | null: false | |
 
-### Inventory tracking modes
+### Inventory mode and derived tracking
+
+Quantity versus individual tracking is not chosen independently on the merchandise class. It is derived from `inventory_mode` and the variant’s `variant_type`:
+
+| Class `inventory_mode` | Variant type | Derived tracking |
+|---|---|---|
+| `inventory` | `standard` | Quantity-tracked |
+| `inventory` | `used` | Individually unit-tracked |
+| `non_inventory` | `standard` | Not inventory-tracked (for example services) |
+| `non_inventory` | `used` | Invalid |
 
 | Value | Meaning |
 |---|---|
-| `quantity` | Interchangeable units tracked by quantity |
-| `individual` | Each physical unit will require a future inventory-unit record |
-| `non_inventory` | Sellable, but does not create or relieve merchandise inventory |
+| `inventory` | Participates in merchandise inventory |
+| `non_inventory` | Sellable without creating or relieving merchandise inventory |
 
 ### Pricing methods
 
@@ -251,29 +259,28 @@ Application logic must prevent hierarchy cycles. Changing a category's default c
 
 ## 6. `merchandise_conditions`
 
-Describes the commercial condition of a variant and indicates whether department resolution should use a merchandise class's standard or used default.
+Describes the condition and pricing tier of a **used variant** (for example `like_new`, `good`, `acceptable`). Conditions belong only to used variants; standard variants must not reference a condition. A future `inventory_unit` represents each physical used copy assigned to that variant.
 
 | **Field** | **Type** | **Constraints** | **Notes** |
 |---|---|---|---|
 | id | uuid | PK; UUIDv7 | |
-| code | varchar | null: false; unique | Examples: `new`, `used_good`, `used_acceptable`, `collectible`, `remainder` |
+| code | varchar | null: false; unique | Examples: `like_new`, `good`, `acceptable`, `collectible` |
 | name | varchar | null: false | |
 | description | text | | |
-| department_basis | varchar | null: false; check enum | `standard` or `used` |
-| price_adjustment_bps | integer | null: false; default `10000`; check `>= 0` | Price multiplier; `10000` means 100% |
+| price_adjustment_bps | integer | null: false; default `10000`; check `>= 0` | Price multiplier for used-variant suggestions; `10000` means 100% |
 | active | boolean | null: false; default `true` | |
 | display_order | integer | null: false; default `0` | |
 | lock_version | integer | null: false; default `0` | Optimistic concurrency |
 | created_at | timestamptz | null: false | |
 | updated_at | timestamptz | null: false | |
 
-The condition adjustment produces only a suggested price:
+The condition adjustment produces only a suggested price for used variants:
 
 \[
 \text{suggested price} = \text{base price} \times \frac{\text{price adjustment bps}}{10000}
 \]
 
-The approved result is stored as `product_variants.regular_price_cents`. Using `department_basis` allows several used or collectible conditions to share the used-department resolution path without treating “used” as a separate variant type.
+The approved result is stored as `product_variants.regular_price_cents`. Department defaults are selected from the variant’s `variant_type`, not from the condition.
 
 ---
 
@@ -327,18 +334,19 @@ index (status, name)
 
 ## 8. `product_variants`
 
-Represents the actual sellable SKU used by later inventory, purchasing, customer-request, and POS workflows.
+Represents the actual sellable SKU used by later inventory, purchasing, customer-request, and POS workflows. A product is condition-neutral and may own both **standard variants** and **used variants**.
 
 | **Field** | **Type** | **Constraints** | **Notes** |
 |---|---|---|---|
 | id | uuid | PK; UUIDv7 | |
 | product_id | uuid | FK: `products`; null: false | |
+| variant_type | varchar | null: false; check enum | `standard` or `used` |
 | sku | char(13) | null: false; unique; immutable | System-generated `221` EAN-13-compatible SKU |
 | industry_identifier | char(13) | unique when present; nullable | Trade identifier belonging specifically to this variant |
 | name | varchar | | Optional distinguishing display name |
 | option_value_1 | varchar | | Corresponds to `products.variant_option_name_1` |
 | option_value_2 | varchar | | Corresponds to `products.variant_option_name_2` |
-| merchandise_condition_id | uuid | FK: `merchandise_conditions`; null: false | Approved condition; required for drafts and active variants |
+| merchandise_condition_id | uuid | FK: `merchandise_conditions`; nullable | Required for used variants; must be null for standard variants |
 | merchandise_class_id | uuid | FK: `merchandise_classes`; nullable in draft; required when active | Approved operational behavior |
 | department_id | uuid | FK: `departments`; nullable in draft; required when active | Stored financial and reporting classification |
 | tax_class_id | uuid | FK: `tax_classes`; nullable in draft; required when active | Stored tax classification |
@@ -347,6 +355,16 @@ Represents the actual sellable SKU used by later inventory, purchasing, customer
 | lock_version | integer | null: false; default `0` | Optimistic concurrency |
 | created_at | timestamptz | null: false | |
 | updated_at | timestamptz | null: false | |
+
+Database invariant:
+
+```sql
+CHECK (
+  (variant_type = 'standard' AND merchandise_condition_id IS NULL)
+  OR
+  (variant_type = 'used' AND merchandise_condition_id IS NOT NULL)
+)
+```
 
 ### SKU rules
 
@@ -371,9 +389,9 @@ When creating or explicitly reclassifying a variant, resolve values in this orde
 | Assignment | Resolution order |
 |---|---|
 | Merchandise class | Explicit selection; product category's default class; unresolved |
-| Department | Explicit selection; class used department when condition basis is `used`; class standard department otherwise; unresolved |
+| Department | Explicit selection; class used department when `variant_type` is `used`; class standard department when `variant_type` is `standard`; unresolved |
 | Tax class | Explicit selection; resolved department's default tax class; unresolved |
-| Price | Explicit price; applicable product-list-price or condition suggestion; later cost-based suggestion |
+| Price | Explicit price; for used variants, list price × condition adjustment; for standard variants, list price as-is; later cost-based suggestion |
 
 The user approves the resolved values before activation. ShelfSense stores those values on the variant. Changing a category, class, condition, or department default later does not silently modify existing variants.
 
@@ -384,8 +402,10 @@ Sellability should be a model or domain-service predicate, not a duplicated stor
 - its status is `active`;
 - its product is active;
 - its SKU is valid;
-- its merchandise class, condition, department, and tax class are active;
-- its condition is permitted by its merchandise class;
+- its merchandise class, department, and tax class are active;
+- for used variants, its merchandise condition is active and the class allows used merchandise (`used_merchandise_allowed`);
+- for used variants, the merchandise class `inventory_mode` is `inventory` (non-inventory used variants are invalid);
+- for standard variants, `merchandise_condition_id` is null;
 - its regular price satisfies the merchandise class's pricing method;
 - required option values and any class-specific attributes are present.
 
@@ -397,13 +417,14 @@ Recommended indexes:
 unique (sku)
 unique (industry_identifier) where industry_identifier is not null
 index (product_id, status)
+index (product_id, variant_type)
 index (merchandise_class_id)
 index (merchandise_condition_id)
 index (department_id)
 index (tax_class_id)
 ```
 
-Do not impose a general uniqueness constraint on `(product_id, option values, condition)` until the option model is proven sufficient for every merchandise class. Individually distinguishable physical copies belong in future `inventory_units`, not duplicate variant records.
+Do not impose a general uniqueness constraint on `(product_id, option values, condition)` until the option model is proven sufficient for every merchandise class. Individually distinguishable physical copies belong in future `inventory_units` under a used variant, not as duplicate variant records.
 
 ---
 

--- a/docs/planning/phase2-financial-classification-and-merchandise-foundation/phase2-authorization.md
+++ b/docs/planning/phase2-financial-classification-and-merchandise-foundation/phase2-authorization.md
@@ -1,0 +1,74 @@
+# Phase 2 Authorization Contract
+
+This document is the authoritative Phase 2 permission catalog and role grants. Phase 1 keys remain documented in [phase1-authorization.md](../phase1-operational-foundation/phase1-authorization.md). Both sets are seeded from `Authorization::PermissionCatalog`.
+
+Phase 2 merchandise and financial reference data are organization-wide master data. Create, update, and lifecycle permissions use `scope_type: global` and require a global role assignment. View and catalog-lookup permissions use `scope_type: either` so store-scoped roles can read the catalog in an active store without granting organization-wide administration.
+
+## Permission verbs
+
+| Verb | Meaning |
+|---|---|
+| `view` | Read and list |
+| `create` | Create new records |
+| `update` | Non-lifecycle edits (does not include deactivate/discontinue) |
+| `deactivate` | Soft-deactivate reference/configuration records |
+| `discontinue` | Move products/variants to discontinued (lifecycle) |
+
+`products.create` authorizes product creation whether the user enters an external primary identifier or chooses Generate ShelfSense identifier (`222`). There is no separate `products.generate_identifier` permission.
+
+## Permission catalog
+
+| Permission | scope_type | group_key |
+|---|---|---|
+| `gl_accounts.view` | either | gl_accounts |
+| `gl_accounts.create` | global | gl_accounts |
+| `gl_accounts.update` | global | gl_accounts |
+| `gl_accounts.deactivate` | global | gl_accounts |
+| `tax_classes.view` | either | tax_classes |
+| `tax_classes.create` | global | tax_classes |
+| `tax_classes.update` | global | tax_classes |
+| `tax_classes.deactivate` | global | tax_classes |
+| `departments.view` | either | departments |
+| `departments.create` | global | departments |
+| `departments.update` | global | departments |
+| `departments.deactivate` | global | departments |
+| `merchandise_classes.view` | either | merchandise_classes |
+| `merchandise_classes.create` | global | merchandise_classes |
+| `merchandise_classes.update` | global | merchandise_classes |
+| `merchandise_classes.deactivate` | global | merchandise_classes |
+| `merchandise_categories.view` | either | merchandise_categories |
+| `merchandise_categories.create` | global | merchandise_categories |
+| `merchandise_categories.update` | global | merchandise_categories |
+| `merchandise_categories.deactivate` | global | merchandise_categories |
+| `merchandise_conditions.view` | either | merchandise_conditions |
+| `merchandise_conditions.create` | global | merchandise_conditions |
+| `merchandise_conditions.update` | global | merchandise_conditions |
+| `merchandise_conditions.deactivate` | global | merchandise_conditions |
+| `products.view` | either | products |
+| `products.create` | global | products |
+| `products.update` | global | products |
+| `products.discontinue` | global | products |
+| `product_variants.view` | either | product_variants |
+| `product_variants.create` | global | product_variants |
+| `product_variants.update` | global | product_variants |
+| `product_variants.discontinue` | global | product_variants |
+| `merchandise.lookup` | either | merchandise |
+| `merchandise.import` | global | merchandise |
+
+## Role grants
+
+| Role | Phase 2 permissions |
+|---|---|
+| `system_administrator` | Entire Phase 2 catalog |
+| `store_manager` | All `*.view` keys above, plus `merchandise.lookup` |
+| `associate` | `merchandise.lookup`, `products.view`, `product_variants.view` |
+
+## Seed ownership
+
+| Kind | Contents |
+|---|---|
+| Production baseline | Permissions, system roles, and only reference codes with application-level semantics |
+| Bootstrap / demo | Example GL accounts, tax classes, departments, merchandise classes/categories (organization-specific; not universal production records) |
+| Test fixtures | Records required only by automated tests |
+
+Merchandise conditions are production-seeded only if application code hard-depends on particular codes. Prefer data-driven behavior via `department_basis` and related fields, with conditions created during organization setup.

--- a/docs/planning/phase2-financial-classification-and-merchandise-foundation/phase2-authorization.md
+++ b/docs/planning/phase2-financial-classification-and-merchandise-foundation/phase2-authorization.md
@@ -71,4 +71,4 @@ Phase 2 merchandise and financial reference data are organization-wide master da
 | Bootstrap / demo | Example GL accounts, tax classes, departments, merchandise classes/categories (organization-specific; not universal production records) |
 | Test fixtures | Records required only by automated tests |
 
-Merchandise conditions are production-seeded only if application code hard-depends on particular codes. Prefer data-driven behavior via `department_basis` and related fields, with conditions created during organization setup.
+Merchandise conditions are production-seeded only if application code hard-depends on particular codes. Prefer organization setup to create used-variant condition tiers (`like_new`, `good`, and so on) as ordinary reference data.

--- a/docs/planning/phase2-financial-classification-and-merchandise-foundation/phase2-plan.md
+++ b/docs/planning/phase2-financial-classification-and-merchandise-foundation/phase2-plan.md
@@ -98,20 +98,16 @@ Phase 2 fields should include:
 * code and name;  
 * description;  
 * active status;  
-* default standard department;  
-* default used department;  
-* inventory tracking mode;  
+* default standard department (for standard variants);  
+* default used department (for used variants);  
+* inventory mode (`inventory` or `non_inventory`);  
 * pricing method;  
 * used-merchandise eligibility;  
 * buyback eligibility;  
 * returnability default;  
 * display order.
 
-Recommended inventory tracking modes:
-
-* `quantity`  
-* `individual`  
-* `non_inventory`
+Quantity versus individual tracking is derived from inventory mode and variant type: inventory + standard ⇒ quantity-tracked; inventory + used ⇒ individually tracked; non-inventory + standard ⇒ not inventory-tracked; non-inventory + used ⇒ invalid.
 
 Later workflows will use these settings, but Phase 2 only needs to capture and validate them.
 
@@ -133,13 +129,14 @@ A category’s default merchandise class is a creation-time suggestion. It shoul
 
 ### Merchandise conditions
 
-Conditions distinguish merchandise states such as:
+Conditions describe the condition and pricing tier of a **used variant**, such as:
 
-* new;  
-* used;  
-* collectible;  
-* damaged;  
-* remainder.
+* like new;  
+* good;  
+* acceptable;  
+* collectible.
+
+They do not apply to standard variants. The product itself is neither standard nor used.
 
 Phase 2 includes:
 
@@ -150,7 +147,7 @@ Phase 2 includes:
 
 If the field represents a price multiplier, `10000` means 100%, while `6000` means 60%.
 
-A condition may suggest a price, but the approved regular price remains stored on the variant.
+A condition may suggest a price for a used variant, but the approved regular price remains stored on the variant.
 
 ---
 
@@ -200,14 +197,15 @@ Rules:
 
 ## 2.4 Product variants
 
-A product variant is the actual sellable record used by later inventory, purchasing, customer-request, and POS workflows.
+A product variant is the actual sellable record used by later inventory, purchasing, customer-request, and POS workflows. Each variant is either a **standard variant** or a **used variant**.
 
 Phase 2 should support:
 
-* one or more variants per product;  
+* one or more variants per product, including both types on the same product;  
+* required `variant_type` (`standard` or `used`);  
 * a required generated SKU;  
 * an optional variant-specific industry identifier;  
-* condition;  
+* merchandise condition only for used variants (prohibited for standard);  
 * merchandise class;  
 * department;  
 * tax class;  
@@ -245,10 +243,11 @@ The product’s primary identifier should not be copied to its variants merely t
 
 The variant should store its approved:
 
+* `variant_type`;  
 * `merchandise_class_id`;  
 * `department_id`;  
 * `tax_class_id`;  
-* `condition_id`;  
+* `merchandise_condition_id` when used (null when standard);  
 * `regular_price_cents`.
 
 These should not remain purely dynamic inherited values. Defaults assist creation, while stored assignments prevent later configuration changes from silently reclassifying existing merchandise.
@@ -270,8 +269,8 @@ A merchandise class is required before the variant can become sellable.
 ### Department
 
 1. Explicit variant department.  
-2. Merchandise class’s used department for a used variant.  
-3. Merchandise class’s standard department otherwise.  
+2. Merchandise class’s used department when `variant_type` is `used`.  
+3. Merchandise class’s standard department when `variant_type` is `standard`.  
 4. Otherwise unresolved.
 
 The resolved department is saved on the variant.
@@ -288,8 +287,8 @@ The resolved tax class is saved on the variant.
 
 Possible price suggestions include:
 
-* product list price;  
-* list price multiplied by the condition adjustment;  
+* product list price (standard variants);  
+* list price multiplied by the used variant’s condition adjustment;  
 * later, cost-based pricing using the department’s target margin.
 
 Phase 2 should store the user-approved `regular_price_cents`. It should not continuously recalculate prices when defaults change.
@@ -305,9 +304,10 @@ A variant should be considered sellable only when it:
 * has an active merchandise class;  
 * has an active department;  
 * has an active tax class;  
-* has an active condition;  
+* for used variants, has an active condition and a class that allows used merchandise and is inventory-mode;  
+* for standard variants, has no condition;  
 * has a valid SKU;  
-* has a valid nonnegative regular price;  
+* satisfies the merchandise class pricing-method price rules;  
 * satisfies any class-specific required attributes.
 
 A product may exist in an incomplete state without having a sellable variant.

--- a/docs/planning/phase2-financial-classification-and-merchandise-foundation/phase2-plan.md
+++ b/docs/planning/phase2-financial-classification-and-merchandise-foundation/phase2-plan.md
@@ -166,7 +166,7 @@ Phase 2 should support:
 * optional list price;  
 * optional publication or release metadata;  
 * merchandise category;  
-* optional unique primary identifier;  
+* mandatory unique primary identifier (entered external ID or generated `222` at creation);  
 * active or discontinued status;  
 * optimistic locking;  
 * auditing of material changes.
@@ -175,26 +175,26 @@ The model must support books, media, games, gifts, stationery, café items, serv
 
 ### Primary identifier
 
-`products.primary_identifier` is nullable and unique when present.
+`products.primary_identifier` is required and unique for every product, including drafts.
 
 It may contain:
 
-* a publisher- or manufacturer-assigned identifier;  
+* a publisher- or manufacturer-assigned identifier; or  
 * a ShelfSense-generated EAN-13-compatible identifier beginning with `222`.
 
 Rules:
 
+* Product creation requires a mutually exclusive choice: enter an external identifier, or generate a ShelfSense identifier.  
 * Remove permitted formatting such as spaces and hyphens.  
 * Convert valid ISBN-10 input to ISBN-13.  
 * Store ISBNs in their canonical 13-digit representation.  
-* Normalize UPC-A to its 13-digit representation if canonical GTIN-13 storage is adopted.  
-* Generate `222` identifiers only when explicitly requested.  
-* Store entered and generated identifiers in the same field.  
-* Do not store identifier type or provenance.  
+* Normalize UPC-A to GTIN-13 by adding a leading zero.  
+* Reject user-entered values in the reserved `222` namespace.  
+* Generate `222` identifiers only when that create-time choice is selected.  
+* Store entered and generated identifiers in the same field (no source column).  
 * Generate a valid check digit.  
-* Prevent reuse and collisions with a unique database index.
-
-Products without identifiers remain valid.
+* Prevent reuse and collisions via `identifier_registry` and a unique database index.  
+* Reserve the identifier in the same transaction as product persistence.
 
 ---
 
@@ -405,7 +405,7 @@ At minimum, enforce:
 * unique GL account numbers;  
 * unique department codes or numbers;  
 * unique reference-data codes;  
-* unique `products.primary_identifier` when non-null;  
+* unique `products.primary_identifier`;  
 * unique `product_variants.sku`;  
 * unique `product_variants.industry_identifier` when non-null;  
 * valid `221` prefix and check digit for generated SKUs;  
@@ -413,7 +413,7 @@ At minimum, enforce:
 * nonnegative monetary values;  
 * valid basis-point ranges;  
 * no self-parenting categories or GL accounts;  
-* required classifications for sellable variants;  
+* required classifications for **active** sellable variants (drafts may omit class/department/tax);  
 * immutable variant SKUs.
 
 Application validation should provide usable messages, but database constraints remain the final protection.
@@ -464,11 +464,11 @@ Phase 2 is complete when:
 * Financial classifications, tax classes, and departments can be administered securely.  
 * Departments can hold the account mappings required by perpetual inventory.  
 * Merchandise categories, classes, and conditions can provide creation defaults.  
-* Products may exist with or without a primary identifier.  
-* Users can enter an identifier or explicitly generate a unique `222` identifier.  
+* Every product has a mandatory primary identifier (entered or generated at creation).  
+* Product creation offers enter-external or generate-`222` as mutually exclusive choices.  
 * Every variant automatically receives an immutable, unique `221` SKU.  
-* Variants store approved class, department, tax class, condition, and regular price assignments.  
-* A valid variant can be identified as sellable, while incomplete variants cannot.  
+* Variants store approved class, department, tax class, condition, and regular price assignments when activated.  
+* A valid variant can be identified as sellable, while incomplete draft variants cannot be activated.  
 * Identifier lookup resolves products and variants without ambiguity.  
 * Minimal product and variant imports are repeatable without duplicates.  
 * Material changes are authorized, audited, and protected against concurrent overwrites.  

--- a/lib/tasks/shelfsense.rake
+++ b/lib/tasks/shelfsense.rake
@@ -37,4 +37,20 @@ namespace :shelfsense do
     puts "Store: #{result[:store].code} (#{result[:store].name})"
     puts "Administrator: #{result[:administrator].username}"
   end
+
+  desc "Idempotently seed permissions and system role grants from PermissionCatalog"
+  task seed_permissions: :environment do
+    granted_by = User.system_actors.order(:created_at).first
+    abort "No system actor found. Bootstrap the installation first." if granted_by.nil?
+
+    before = Role.find_by(key: "system_administrator")&.permissions&.pluck(:key) || []
+    Authorization::PermissionCatalog.seed!(granted_by: granted_by)
+    after = Role.find_by!(key: "system_administrator").permissions.pluck(:key)
+
+    added = after - before
+    puts "Permission catalog seeded."
+    puts "Permissions: #{Permission.count}"
+    puts "system_administrator grants: #{after.size}"
+    puts "Newly granted to system_administrator: #{added.sort.join(', ')}" if added.any?
+  end
 end

--- a/test/integration/phase2_admin_authz_test.rb
+++ b/test/integration/phase2_admin_authz_test.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Phase2AdminAuthzTest < ActionDispatch::IntegrationTest
+  setup do
+    @bootstrap = bootstrap!
+    @admin = @bootstrap[:administrator]
+    @store = @bootstrap[:store]
+    @associate = User.create!(
+      username: "associate",
+      display_name: "Associate User",
+      password: "correct-horse-battery",
+      password_confirmation: "correct-horse-battery"
+    )
+    RoleAssignment.create!(
+      user: @associate,
+      role: Role.find_by!(key: "associate"),
+      store: @store,
+      assigned_by: @admin,
+      effective_at: Time.current
+    )
+  end
+
+  test "admin can create GL accounts and tax classes" do
+    sign_in_as("admin")
+
+    post admin_gl_accounts_path, params: {
+      gl_account: {
+        account_number: "1200",
+        name: "Inventory",
+        account_type: "asset",
+        account_category: "inventory",
+        posting_allowed: "1",
+        display_order: 0
+      }
+    }
+    assert_response :redirect
+    assert GlAccount.exists?(account_number: "1200")
+
+    post admin_tax_classes_path, params: {
+      tax_class: { code: "taxable", name: "Taxable", display_order: 0 }
+    }
+    assert_response :redirect
+    assert TaxClass.exists?(code: "taxable")
+  end
+
+  test "associate is denied gl_accounts.create" do
+    sign_in_as("associate")
+
+    post admin_gl_accounts_path, params: {
+      gl_account: {
+        account_number: "1300",
+        name: "Denied",
+        account_type: "asset",
+        account_category: "cash",
+        posting_allowed: "1",
+        display_order: 0
+      }
+    }
+    assert_redirected_to root_path
+    assert_not GlAccount.exists?(account_number: "1300")
+    assert_equal "denied", AuditEvent.where(action: "authorization.denied").order(:created_at).last.outcome
+  end
+
+  test "associate may use merchandise.lookup" do
+    sign_in_as("associate")
+
+    get new_admin_merchandise_lookup_path
+    assert_response :success
+
+    post admin_merchandise_lookups_path, params: { lookup: { raw: external_isbn13 } }
+    assert_response :success
+    assert_match(/not_found|Status/i, response.body)
+  end
+
+  test "merchandise.import requires merchandise.import permission" do
+    sign_in_as("associate")
+
+    get new_admin_merchandise_import_path
+    assert_redirected_to root_path
+
+    sign_in_as("admin")
+    get new_admin_merchandise_import_path
+    assert_response :success
+  end
+
+  private
+
+  def sign_in_as(username)
+    delete session_path
+    follow_redirect! while response.redirect?
+    post session_path, params: { session: { username: username, password: "correct-horse-battery" } }
+    follow_redirect! if response.redirect?
+  end
+end

--- a/test/integration/phase2_hardening_test.rb
+++ b/test/integration/phase2_hardening_test.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Phase2HardeningTest < ActionDispatch::IntegrationTest
+  setup do
+    @bootstrap = bootstrap!
+    @actor = @bootstrap[:administrator]
+    sign_in_as("admin")
+    @tax = tax_class(code: "books")
+    @dept = department(code: "new_books", default_tax_class: @tax)
+    @klass = merchandise_class(code: "book", pricing_method: "fixed", default_standard_department: @dept)
+    @condition = merchandise_condition(code: "new")
+  end
+
+  test "cross-namespace uniqueness blocks product primary equal to variant sku" do
+    product = Products::Create.call(
+      attributes: { name: "Owner", status: "draft" },
+      actor: @actor,
+      identifier_mode: "generate"
+    )
+    variant = ProductVariants::Create.call(
+      product: product,
+      actor: @actor,
+      attributes: { merchandise_condition_id: @condition.id }
+    )
+
+    error = assert_raises(Products::Create::Error) do
+      Products::Create.call(
+        attributes: { name: "Collision", status: "draft" },
+        actor: @actor,
+        identifier_mode: "enter",
+        external_identifier: variant.sku
+      )
+    end
+    assert_match(/already reserved/i, error.message)
+  end
+
+  test "draft product delete leaves a retired registry tombstone" do
+    product = Products::Create.call(
+      attributes: { name: "Draft delete", status: "draft" },
+      actor: @actor,
+      identifier_mode: "generate"
+    )
+    value = product.primary_identifier
+
+    delete admin_product_path(product)
+    assert_redirected_to admin_products_path
+    assert_nil Product.find_by(id: product.id)
+
+    row = Identifiers::Registry.find_any(value)
+    assert row.present?
+    assert row.retired_at.present?
+    assert_nil row.product_id
+  end
+
+  test "retired identifiers cannot be reallocated" do
+    product = Products::Create.call(
+      attributes: { name: "Retire", status: "draft" },
+      actor: @actor,
+      identifier_mode: "generate"
+    )
+    value = product.primary_identifier
+    delete admin_product_path(product)
+
+    error = assert_raises(Identifiers::Registry::ConflictError) do
+      Identifiers::Registry.reserve!(
+        value: value,
+        kind: "product_primary",
+        product: Products::Create.call(
+          attributes: { name: "Other", status: "draft" },
+          actor: @actor,
+          identifier_mode: "enter",
+          external_identifier: external_isbn13
+        )
+      )
+    end
+    assert_match(/already reserved/i, error.message)
+
+    error = assert_raises(Products::Create::Error) do
+      Products::Create.call(
+        attributes: { name: "Reuse 222", status: "draft" },
+        actor: @actor,
+        identifier_mode: "enter",
+        external_identifier: value
+      )
+    end
+    assert_match(/reserved 222|already reserved/i, error.message)
+  end
+
+  test "sequence exhaustion raises Generator::ExhaustedError" do
+    connection = ActiveRecord::Base.connection
+    original_select = connection.method(:select_value)
+
+    connection.define_singleton_method(:select_value) do |sql|
+      if sql.to_s.include?("nextval") && sql.to_s.include?("shelfsense_product_222_seq")
+        raise ActiveRecord::StatementInvalid, "PG::SequenceError: nextval: reached maximum value of sequence \"shelfsense_product_222_seq\" (MAXVALUE)"
+      end
+
+      original_select.call(sql)
+    end
+
+    begin
+      assert_raises(Identifiers::Generator::ExhaustedError) do
+        Identifiers::Generator.next_ean13!("222")
+      end
+    ensure
+      connection.define_singleton_method(:select_value) do |sql|
+        original_select.call(sql)
+      end
+    end
+  end
+
+  test "inactive reference is rejected on new assignment" do
+    inactive_tax = tax_class(code: "inactive_tax", active: false)
+    inactive_class = merchandise_class(code: "inactive_class", active: false, default_standard_department: @dept)
+    inactive_condition = merchandise_condition(code: "inactive_cond", active: false)
+    inactive_dept = department(code: "inactive_dept", default_tax_class: @tax, active: false)
+
+    product = Products::Create.call(
+      attributes: { name: "Refs", status: "draft" },
+      actor: @actor,
+      identifier_mode: "generate"
+    )
+
+    assert_raises(ProductVariants::Create::Error) do
+      ProductVariants::Create.call(
+        product: product,
+        actor: @actor,
+        attributes: { merchandise_condition_id: inactive_condition.id }
+      )
+    end
+
+    variant = ProductVariants::Create.call(
+      product: product,
+      actor: @actor,
+      attributes: { merchandise_condition_id: @condition.id }
+    )
+
+    variant.merchandise_class = inactive_class
+    assert_not variant.valid?
+    assert_includes variant.errors[:merchandise_class_id], "must be an active merchandise class"
+
+    variant.reload
+    variant.department = inactive_dept
+    assert_not variant.valid?
+    assert_includes variant.errors[:department_id], "must be an active department"
+
+    variant.reload
+    variant.tax_class = inactive_tax
+    assert_not variant.valid?
+    assert_includes variant.errors[:tax_class_id], "must be an active tax class"
+  end
+
+  private
+
+  def sign_in_as(username)
+    post session_path, params: { session: { username: username, password: "correct-horse-battery" } }
+    follow_redirect! if response.redirect?
+  end
+end

--- a/test/integration/phase2_hardening_test.rb
+++ b/test/integration/phase2_hardening_test.rb
@@ -22,7 +22,7 @@ class Phase2HardeningTest < ActionDispatch::IntegrationTest
     variant = ProductVariants::Create.call(
       product: product,
       actor: @actor,
-      attributes: { merchandise_condition_id: @condition.id }
+      attributes: { variant_type: "standard" }
     )
 
     error = assert_raises(Products::Create::Error) do
@@ -127,14 +127,23 @@ class Phase2HardeningTest < ActionDispatch::IntegrationTest
       ProductVariants::Create.call(
         product: product,
         actor: @actor,
-        attributes: { merchandise_condition_id: inactive_condition.id }
+        attributes: {
+          variant_type: "used",
+          merchandise_condition_id: inactive_condition.id,
+          merchandise_class_id: merchandise_class(
+            code: "used_ok",
+            used_merchandise_allowed: true,
+            default_standard_department: @dept,
+            default_used_department: @dept
+          ).id
+        }
       )
     end
 
     variant = ProductVariants::Create.call(
       product: product,
       actor: @actor,
-      attributes: { merchandise_condition_id: @condition.id }
+      attributes: { variant_type: "standard" }
     )
 
     variant.merchandise_class = inactive_class

--- a/test/models/department_test.rb
+++ b/test/models/department_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DepartmentTest < ActiveSupport::TestCase
+  setup do
+    @tax = tax_class(code: "books")
+    @inventory = inventory_gl
+    @cogs = cogs_gl
+    @sales = sales_gl
+  end
+
+  test "rejects GL mapping with incompatible type or category" do
+    record = Department.new(
+      code: "new_books",
+      name: "New Books",
+      default_tax_class: @tax,
+      inventory_asset_gl_account: @sales
+    )
+    assert_not record.valid?
+    assert_includes record.errors[:inventory_asset_gl_account_id], "must be asset/inventory"
+  end
+
+  test "rejects inactive GL on new mapping" do
+    inactive = inventory_gl(account_number: "1299")
+    inactive.update!(active: false)
+
+    record = Department.new(
+      code: "cafe",
+      name: "Café",
+      default_tax_class: @tax,
+      inventory_asset_gl_account: inactive
+    )
+    assert_not record.valid?
+    assert_includes record.errors[:inventory_asset_gl_account_id], "must be an active posting account"
+  end
+
+  test "historical inactive GL mapping is retained when editing unrelated fields" do
+    record = department(
+      code: "media",
+      default_tax_class: @tax,
+      inventory_asset_gl_account: @inventory,
+      cost_of_goods_sold_gl_account: @cogs,
+      sales_revenue_gl_account: @sales
+    )
+    @inventory.update!(active: false)
+
+    record.name = "Media Updated"
+    assert record.valid?
+    assert record.save
+    assert_equal @inventory.id, record.reload.inventory_asset_gl_account_id
+  end
+
+  test "changing a mapping revalidates assignability" do
+    record = department(
+      code: "gifts",
+      default_tax_class: @tax,
+      inventory_asset_gl_account: @inventory
+    )
+    inactive = inventory_gl(account_number: "1210")
+    inactive.update!(active: false)
+
+    record.inventory_asset_gl_account = inactive
+    assert_not record.valid?
+    assert_includes record.errors[:inventory_asset_gl_account_id], "must be an active posting account"
+  end
+end

--- a/test/models/gl_account_test.rb
+++ b/test/models/gl_account_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class GlAccountTest < ActiveSupport::TestCase
+  test "account_number is unique" do
+    gl_account(account_number: "1000", account_type: "asset", account_category: "cash")
+    duplicate = GlAccount.new(
+      account_number: "1000",
+      name: "Dup",
+      account_type: "asset",
+      account_category: "cash"
+    )
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:account_number], "has already been taken"
+  end
+
+  test "parent must have the same account type" do
+    parent = gl_account(account_number: "1100", account_type: "asset", account_category: "cash")
+    child = GlAccount.new(
+      account_number: "4100",
+      name: "Sales child",
+      account_type: "revenue",
+      account_category: "sales",
+      parent: parent
+    )
+    assert_not child.valid?
+    assert_includes child.errors[:parent_id], "must have the same account type"
+  end
+
+  test "parent hierarchy cannot cycle" do
+    a = gl_account(account_number: "2000", account_type: "liability", account_category: "accounts_payable")
+    b = gl_account(account_number: "2100", account_type: "liability", account_category: "accounts_payable", parent: a)
+
+    a.parent = b
+    assert_not a.valid?
+    assert_includes a.errors[:parent_id], "would create a hierarchy cycle"
+  end
+
+  test "account cannot parent itself" do
+    account = gl_account(account_number: "3000", account_type: "equity", account_category: "equity")
+    account.parent_id = account.id
+    assert_not account.valid?
+    assert_includes account.errors[:parent_id], "cannot reference itself"
+  end
+end

--- a/test/models/merchandise_reference_test.rb
+++ b/test/models/merchandise_reference_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class MerchandiseReferenceTest < ActiveSupport::TestCase
+  setup do
+    @tax = tax_class(code: "standard")
+    @department = department(code: "books", default_tax_class: @tax)
+  end
+
+  test "merchandise class code is unique" do
+    merchandise_class(code: "book", default_standard_department: @department)
+    duplicate = MerchandiseClass.new(
+      code: " Book ",
+      name: "Other",
+      inventory_tracking_mode: "quantity",
+      pricing_method: "fixed"
+    )
+    assert_not duplicate.valid?
+    assert_equal "book", duplicate.code
+    assert_includes duplicate.errors[:code], "has already been taken"
+  end
+
+  test "merchandise condition code is unique" do
+    merchandise_condition(code: "new")
+    duplicate = MerchandiseCondition.new(
+      code: "NEW",
+      name: "Brand new",
+      department_basis: "standard",
+      price_adjustment_bps: 10_000
+    )
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:code], "has already been taken"
+  end
+
+  test "merchandise category root name uniqueness is enforced" do
+    merchandise_category(name: "Fiction")
+    assert_raises(ActiveRecord::RecordNotUnique) do
+      MerchandiseCategory.create!(name: "fiction", display_order: 0)
+    end
+  end
+
+  test "merchandise category parent hierarchy cannot cycle" do
+    parent = merchandise_category(name: "Parent")
+    child = merchandise_category(name: "Child", parent: parent)
+
+    parent.parent = child
+    assert_not parent.valid?
+    assert_includes parent.errors[:parent_id], "would create a hierarchy cycle"
+  end
+
+  test "used_basis? reflects department_basis" do
+    standard = merchandise_condition(code: "new", department_basis: "standard")
+    used = merchandise_condition(code: "used", department_basis: "used", price_adjustment_bps: 6_000)
+
+    assert_not standard.used_basis?
+    assert used.used_basis?
+  end
+end

--- a/test/models/merchandise_reference_test.rb
+++ b/test/models/merchandise_reference_test.rb
@@ -13,7 +13,7 @@ class MerchandiseReferenceTest < ActiveSupport::TestCase
     duplicate = MerchandiseClass.new(
       code: " Book ",
       name: "Other",
-      inventory_tracking_mode: "quantity",
+      inventory_mode: "inventory",
       pricing_method: "fixed"
     )
     assert_not duplicate.valid?
@@ -22,11 +22,10 @@ class MerchandiseReferenceTest < ActiveSupport::TestCase
   end
 
   test "merchandise condition code is unique" do
-    merchandise_condition(code: "new")
+    merchandise_condition(code: "like_new")
     duplicate = MerchandiseCondition.new(
-      code: "NEW",
-      name: "Brand new",
-      department_basis: "standard",
+      code: "LIKE_NEW",
+      name: "Like new",
       price_adjustment_bps: 10_000
     )
     assert_not duplicate.valid?
@@ -49,11 +48,19 @@ class MerchandiseReferenceTest < ActiveSupport::TestCase
     assert_includes parent.errors[:parent_id], "would create a hierarchy cycle"
   end
 
-  test "used_basis? reflects department_basis" do
-    standard = merchandise_condition(code: "new", department_basis: "standard")
-    used = merchandise_condition(code: "used", department_basis: "used", price_adjustment_bps: 6_000)
+  test "inventory_mode accepts inventory and non_inventory" do
+    inventory = merchandise_class(code: "book", inventory_mode: "inventory", default_standard_department: @department)
+    service = merchandise_class(code: "service", inventory_mode: "non_inventory", default_standard_department: @department)
 
-    assert_not standard.used_basis?
-    assert used.used_basis?
+    assert inventory.inventory?
+    assert service.non_inventory?
+    invalid = MerchandiseClass.new(
+      code: "bad",
+      name: "Bad",
+      inventory_mode: "quantity",
+      pricing_method: "fixed"
+    )
+    assert_not invalid.valid?
+    assert_includes invalid.errors[:inventory_mode], "is not included in the list"
   end
 end

--- a/test/models/tax_class_test.rb
+++ b/test/models/tax_class_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TaxClassTest < ActiveSupport::TestCase
+  test "code is unique after normalization" do
+    tax_class(code: "taxable")
+    duplicate = TaxClass.new(code: " Taxable ", name: "Other")
+    assert_not duplicate.valid?
+    assert_equal "taxable", duplicate.code
+    assert_includes duplicate.errors[:code], "has already been taken"
+  end
+
+  test "normalize_code downcases and replaces spaces" do
+    record = TaxClass.create!(code: " Physical Book ", name: "Physical book")
+    assert_equal "physical_book", record.code
+  end
+end

--- a/test/services/identifiers/assign_industry_test.rb
+++ b/test/services/identifiers/assign_industry_test.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Identifiers::AssignIndustryTest < ActiveSupport::TestCase
+  setup do
+    @actor = actor_user
+    @product = Products::Create.call(
+      attributes: { name: "Industry product", status: "draft" },
+      actor: @actor,
+      identifier_mode: "generate"
+    )
+    @variant = ProductVariants::Create.call(
+      product: @product,
+      actor: @actor,
+      attributes: { variant_type: "standard", status: "draft" }
+    )
+    @industry = unique_industry_identifier
+    @replacement = unique_industry_identifier
+  end
+
+  test "assigns industry identifier through the registry" do
+    Identifiers::AssignIndustry.call(variant: @variant, raw_value: @industry)
+
+    assert_equal @industry, @variant.reload.industry_identifier
+    row = IdentifierRegistry.find_by!(value: @industry)
+    assert_equal "variant_industry", row.identifier_kind
+    assert_equal @variant.id, row.product_variant_id
+    assert_nil row.product_id
+    assert_nil row.retired_at
+  end
+
+  test "replaces industry identifier and retires the previous registry row" do
+    Identifiers::AssignIndustry.call(variant: @variant, raw_value: @industry)
+    Identifiers::AssignIndustry.call(variant: @variant, raw_value: @replacement)
+
+    assert_equal @replacement, @variant.reload.industry_identifier
+    assert IdentifierRegistry.find_by!(value: @industry).retired_at.present?
+    assert_nil IdentifierRegistry.find_by!(value: @replacement).retired_at
+  end
+
+  test "clears industry identifier and retires the registry row" do
+    Identifiers::AssignIndustry.call(variant: @variant, raw_value: @industry)
+    Identifiers::AssignIndustry.call(variant: @variant, raw_value: nil)
+
+    assert_nil @variant.reload.industry_identifier
+    assert IdentifierRegistry.find_by!(value: @industry).retired_at.present?
+  end
+
+  test "product variant update routes industry changes through assign industry" do
+    ProductVariants::Update.call(
+      variant: @variant,
+      actor: @actor,
+      attributes: { industry_identifier: @industry }
+    )
+    ProductVariants::Update.call(
+      variant: @variant.reload,
+      actor: @actor,
+      attributes: { industry_identifier: @replacement, name: "Renamed" }
+    )
+
+    @variant.reload
+    assert_equal @replacement, @variant.industry_identifier
+    assert_equal "Renamed", @variant.name
+    assert IdentifierRegistry.find_by!(value: @industry).retired_at.present?
+    assert_operator AuditEvent.where(
+      action: "product_variants.update",
+      subject_type: "ProductVariant",
+      subject_id: @variant.id
+    ).count, :>=, 2
+  end
+
+  private
+
+  def unique_industry_identifier
+    20.times do
+      value = Identifiers::Ean13.complete("978", format("%09d", SecureRandom.random_number(1_000_000_000)))
+      next if value == @variant.sku
+      next if IdentifierRegistry.exists?(value: value)
+      next if ProductVariant.exists?(industry_identifier: value)
+
+      return value
+    end
+    raise "unable to allocate unique industry identifier for test"
+  end
+end

--- a/test/services/identifiers/assign_industry_test.rb
+++ b/test/services/identifiers/assign_industry_test.rb
@@ -51,12 +51,16 @@ class Identifiers::AssignIndustryTest < ActiveSupport::TestCase
     ProductVariants::Update.call(
       variant: @variant,
       actor: @actor,
-      attributes: { industry_identifier: @industry }
+      attributes: { industry_identifier: @industry, lock_version: @variant.lock_version }
     )
     ProductVariants::Update.call(
       variant: @variant.reload,
       actor: @actor,
-      attributes: { industry_identifier: @replacement, name: "Renamed" }
+      attributes: {
+        industry_identifier: @replacement,
+        name: "Renamed",
+        lock_version: @variant.lock_version
+      }
     )
 
     @variant.reload
@@ -68,6 +72,47 @@ class Identifiers::AssignIndustryTest < ActiveSupport::TestCase
       subject_type: "ProductVariant",
       subject_id: @variant.id
     ).count, :>=, 2
+  end
+
+  test "updating industry identifier with current lock_version succeeds" do
+    Identifiers::AssignIndustry.call(variant: @variant, raw_value: @industry)
+    @variant.reload
+
+    assert_nothing_raised do
+      ProductVariants::Update.call(
+        variant: @variant,
+        actor: @actor,
+        attributes: {
+          industry_identifier: @replacement,
+          lock_version: @variant.lock_version
+        }
+      )
+    end
+
+    assert_equal @replacement, @variant.reload.industry_identifier
+  end
+
+  test "stale lock_version rejects industry identifier update and rolls back registry" do
+    Identifiers::AssignIndustry.call(variant: @variant, raw_value: @industry)
+    @variant.reload
+    stale = @variant.lock_version
+    @variant.update!(name: "Concurrent edit")
+
+    assert_raises(ActiveRecord::StaleObjectError) do
+      ProductVariants::Update.call(
+        variant: ProductVariant.find(@variant.id),
+        actor: @actor,
+        attributes: {
+          industry_identifier: @replacement,
+          lock_version: stale
+        }
+      )
+    end
+
+    @variant.reload
+    assert_equal @industry, @variant.industry_identifier
+    assert_nil IdentifierRegistry.find_by(value: @replacement)
+    assert_nil IdentifierRegistry.find_by!(value: @industry).retired_at
   end
 
   private

--- a/test/services/identifiers/generator_and_registry_test.rb
+++ b/test/services/identifiers/generator_and_registry_test.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Identifiers::GeneratorAndRegistryTest < ActiveSupport::TestCase
+  setup do
+    @actor = actor_user
+  end
+
+  test "generates 222 and 221 identifiers with valid check digits" do
+    product_id = Identifiers::Generator.next_ean13!("222")
+    sku = Identifiers::Generator.next_ean13!("221")
+
+    assert_match(/\A222\d{10}\z/, product_id)
+    assert_match(/\A221\d{10}\z/, sku)
+    assert Identifiers::Ean13.valid?(product_id)
+    assert Identifiers::Ean13.valid?(sku)
+  end
+
+  test "reserve raises on conflict" do
+    product = Products::Create.call(
+      attributes: { name: "Reserved", status: "draft" },
+      actor: @actor,
+      identifier_mode: "generate"
+    )
+
+    error = assert_raises(Identifiers::Registry::ConflictError) do
+      Identifiers::Registry.reserve!(
+        value: product.primary_identifier,
+        kind: "product_primary",
+        product: product
+      )
+    end
+    assert_match(/already reserved/i, error.message)
+  end
+
+  test "retire marks registry row inactive while retaining the value" do
+    product = Products::Create.call(
+      attributes: { name: "Retire me", status: "draft" },
+      actor: @actor,
+      identifier_mode: "generate"
+    )
+    value = product.primary_identifier
+
+    Identifiers::Registry.retire!(value: value)
+    row = Identifiers::Registry.find_any(value)
+
+    assert row.retired_at.present?
+    assert_nil Identifiers::Registry.find_active(value)
+  end
+
+  test "active ownership requires exactly one owner" do
+    row = IdentifierRegistry.new(
+      value: Identifiers::Ean13.complete("978", "111111111"),
+      identifier_kind: "product_primary",
+      retired_at: nil
+    )
+    assert_not row.valid?
+    assert_includes row.errors[:base], "active registry rows require exactly one owner"
+  end
+
+  test "failed product create rolls back reservation" do
+    external = external_isbn13
+    before_products = Product.count
+    before_registry = IdentifierRegistry.count
+
+    original = Audit::Recorder.method(:record!)
+    Audit::Recorder.define_singleton_method(:record!) do |**_|
+      raise "simulated audit failure"
+    end
+
+    begin
+      assert_raises(RuntimeError) do
+        Products::Create.call(
+          attributes: { name: "Rollback", status: "draft" },
+          actor: @actor,
+          identifier_mode: "enter",
+          external_identifier: external
+        )
+      end
+    ensure
+      Audit::Recorder.define_singleton_method(:record!, original)
+    end
+
+    assert_equal before_products, Product.count
+    assert_equal before_registry, IdentifierRegistry.count
+    assert_nil Identifiers::Registry.find_any(external)
+  end
+end

--- a/test/services/identifiers/generator_and_registry_test.rb
+++ b/test/services/identifiers/generator_and_registry_test.rb
@@ -97,6 +97,71 @@ class Identifiers::GeneratorAndRegistryTest < ActiveSupport::TestCase
     end
   end
 
+  test "retired registry rows may not have two owners" do
+    product = Products::Create.call(
+      attributes: { name: "Dual owner", status: "draft" },
+      actor: @actor,
+      identifier_mode: "generate"
+    )
+    variant = ProductVariants::Create.call(
+      product: product,
+      actor: @actor,
+      attributes: { variant_type: "standard" }
+    )
+
+    row = IdentifierRegistry.new(
+      value: Identifiers::Ean13.complete("978", "555555555"),
+      identifier_kind: "variant_industry",
+      product: product,
+      product_variant: variant,
+      retired_at: Time.current
+    )
+    assert_not row.valid?
+    assert_includes row.errors[:base], "registry rows may have at most one owner"
+
+    assert_raises(ActiveRecord::StatementInvalid) do
+      IdentifierRegistry.insert!({
+        id: SecureRandom.uuid_v7,
+        value: Identifiers::Ean13.complete("978", "666666666"),
+        identifier_kind: "variant_industry",
+        product_id: product.id,
+        product_variant_id: variant.id,
+        retired_at: Time.current,
+        created_at: Time.current,
+        updated_at: Time.current
+      })
+    end
+  end
+
+  test "direct product and variant persistence cannot bypass identifier services" do
+    assert_raises(ActiveRecord::RecordInvalid) do
+      Product.create!(
+        name: "Bypass",
+        primary_identifier: Identifiers::Ean13.complete("978", "777777777"),
+        status: "draft"
+      )
+    end
+
+    product = Products::Create.call(
+      attributes: { name: "Guarded", status: "draft" },
+      actor: @actor,
+      identifier_mode: "generate"
+    )
+    assert_raises(ActiveRecord::RecordInvalid) do
+      product.update!(primary_identifier: Identifiers::Ean13.complete("978", "888888888"))
+    end
+
+    variant = ProductVariants::Create.call(
+      product: product,
+      actor: @actor,
+      attributes: { variant_type: "standard" }
+    )
+    assert_raises(ActiveRecord::RecordInvalid) do
+      variant.update!(industry_identifier: Identifiers::Ean13.complete("978", "999999999"))
+    end
+    assert_nil variant.reload.industry_identifier
+  end
+
   test "failed product create rolls back reservation" do
     external = external_isbn13
     before_products = Product.count

--- a/test/services/identifiers/generator_and_registry_test.rb
+++ b/test/services/identifiers/generator_and_registry_test.rb
@@ -49,14 +49,52 @@ class Identifiers::GeneratorAndRegistryTest < ActiveSupport::TestCase
     assert_nil Identifiers::Registry.find_active(value)
   end
 
-  test "active ownership requires exactly one owner" do
+  test "active product_primary requires a product owner only" do
     row = IdentifierRegistry.new(
       value: Identifiers::Ean13.complete("978", "111111111"),
       identifier_kind: "product_primary",
       retired_at: nil
     )
     assert_not row.valid?
-    assert_includes row.errors[:base], "active registry rows require exactly one owner"
+    assert_includes row.errors[:product_id], "is required for active product_primary rows"
+  end
+
+  test "active variant_sku rejects product ownership" do
+    product = Products::Create.call(
+      attributes: { name: "Owner mismatch", status: "draft" },
+      actor: @actor,
+      identifier_mode: "generate"
+    )
+    row = IdentifierRegistry.new(
+      value: Identifiers::Ean13.complete("221", "333333333"),
+      identifier_kind: "variant_sku",
+      product: product,
+      retired_at: nil
+    )
+    assert_not row.valid?
+    assert_includes row.errors[:product_variant_id], "is required for active variant_sku rows"
+    assert_includes row.errors[:product_id], "must be blank for variant_sku rows"
+  end
+
+  test "database enforces kind-specific registry ownership" do
+    product = Products::Create.call(
+      attributes: { name: "DB owner", status: "draft" },
+      actor: @actor,
+      identifier_mode: "generate"
+    )
+
+    assert_raises(ActiveRecord::StatementInvalid) do
+      IdentifierRegistry.insert!({
+        id: SecureRandom.uuid_v7,
+        value: Identifiers::Ean13.complete("221", "444444444"),
+        identifier_kind: "variant_sku",
+        product_id: product.id,
+        product_variant_id: nil,
+        retired_at: nil,
+        created_at: Time.current,
+        updated_at: Time.current
+      })
+    end
   end
 
   test "failed product create rolls back reservation" do

--- a/test/services/identifiers/lookup_test.rb
+++ b/test/services/identifiers/lookup_test.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Identifiers::LookupTest < ActiveSupport::TestCase
+  setup do
+    @actor = actor_user
+    @tax = tax_class(code: "books")
+    @dept = department(code: "new_books", default_tax_class: @tax)
+    @klass = merchandise_class(
+      code: "book",
+      pricing_method: "fixed",
+      default_standard_department: @dept
+    )
+    @condition = merchandise_condition(code: "new")
+    @condition_used = merchandise_condition(code: "used", department_basis: "used", price_adjustment_bps: 6_000)
+    @klass.update!(used_merchandise_allowed: true, default_used_department: @dept)
+    @product = Products::Create.call(
+      attributes: { name: "Lookup Product", status: "active" },
+      actor: @actor,
+      identifier_mode: "enter",
+      external_identifier: external_isbn13
+    )
+  end
+
+  test "resolves variant by sku" do
+    variant = create_sellable_variant!(name: "SKU variant")
+    result = Identifiers::Lookup.call(variant.sku)
+
+    assert_equal :variant, result.status
+    assert_equal variant.id, result.variant.id
+    assert_equal @product.id, result.product.id
+  end
+
+  test "resolves product when no sellable variants exist" do
+    result = Identifiers::Lookup.call(@product.primary_identifier)
+
+    assert_equal :product, result.status
+    assert_equal @product.id, result.product.id
+    assert_nil result.variant
+  end
+
+  test "resolves multi_variant when multiple sellable variants exist" do
+    first = create_sellable_variant!(name: "First", condition: @condition)
+    second = create_sellable_variant!(name: "Second", condition: @condition_used)
+    result = Identifiers::Lookup.call(@product.primary_identifier)
+
+    assert_equal :multi_variant, result.status
+    assert_equal @product.id, result.product.id
+    assert_equal [ first.id, second.id ].sort, result.variants.map(&:id).sort
+  end
+
+  test "returns not_found for unknown identifier" do
+    unknown = Identifiers::Ean13.complete("978", "999999999")
+    result = Identifiers::Lookup.call(unknown)
+
+    assert_equal :not_found, result.status
+  end
+
+  test "returns retired for tombstoned identifier" do
+    Identifiers::Registry.retire!(value: @product.primary_identifier)
+    result = Identifiers::Lookup.call(@product.primary_identifier)
+
+    assert_equal :retired, result.status
+  end
+
+  test "returns invalid for bad input" do
+    result = Identifiers::Lookup.call("not-an-identifier")
+
+    assert_equal :invalid, result.status
+    assert_match(/13 digits|blank|check digit/i, result.message)
+  end
+
+  private
+
+  def create_sellable_variant!(name:, condition: @condition)
+    ProductVariants::Create.call(
+      product: @product,
+      actor: @actor,
+      attributes: {
+        name: name,
+        merchandise_condition_id: condition.id,
+        merchandise_class_id: @klass.id,
+        department_id: @dept.id,
+        tax_class_id: @tax.id,
+        regular_price_cents: 1_500,
+        status: "active"
+      }
+    )
+  end
+end

--- a/test/services/identifiers/lookup_test.rb
+++ b/test/services/identifiers/lookup_test.rb
@@ -12,9 +12,14 @@ class Identifiers::LookupTest < ActiveSupport::TestCase
       pricing_method: "fixed",
       default_standard_department: @dept
     )
-    @condition = merchandise_condition(code: "new")
-    @condition_used = merchandise_condition(code: "used", department_basis: "used", price_adjustment_bps: 6_000)
-    @klass.update!(used_merchandise_allowed: true, default_used_department: @dept)
+    @used_klass = merchandise_class(
+      code: "used_book",
+      pricing_method: "fixed",
+      used_merchandise_allowed: true,
+      default_standard_department: @dept,
+      default_used_department: @dept
+    )
+    @like_new = merchandise_condition(code: "like_new", price_adjustment_bps: 6_000)
     @product = Products::Create.call(
       attributes: { name: "Lookup Product", status: "active" },
       actor: @actor,
@@ -24,7 +29,7 @@ class Identifiers::LookupTest < ActiveSupport::TestCase
   end
 
   test "resolves variant by sku" do
-    variant = create_sellable_variant!(name: "SKU variant")
+    variant = create_sellable_standard!(name: "SKU variant")
     result = Identifiers::Lookup.call(variant.sku)
 
     assert_equal :variant, result.status
@@ -41,8 +46,8 @@ class Identifiers::LookupTest < ActiveSupport::TestCase
   end
 
   test "resolves multi_variant when multiple sellable variants exist" do
-    first = create_sellable_variant!(name: "First", condition: @condition)
-    second = create_sellable_variant!(name: "Second", condition: @condition_used)
+    first = create_sellable_standard!(name: "First")
+    second = create_sellable_used!(name: "Second")
     result = Identifiers::Lookup.call(@product.primary_identifier)
 
     assert_equal :multi_variant, result.status
@@ -73,17 +78,34 @@ class Identifiers::LookupTest < ActiveSupport::TestCase
 
   private
 
-  def create_sellable_variant!(name:, condition: @condition)
+  def create_sellable_standard!(name:)
     ProductVariants::Create.call(
       product: @product,
       actor: @actor,
       attributes: {
+        variant_type: "standard",
         name: name,
-        merchandise_condition_id: condition.id,
         merchandise_class_id: @klass.id,
         department_id: @dept.id,
         tax_class_id: @tax.id,
         regular_price_cents: 1_500,
+        status: "active"
+      }
+    )
+  end
+
+  def create_sellable_used!(name:)
+    ProductVariants::Create.call(
+      product: @product,
+      actor: @actor,
+      attributes: {
+        variant_type: "used",
+        name: name,
+        merchandise_condition_id: @like_new.id,
+        merchandise_class_id: @used_klass.id,
+        department_id: @dept.id,
+        tax_class_id: @tax.id,
+        regular_price_cents: 1_200,
         status: "active"
       }
     )

--- a/test/services/identifiers/normalizer_test.rb
+++ b/test/services/identifiers/normalizer_test.rb
@@ -14,6 +14,17 @@ class Identifiers::NormalizerTest < ActiveSupport::TestCase
     assert_equal "9780306406157", Identifiers::Normalizer.normalize("0306406152")
   end
 
+  test "rejects ISBN-10 with invalid check digit before conversion" do
+    error = assert_raises(Identifiers::NormalizationError) do
+      Identifiers::Normalizer.normalize("0306406153")
+    end
+    assert_match(/invalid ISBN-10 check digit/i, error.message)
+  end
+
+  test "accepts ISBN-10 terminating in X" do
+    assert_equal "9780804429573", Identifiers::Normalizer.normalize("080442957X")
+  end
+
   test "converts UPC-A to GTIN-13" do
     ean13 = Identifiers::Ean13.complete("012", "345678901")
     upc_a = ean13[1, 12]

--- a/test/services/identifiers/normalizer_test.rb
+++ b/test/services/identifiers/normalizer_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Identifiers::NormalizerTest < ActiveSupport::TestCase
+  test "strips spaces and hyphens" do
+    value = Identifiers::Ean13.complete("978", "123456789")
+    formatted = "#{value[0, 3]}-#{value[3, 1]}-#{value[4, 6]}-#{value[10, 2]}-#{value[12]}"
+    assert_equal value, Identifiers::Normalizer.normalize(" #{formatted} ")
+  end
+
+  test "converts ISBN-10 to ISBN-13" do
+    assert_equal "9780306406157", Identifiers::Normalizer.normalize("0-306-40615-2")
+    assert_equal "9780306406157", Identifiers::Normalizer.normalize("0306406152")
+  end
+
+  test "converts UPC-A to GTIN-13" do
+    ean13 = Identifiers::Ean13.complete("012", "345678901")
+    upc_a = ean13[1, 12]
+    assert_equal 12, upc_a.length
+    assert_equal ean13, Identifiers::Normalizer.normalize(upc_a)
+  end
+
+  test "rejects invalid check digit" do
+    body = "978123456789"
+    bad = "#{body}#{(Identifiers::Ean13.check_digit(body) + 1) % 10}"
+    error = assert_raises(Identifiers::NormalizationError) do
+      Identifiers::Normalizer.normalize(bad)
+    end
+    assert_match(/invalid check digit/i, error.message)
+  end
+
+  test "rejects entered 222 namespace unless allowed" do
+    value = Identifiers::Ean13.complete("222", "000000001")
+    error = assert_raises(Identifiers::NormalizationError) do
+      Identifiers::Normalizer.normalize(value, allow_shelfsense_222: false)
+    end
+    assert_match(/reserved 222/i, error.message)
+
+    assert_equal value, Identifiers::Normalizer.normalize(value, allow_shelfsense_222: true)
+  end
+end

--- a/test/services/installation/bootstrap_test.rb
+++ b/test/services/installation/bootstrap_test.rb
@@ -30,9 +30,16 @@ class Installation::BootstrapTest < ActiveSupport::TestCase
     assert_equal "system_administrator", result[:assignment].role.key
     assert_nil result[:assignment].store_id
 
-    assert_equal 22, Permission.count
+    assert_equal Authorization::PermissionCatalog::PERMISSIONS.size, Permission.count
     assert_equal 3, Role.count
     assert Role.find_by!(key: "store_manager").assignment_scope == "store"
+
+    admin_role = Role.find_by!(key: "system_administrator")
+    assert_equal Authorization::PermissionCatalog::PERMISSIONS.map { |p| p[:key] }.sort,
+                 admin_role.permissions.pluck(:key).sort
+    Authorization::PermissionCatalog::PHASE2_PERMISSIONS.each do |permission|
+      assert_includes admin_role.permissions.pluck(:key), permission[:key]
+    end
 
     actions = AuditEvent.order(:occurred_at).pluck(:action)
     assert_includes actions, "installation.started"

--- a/test/services/merchandise/csv_importer_test.rb
+++ b/test/services/merchandise/csv_importer_test.rb
@@ -9,7 +9,14 @@ class Merchandise::CsvImporterTest < ActiveSupport::TestCase
     @tax = tax_class(code: "books")
     @dept = department(code: "new_books", default_tax_class: @tax)
     @klass = merchandise_class(code: "book", pricing_method: "fixed", default_standard_department: @dept)
-    @condition = merchandise_condition(code: "new")
+    @used_klass = merchandise_class(
+      code: "used_book",
+      pricing_method: "fixed",
+      used_merchandise_allowed: true,
+      default_standard_department: @dept,
+      default_used_department: @dept
+    )
+    @condition = merchandise_condition(code: "like_new")
   end
 
   test "matches product by normalized primary_identifier" do
@@ -72,7 +79,7 @@ class Merchandise::CsvImporterTest < ActiveSupport::TestCase
       product: product,
       actor: @actor,
       attributes: {
-        merchandise_condition_id: @condition.id,
+        variant_type: "standard",
         name: "First",
         industry_identifier: industry
       }
@@ -93,7 +100,7 @@ class Merchandise::CsvImporterTest < ActiveSupport::TestCase
     assert_equal "By Industry", variant.reload.name
   end
 
-  test "insufficient identity error when variant fields lack condition and match keys" do
+  test "insufficient identity error when variant fields lack type and match keys" do
     product = Products::Create.call(
       attributes: { name: "Identity", status: "draft" },
       actor: @actor,
@@ -119,13 +126,31 @@ class Merchandise::CsvImporterTest < ActiveSupport::TestCase
     fake_sku = Identifiers::Ean13.complete("221", "888888888")
 
     result = import_csv(<<~CSV)
-      primary_identifier,name,generate_primary_identifier,sku,variant_condition_code,variant_name
-      #{product.primary_identifier},Caller SKU,false,#{fake_sku},new,Should Fail
+      primary_identifier,name,generate_primary_identifier,sku,variant_type,variant_name
+      #{product.primary_identifier},Caller SKU,false,#{fake_sku},standard,Should Fail
     CSV
 
     assert_equal 1, result.errors.size
     assert_match(/caller-assigned SKU|not accepted/i, result.errors.first[:message])
     assert_nil ProductVariant.find_by(sku: fake_sku)
+  end
+
+  test "creates used variant with condition and standard without" do
+    product = Products::Create.call(
+      attributes: { name: "Typed", status: "draft" },
+      actor: @actor,
+      identifier_mode: "generate"
+    )
+
+    result = import_csv(<<~CSV)
+      primary_identifier,name,generate_primary_identifier,variant_type,variant_condition_code,merchandise_class_code,regular_price_cents
+      #{product.primary_identifier},Typed,false,used,like_new,used_book,1200
+    CSV
+    assert_empty result.errors
+    assert_equal 1, result.created_variants
+    used = product.product_variants.used.first
+    assert used.present?
+    assert_equal @condition.id, used.merchandise_condition_id
   end
 
   private

--- a/test/services/merchandise/csv_importer_test.rb
+++ b/test/services/merchandise/csv_importer_test.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "stringio"
+
+class Merchandise::CsvImporterTest < ActiveSupport::TestCase
+  setup do
+    @actor = actor_user
+    @tax = tax_class(code: "books")
+    @dept = department(code: "new_books", default_tax_class: @tax)
+    @klass = merchandise_class(code: "book", pricing_method: "fixed", default_standard_department: @dept)
+    @condition = merchandise_condition(code: "new")
+  end
+
+  test "matches product by normalized primary_identifier" do
+    existing = Products::Create.call(
+      attributes: { name: "Original", status: "draft" },
+      actor: @actor,
+      identifier_mode: "enter",
+      external_identifier: external_isbn13
+    )
+
+    result = import_csv(<<~CSV)
+      primary_identifier,name,generate_primary_identifier
+      978-123456789-#{Identifiers::Ean13.check_digit("978123456789")},Renamed,false
+    CSV
+
+    assert_equal 0, result.created_products
+    assert_equal 1, result.updated_products
+    assert_empty result.errors
+    assert_equal "Renamed", existing.reload.name
+  end
+
+  test "generate path creates a 222 product" do
+    result = import_csv(<<~CSV)
+      primary_identifier,name,generate_primary_identifier
+      ,Generated Import,true
+    CSV
+
+    assert_equal 1, result.created_products
+    assert_empty result.errors
+    product = Product.order(:created_at).last
+    assert_match(/\A222\d{10}\z/, product.primary_identifier)
+  end
+
+  test "re-import by assigned 222 updates the existing product" do
+    product = Products::Create.call(
+      attributes: { name: "Generated", status: "draft" },
+      actor: @actor,
+      identifier_mode: "generate"
+    )
+
+    result = import_csv(<<~CSV)
+      primary_identifier,name,generate_primary_identifier
+      #{product.primary_identifier},Updated Generated,false
+    CSV
+
+    assert_equal 0, result.created_products
+    assert_equal 1, result.updated_products
+    assert_empty result.errors
+    assert_equal "Updated Generated", product.reload.name
+  end
+
+  test "matches variant by sku or industry identifier" do
+    product = Products::Create.call(
+      attributes: { name: "With variants", status: "draft" },
+      actor: @actor,
+      identifier_mode: "generate"
+    )
+    industry = Identifiers::Ean13.complete("978", "555555555")
+    variant = ProductVariants::Create.call(
+      product: product,
+      actor: @actor,
+      attributes: {
+        merchandise_condition_id: @condition.id,
+        name: "First",
+        industry_identifier: industry
+      }
+    )
+
+    by_sku = import_csv(<<~CSV)
+      primary_identifier,name,generate_primary_identifier,sku,variant_name
+      #{product.primary_identifier},With variants,false,#{variant.sku},By SKU
+    CSV
+    assert_equal 1, by_sku.updated_variants
+    assert_equal "By SKU", variant.reload.name
+
+    by_industry = import_csv(<<~CSV)
+      primary_identifier,name,generate_primary_identifier,industry_identifier,variant_name
+      #{product.primary_identifier},With variants,false,#{industry},By Industry
+    CSV
+    assert_equal 1, by_industry.updated_variants
+    assert_equal "By Industry", variant.reload.name
+  end
+
+  test "insufficient identity error when variant fields lack condition and match keys" do
+    product = Products::Create.call(
+      attributes: { name: "Identity", status: "draft" },
+      actor: @actor,
+      identifier_mode: "generate"
+    )
+    unknown_industry = Identifiers::Ean13.complete("978", "777777777")
+
+    result = import_csv(<<~CSV)
+      primary_identifier,name,generate_primary_identifier,industry_identifier,variant_name
+      #{product.primary_identifier},Identity,false,#{unknown_industry},Orphan
+    CSV
+
+    assert_equal 1, result.errors.size
+    assert_match(/insufficient identity/i, result.errors.first[:message])
+  end
+
+  test "rejects assigning caller SKU to new variant" do
+    product = Products::Create.call(
+      attributes: { name: "Caller SKU", status: "draft" },
+      actor: @actor,
+      identifier_mode: "generate"
+    )
+    fake_sku = Identifiers::Ean13.complete("221", "888888888")
+
+    result = import_csv(<<~CSV)
+      primary_identifier,name,generate_primary_identifier,sku,variant_condition_code,variant_name
+      #{product.primary_identifier},Caller SKU,false,#{fake_sku},new,Should Fail
+    CSV
+
+    assert_equal 1, result.errors.size
+    assert_match(/caller-assigned SKU|not accepted/i, result.errors.first[:message])
+    assert_nil ProductVariant.find_by(sku: fake_sku)
+  end
+
+  private
+
+  def import_csv(text)
+    Merchandise::CsvImporter.call(io: StringIO.new(text), actor: @actor)
+  end
+end

--- a/test/services/merchandise/csv_importer_test.rb
+++ b/test/services/merchandise/csv_importer_test.rb
@@ -153,6 +153,74 @@ class Merchandise::CsvImporterTest < ActiveSupport::TestCase
     assert_equal @condition.id, used.merchandise_condition_id
   end
 
+  test "rolls back the product group when a later variant row fails" do
+    isbn = Identifiers::Ean13.complete("978", "333333333")
+    before_products = Product.count
+
+    result = import_csv(<<~CSV)
+      primary_identifier,name,generate_primary_identifier,variant_type,variant_condition_code,merchandise_class_code,regular_price_cents
+      #{isbn},Grouped,false,standard,,book,1500
+      #{isbn},Grouped,false,used,,book,900
+    CSV
+
+    assert_equal 1, result.errors.size
+    assert_match(/variant_condition_code is required/i, result.errors.first[:message])
+    assert_equal before_products, Product.count
+    assert_nil Product.find_by(primary_identifier: isbn)
+    assert_equal 0, result.created_products
+    assert_equal 0, result.created_variants
+  end
+
+  test "rejects unknown reference codes instead of defaulting" do
+    product = Products::Create.call(
+      attributes: { name: "Refs", status: "draft" },
+      actor: @actor,
+      identifier_mode: "generate"
+    )
+
+    result = import_csv(<<~CSV)
+      primary_identifier,name,generate_primary_identifier,variant_type,merchandise_class_code,regular_price_cents
+      #{product.primary_identifier},Refs,false,standard,missing_class,1500
+    CSV
+
+    assert_equal 1, result.errors.size
+    assert_match(/unknown merchandise_class_code/i, result.errors.first[:message])
+    assert_equal 0, product.product_variants.count
+  end
+
+  test "generate-only rows are create-only across reimports" do
+    first = import_csv(<<~CSV)
+      primary_identifier,name,generate_primary_identifier
+      ,Generated A,true
+    CSV
+    second = import_csv(<<~CSV)
+      primary_identifier,name,generate_primary_identifier
+      ,Generated A,true
+    CSV
+
+    assert_equal 1, first.created_products
+    assert_equal 1, second.created_products
+    assert_equal 2, Product.where(name: "Generated A").count
+  end
+
+  test "import updates create record-level audit events" do
+    product = Products::Create.call(
+      attributes: { name: "Audit Me", status: "draft" },
+      actor: @actor,
+      identifier_mode: "enter",
+      external_identifier: external_isbn13
+    )
+
+    result = import_csv(<<~CSV)
+      primary_identifier,name,generate_primary_identifier
+      #{product.primary_identifier},Audited Name,false
+    CSV
+
+    assert_empty result.errors
+    assert AuditEvent.where(action: "products.update", subject_type: "Product", subject_id: product.id).exists?
+    assert_equal "Audited Name", product.reload.name
+  end
+
   private
 
   def import_csv(text)

--- a/test/services/product_variants/create_and_activation_test.rb
+++ b/test/services/product_variants/create_and_activation_test.rb
@@ -251,4 +251,42 @@ class ProductVariants::CreateAndActivationTest < ActiveSupport::TestCase
       })
     end
   end
+
+  test "active variants cannot be saved incomplete" do
+    @product.update!(status: "active")
+    variant = ProductVariants::Create.call(
+      product: @product,
+      actor: @actor,
+      attributes: {
+        variant_type: "standard",
+        merchandise_class_id: @klass.id,
+        department_id: @standard_dept.id,
+        tax_class_id: @tax.id,
+        regular_price_cents: 1_999,
+        status: "active"
+      }
+    )
+
+    error = assert_raises(ProductVariants::Update::Error) do
+      ProductVariants::Update.call(
+        variant: variant,
+        actor: @actor,
+        attributes: { merchandise_class_id: nil }
+      )
+    end
+    assert_match(/merchandise class/i, error.message)
+    assert_equal @klass.id, variant.reload.merchandise_class_id
+  end
+
+  test "used price suggestion uses integer half-up rounding" do
+    @product.update!(list_price_cents: 1_005)
+    @like_new.update!(price_adjustment_bps: 3_333)
+    result = ProductVariants::DefaultResolver.resolve(
+      product: @product,
+      variant_type: "used",
+      condition: @like_new
+    )
+    # (1005 * 3333 + 5000) / 10000 = 335
+    assert_equal 335, result.suggested_price_cents
+  end
 end

--- a/test/services/product_variants/create_and_activation_test.rb
+++ b/test/services/product_variants/create_and_activation_test.rb
@@ -278,6 +278,34 @@ class ProductVariants::CreateAndActivationTest < ActiveSupport::TestCase
     assert_equal @klass.id, variant.reload.merchandise_class_id
   end
 
+  test "active used variant with deactivated condition allows unrelated edits" do
+    @product.update!(status: "active")
+    variant = ProductVariants::Create.call(
+      product: @product,
+      actor: @actor,
+      attributes: {
+        variant_type: "used",
+        merchandise_condition_id: @like_new.id,
+        merchandise_class_id: @used_klass.id,
+        department_id: @used_dept.id,
+        tax_class_id: @tax.id,
+        regular_price_cents: 1_200,
+        status: "active"
+      }
+    )
+
+    @like_new.update!(active: false)
+    variant.reload
+
+    assert_not variant.sellable?
+    assert variant.update(name: "Still editable")
+    assert_equal "Still editable", variant.reload.name
+
+    retired_condition = merchandise_condition(code: "fair", active: false)
+    assert_not variant.update(merchandise_condition: retired_condition)
+    assert_includes variant.errors[:merchandise_condition_id], "must be an active condition"
+  end
+
   test "used price suggestion uses integer half-up rounding" do
     @product.update!(list_price_cents: 1_005)
     @like_new.update!(price_adjustment_bps: 3_333)

--- a/test/services/product_variants/create_and_activation_test.rb
+++ b/test/services/product_variants/create_and_activation_test.rb
@@ -15,14 +15,26 @@ class ProductVariants::CreateAndActivationTest < ActiveSupport::TestCase
       default_standard_department: @standard_dept,
       default_used_department: @used_dept
     )
+    @used_klass = merchandise_class(
+      code: "used_book",
+      pricing_method: "fixed",
+      used_merchandise_allowed: true,
+      default_standard_department: @standard_dept,
+      default_used_department: @used_dept
+    )
     @open_klass = merchandise_class(
       code: "open_item",
       pricing_method: "open_price",
       default_standard_department: @standard_dept
     )
+    @service_klass = merchandise_class(
+      code: "service",
+      inventory_mode: "non_inventory",
+      pricing_method: "fixed",
+      default_standard_department: @standard_dept
+    )
     @category = merchandise_category(name: "Fiction", default_merchandise_class: @klass)
-    @new_condition = merchandise_condition(code: "new", department_basis: "standard")
-    @used_condition = merchandise_condition(code: "used", department_basis: "used", price_adjustment_bps: 6_000)
+    @like_new = merchandise_condition(code: "like_new", price_adjustment_bps: 6_000)
     @product = Products::Create.call(
       attributes: { name: "Example", status: "draft", merchandise_category: @category, list_price_cents: 2_000 },
       actor: @actor,
@@ -30,7 +42,7 @@ class ProductVariants::CreateAndActivationTest < ActiveSupport::TestCase
     )
   end
 
-  test "draft can omit class department and tax when no defaults apply" do
+  test "draft standard can omit class department and tax when no defaults apply" do
     bare = Products::Create.call(
       attributes: { name: "Bare", status: "draft" },
       actor: @actor,
@@ -39,32 +51,46 @@ class ProductVariants::CreateAndActivationTest < ActiveSupport::TestCase
     variant = ProductVariants::Create.call(
       product: bare,
       actor: @actor,
-      attributes: { merchandise_condition_id: @new_condition.id, status: "draft" }
+      attributes: { variant_type: "standard", status: "draft" }
     )
 
     assert variant.draft?
+    assert variant.standard?
+    assert_nil variant.merchandise_condition_id
     assert_nil variant.merchandise_class_id
     assert_nil variant.department_id
     assert_nil variant.tax_class_id
   end
 
-  test "condition is required" do
+  test "used variant requires condition and standard forbids it" do
     error = assert_raises(ProductVariants::Create::Error) do
       ProductVariants::Create.call(
         product: @product,
         actor: @actor,
-        attributes: { name: "No condition" }
+        attributes: { variant_type: "used", merchandise_class_id: @used_klass.id }
       )
     end
-    assert_match(/merchandise_condition_id is required/i, error.message)
+    assert_match(/merchandise_condition_id is required for used/i, error.message)
+
+    error = assert_raises(ProductVariants::Create::Error) do
+      ProductVariants::Create.call(
+        product: @product,
+        actor: @actor,
+        attributes: {
+          variant_type: "standard",
+          merchandise_condition_id: @like_new.id
+        }
+      )
+    end
+    assert_match(/must be blank for standard/i, error.message)
   end
 
-  test "activation requires class department tax and pricing matrix" do
+  test "activation requires class department tax and pricing matrix for standard" do
     variant = ProductVariants::Create.call(
       product: @product,
       actor: @actor,
       attributes: {
-        merchandise_condition_id: @new_condition.id,
+        variant_type: "standard",
         merchandise_class_id: @klass.id,
         department_id: @standard_dept.id,
         tax_class_id: @tax.id,
@@ -93,7 +119,7 @@ class ProductVariants::CreateAndActivationTest < ActiveSupport::TestCase
       product: @product,
       actor: @actor,
       attributes: {
-        merchandise_condition_id: @new_condition.id,
+        variant_type: "standard",
         merchandise_class_id: @open_klass.id,
         department_id: @standard_dept.id,
         tax_class_id: @tax.id,
@@ -107,40 +133,45 @@ class ProductVariants::CreateAndActivationTest < ActiveSupport::TestCase
     assert variant.valid?
   end
 
-  test "used condition is blocked unless class allows used merchandise" do
-    @product.update!(status: "active")
-    variant = ProductVariants::Create.call(
-      product: @product,
-      actor: @actor,
-      attributes: {
-        merchandise_condition_id: @used_condition.id,
-        merchandise_class_id: @klass.id,
-        department_id: @used_dept.id,
-        tax_class_id: @tax.id,
-        regular_price_cents: 1_200,
-        status: "draft"
-      }
-    )
+  test "used variant blocked without used_merchandise_allowed" do
+    error = assert_raises(ProductVariants::Create::Error) do
+      ProductVariants::Create.call(
+        product: @product,
+        actor: @actor,
+        attributes: {
+          variant_type: "used",
+          merchandise_condition_id: @like_new.id,
+          merchandise_class_id: @klass.id,
+          department_id: @used_dept.id,
+          tax_class_id: @tax.id,
+          regular_price_cents: 1_200
+        }
+      )
+    end
+    assert_match(/allows used merchandise/i, error.message)
+  end
 
-    variant.status = "active"
-    assert_not variant.valid?
-    assert_includes variant.errors[:base], "condition is not allowed for this merchandise class"
-
-    allowed = merchandise_class(
-      code: "used_book",
-      used_merchandise_allowed: true,
-      default_standard_department: @standard_dept,
-      default_used_department: @used_dept
-    )
-    variant.merchandise_class = allowed
-    assert variant.valid?
+  test "used variant blocked on non_inventory class" do
+    error = assert_raises(ProductVariants::Create::Error) do
+      ProductVariants::Create.call(
+        product: @product,
+        actor: @actor,
+        attributes: {
+          variant_type: "used",
+          merchandise_condition_id: @like_new.id,
+          merchandise_class_id: @service_klass.id,
+          regular_price_cents: 1_200
+        }
+      )
+    end
+    assert_match(/non-inventory/i, error.message)
   end
 
   test "sku is immutable" do
     variant = ProductVariants::Create.call(
       product: @product,
       actor: @actor,
-      attributes: { merchandise_condition_id: @new_condition.id }
+      attributes: { variant_type: "standard" }
     )
     original = variant.sku
     variant.sku = Identifiers::Ean13.complete("221", "999999999")
@@ -149,24 +180,75 @@ class ProductVariants::CreateAndActivationTest < ActiveSupport::TestCase
     assert_equal original, variant.reload.sku
   end
 
-  test "default resolution fills class department tax and suggested price" do
+  test "default resolution uses variant_type for department and price" do
+    standard = ProductVariants::Create.call(
+      product: @product,
+      actor: @actor,
+      attributes: { variant_type: "standard" }
+    )
+
+    assert_equal @klass.id, standard.merchandise_class_id
+    assert_equal @standard_dept.id, standard.department_id
+    assert_equal @tax.id, standard.tax_class_id
+    assert_equal 2_000, standard.regular_price_cents
+    assert_equal "quantity", standard.derived_inventory_tracking
+
+    used = ProductVariants::Create.call(
+      product: @product,
+      actor: @actor,
+      attributes: {
+        variant_type: "used",
+        merchandise_condition_id: @like_new.id,
+        merchandise_class_id: @used_klass.id
+      }
+    )
+    assert_equal @used_dept.id, used.department_id
+    assert_equal 1_200, used.regular_price_cents
+    assert_equal "individual", used.derived_inventory_tracking
+  end
+
+  test "changing class defaults does not mutate existing variants" do
     variant = ProductVariants::Create.call(
       product: @product,
       actor: @actor,
-      attributes: { merchandise_condition_id: @new_condition.id }
+      attributes: { variant_type: "standard" }
     )
+    original_dept = variant.department_id
+    other = department(code: "other_books", default_tax_class: @tax)
+    @klass.update!(default_standard_department: other)
 
-    assert_equal @klass.id, variant.merchandise_class_id
-    assert_equal @standard_dept.id, variant.department_id
-    assert_equal @tax.id, variant.tax_class_id
-    assert_equal 2_000, variant.regular_price_cents
+    assert_equal original_dept, variant.reload.department_id
+  end
 
-    used_variant = ProductVariants::Create.call(
-      product: @product,
-      actor: @actor,
-      attributes: { merchandise_condition_id: @used_condition.id }
-    )
-    assert_equal @used_dept.id, used_variant.department_id
-    assert_equal 1_200, used_variant.regular_price_cents
+  test "database rejects standard with condition and used without" do
+    sku = Identifiers::Ean13.complete("221", "111111111")
+    assert_raises(ActiveRecord::StatementInvalid) do
+      ProductVariant.insert!({
+        id: SecureRandom.uuid_v7,
+        product_id: @product.id,
+        variant_type: "standard",
+        sku: sku,
+        merchandise_condition_id: @like_new.id,
+        status: "draft",
+        lock_version: 0,
+        created_at: Time.current,
+        updated_at: Time.current
+      })
+    end
+
+    sku2 = Identifiers::Ean13.complete("221", "222222222")
+    assert_raises(ActiveRecord::StatementInvalid) do
+      ProductVariant.insert!({
+        id: SecureRandom.uuid_v7,
+        product_id: @product.id,
+        variant_type: "used",
+        sku: sku2,
+        merchandise_condition_id: nil,
+        status: "draft",
+        lock_version: 0,
+        created_at: Time.current,
+        updated_at: Time.current
+      })
+    end
   end
 end

--- a/test/services/product_variants/create_and_activation_test.rb
+++ b/test/services/product_variants/create_and_activation_test.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ProductVariants::CreateAndActivationTest < ActiveSupport::TestCase
+  setup do
+    @actor = actor_user
+    @tax = tax_class(code: "books")
+    @standard_dept = department(code: "new_books", default_tax_class: @tax)
+    @used_dept = department(code: "used_books", default_tax_class: @tax)
+    @klass = merchandise_class(
+      code: "book",
+      pricing_method: "fixed",
+      used_merchandise_allowed: false,
+      default_standard_department: @standard_dept,
+      default_used_department: @used_dept
+    )
+    @open_klass = merchandise_class(
+      code: "open_item",
+      pricing_method: "open_price",
+      default_standard_department: @standard_dept
+    )
+    @category = merchandise_category(name: "Fiction", default_merchandise_class: @klass)
+    @new_condition = merchandise_condition(code: "new", department_basis: "standard")
+    @used_condition = merchandise_condition(code: "used", department_basis: "used", price_adjustment_bps: 6_000)
+    @product = Products::Create.call(
+      attributes: { name: "Example", status: "draft", merchandise_category: @category, list_price_cents: 2_000 },
+      actor: @actor,
+      identifier_mode: "generate"
+    )
+  end
+
+  test "draft can omit class department and tax when no defaults apply" do
+    bare = Products::Create.call(
+      attributes: { name: "Bare", status: "draft" },
+      actor: @actor,
+      identifier_mode: "generate"
+    )
+    variant = ProductVariants::Create.call(
+      product: bare,
+      actor: @actor,
+      attributes: { merchandise_condition_id: @new_condition.id, status: "draft" }
+    )
+
+    assert variant.draft?
+    assert_nil variant.merchandise_class_id
+    assert_nil variant.department_id
+    assert_nil variant.tax_class_id
+  end
+
+  test "condition is required" do
+    error = assert_raises(ProductVariants::Create::Error) do
+      ProductVariants::Create.call(
+        product: @product,
+        actor: @actor,
+        attributes: { name: "No condition" }
+      )
+    end
+    assert_match(/merchandise_condition_id is required/i, error.message)
+  end
+
+  test "activation requires class department tax and pricing matrix" do
+    variant = ProductVariants::Create.call(
+      product: @product,
+      actor: @actor,
+      attributes: {
+        merchandise_condition_id: @new_condition.id,
+        merchandise_class_id: @klass.id,
+        department_id: @standard_dept.id,
+        tax_class_id: @tax.id,
+        regular_price_cents: 1_999,
+        status: "draft"
+      }
+    )
+
+    variant.status = "active"
+    assert_not variant.valid?
+    assert_includes variant.errors[:product_id], "product must be active"
+
+    @product.update!(status: "active")
+    variant.regular_price_cents = nil
+    assert_not variant.valid?
+    assert_includes variant.errors[:regular_price_cents], "is required for this pricing method"
+
+    variant.regular_price_cents = 1_999
+    assert variant.valid?
+    assert variant.save
+  end
+
+  test "open_price activation may leave regular price null" do
+    @product.update!(status: "active")
+    variant = ProductVariants::Create.call(
+      product: @product,
+      actor: @actor,
+      attributes: {
+        merchandise_condition_id: @new_condition.id,
+        merchandise_class_id: @open_klass.id,
+        department_id: @standard_dept.id,
+        tax_class_id: @tax.id,
+        regular_price_cents: nil,
+        status: "draft"
+      }
+    )
+
+    variant.status = "active"
+    assert_nil variant.regular_price_cents
+    assert variant.valid?
+  end
+
+  test "used condition is blocked unless class allows used merchandise" do
+    @product.update!(status: "active")
+    variant = ProductVariants::Create.call(
+      product: @product,
+      actor: @actor,
+      attributes: {
+        merchandise_condition_id: @used_condition.id,
+        merchandise_class_id: @klass.id,
+        department_id: @used_dept.id,
+        tax_class_id: @tax.id,
+        regular_price_cents: 1_200,
+        status: "draft"
+      }
+    )
+
+    variant.status = "active"
+    assert_not variant.valid?
+    assert_includes variant.errors[:base], "condition is not allowed for this merchandise class"
+
+    allowed = merchandise_class(
+      code: "used_book",
+      used_merchandise_allowed: true,
+      default_standard_department: @standard_dept,
+      default_used_department: @used_dept
+    )
+    variant.merchandise_class = allowed
+    assert variant.valid?
+  end
+
+  test "sku is immutable" do
+    variant = ProductVariants::Create.call(
+      product: @product,
+      actor: @actor,
+      attributes: { merchandise_condition_id: @new_condition.id }
+    )
+    original = variant.sku
+    variant.sku = Identifiers::Ean13.complete("221", "999999999")
+    assert_not variant.valid?
+    assert_includes variant.errors[:sku], "cannot be changed"
+    assert_equal original, variant.reload.sku
+  end
+
+  test "default resolution fills class department tax and suggested price" do
+    variant = ProductVariants::Create.call(
+      product: @product,
+      actor: @actor,
+      attributes: { merchandise_condition_id: @new_condition.id }
+    )
+
+    assert_equal @klass.id, variant.merchandise_class_id
+    assert_equal @standard_dept.id, variant.department_id
+    assert_equal @tax.id, variant.tax_class_id
+    assert_equal 2_000, variant.regular_price_cents
+
+    used_variant = ProductVariants::Create.call(
+      product: @product,
+      actor: @actor,
+      attributes: { merchandise_condition_id: @used_condition.id }
+    )
+    assert_equal @used_dept.id, used_variant.department_id
+    assert_equal 1_200, used_variant.regular_price_cents
+  end
+end

--- a/test/services/products/create_test.rb
+++ b/test/services/products/create_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Products::CreateTest < ActiveSupport::TestCase
+  setup do
+    @actor = actor_user
+  end
+
+  test "enter mode stores normalized external identifier" do
+    product = Products::Create.call(
+      attributes: { name: "Entered Book", status: "draft" },
+      actor: @actor,
+      identifier_mode: "enter",
+      external_identifier: "978-123456789-#{Identifiers::Ean13.check_digit("978123456789")}"
+    )
+
+    expected = Identifiers::Ean13.complete("978", "123456789")
+    assert_equal expected, product.primary_identifier
+    assert Identifiers::Registry.find_active(expected)
+    assert_equal "product_primary", Identifiers::Registry.find_active(expected).identifier_kind
+  end
+
+  test "generate mode allocates a 222 identifier" do
+    product = Products::Create.call(
+      attributes: { name: "Generated", status: "draft" },
+      actor: @actor,
+      identifier_mode: "generate"
+    )
+
+    assert_match(/\A222\d{10}\z/, product.primary_identifier)
+    assert Identifiers::Ean13.valid?(product.primary_identifier)
+  end
+
+  test "rejects when neither enter nor generate is chosen" do
+    error = assert_raises(Products::Create::Error) do
+      Products::Create.call(
+        attributes: { name: "Missing mode", status: "draft" },
+        actor: @actor,
+        identifier_mode: "none"
+      )
+    end
+    assert_match(/enter or generate/i, error.message)
+  end
+
+  test "rejects entered 222 namespace" do
+    value = shelfsense_222
+    error = assert_raises(Products::Create::Error) do
+      Products::Create.call(
+        attributes: { name: "Bad 222", status: "draft" },
+        actor: @actor,
+        identifier_mode: "enter",
+        external_identifier: value
+      )
+    end
+    assert_match(/reserved 222/i, error.message)
+    assert_nil Product.find_by(primary_identifier: value)
+  end
+
+  test "concurrent-style conflict on duplicate entered identifier" do
+    external = external_isbn13
+    Products::Create.call(
+      attributes: { name: "First", status: "draft" },
+      actor: @actor,
+      identifier_mode: "enter",
+      external_identifier: external
+    )
+
+    error = assert_raises(Products::Create::Error) do
+      Products::Create.call(
+        attributes: { name: "Second", status: "draft" },
+        actor: @actor,
+        identifier_mode: "enter",
+        external_identifier: external
+      )
+    end
+    assert_match(/already reserved|taken|unique/i, error.message)
+    assert_equal 1, Product.where(primary_identifier: external).count
+  end
+end

--- a/test/support/phase2_fixtures.rb
+++ b/test/support/phase2_fixtures.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+module Phase2Fixtures
+  module_function
+
+  BOOTSTRAP_ATTRS = {
+    organization_name: "Example Books",
+    store_number: "1",
+    store_code: "main",
+    store_name: "Main Store",
+    store_timezone: "America/New_York",
+    store_country_code: "US",
+    admin_username: "admin",
+    admin_display_name: "Admin User",
+    admin_password: "correct-horse-battery"
+  }.freeze
+
+  def bootstrap!(**overrides)
+    Installation::Bootstrap.call(**BOOTSTRAP_ATTRS, **overrides)
+  end
+
+  def actor_user(bootstrap: nil)
+    bootstrap ||= bootstrap!
+    bootstrap[:administrator]
+  end
+
+  def external_isbn13
+    Identifiers::Ean13.complete("978", "123456789")
+  end
+
+  def shelfsense_222(payload9 = "000000001")
+    Identifiers::Ean13.complete("222", payload9)
+  end
+
+  def shelfsense_221(payload9 = "000000001")
+    Identifiers::Ean13.complete("221", payload9)
+  end
+
+  def tax_class(code: "taxable", name: nil, active: true, **attrs)
+    TaxClass.create!(
+      {
+        code: code,
+        name: name || code.to_s.tr("_", " ").capitalize,
+        active: active,
+        display_order: 0
+      }.merge(attrs)
+    )
+  end
+
+  def gl_account(account_number:, account_type:, account_category:, posting_allowed: true, active: true, name: nil, **attrs)
+    GlAccount.create!(
+      {
+        account_number: account_number,
+        name: name || "Account #{account_number}",
+        account_type: account_type,
+        account_category: account_category,
+        posting_allowed: posting_allowed,
+        active: active,
+        display_order: 0
+      }.merge(attrs)
+    )
+  end
+
+  def department(code:, default_tax_class: nil, name: nil, active: true, **gl_mappings)
+    default_tax_class ||= tax_class(code: "#{code}_tax")
+    Department.create!(
+      {
+        code: code,
+        name: name || code.to_s.tr("_", " ").capitalize,
+        default_tax_class: default_tax_class,
+        active: active,
+        display_order: 0
+      }.merge(gl_mappings)
+    )
+  end
+
+  def merchandise_class(
+    code:,
+    pricing_method: "fixed",
+    used_merchandise_allowed: false,
+    inventory_tracking_mode: "quantity",
+    default_standard_department: nil,
+    default_used_department: nil,
+    name: nil,
+    active: true,
+    **attrs
+  )
+    MerchandiseClass.create!(
+      {
+        code: code,
+        name: name || code.to_s.tr("_", " ").capitalize,
+        pricing_method: pricing_method,
+        inventory_tracking_mode: inventory_tracking_mode,
+        used_merchandise_allowed: used_merchandise_allowed,
+        default_standard_department: default_standard_department,
+        default_used_department: default_used_department,
+        active: active,
+        display_order: 0
+      }.merge(attrs)
+    )
+  end
+
+  def merchandise_category(name:, default_merchandise_class: nil, code: nil, parent: nil, active: true, **attrs)
+    MerchandiseCategory.create!(
+      {
+        name: name,
+        code: code,
+        default_merchandise_class: default_merchandise_class,
+        parent: parent,
+        active: active,
+        display_order: 0
+      }.merge(attrs)
+    )
+  end
+
+  def merchandise_condition(
+    code:,
+    department_basis: "standard",
+    price_adjustment_bps: 10_000,
+    name: nil,
+    active: true,
+    **attrs
+  )
+    MerchandiseCondition.create!(
+      {
+        code: code,
+        name: name || code.to_s.tr("_", " ").capitalize,
+        department_basis: department_basis,
+        price_adjustment_bps: price_adjustment_bps,
+        active: active,
+        display_order: 0
+      }.merge(attrs)
+    )
+  end
+
+  def inventory_gl(account_number: "1200")
+    gl_account(account_number: account_number, account_type: "asset", account_category: "inventory")
+  end
+
+  def cogs_gl(account_number: "5000")
+    gl_account(account_number: account_number, account_type: "expense", account_category: "cost_of_goods_sold")
+  end
+
+  def sales_gl(account_number: "4000")
+    gl_account(account_number: account_number, account_type: "revenue", account_category: "sales")
+  end
+end

--- a/test/support/phase2_fixtures.rb
+++ b/test/support/phase2_fixtures.rb
@@ -78,7 +78,7 @@ module Phase2Fixtures
     code:,
     pricing_method: "fixed",
     used_merchandise_allowed: false,
-    inventory_tracking_mode: "quantity",
+    inventory_mode: "inventory",
     default_standard_department: nil,
     default_used_department: nil,
     name: nil,
@@ -90,7 +90,7 @@ module Phase2Fixtures
         code: code,
         name: name || code.to_s.tr("_", " ").capitalize,
         pricing_method: pricing_method,
-        inventory_tracking_mode: inventory_tracking_mode,
+        inventory_mode: inventory_mode,
         used_merchandise_allowed: used_merchandise_allowed,
         default_standard_department: default_standard_department,
         default_used_department: default_used_department,
@@ -115,7 +115,6 @@ module Phase2Fixtures
 
   def merchandise_condition(
     code:,
-    department_basis: "standard",
     price_adjustment_bps: 10_000,
     name: nil,
     active: true,
@@ -125,7 +124,6 @@ module Phase2Fixtures
       {
         code: code,
         name: name || code.to_s.tr("_", " ").capitalize,
-        department_basis: department_basis,
         price_adjustment_bps: price_adjustment_bps,
         active: active,
         display_order: 0

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
+require_relative "support/phase2_fixtures"
 
 module ActiveSupport
   class TestCase
@@ -10,6 +11,6 @@ module ActiveSupport
     # Fixtures are opt-in per test case until a stable fixture set exists.
     # fixtures :all
 
-    # Add more helper methods to be used by all tests here...
+    include Phase2Fixtures
   end
 end


### PR DESCRIPTION
## Summary
- Adds Phase 2 financial classification and merchandise foundation: GL accounts, tax classes, departments with explicit GL mappings, merchandise classes/categories/conditions, products with mandatory primary identifiers (`222` generate or enter), identifier registry with tombstones, and product variants (`standard`/`used`) with immutable `221` SKUs.
- Includes identifier lookup, audited create/update/discontinue flows, CSV import with atomic product groups and record-level audits, admin UI, permissions, and schema/docs updates.
- Hardens integrity before merge: transactional industry-identifier assignment with optimistic locking, registry ownership constraints (including retired rows), model-level identifier write guards, active-variant completeness, ISBN-10 checksum validation, and integer half-up used pricing.

## Test plan
- [x] `./dev/rails-docker bin/rails db:prepare`
- [x] `./dev/rails-docker bin/rails test`
- [x] `./dev/rails-docker bin/rubocop`
- [x] Smoke admin flows: create GL/tax/department/merchandise refs; create product (enter + generate); create standard and used variants; update industry identifier with `lock_version`; discontinue/deactivate
- [x] Confirm CSV import: multi-row product group atomicity; unknown reference codes error; generate-only rows are create-only; reimport by durable identifier is idempotent
- [x] Confirm unauthorized direct requests are denied for Phase 2 permissions
- [x] Confirm identifier registry rejects kind/owner mismatches and dual-owner retired rows


Made with [Cursor](https://cursor.com)