### PR TITLE
Implement Phase 2.1 merchandise correctness and operability

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -80,5 +80,20 @@ module Admin
         )
       end
     end
+
+    def reactivate_configuration!(record, permission_key:, audit_action:, redirect_path:)
+      rescue_stale do
+        Configuration::Reactivate.call(
+          record: record,
+          actor: current_user,
+          store: current_store,
+          lock_version: params.dig(record.model_name.param_key, :lock_version) || params[:lock_version],
+          audit_action: audit_action
+        )
+        redirect_to redirect_path, notice: "#{record.class.model_name.human} reactivated."
+      rescue Configuration::Reactivate::Error => e
+        redirect_to redirect_path, alert: e.message
+      end
+    end
   end
 end

--- a/app/controllers/admin/departments_controller.rb
+++ b/app/controllers/admin/departments_controller.rb
@@ -5,8 +5,8 @@ module Admin
     before_action -> { require_permission!("departments.view") }, only: %i[index show]
     before_action -> { require_permission!("departments.create") }, only: %i[new create]
     before_action -> { require_permission!("departments.update") }, only: %i[edit update]
-    before_action -> { require_permission!("departments.deactivate") }, only: :destroy
-    before_action :set_department, only: %i[show edit update destroy]
+    before_action -> { require_permission!("departments.deactivate") }, only: %i[destroy reactivate]
+    before_action :set_department, only: %i[show edit update destroy reactivate]
 
     def index
       @departments = Department.order(:display_order, :code)
@@ -41,9 +41,9 @@ module Admin
       rescue_stale do
         if save_and_audit!(
           @department,
-          attrs: department_params,
+          attrs: department_params.except(:code),
           action: "departments.update",
-          before_keys: audit_attribute_keys
+          before_keys: audit_attribute_keys - %w[code]
         )
           redirect_to admin_department_path(@department), notice: "Department updated."
         else
@@ -56,6 +56,15 @@ module Admin
     def destroy
       mutate_and_audit!(@department, action: "departments.deactivate") { @department.update!(active: false) }
       redirect_to admin_departments_path, notice: "Department deactivated."
+    end
+
+    def reactivate
+      reactivate_configuration!(
+        @department,
+        permission_key: "departments.deactivate",
+        audit_action: "departments.reactivate",
+        redirect_path: admin_department_path(@department)
+      )
     end
 
     private

--- a/app/controllers/admin/gl_accounts_controller.rb
+++ b/app/controllers/admin/gl_accounts_controller.rb
@@ -5,8 +5,8 @@ module Admin
     before_action -> { require_permission!("gl_accounts.view") }, only: %i[index show]
     before_action -> { require_permission!("gl_accounts.create") }, only: %i[new create]
     before_action -> { require_permission!("gl_accounts.update") }, only: %i[edit update]
-    before_action -> { require_permission!("gl_accounts.deactivate") }, only: :destroy
-    before_action :set_gl_account, only: %i[show edit update destroy]
+    before_action -> { require_permission!("gl_accounts.deactivate") }, only: %i[destroy reactivate]
+    before_action :set_gl_account, only: %i[show edit update destroy reactivate]
 
     def index
       @gl_accounts = GlAccount.order(:display_order, :account_number)
@@ -20,14 +20,15 @@ module Admin
     end
 
     def create
-      @gl_account = GlAccount.new(gl_account_params.except(:lock_version))
+      @gl_account = GlAccount.new(gl_account_params.except(:lock_version, :account_type))
       if create_and_audit!(
         @gl_account,
         action: "gl_accounts.create",
         after_values: {
           account_number: @gl_account.account_number,
           name: @gl_account.name,
-          account_type: @gl_account.account_type
+          account_type: @gl_account.account_type,
+          account_category: @gl_account.account_category
         }
       )
         redirect_to admin_gl_account_path(@gl_account), notice: "GL account created."
@@ -45,7 +46,7 @@ module Admin
       rescue_stale do
         if save_and_audit!(
           @gl_account,
-          attrs: gl_account_params,
+          attrs: gl_account_params.except(:account_type),
           action: "gl_accounts.update",
           before_keys: %w[
             account_number name description account_type account_category
@@ -65,6 +66,15 @@ module Admin
       redirect_to admin_gl_accounts_path, notice: "GL account deactivated."
     end
 
+    def reactivate
+      reactivate_configuration!(
+        @gl_account,
+        permission_key: "gl_accounts.deactivate",
+        audit_action: "gl_accounts.reactivate",
+        redirect_path: admin_gl_account_path(@gl_account)
+      )
+    end
+
     private
 
     def set_gl_account
@@ -79,7 +89,7 @@ module Admin
 
     def gl_account_params
       permitted = params.require(:gl_account).permit(
-        :account_number, :name, :description, :account_type, :account_category,
+        :account_number, :name, :description, :account_category,
         :parent_id, :posting_allowed, :display_order, :lock_version
       )
       permitted[:parent_id] = nil if permitted[:parent_id].blank?

--- a/app/controllers/admin/merchandise_categories_controller.rb
+++ b/app/controllers/admin/merchandise_categories_controller.rb
@@ -5,8 +5,8 @@ module Admin
     before_action -> { require_permission!("merchandise_categories.view") }, only: %i[index show]
     before_action -> { require_permission!("merchandise_categories.create") }, only: %i[new create]
     before_action -> { require_permission!("merchandise_categories.update") }, only: %i[edit update]
-    before_action -> { require_permission!("merchandise_categories.deactivate") }, only: :destroy
-    before_action :set_merchandise_category, only: %i[show edit update destroy]
+    before_action -> { require_permission!("merchandise_categories.deactivate") }, only: %i[destroy reactivate]
+    before_action :set_merchandise_category, only: %i[show edit update destroy reactivate]
 
     def index
       @merchandise_categories = MerchandiseCategory.order(:display_order, :name)
@@ -41,9 +41,9 @@ module Admin
       rescue_stale do
         if save_and_audit!(
           @merchandise_category,
-          attrs: merchandise_category_params,
+          attrs: merchandise_category_params.except(:code),
           action: "merchandise_categories.update",
-          before_keys: %w[code name description parent_id default_merchandise_class_id display_order]
+          before_keys: %w[name description parent_id default_merchandise_class_id display_order]
         )
           redirect_to admin_merchandise_category_path(@merchandise_category), notice: "Merchandise category updated."
         else
@@ -58,6 +58,15 @@ module Admin
         @merchandise_category.update!(active: false)
       end
       redirect_to admin_merchandise_categories_path, notice: "Merchandise category deactivated."
+    end
+
+    def reactivate
+      reactivate_configuration!(
+        @merchandise_category,
+        permission_key: "merchandise_categories.deactivate",
+        audit_action: "merchandise_categories.reactivate",
+        redirect_path: admin_merchandise_category_path(@merchandise_category)
+      )
     end
 
     private

--- a/app/controllers/admin/merchandise_classes_controller.rb
+++ b/app/controllers/admin/merchandise_classes_controller.rb
@@ -5,8 +5,8 @@ module Admin
     before_action -> { require_permission!("merchandise_classes.view") }, only: %i[index show]
     before_action -> { require_permission!("merchandise_classes.create") }, only: %i[new create]
     before_action -> { require_permission!("merchandise_classes.update") }, only: %i[edit update]
-    before_action -> { require_permission!("merchandise_classes.deactivate") }, only: :destroy
-    before_action :set_merchandise_class, only: %i[show edit update destroy]
+    before_action -> { require_permission!("merchandise_classes.deactivate") }, only: %i[destroy reactivate]
+    before_action :set_merchandise_class, only: %i[show edit update destroy reactivate]
 
     def index
       @merchandise_classes = MerchandiseClass.order(:display_order, :code)
@@ -45,12 +45,12 @@ module Admin
       rescue_stale do
         if save_and_audit!(
           @merchandise_class,
-          attrs: merchandise_class_params,
+          attrs: merchandise_class_params.except(:code),
           action: "merchandise_classes.update",
           before_keys: %w[
-            code name description inventory_mode pricing_method
+            name description inventory_mode pricing_method
             default_standard_department_id default_used_department_id
-            used_merchandise_allowed buyback_allowed default_returnable display_order
+            used_merchandise_allowed buyback_allowed default_supplier_returnable display_order
           ]
         )
           redirect_to admin_merchandise_class_path(@merchandise_class), notice: "Merchandise class updated."
@@ -68,6 +68,15 @@ module Admin
       redirect_to admin_merchandise_classes_path, notice: "Merchandise class deactivated."
     end
 
+    def reactivate
+      reactivate_configuration!(
+        @merchandise_class,
+        permission_key: "merchandise_classes.deactivate",
+        audit_action: "merchandise_classes.reactivate",
+        redirect_path: admin_merchandise_class_path(@merchandise_class)
+      )
+    end
+
     private
 
     def set_merchandise_class
@@ -82,7 +91,7 @@ module Admin
       permitted = params.require(:merchandise_class).permit(
         :code, :name, :description, :inventory_mode, :pricing_method,
         :default_standard_department_id, :default_used_department_id,
-        :used_merchandise_allowed, :buyback_allowed, :default_returnable,
+        :used_merchandise_allowed, :buyback_allowed, :default_supplier_returnable,
         :display_order, :lock_version
       )
       %i[default_standard_department_id default_used_department_id].each do |key|

--- a/app/controllers/admin/merchandise_conditions_controller.rb
+++ b/app/controllers/admin/merchandise_conditions_controller.rb
@@ -5,8 +5,8 @@ module Admin
     before_action -> { require_permission!("merchandise_conditions.view") }, only: %i[index show]
     before_action -> { require_permission!("merchandise_conditions.create") }, only: %i[new create]
     before_action -> { require_permission!("merchandise_conditions.update") }, only: %i[edit update]
-    before_action -> { require_permission!("merchandise_conditions.deactivate") }, only: :destroy
-    before_action :set_merchandise_condition, only: %i[show edit update destroy]
+    before_action -> { require_permission!("merchandise_conditions.deactivate") }, only: %i[destroy reactivate]
+    before_action :set_merchandise_condition, only: %i[show edit update destroy reactivate]
 
     def index
       @merchandise_conditions = MerchandiseCondition.order(:display_order, :code)
@@ -40,9 +40,9 @@ module Admin
       rescue_stale do
         if save_and_audit!(
           @merchandise_condition,
-          attrs: merchandise_condition_params,
+          attrs: merchandise_condition_params.except(:code),
           action: "merchandise_conditions.update",
-          before_keys: %w[code name description price_adjustment_bps display_order]
+          before_keys: %w[name description price_adjustment_bps display_order]
         )
           redirect_to admin_merchandise_condition_path(@merchandise_condition), notice: "Merchandise condition updated."
         else
@@ -56,6 +56,15 @@ module Admin
         @merchandise_condition.update!(active: false)
       end
       redirect_to admin_merchandise_conditions_path, notice: "Merchandise condition deactivated."
+    end
+
+    def reactivate
+      reactivate_configuration!(
+        @merchandise_condition,
+        permission_key: "merchandise_conditions.deactivate",
+        audit_action: "merchandise_conditions.reactivate",
+        redirect_path: admin_merchandise_condition_path(@merchandise_condition)
+      )
     end
 
     private

--- a/app/controllers/admin/merchandise_imports_controller.rb
+++ b/app/controllers/admin/merchandise_imports_controller.rb
@@ -1,10 +1,26 @@
 # frozen_string_literal: true
 
+require "csv"
+
 module Admin
   class MerchandiseImportsController < BaseController
+    TEMPLATE_HEADERS = %w[
+      primary_identifier name generate_primary_identifier status sku variant_type variant_name
+      industry_identifier variant_condition_code merchandise_class_code department_code
+      tax_class_code regular_price_cents
+    ].freeze
+
     before_action -> { require_permission!("merchandise.import") }
 
     def new; end
+
+    def template
+      csv = CSV.generate(force_quotes: false) { |out| out << TEMPLATE_HEADERS }
+      send_data csv,
+                filename: "merchandise_import_template.csv",
+                type: "text/csv; charset=utf-8",
+                disposition: "attachment"
+    end
 
     def create
       upload = params.require(:import).permit(:file)[:file]

--- a/app/controllers/admin/products_controller.rb
+++ b/app/controllers/admin/products_controller.rb
@@ -139,14 +139,26 @@ module Admin
     def product_params
       permitted = params.require(:product).permit(
         :name, :subtitle, :description, :brand_name, :product_model, :merchandise_category_id,
-        :list_price_cents, :release_date, :status, :variant_option_name_1, :variant_option_name_2,
+        :list_price, :list_price_cents, :release_date, :status, :variant_option_name_1, :variant_option_name_2,
         :lock_version
       )
+
+      if permitted.key?(:list_price) || params[:product]&.key?(:list_price)
+        raw = permitted.delete(:list_price).presence || params.dig(:product, :list_price)
+        permitted[:list_price_cents] = raw.blank? ? nil : dollars_to_cents(raw)
+      end
+
       %i[merchandise_category_id list_price_cents release_date subtitle description brand_name
          product_model variant_option_name_1 variant_option_name_2].each do |key|
         permitted[key] = nil if permitted[key].blank?
       end
       permitted
+    end
+
+    def dollars_to_cents(raw)
+      (BigDecimal(raw.to_s.strip) * 100).round.to_i
+    rescue ArgumentError
+      raise ActionController::BadRequest, "list price is not a valid amount"
     end
   end
 end

--- a/app/controllers/admin/tax_classes_controller.rb
+++ b/app/controllers/admin/tax_classes_controller.rb
@@ -5,8 +5,8 @@ module Admin
     before_action -> { require_permission!("tax_classes.view") }, only: %i[index show]
     before_action -> { require_permission!("tax_classes.create") }, only: %i[new create]
     before_action -> { require_permission!("tax_classes.update") }, only: %i[edit update]
-    before_action -> { require_permission!("tax_classes.deactivate") }, only: :destroy
-    before_action :set_tax_class, only: %i[show edit update destroy]
+    before_action -> { require_permission!("tax_classes.deactivate") }, only: %i[destroy reactivate]
+    before_action :set_tax_class, only: %i[show edit update destroy reactivate]
 
     def index
       @tax_classes = TaxClass.order(:display_order, :code)
@@ -37,9 +37,9 @@ module Admin
       rescue_stale do
         if save_and_audit!(
           @tax_class,
-          attrs: tax_class_params,
+          attrs: tax_class_params.except(:code),
           action: "tax_classes.update",
-          before_keys: %w[code name description display_order]
+          before_keys: %w[name description display_order]
         )
           redirect_to admin_tax_class_path(@tax_class), notice: "Tax class updated."
         else
@@ -51,6 +51,15 @@ module Admin
     def destroy
       mutate_and_audit!(@tax_class, action: "tax_classes.deactivate") { @tax_class.update!(active: false) }
       redirect_to admin_tax_classes_path, notice: "Tax class deactivated."
+    end
+
+    def reactivate
+      reactivate_configuration!(
+        @tax_class,
+        permission_key: "tax_classes.deactivate",
+        audit_action: "tax_classes.reactivate",
+        redirect_path: admin_tax_class_path(@tax_class)
+      )
     end
 
     private

--- a/app/models/concerns/has_machine_code.rb
+++ b/app/models/concerns/has_machine_code.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module HasMachineCode
+  extend ActiveSupport::Concern
+
+  included do
+    before_validation :prepare_machine_code
+    validate :code_immutable_after_create, on: :update
+  end
+
+  class_methods do
+    def machine_code_optional?
+      false
+    end
+  end
+
+  private
+
+  def prepare_machine_code
+    if new_record?
+      source = code.presence || name
+      if source.blank?
+        self.code = nil if self.class.machine_code_optional?
+        return
+      end
+
+      normalized = Codes::Normalizer.normalize(source)
+      if normalized.blank?
+        errors.add(:code, "is blank after normalization")
+        self.code = nil
+        return
+      end
+      self.code = normalized
+    elsif will_save_change_to_code?
+      # Leave value for immutability validation; do not re-normalize from name.
+    end
+  end
+
+  def code_immutable_after_create
+    return unless will_save_change_to_code?
+
+    errors.add(:code, "cannot be changed after creation")
+  end
+end

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Department < ApplicationRecord
+  include HasMachineCode
+
   GL_MAPPING_EXPECTATIONS = {
     inventory_asset_gl_account_id: { account_type: "asset", account_category: "inventory" },
     cost_of_goods_sold_gl_account_id: { account_type: "expense", account_category: "cost_of_goods_sold" },
@@ -29,10 +31,10 @@ class Department < ApplicationRecord
   belongs_to :inventory_adjustment_loss_gl_account, class_name: "GlAccount", optional: true
   belongs_to :inventory_write_down_gl_account, class_name: "GlAccount", optional: true
 
-  before_validation :normalize_code
+  before_validation :normalize_department_number
 
   validates :code, :name, :default_tax_class_id, presence: true
-  validates :code, uniqueness: true
+  validates :code, uniqueness: true, format: { with: Codes::Normalizer::FORMAT }
   validates :default_target_margin_bps,
             numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than: 10_000 },
             allow_nil: true
@@ -46,10 +48,38 @@ class Department < ApplicationRecord
     active?
   end
 
+  def reactivation_blockers
+    blockers = []
+    if default_tax_class.blank? || !default_tax_class.active?
+      blockers << "default tax class must be active"
+    end
+
+    GL_MAPPING_EXPECTATIONS.each do |field, expectation|
+      account = public_send(field.to_s.delete_suffix("_id"))
+      next if account.nil?
+
+      unless account.assignable?
+        blockers << "#{field} must be an active posting account"
+        next
+      end
+      if account.account_type != expectation[:account_type] || account.account_category != expectation[:account_category]
+        blockers << "#{field} must be #{expectation[:account_type]}/#{expectation[:account_category]}"
+      end
+    end
+
+    FLEXIBLE_GL_FIELDS.each do |field|
+      account = public_send(field.delete_suffix("_id"))
+      next if account.nil?
+
+      blockers << "#{field} must be an active posting account" unless account.assignable?
+    end
+
+    blockers
+  end
+
   private
 
-  def normalize_code
-    self.code = code.to_s.strip.downcase.tr(" ", "_")
+  def normalize_department_number
     self.department_number = department_number.to_s.strip.presence
   end
 

--- a/app/models/gl_account.rb
+++ b/app/models/gl_account.rb
@@ -2,17 +2,33 @@
 
 class GlAccount < ApplicationRecord
   ACCOUNT_TYPES = %w[asset liability equity revenue expense].freeze
-  ACCOUNT_CATEGORIES = %w[
-    cash accounts_receivable inventory other_current_asset fixed_asset
-    accounts_payable other_current_liability long_term_liability equity
-    sales sales_returns cost_of_goods_sold freight_in inventory_shrinkage
-    inventory_adjustment inventory_write_down other_revenue other_expense
-  ].freeze
+  CATEGORY_TO_TYPE = {
+    "cash" => "asset",
+    "accounts_receivable" => "asset",
+    "inventory" => "asset",
+    "other_current_asset" => "asset",
+    "fixed_asset" => "asset",
+    "accounts_payable" => "liability",
+    "other_current_liability" => "liability",
+    "long_term_liability" => "liability",
+    "equity" => "equity",
+    "sales" => "revenue",
+    "sales_returns" => "revenue",
+    "other_revenue" => "revenue",
+    "cost_of_goods_sold" => "expense",
+    "freight_in" => "expense",
+    "inventory_shrinkage" => "expense",
+    "inventory_adjustment" => "expense",
+    "inventory_write_down" => "expense",
+    "other_expense" => "expense"
+  }.freeze
+  ACCOUNT_CATEGORIES = CATEGORY_TO_TYPE.keys.freeze
 
   belongs_to :parent, class_name: "GlAccount", optional: true
   has_many :children, class_name: "GlAccount", foreign_key: :parent_id, inverse_of: :parent, dependent: :restrict_with_exception
 
   before_validation :normalize_account_number
+  before_validation :derive_account_type_from_category
 
   validates :account_number, :name, :account_type, :account_category, presence: true
   validates :account_number, uniqueness: true
@@ -21,6 +37,7 @@ class GlAccount < ApplicationRecord
   validate :parent_not_self
   validate :parent_same_account_type
   validate :no_parent_cycle
+  validate :category_matches_type
 
   scope :active, -> { where(active: true) }
   scope :posting, -> { where(posting_allowed: true) }
@@ -30,19 +47,45 @@ class GlAccount < ApplicationRecord
     active? && posting_allowed?
   end
 
+  def reactivation_blockers
+    blockers = []
+    if parent.present? && !parent.active?
+      blockers << "parent GL account must be active"
+    end
+    blockers
+  end
+
   private
 
   def normalize_account_number
     self.account_number = account_number.to_s.strip
   end
 
+  def derive_account_type_from_category
+    return if account_category.blank?
+
+    derived = CATEGORY_TO_TYPE[account_category]
+    self.account_type = derived if derived.present?
+  end
+
+  def category_matches_type
+    return if account_category.blank? || account_type.blank?
+
+    expected = CATEGORY_TO_TYPE[account_category]
+    return if expected.blank?
+
+    errors.add(:account_type, "must be #{expected} for category #{account_category}") if account_type != expected
+  end
+
   def parent_not_self
     return if parent_id.blank? || id.blank?
+
     errors.add(:parent_id, "cannot reference itself") if parent_id == id
   end
 
   def parent_same_account_type
     return if parent.blank?
+
     errors.add(:parent_id, "must have the same account type") if parent.account_type != account_type
   end
 

--- a/app/models/merchandise_category.rb
+++ b/app/models/merchandise_category.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 class MerchandiseCategory < ApplicationRecord
+  include HasMachineCode
+
   belongs_to :parent, class_name: "MerchandiseCategory", optional: true
   belongs_to :default_merchandise_class, class_name: "MerchandiseClass", optional: true
   has_many :children, class_name: "MerchandiseCategory", foreign_key: :parent_id, inverse_of: :parent, dependent: :restrict_with_exception
 
-  before_validation :normalize_code
-
   validates :name, presence: true
+  validates :code, uniqueness: true, allow_nil: true, format: { with: Codes::Normalizer::FORMAT, allow_nil: true }
   validate :parent_not_self
   validate :no_parent_cycle
   validate :validate_changed_default_class
@@ -15,18 +16,42 @@ class MerchandiseCategory < ApplicationRecord
   scope :active, -> { where(active: true) }
   scope :assignable, -> { active }
 
+  def self.machine_code_optional?
+    true
+  end
+
   def assignable?
     active?
   end
 
+  def reactivation_blockers
+    blockers = []
+    blockers << "parent category must be active" if parent.present? && !parent.active?
+    if default_merchandise_class.present? && !default_merchandise_class.active?
+      blockers << "default merchandise class must be active"
+    end
+    blockers
+  end
+
   private
 
-  def normalize_code
-    self.code = code.to_s.strip.downcase.tr(" ", "_").presence
+  def prepare_machine_code
+    if new_record?
+      if code.blank?
+        # Optional: leave blank unless supplied or name is used for generation when code was omitted intentionally.
+        # Spec: blank generates from name. Categories generate when name present.
+        if name.present?
+          self.code = Codes::Normalizer.normalize(name).presence
+        end
+        return
+      end
+      self.code = Codes::Normalizer.normalize(code).presence
+    end
   end
 
   def parent_not_self
     return if parent_id.blank? || id.blank?
+
     errors.add(:parent_id, "cannot reference itself") if parent_id == id
   end
 

--- a/app/models/merchandise_category.rb
+++ b/app/models/merchandise_category.rb
@@ -24,6 +24,27 @@ class MerchandiseCategory < ApplicationRecord
     active?
   end
 
+  # Root categories return their name; nested categories return "Parent > Child > …".
+  def path_label(separator: " > ")
+    names = []
+    current = self
+    seen = Set.new
+
+    while current
+      break if seen.include?(current.id)
+
+      seen << current.id
+      names.unshift(current.name)
+      current = current.parent
+    end
+
+    names.join(separator)
+  end
+
+  def self.options_for_select(records)
+    Array(records).map { |category| [category.path_label, category.id] }
+  end
+
   def reactivation_blockers
     blockers = []
     blockers << "parent category must be active" if parent.present? && !parent.active?

--- a/app/models/merchandise_category.rb
+++ b/app/models/merchandise_category.rb
@@ -42,7 +42,7 @@ class MerchandiseCategory < ApplicationRecord
   end
 
   def self.options_for_select(records)
-    Array(records).map { |category| [category.path_label, category.id] }
+    Array(records).map { |category| [ category.path_label, category.id ] }
   end
 
   def reactivation_blockers

--- a/app/models/merchandise_class.rb
+++ b/app/models/merchandise_class.rb
@@ -1,19 +1,20 @@
 # frozen_string_literal: true
 
 class MerchandiseClass < ApplicationRecord
+  include HasMachineCode
+
   INVENTORY_MODES = %w[inventory non_inventory].freeze
   PRICING_METHODS = %w[fixed list_price cost_based open_price].freeze
 
   belongs_to :default_standard_department, class_name: "Department", optional: true
   belongs_to :default_used_department, class_name: "Department", optional: true
 
-  before_validation :normalize_code
-
   validates :code, :name, :inventory_mode, :pricing_method, presence: true
-  validates :code, uniqueness: true
+  validates :code, uniqueness: true, format: { with: Codes::Normalizer::FORMAT }
   validates :inventory_mode, inclusion: { in: INVENTORY_MODES }
   validates :pricing_method, inclusion: { in: PRICING_METHODS }
   validate :validate_changed_departments
+  validate :buyback_implication
 
   scope :active, -> { where(active: true) }
   scope :assignable, -> { active }
@@ -30,11 +31,18 @@ class MerchandiseClass < ApplicationRecord
     inventory_mode == "non_inventory"
   end
 
-  private
-
-  def normalize_code
-    self.code = code.to_s.strip.downcase.tr(" ", "_")
+  def reactivation_blockers
+    blockers = []
+    if default_standard_department.present? && !default_standard_department.active?
+      blockers << "default standard department must be active"
+    end
+    if default_used_department.present? && !default_used_department.active?
+      blockers << "default used department must be active"
+    end
+    blockers
   end
+
+  private
 
   def validate_changed_departments
     if default_standard_department_id_changed? && default_standard_department.present? && !default_standard_department.assignable?
@@ -42,6 +50,14 @@ class MerchandiseClass < ApplicationRecord
     end
     if default_used_department_id_changed? && default_used_department.present? && !default_used_department.assignable?
       errors.add(:default_used_department_id, "must be an active department")
+    end
+  end
+
+  def buyback_implication
+    return unless buyback_allowed?
+
+    unless used_merchandise_allowed? && inventory?
+      errors.add(:buyback_allowed, "requires used merchandise allowed and inventory mode")
     end
   end
 end

--- a/app/models/merchandise_condition.rb
+++ b/app/models/merchandise_condition.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class MerchandiseCondition < ApplicationRecord
-  before_validation :normalize_code
+  include HasMachineCode
 
   validates :code, :name, presence: true
-  validates :code, uniqueness: true
+  validates :code, uniqueness: true, format: { with: Codes::Normalizer::FORMAT }
   validates :price_adjustment_bps, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
   scope :active, -> { where(active: true) }
@@ -14,9 +14,7 @@ class MerchandiseCondition < ApplicationRecord
     active?
   end
 
-  private
-
-  def normalize_code
-    self.code = code.to_s.strip.downcase.tr(" ", "_")
+  def reactivation_blockers
+    []
   end
 end

--- a/app/models/system_settings.rb
+++ b/app/models/system_settings.rb
@@ -7,8 +7,10 @@ class SystemSettings < ApplicationRecord
   validates :base_currency_code, length: { is: 3 }
   validates :default_country_code, length: { is: 2 }
   validates :fiscal_year_start_month, inclusion: { in: 1..12 }
-  validates :default_supplier_cancellation_days, :default_customer_reservation_expiration_days,
+  validates :default_supplier_cancellation_days,
             numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :default_customer_reservation_expiration_days,
+            numericality: { only_integer: true, greater_than: 0 }
   validate :singleton_row
 
   def self.current

--- a/app/models/tax_class.rb
+++ b/app/models/tax_class.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class TaxClass < ApplicationRecord
-  before_validation :normalize_code
+  include HasMachineCode
 
   validates :code, :name, presence: true
-  validates :code, uniqueness: true
+  validates :code, uniqueness: true, format: { with: Codes::Normalizer::FORMAT }
 
   scope :active, -> { where(active: true) }
   scope :assignable, -> { active }
@@ -13,9 +13,7 @@ class TaxClass < ApplicationRecord
     active?
   end
 
-  private
-
-  def normalize_code
-    self.code = code.to_s.strip.downcase.tr(" ", "_")
+  def reactivation_blockers
+    []
   end
 end

--- a/app/services/codes/normalizer.rb
+++ b/app/services/codes/normalizer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Codes
+  module Normalizer
+    module_function
+
+    FORMAT = /\A[a-z0-9]+(?:_[a-z0-9]+)*\z/
+
+    def normalize(raw)
+      value = ActiveSupport::Inflector.transliterate(raw.to_s)
+      value = value.downcase
+      value = value.gsub(/[^a-z0-9]+/, "_")
+      value = value.gsub(/\A_+|_+\z/, "")
+      value = value.gsub(/_+/, "_")
+      value
+    end
+
+    def normalize!(raw)
+      value = normalize(raw)
+      raise ArgumentError, "code is blank after normalization" if value.blank?
+      raise ArgumentError, "code has invalid format" unless value.match?(FORMAT)
+
+      value
+    end
+  end
+end

--- a/app/services/configuration/reactivate.rb
+++ b/app/services/configuration/reactivate.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Configuration
+  class Reactivate
+    class Error < StandardError; end
+
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(record:, actor:, lock_version: nil, store: nil, audit_action:)
+      @record = record
+      @actor = actor
+      @lock_version = lock_version
+      @store = store
+      @audit_action = audit_action
+    end
+
+    def call
+      raise Error, "record is already active" if @record.active?
+
+      blockers = @record.reactivation_blockers
+      raise Error, blockers.to_sentence if blockers.any?
+
+      @record.class.transaction do
+        @record.lock_version = @lock_version unless @lock_version.nil?
+        @record.update!(active: true)
+        Audit::Recorder.record!(
+          action: @audit_action,
+          outcome: "succeeded",
+          actor_user: @actor,
+          actor_label: @actor.display_name,
+          store: @store,
+          subject: @record,
+          before_values: { active: false },
+          after_values: { active: true }
+        )
+      end
+      @record
+    rescue ActiveRecord::RecordInvalid => e
+      raise Error, e.message
+    end
+  end
+end

--- a/app/services/product_variants/create.rb
+++ b/app/services/product_variants/create.rb
@@ -50,9 +50,12 @@ module ProductVariants
           end
         raise Error, "industry identifier cannot equal SKU" if normalized_industry.present? && normalized_industry == sku
 
+        resolved_name = @attributes[:name].presence || default_variant_name(variant_type, condition)
+
         variant = @product.product_variants.new(
           @attributes.except(:industry_identifier, :sku).merge(
             variant_type: variant_type,
+            name: resolved_name,
             sku: sku,
             industry_identifier: normalized_industry,
             merchandise_condition: condition,
@@ -126,6 +129,14 @@ module ProductVariants
       rescue Identifiers::Registry::ConflictError
         retry if attempts < 5
         raise
+      end
+    end
+
+    def default_variant_name(variant_type, condition)
+      if variant_type == "used"
+        condition.name
+      else
+        "Standard"
       end
     end
   end

--- a/app/services/product_variants/create.rb
+++ b/app/services/product_variants/create.rb
@@ -62,11 +62,9 @@ module ProductVariants
             merchandise_class: resolved.merchandise_class,
             department: resolved.department,
             tax_class: resolved.tax_class,
-            regular_price_cents: if @attributes.key?(:regular_price_cents)
-                                   @attributes[:regular_price_cents]
-                                 else
-                                   resolved.suggested_price_cents
-                                 end,
+            # DefaultResolver already applies list_price suggestions when the
+            # submitted regular_price_cents is nil (blank UI fields still send the key).
+            regular_price_cents: resolved.suggested_price_cents,
             status: @attributes[:status].presence || "draft"
           )
         )

--- a/app/services/product_variants/default_resolver.rb
+++ b/app/services/product_variants/default_resolver.rb
@@ -23,14 +23,8 @@ module ProductVariants
       department = @department || department_from(klass)
       tax = @tax_class || department&.default_tax_class
       price = @regular_price_cents
-      if price.nil? && @product.list_price_cents.present?
-        price =
-          if @variant_type == "used" && @condition
-            # Half-up integer rounding: (cents * bps + 5000) / 10000
-            (@product.list_price_cents * @condition.price_adjustment_bps + 5_000) / 10_000
-          else
-            @product.list_price_cents
-          end
+      if price.nil?
+        price = suggested_price_for(klass)
       end
 
       Result.new(
@@ -50,6 +44,18 @@ module ProductVariants
         klass.default_used_department
       else
         klass.default_standard_department
+      end
+    end
+
+    def suggested_price_for(klass)
+      return if klass.blank?
+      return unless klass.pricing_method == "list_price"
+      return if @product.list_price_cents.blank?
+
+      if @variant_type == "used" && @condition
+        (@product.list_price_cents * @condition.price_adjustment_bps + 5_000) / 10_000
+      else
+        @product.list_price_cents
       end
     end
   end

--- a/app/views/admin/departments/_form.html.erb
+++ b/app/views/admin/departments/_form.html.erb
@@ -1,7 +1,15 @@
 <%= form_with model: [:admin, department] do |form| %>
   <% if department.errors.any? %><ul><% department.errors.full_messages.each do |m| %><li><%= m %></li><% end %></ul><% end %>
   <%= form.hidden_field :lock_version %>
-  <p><%= form.label :code %><%= form.text_field :code %></p>
+  <% if department.persisted? %>
+    <p>Code: <code><%= department.code %></code> (immutable)</p>
+  <% else %>
+    <p>
+      <%= form.label :code %>
+      <%= form.text_field :code %>
+      <span>Leave blank to generate from the name. Later changes are not allowed.</span>
+    </p>
+  <% end %>
   <p><%= form.label :department_number %><%= form.text_field :department_number %></p>
   <p><%= form.label :name %><%= form.text_field :name %></p>
   <p><%= form.label :description %><%= form.text_area :description %></p>

--- a/app/views/admin/departments/show.html.erb
+++ b/app/views/admin/departments/show.html.erb
@@ -12,6 +12,8 @@
   <%= link_to "Edit", edit_admin_department_path(@department) if effective_permissions.include?("departments.update") %>
   <% if effective_permissions.include?("departments.deactivate") && @department.active? %>
     <%= button_to "Deactivate", admin_department_path(@department), method: :delete, form: { data: { turbo_confirm: "Deactivate this department?" } } %>
+  <% elsif effective_permissions.include?("departments.deactivate") && !@department.active? %>
+    <%= button_to "Reactivate", reactivate_admin_department_path(@department), method: :post, params: { lock_version: @department.lock_version } %>
   <% end %>
 </p>
 <p><%= link_to "Back to departments", admin_departments_path %></p>

--- a/app/views/admin/gl_accounts/_form.html.erb
+++ b/app/views/admin/gl_accounts/_form.html.erb
@@ -5,13 +5,12 @@
   <p><%= form.label :name %><%= form.text_field :name %></p>
   <p><%= form.label :description %><%= form.text_area :description %></p>
   <p>
-    <%= form.label :account_type %>
-    <%= form.select :account_type, GlAccount::ACCOUNT_TYPES.map { |t| [t.humanize, t] }, include_blank: true %>
-  </p>
-  <p>
     <%= form.label :account_category %>
     <%= form.select :account_category, GlAccount::ACCOUNT_CATEGORIES.map { |c| [c.humanize, c] }, include_blank: true %>
   </p>
+  <% if gl_account.account_type.present? %>
+    <p>Derived account type: <%= gl_account.account_type %></p>
+  <% end %>
   <p>
     <%= form.label :parent_id, "Parent" %>
     <%= form.select :parent_id, @parent_options.map { |a| ["#{a.account_number} — #{a.name}", a.id] }, include_blank: "None" %>

--- a/app/views/admin/gl_accounts/show.html.erb
+++ b/app/views/admin/gl_accounts/show.html.erb
@@ -14,6 +14,8 @@
   <%= link_to "Edit", edit_admin_gl_account_path(@gl_account) if effective_permissions.include?("gl_accounts.update") %>
   <% if effective_permissions.include?("gl_accounts.deactivate") && @gl_account.active? %>
     <%= button_to "Deactivate", admin_gl_account_path(@gl_account), method: :delete, form: { data: { turbo_confirm: "Deactivate this GL account?" } } %>
+  <% elsif effective_permissions.include?("gl_accounts.deactivate") && !@gl_account.active? %>
+    <%= button_to "Reactivate", reactivate_admin_gl_account_path(@gl_account), method: :post, params: { lock_version: @gl_account.lock_version } %>
   <% end %>
 </p>
 <p><%= link_to "Back to GL accounts", admin_gl_accounts_path %></p>

--- a/app/views/admin/merchandise_categories/_form.html.erb
+++ b/app/views/admin/merchandise_categories/_form.html.erb
@@ -1,7 +1,15 @@
 <%= form_with model: [:admin, merchandise_category] do |form| %>
   <% if merchandise_category.errors.any? %><ul><% merchandise_category.errors.full_messages.each do |m| %><li><%= m %></li><% end %></ul><% end %>
   <%= form.hidden_field :lock_version %>
-  <p><%= form.label :code %><%= form.text_field :code %></p>
+  <% if merchandise_category.persisted? %>
+    <p>Code: <code><%= merchandise_category.code.presence || "—" %></code> (immutable)</p>
+  <% else %>
+    <p>
+      <%= form.label :code %>
+      <%= form.text_field :code %>
+      <span>Leave blank to generate from the name. Later changes are not allowed.</span>
+    </p>
+  <% end %>
   <p><%= form.label :name %><%= form.text_field :name %></p>
   <p><%= form.label :description %><%= form.text_area :description %></p>
   <p>

--- a/app/views/admin/merchandise_categories/_form.html.erb
+++ b/app/views/admin/merchandise_categories/_form.html.erb
@@ -14,7 +14,7 @@
   <p><%= form.label :description %><%= form.text_area :description %></p>
   <p>
     <%= form.label :parent_id, "Parent" %>
-    <%= form.select :parent_id, @parent_options.map { |c| [c.name, c.id] }, include_blank: "None" %>
+    <%= form.select :parent_id, MerchandiseCategory.options_for_select(@parent_options), include_blank: "None" %>
   </p>
   <p>
     <%= form.label :default_merchandise_class_id, "Default merchandise class" %>

--- a/app/views/admin/merchandise_categories/index.html.erb
+++ b/app/views/admin/merchandise_categories/index.html.erb
@@ -4,7 +4,7 @@
 <ul>
   <% @merchandise_categories.each do |category| %>
     <li>
-      <%= link_to "#{category.code.presence || "—"} — #{category.name}", admin_merchandise_category_path(category) %>
+      <%= link_to "#{category.code.presence || "—"} — #{category.path_label}", admin_merchandise_category_path(category) %>
       <%= "inactive" unless category.active? %>
     </li>
   <% end %>

--- a/app/views/admin/merchandise_categories/show.html.erb
+++ b/app/views/admin/merchandise_categories/show.html.erb
@@ -11,6 +11,8 @@
   <%= link_to "Edit", edit_admin_merchandise_category_path(@merchandise_category) if effective_permissions.include?("merchandise_categories.update") %>
   <% if effective_permissions.include?("merchandise_categories.deactivate") && @merchandise_category.active? %>
     <%= button_to "Deactivate", admin_merchandise_category_path(@merchandise_category), method: :delete, form: { data: { turbo_confirm: "Deactivate this category?" } } %>
+  <% elsif effective_permissions.include?("merchandise_categories.deactivate") && !@merchandise_category.active? %>
+    <%= button_to "Reactivate", reactivate_admin_merchandise_category_path(@merchandise_category), method: :post, params: { lock_version: @merchandise_category.lock_version } %>
   <% end %>
 </p>
 <p><%= link_to "Back to categories", admin_merchandise_categories_path %></p>

--- a/app/views/admin/merchandise_categories/show.html.erb
+++ b/app/views/admin/merchandise_categories/show.html.erb
@@ -1,7 +1,7 @@
-<% content_for :title, @merchandise_category.name %>
-<h1><%= @merchandise_category.code.presence || "—" %> — <%= @merchandise_category.name %></h1>
+<% content_for :title, @merchandise_category.path_label %>
+<h1><%= @merchandise_category.code.presence || "—" %> — <%= @merchandise_category.path_label %></h1>
 <p>
-  Parent: <%= @merchandise_category.parent&.name || "—" %> ·
+  Parent: <%= @merchandise_category.parent&.path_label || "—" %> ·
   Default class: <%= @merchandise_category.default_merchandise_class&.code || "—" %> ·
   Order: <%= @merchandise_category.display_order %> ·
   <%= @merchandise_category.active? ? "active" : "inactive" %>

--- a/app/views/admin/merchandise_classes/_form.html.erb
+++ b/app/views/admin/merchandise_classes/_form.html.erb
@@ -1,7 +1,15 @@
 <%= form_with model: [:admin, merchandise_class] do |form| %>
   <% if merchandise_class.errors.any? %><ul><% merchandise_class.errors.full_messages.each do |m| %><li><%= m %></li><% end %></ul><% end %>
   <%= form.hidden_field :lock_version %>
-  <p><%= form.label :code %><%= form.text_field :code %></p>
+  <% if merchandise_class.persisted? %>
+    <p>Code: <code><%= merchandise_class.code %></code> (immutable)</p>
+  <% else %>
+    <p>
+      <%= form.label :code %>
+      <%= form.text_field :code %>
+      <span>Leave blank to generate from the name. Later changes are not allowed.</span>
+    </p>
+  <% end %>
   <p><%= form.label :name %><%= form.text_field :name %></p>
   <p><%= form.label :description %><%= form.text_area :description %></p>
   <p>
@@ -21,8 +29,8 @@
     <%= form.select :default_used_department_id, @departments.map { |d| ["#{d.code} — #{d.name}", d.id] }, include_blank: "None" %>
   </p>
   <p><%= form.check_box :used_merchandise_allowed %><%= form.label :used_merchandise_allowed %></p>
-  <p><%= form.check_box :buyback_allowed %><%= form.label :buyback_allowed %></p>
-  <p><%= form.check_box :default_returnable %><%= form.label :default_returnable %></p>
+  <p><%= form.check_box :buyback_allowed %><%= form.label :buyback_allowed, "Buyback allowed (requires used + inventory)" %></p>
+  <p><%= form.check_box :default_supplier_returnable %><%= form.label :default_supplier_returnable, "Default supplier returnable" %></p>
   <p><%= form.label :display_order %><%= form.number_field :display_order %></p>
   <p><%= form.submit %></p>
 <% end %>

--- a/app/views/admin/merchandise_classes/show.html.erb
+++ b/app/views/admin/merchandise_classes/show.html.erb
@@ -11,6 +11,8 @@
   <%= link_to "Edit", edit_admin_merchandise_class_path(@merchandise_class) if effective_permissions.include?("merchandise_classes.update") %>
   <% if effective_permissions.include?("merchandise_classes.deactivate") && @merchandise_class.active? %>
     <%= button_to "Deactivate", admin_merchandise_class_path(@merchandise_class), method: :delete, form: { data: { turbo_confirm: "Deactivate this merchandise class?" } } %>
+  <% elsif effective_permissions.include?("merchandise_classes.deactivate") && !@merchandise_class.active? %>
+    <%= button_to "Reactivate", reactivate_admin_merchandise_class_path(@merchandise_class), method: :post, params: { lock_version: @merchandise_class.lock_version } %>
   <% end %>
 </p>
 <p><%= link_to "Back to merchandise classes", admin_merchandise_classes_path %></p>

--- a/app/views/admin/merchandise_conditions/_form.html.erb
+++ b/app/views/admin/merchandise_conditions/_form.html.erb
@@ -1,7 +1,15 @@
 <%= form_with model: [:admin, merchandise_condition] do |form| %>
   <% if merchandise_condition.errors.any? %><ul><% merchandise_condition.errors.full_messages.each do |m| %><li><%= m %></li><% end %></ul><% end %>
   <%= form.hidden_field :lock_version %>
-  <p><%= form.label :code %><%= form.text_field :code %></p>
+  <% if merchandise_condition.persisted? %>
+    <p>Code: <code><%= merchandise_condition.code %></code> (immutable)</p>
+  <% else %>
+    <p>
+      <%= form.label :code %>
+      <%= form.text_field :code %>
+      <span>Leave blank to generate from the name. Later changes are not allowed.</span>
+    </p>
+  <% end %>
   <p><%= form.label :name %><%= form.text_field :name %></p>
   <p><%= form.label :description %><%= form.text_area :description %></p>
   <p><%= form.label :price_adjustment_bps %><%= form.number_field :price_adjustment_bps %></p>

--- a/app/views/admin/merchandise_conditions/show.html.erb
+++ b/app/views/admin/merchandise_conditions/show.html.erb
@@ -10,6 +10,8 @@
   <%= link_to "Edit", edit_admin_merchandise_condition_path(@merchandise_condition) if effective_permissions.include?("merchandise_conditions.update") %>
   <% if effective_permissions.include?("merchandise_conditions.deactivate") && @merchandise_condition.active? %>
     <%= button_to "Deactivate", admin_merchandise_condition_path(@merchandise_condition), method: :delete, form: { data: { turbo_confirm: "Deactivate this condition?" } } %>
+  <% elsif effective_permissions.include?("merchandise_conditions.deactivate") && !@merchandise_condition.active? %>
+    <%= button_to "Reactivate", reactivate_admin_merchandise_condition_path(@merchandise_condition), method: :post, params: { lock_version: @merchandise_condition.lock_version } %>
   <% end %>
 </p>
 <p><%= link_to "Back to conditions", admin_merchandise_conditions_path %></p>

--- a/app/views/admin/merchandise_imports/new.html.erb
+++ b/app/views/admin/merchandise_imports/new.html.erb
@@ -1,5 +1,28 @@
 <% content_for :title, "Merchandise import" %>
 <h1>Merchandise CSV import</h1>
+
+<p>
+  <%= link_to "Download CSV template", template_admin_merchandise_imports_path %>
+</p>
+
+<section>
+  <h2>Column dictionary</h2>
+  <ul>
+    <li><code>primary_identifier</code> — required unless <code>generate_primary_identifier</code> is true</li>
+    <li><code>name</code> — required for a new product</li>
+    <li><code>generate_primary_identifier</code> — <code>true</code>/<code>false</code>; blank+true is create-only and not idempotent on reimport</li>
+    <li><code>status</code> — optional product status</li>
+    <li><code>sku</code> — identifies an existing variant for update; cannot assign a SKU to a new variant</li>
+    <li><code>variant_type</code> — <code>standard</code> or <code>used</code> for new variants</li>
+    <li><code>variant_name</code> — maps to <code>product_variants.name</code>; blank uses shared create defaults</li>
+    <li><code>industry_identifier</code> — optional GTIN/ISBN-style identifier</li>
+    <li><code>variant_condition_code</code> — required for used; prohibited for standard; exact canonical code match</li>
+    <li><code>merchandise_class_code</code>, <code>department_code</code>, <code>tax_class_code</code> — exact canonical codes; blank uses defaults; unknown codes error</li>
+    <li><code>regular_price_cents</code> — integer minor units (cents)</li>
+  </ul>
+  <p>Rows sharing a normalized entered product identifier are one transaction group; a failure rolls back that group.</p>
+</section>
+
 <%= form_with url: admin_merchandise_imports_path, scope: :import, html: { multipart: true } do |form| %>
   <p><%= form.label :file, "CSV file" %><%= form.file_field :file, accept: ".csv,text/csv" %></p>
   <p><%= form.submit "Import" %></p>

--- a/app/views/admin/products/_form.html.erb
+++ b/app/views/admin/products/_form.html.erb
@@ -21,8 +21,15 @@
   <p>
     <%= form.label :merchandise_category_id, "Category" %>
     <%= form.select :merchandise_category_id, @merchandise_categories.map { |c| [c.name, c.id] }, include_blank: "None" %>
+    <span>Supplies the default merchandise class for newly created variants. Changing it does not rewrite existing variants.</span>
   </p>
-  <p><%= form.label :list_price_cents %><%= form.number_field :list_price_cents %></p>
+  <p>
+    <%= label_tag :list_price, "List price" %>
+    <%= text_field_tag "product[list_price]",
+          params.dig(:product, :list_price).presence || (product.list_price_cents.present? ? format("%.2f", product.list_price_cents / 100.0) : nil),
+          inputmode: "decimal" %>
+    <span>Product-level reference price. Changing it does not rewrite existing variant prices.</span>
+  </p>
   <p><%= form.label :release_date %><%= form.date_field :release_date %></p>
   <p>
     <%= form.label :status %>

--- a/app/views/admin/products/_form.html.erb
+++ b/app/views/admin/products/_form.html.erb
@@ -19,16 +19,16 @@
   <p><%= form.label :brand_name %><%= form.text_field :brand_name %></p>
   <p><%= form.label :product_model, "Model" %><%= form.text_field :product_model %></p>
   <p>
-    <%= form.label :merchandise_category_id, "Category" %>
-    <%= form.select :merchandise_category_id, @merchandise_categories.map { |c| [c.name, c.id] }, include_blank: "None" %>
-    <span>Supplies the default merchandise class for newly created variants. Changing it does not rewrite existing variants.</span>
+    <%= form.label :merchandise_category_id, "Merchandise category" %>
+    <%= form.select :merchandise_category_id, MerchandiseCategory.options_for_select(@merchandise_categories), include_blank: "None" %>
+    <span>Supplies the default merchandise class for newly created variants. Changing it does not rewrite existing variants. Merchandise class itself is set on each variant.</span>
   </p>
   <p>
     <%= label_tag :list_price, "List price" %>
     <%= text_field_tag "product[list_price]",
           params.dig(:product, :list_price).presence || (product.list_price_cents.present? ? format("%.2f", product.list_price_cents / 100.0) : nil),
           inputmode: "decimal" %>
-    <span>Product-level reference price. Changing it does not rewrite existing variant prices.</span>
+    <span>Product-level reference price (currency amount, not cents). Changing it does not rewrite existing variant prices.</span>
   </p>
   <p><%= form.label :release_date %><%= form.date_field :release_date %></p>
   <p>

--- a/app/views/admin/products/show.html.erb
+++ b/app/views/admin/products/show.html.erb
@@ -3,7 +3,8 @@
 <p>
   Identifier: <%= @product.primary_identifier %> ·
   Status: <%= @product.status %> ·
-  Category: <%= @product.merchandise_category&.name || "—" %>
+  Merchandise category: <%= @product.merchandise_category&.path_label || "—" %> ·
+  List price: <%= @product.list_price_cents.present? ? format("%.2f", @product.list_price_cents / 100.0) : "—" %>
 </p>
 <% if @product.description.present? %><p><%= @product.description %></p><% end %>
 

--- a/app/views/admin/tax_classes/_form.html.erb
+++ b/app/views/admin/tax_classes/_form.html.erb
@@ -1,7 +1,15 @@
 <%= form_with model: [:admin, tax_class] do |form| %>
   <% if tax_class.errors.any? %><ul><% tax_class.errors.full_messages.each do |m| %><li><%= m %></li><% end %></ul><% end %>
   <%= form.hidden_field :lock_version %>
-  <p><%= form.label :code %><%= form.text_field :code %></p>
+  <% if tax_class.persisted? %>
+    <p>Code: <code><%= tax_class.code %></code> (immutable)</p>
+  <% else %>
+    <p>
+      <%= form.label :code %>
+      <%= form.text_field :code %>
+      <span>Leave blank to generate from the name. Later changes are not allowed.</span>
+    </p>
+  <% end %>
   <p><%= form.label :name %><%= form.text_field :name %></p>
   <p><%= form.label :description %><%= form.text_area :description %></p>
   <p><%= form.label :display_order %><%= form.number_field :display_order %></p>

--- a/app/views/admin/tax_classes/show.html.erb
+++ b/app/views/admin/tax_classes/show.html.erb
@@ -6,6 +6,8 @@
   <%= link_to "Edit", edit_admin_tax_class_path(@tax_class) if effective_permissions.include?("tax_classes.update") %>
   <% if effective_permissions.include?("tax_classes.deactivate") && @tax_class.active? %>
     <%= button_to "Deactivate", admin_tax_class_path(@tax_class), method: :delete, form: { data: { turbo_confirm: "Deactivate this tax class?" } } %>
+  <% elsif effective_permissions.include?("tax_classes.deactivate") && !@tax_class.active? %>
+    <%= button_to "Reactivate", reactivate_admin_tax_class_path(@tax_class), method: :post, params: { lock_version: @tax_class.lock_version } %>
   <% end %>
 </p>
 <p><%= link_to "Back to tax classes", admin_tax_classes_path %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,12 +9,24 @@ Rails.application.routes.draw do
   namespace :admin do
     resource :system_settings, only: %i[show edit update]
     resources :stores
-    resources :gl_accounts
-    resources :tax_classes
-    resources :departments
-    resources :merchandise_classes
-    resources :merchandise_categories
-    resources :merchandise_conditions
+    resources :gl_accounts do
+      member { post :reactivate }
+    end
+    resources :tax_classes do
+      member { post :reactivate }
+    end
+    resources :departments do
+      member { post :reactivate }
+    end
+    resources :merchandise_classes do
+      member { post :reactivate }
+    end
+    resources :merchandise_categories do
+      member { post :reactivate }
+    end
+    resources :merchandise_conditions do
+      member { post :reactivate }
+    end
     resources :products do
       member do
         post :discontinue
@@ -26,7 +38,9 @@ Rails.application.routes.draw do
       end
     end
     resources :merchandise_lookups, only: %i[new create]
-    resources :merchandise_imports, only: %i[new create]
+    resources :merchandise_imports, only: %i[new create] do
+      collection { get :template }
+    end
     resources :users do
       member do
         post :deactivate

--- a/db/migrate/20260811150000_normalize_phase21_machine_codes.rb
+++ b/db/migrate/20260811150000_normalize_phase21_machine_codes.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+class NormalizePhase21MachineCodes < ActiveRecord::Migration[8.1]
+  TABLES = {
+    "tax_classes" => { nullable: false },
+    "departments" => { nullable: false },
+    "merchandise_classes" => { nullable: false },
+    "merchandise_conditions" => { nullable: false },
+    "merchandise_categories" => { nullable: true }
+  }.freeze
+
+  def up
+    TABLES.each do |table, opts|
+      rows = connection.select_all("SELECT id, code FROM #{table} WHERE code IS NOT NULL")
+      collisions = Hash.new { |h, k| h[k] = [] }
+
+      rows.each do |row|
+        normalized = normalize_code(row["code"])
+        if normalized.blank?
+          raise ActiveRecord::IrreversibleMigration,
+                "#{table} id=#{row["id"]} code=#{row["code"].inspect} normalizes to blank"
+        end
+        collisions[normalized] << row["id"]
+      end
+
+      dupes = collisions.select { |_, ids| ids.size > 1 }
+      if dupes.any?
+        report = dupes.map { |code, ids| "#{code}: #{ids.join(", ")}" }.join("; ")
+        raise ActiveRecord::IrreversibleMigration,
+              "Normalized code collisions in #{table}: #{report}"
+      end
+
+      rows.each do |row|
+        normalized = normalize_code(row["code"])
+        next if normalized == row["code"]
+
+        connection.execute(
+          sanitize("UPDATE #{table} SET code = ?, updated_at = ? WHERE id = ?",
+                   normalized, Time.current, row["id"])
+        )
+      end
+
+      if opts[:nullable]
+        add_check_constraint table,
+                             "code IS NULL OR code ~ '^[a-z0-9]+(_[a-z0-9]+)*$'",
+                             name: "#{table}_code_format"
+      else
+        add_check_constraint table,
+                             "code ~ '^[a-z0-9]+(_[a-z0-9]+)*$'",
+                             name: "#{table}_code_format"
+      end
+    end
+  end
+
+  def down
+    TABLES.each_key do |table|
+      remove_check_constraint table, name: "#{table}_code_format", if_exists: true
+    end
+  end
+
+  private
+
+  def normalize_code(raw)
+    value = ActiveSupport::Inflector.transliterate(raw.to_s)
+    value = value.downcase
+    value = value.gsub(/[^a-z0-9]+/, "_")
+    value = value.gsub(/\A_+|_+\z/, "")
+    value.gsub(/_+/, "_")
+  end
+
+  def sanitize(sql, *binds)
+    ActiveRecord::Base.sanitize_sql_array([ sql, *binds ])
+  end
+end

--- a/db/migrate/20260811151000_rename_default_returnable_to_supplier_returnable.rb
+++ b/db/migrate/20260811151000_rename_default_returnable_to_supplier_returnable.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenameDefaultReturnableToSupplierReturnable < ActiveRecord::Migration[8.1]
+  def change
+    rename_column :merchandise_classes, :default_returnable, :default_supplier_returnable
+  end
+end

--- a/db/migrate/20260811152000_enforce_gl_account_category_type_mapping.rb
+++ b/db/migrate/20260811152000_enforce_gl_account_category_type_mapping.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class EnforceGlAccountCategoryTypeMapping < ActiveRecord::Migration[8.1]
+  CATEGORY_TO_TYPE = {
+    "cash" => "asset",
+    "accounts_receivable" => "asset",
+    "inventory" => "asset",
+    "other_current_asset" => "asset",
+    "fixed_asset" => "asset",
+    "accounts_payable" => "liability",
+    "other_current_liability" => "liability",
+    "long_term_liability" => "liability",
+    "equity" => "equity",
+    "sales" => "revenue",
+    "sales_returns" => "revenue",
+    "other_revenue" => "revenue",
+    "cost_of_goods_sold" => "expense",
+    "freight_in" => "expense",
+    "inventory_shrinkage" => "expense",
+    "inventory_adjustment" => "expense",
+    "inventory_write_down" => "expense",
+    "other_expense" => "expense"
+  }.freeze
+
+  def up
+    bad = connection.select_all(<<~SQL.squish)
+      SELECT id, account_number, account_category, account_type
+      FROM gl_accounts
+    SQL
+
+    inconsistent = bad.reject do |row|
+      CATEGORY_TO_TYPE[row["account_category"]] == row["account_type"]
+    end
+    if inconsistent.any?
+      report = inconsistent.map { |r| "#{r["account_number"]}(#{r["account_category"]}/#{r["account_type"]})" }.join(", ")
+      raise ActiveRecord::IrreversibleMigration, "Inconsistent GL category/type pairs: #{report}"
+    end
+
+    clauses = CATEGORY_TO_TYPE.map do |category, type|
+      "(account_category = #{connection.quote(category)} AND account_type = #{connection.quote(type)})"
+    end.join(" OR ")
+
+    add_check_constraint :gl_accounts, clauses, name: "gl_accounts_category_matches_type"
+  end
+
+  def down
+    remove_check_constraint :gl_accounts, name: "gl_accounts_category_matches_type"
+  end
+end

--- a/db/migrate/20260811153000_enforce_merchandise_class_buyback_implication.rb
+++ b/db/migrate/20260811153000_enforce_merchandise_class_buyback_implication.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class EnforceMerchandiseClassBuybackImplication < ActiveRecord::Migration[8.1]
+  def up
+    bad = connection.select_all(<<~SQL.squish)
+      SELECT id, code FROM merchandise_classes
+      WHERE buyback_allowed = TRUE
+        AND NOT (used_merchandise_allowed = TRUE AND inventory_mode = 'inventory')
+    SQL
+    if bad.any?
+      report = bad.map { |r| r["code"] }.join(", ")
+      raise ActiveRecord::IrreversibleMigration,
+            "buyback_allowed requires used_merchandise_allowed and inventory mode for: #{report}"
+    end
+
+    add_check_constraint :merchandise_classes,
+                         "NOT buyback_allowed OR (used_merchandise_allowed AND inventory_mode = 'inventory')",
+                         name: "merchandise_classes_buyback_implies_used_inventory"
+  end
+
+  def down
+    remove_check_constraint :merchandise_classes, name: "merchandise_classes_buyback_implies_used_inventory"
+  end
+end

--- a/db/migrate/20260811154000_require_positive_customer_reservation_days.rb
+++ b/db/migrate/20260811154000_require_positive_customer_reservation_days.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class RequirePositiveCustomerReservationDays < ActiveRecord::Migration[8.1]
+  def up
+    bad = connection.select_value(<<~SQL.squish)
+      SELECT COUNT(*) FROM system_settings
+      WHERE default_customer_reservation_expiration_days IS NULL
+         OR default_customer_reservation_expiration_days < 1
+    SQL
+    if bad.to_i.positive?
+      raise ActiveRecord::IrreversibleMigration,
+            "default_customer_reservation_expiration_days must be >= 1 before tightening the constraint"
+    end
+
+    remove_check_constraint :system_settings, name: "system_settings_reservation_days_nonnegative"
+    add_check_constraint :system_settings,
+                         "default_customer_reservation_expiration_days > 0",
+                         name: "system_settings_reservation_days_positive"
+  end
+
+  def down
+    remove_check_constraint :system_settings, name: "system_settings_reservation_days_positive"
+    add_check_constraint :system_settings,
+                         "default_customer_reservation_expiration_days >= 0",
+                         name: "system_settings_reservation_days_nonnegative"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_10_220000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_11_154000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -86,6 +86,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_220000) do
     t.index ["receiving_clearing_gl_account_id"], name: "index_departments_on_receiving_clearing_gl_account_id"
     t.index ["sales_returns_gl_account_id"], name: "index_departments_on_sales_returns_gl_account_id"
     t.index ["sales_revenue_gl_account_id"], name: "index_departments_on_sales_revenue_gl_account_id"
+    t.check_constraint "code::text ~ '^[a-z0-9]+(_[a-z0-9]+)*$'::text", name: "departments_code_format"
     t.check_constraint "default_target_margin_bps IS NULL OR default_target_margin_bps >= 0 AND default_target_margin_bps < 10000", name: "departments_margin_bps_range"
   end
 
@@ -105,6 +106,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_220000) do
     t.index ["account_number"], name: "index_gl_accounts_on_account_number", unique: true
     t.index ["active", "account_number"], name: "index_gl_accounts_on_active_and_account_number"
     t.index ["parent_id"], name: "index_gl_accounts_on_parent_id"
+    t.check_constraint "account_category::text = 'cash'::text AND account_type::text = 'asset'::text OR account_category::text = 'accounts_receivable'::text AND account_type::text = 'asset'::text OR account_category::text = 'inventory'::text AND account_type::text = 'asset'::text OR account_category::text = 'other_current_asset'::text AND account_type::text = 'asset'::text OR account_category::text = 'fixed_asset'::text AND account_type::text = 'asset'::text OR account_category::text = 'accounts_payable'::text AND account_type::text = 'liability'::text OR account_category::text = 'other_current_liability'::text AND account_type::text = 'liability'::text OR account_category::text = 'long_term_liability'::text AND account_type::text = 'liability'::text OR account_category::text = 'equity'::text AND account_type::text = 'equity'::text OR account_category::text = 'sales'::text AND account_type::text = 'revenue'::text OR account_category::text = 'sales_returns'::text AND account_type::text = 'revenue'::text OR account_category::text = 'other_revenue'::text AND account_type::text = 'revenue'::text OR account_category::text = 'cost_of_goods_sold'::text AND account_type::text = 'expense'::text OR account_category::text = 'freight_in'::text AND account_type::text = 'expense'::text OR account_category::text = 'inventory_shrinkage'::text AND account_type::text = 'expense'::text OR account_category::text = 'inventory_adjustment'::text AND account_type::text = 'expense'::text OR account_category::text = 'inventory_write_down'::text AND account_type::text = 'expense'::text OR account_category::text = 'other_expense'::text AND account_type::text = 'expense'::text", name: "gl_accounts_category_matches_type"
     t.check_constraint "account_type::text = ANY (ARRAY['asset'::character varying, 'liability'::character varying, 'equity'::character varying, 'revenue'::character varying, 'expense'::character varying]::text[])", name: "gl_accounts_account_type_valid"
     t.check_constraint "parent_id IS NULL OR parent_id <> id", name: "gl_accounts_parent_not_self"
   end
@@ -140,6 +142,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_220000) do
     t.index "lower((name)::text)", name: "index_merchandise_categories_root_name", unique: true, where: "(parent_id IS NULL)"
     t.index "parent_id, lower((name)::text)", name: "index_merchandise_categories_sibling_name", unique: true, where: "(parent_id IS NOT NULL)"
     t.index ["code"], name: "index_merchandise_categories_on_code", unique: true, where: "(code IS NOT NULL)"
+    t.check_constraint "code IS NULL OR code::text ~ '^[a-z0-9]+(_[a-z0-9]+)*$'::text", name: "merchandise_categories_code_format"
     t.check_constraint "parent_id IS NULL OR parent_id <> id", name: "merchandise_categories_parent_not_self"
   end
 
@@ -148,8 +151,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_220000) do
     t.boolean "buyback_allowed", default: false, null: false
     t.string "code", null: false
     t.timestamptz "created_at", null: false
-    t.boolean "default_returnable", default: true, null: false
     t.uuid "default_standard_department_id"
+    t.boolean "default_supplier_returnable", default: true, null: false
     t.uuid "default_used_department_id"
     t.text "description"
     t.integer "display_order", default: 0, null: false
@@ -160,6 +163,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_220000) do
     t.timestamptz "updated_at", null: false
     t.boolean "used_merchandise_allowed", default: false, null: false
     t.index ["code"], name: "index_merchandise_classes_on_code", unique: true
+    t.check_constraint "NOT buyback_allowed OR used_merchandise_allowed AND inventory_mode::text = 'inventory'::text", name: "merchandise_classes_buyback_implies_used_inventory"
+    t.check_constraint "code::text ~ '^[a-z0-9]+(_[a-z0-9]+)*$'::text", name: "merchandise_classes_code_format"
     t.check_constraint "inventory_mode::text = ANY (ARRAY['inventory'::character varying, 'non_inventory'::character varying]::text[])", name: "merchandise_classes_inventory_mode_valid"
     t.check_constraint "pricing_method::text = ANY (ARRAY['fixed'::character varying, 'list_price'::character varying, 'cost_based'::character varying, 'open_price'::character varying]::text[])", name: "merchandise_classes_pricing_method_valid"
   end
@@ -175,6 +180,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_220000) do
     t.integer "price_adjustment_bps", default: 10000, null: false
     t.timestamptz "updated_at", null: false
     t.index ["code"], name: "index_merchandise_conditions_on_code", unique: true
+    t.check_constraint "code::text ~ '^[a-z0-9]+(_[a-z0-9]+)*$'::text", name: "merchandise_conditions_code_format"
     t.check_constraint "price_adjustment_bps >= 0", name: "merchandise_conditions_price_adjustment_nonnegative"
   end
 
@@ -333,7 +339,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_220000) do
     t.boolean "singleton_key", default: true, null: false
     t.timestamptz "updated_at", null: false
     t.index ["singleton_key"], name: "index_system_settings_on_singleton_key", unique: true
-    t.check_constraint "default_customer_reservation_expiration_days >= 0", name: "system_settings_reservation_days_nonnegative"
+    t.check_constraint "default_customer_reservation_expiration_days > 0", name: "system_settings_reservation_days_positive"
     t.check_constraint "default_supplier_cancellation_days >= 0", name: "system_settings_supplier_cancellation_days_nonnegative"
     t.check_constraint "fiscal_year_start_month >= 1 AND fiscal_year_start_month <= 12", name: "system_settings_fiscal_year_start_month_range"
     t.check_constraint "singleton_key = true", name: "system_settings_singleton_key_true"
@@ -349,6 +355,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_220000) do
     t.string "name", null: false
     t.timestamptz "updated_at", null: false
     t.index ["code"], name: "index_tax_classes_on_code", unique: true
+    t.check_constraint "code::text ~ '^[a-z0-9]+(_[a-z0-9]+)*$'::text", name: "tax_classes_code_format"
   end
 
   create_table "user_sessions", id: :uuid, default: nil, force: :cascade do |t|

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ This directory contains the project’s technical authority, development guidanc
 | [Phase 2 plan](planning/phase2-financial-classification-and-merchandise-foundation/phase2-plan.md) | Phase 2 scope, slices, and completion criteria |
 | [Phase 2 schema](planning/phase2-financial-classification-and-merchandise-foundation/phase-2-database-schema.md) | Phase 2 tables, fields, and constraints |
 | [Phase 2 authorization](planning/phase2-financial-classification-and-merchandise-foundation/phase2-authorization.md) | Phase 2 permission catalog and role grants |
+| [Phase 2.1 refinements](planning/phase2.1-platform-merchandise-refinement/phase-2.1-platform-and-merchandise-refinements.md) | Merchandise correctness and operability patch before inventory |
 | [Development guide](development.md) | Docker-only local setup, PostgreSQL configuration, application commands, and troubleshooting |
 | [Testing and CI](testing.md) | Active GitHub Actions checks and prerequisites for deferred checks |
 | [GitHub work management](github-workflow.md) | Issues, PRs, milestones, labels, and release tagging |

--- a/docs/planning/phase2-financial-classification-and-merchandise-foundation/phase-2-database-schema.md
+++ b/docs/planning/phase2-financial-classification-and-merchandise-foundation/phase-2-database-schema.md
@@ -192,7 +192,7 @@ Examples include `book`, `recorded_music`, `video`, `greeting_card`, `apparel`, 
 | default_used_department_id | uuid | FK: `departments`; nullable | Default for used variants |
 | used_merchandise_allowed | boolean | null: false; default `false` | Whether used variants may use this class |
 | buyback_allowed | boolean | null: false; default `false` | Future behavior; buyback is deferred |
-| default_returnable | boolean | null: false; default `true` | Default used by later purchasing and return workflows |
+| default_supplier_returnable | boolean | null: false; default `true` | Default used by later purchasing supplier-return workflows |
 | active | boolean | null: false; default `true` | |
 | display_order | integer | null: false; default `0` | |
 | lock_version | integer | null: false; default `0` | Optimistic concurrency |

--- a/docs/planning/phase2-financial-classification-and-merchandise-foundation/phase2-authorization.md
+++ b/docs/planning/phase2-financial-classification-and-merchandise-foundation/phase2-authorization.md
@@ -11,7 +11,7 @@ Phase 2 merchandise and financial reference data are organization-wide master da
 | `view` | Read and list |
 | `create` | Create new records |
 | `update` | Non-lifecycle edits (does not include deactivate/discontinue) |
-| `deactivate` | Soft-deactivate reference/configuration records |
+| `deactivate` | Soft-deactivate or reactivate reference/configuration records (same permission family) |
 | `discontinue` | Move products/variants to discontinued (lifecycle) |
 
 `products.create` authorizes product creation whether the user enters an external primary identifier or chooses Generate ShelfSense identifier (`222`). There is no separate `products.generate_identifier` permission.

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -3,7 +3,7 @@
 # Bootstrap the application
 ./dev/rails-docker env \
   ORGANIZATION_NAME="Example Books" \
-  STORE_NUMBER=1 \
+  STORE_NUMBER=001 \
   STORE_CODE=main \
   STORE_NAME="Main Store" \
   STORE_TIMEZONE=America/New_York \

--- a/test/models/gl_account_test.rb
+++ b/test/models/gl_account_test.rb
@@ -43,4 +43,33 @@ class GlAccountTest < ActiveSupport::TestCase
     assert_not account.valid?
     assert_includes account.errors[:parent_id], "cannot reference itself"
   end
+
+  test "category derives account type" do
+    account = GlAccount.new(
+      account_number: "5000",
+      name: "COGS",
+      account_category: "cost_of_goods_sold",
+      account_type: "asset"
+    )
+    assert account.valid?
+    assert_equal "expense", account.account_type
+  end
+
+  test "database rejects inconsistent category type pairs" do
+    assert_raises(ActiveRecord::StatementInvalid) do
+      GlAccount.insert!({
+        id: SecureRandom.uuid_v7,
+        account_number: "9999",
+        name: "Bad",
+        account_category: "sales",
+        account_type: "asset",
+        posting_allowed: true,
+        active: true,
+        display_order: 0,
+        lock_version: 0,
+        created_at: Time.current,
+        updated_at: Time.current
+      })
+    end
+  end
 end

--- a/test/models/merchandise_reference_test.rb
+++ b/test/models/merchandise_reference_test.rb
@@ -65,7 +65,7 @@ class MerchandiseReferenceTest < ActiveSupport::TestCase
     assert_equal "Books", root.path_label
     assert_equal "Books > Fiction", parent.path_label
     assert_equal "Books > Fiction > Mystery", child.path_label
-    assert_equal [["Books > Fiction > Mystery", child.id]], MerchandiseCategory.options_for_select([child])
+    assert_equal [ [ "Books > Fiction > Mystery", child.id ] ], MerchandiseCategory.options_for_select([ child ])
   end
 
   test "inventory_mode accepts inventory and non_inventory" do

--- a/test/models/merchandise_reference_test.rb
+++ b/test/models/merchandise_reference_test.rb
@@ -57,6 +57,17 @@ class MerchandiseReferenceTest < ActiveSupport::TestCase
     assert_includes parent.errors[:parent_id], "would create a hierarchy cycle"
   end
 
+  test "merchandise category path_label includes ancestors" do
+    root = merchandise_category(name: "Books", code: "books_root")
+    parent = merchandise_category(name: "Fiction", code: "fiction", parent: root)
+    child = merchandise_category(name: "Mystery", code: "mystery", parent: parent)
+
+    assert_equal "Books", root.path_label
+    assert_equal "Books > Fiction", parent.path_label
+    assert_equal "Books > Fiction > Mystery", child.path_label
+    assert_equal [["Books > Fiction > Mystery", child.id]], MerchandiseCategory.options_for_select([child])
+  end
+
   test "inventory_mode accepts inventory and non_inventory" do
     inventory = merchandise_class(code: "book", inventory_mode: "inventory", default_standard_department: @department)
     service = merchandise_class(code: "service", inventory_mode: "non_inventory", default_standard_department: @department)

--- a/test/models/merchandise_reference_test.rb
+++ b/test/models/merchandise_reference_test.rb
@@ -33,9 +33,18 @@ class MerchandiseReferenceTest < ActiveSupport::TestCase
   end
 
   test "merchandise category root name uniqueness is enforced" do
-    merchandise_category(name: "Fiction")
+    merchandise_category(name: "Fiction", code: "fiction_root")
     assert_raises(ActiveRecord::RecordNotUnique) do
-      MerchandiseCategory.create!(name: "fiction", display_order: 0)
+      MerchandiseCategory.insert!({
+        id: SecureRandom.uuid_v7,
+        name: "fiction",
+        code: "fiction_other",
+        active: true,
+        display_order: 0,
+        lock_version: 0,
+        created_at: Time.current,
+        updated_at: Time.current
+      })
     end
   end
 
@@ -62,5 +71,35 @@ class MerchandiseReferenceTest < ActiveSupport::TestCase
     )
     assert_not invalid.valid?
     assert_includes invalid.errors[:inventory_mode], "is not included in the list"
+  end
+
+  test "buyback requires used merchandise and inventory mode" do
+    klass = merchandise_class(code: "gift_card", inventory_mode: "non_inventory", default_standard_department: @department)
+    klass.buyback_allowed = true
+    assert_not klass.valid?
+    assert_includes klass.errors[:buyback_allowed], "requires used merchandise allowed and inventory mode"
+  end
+
+  test "default_supplier_returnable is the returnability column" do
+    klass = merchandise_class(code: "book", default_standard_department: @department)
+    assert klass.respond_to?(:default_supplier_returnable)
+    assert_not klass.respond_to?(:default_returnable)
+  end
+
+  test "codes are immutable after create" do
+    klass = merchandise_class(code: "immutable", default_standard_department: @department)
+    klass.code = "changed"
+    assert_not klass.valid?
+    assert_includes klass.errors[:code], "cannot be changed after creation"
+  end
+
+  test "blank code generates from name" do
+    klass = MerchandiseClass.create!(
+      name: "Used Books & Media",
+      inventory_mode: "inventory",
+      pricing_method: "fixed",
+      default_standard_department: @department
+    )
+    assert_equal "used_books_media", klass.code
   end
 end

--- a/test/models/system_settings_validation_test.rb
+++ b/test/models/system_settings_validation_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SystemSettingsValidationTest < ActiveSupport::TestCase
+  test "customer reservation days must be positive" do
+    actor_user
+    settings = SystemSettings.current
+    settings.default_customer_reservation_expiration_days = 0
+    assert_not settings.valid?
+    assert settings.errors[:default_customer_reservation_expiration_days].any?
+  end
+end

--- a/test/models/tax_class_test.rb
+++ b/test/models/tax_class_test.rb
@@ -15,4 +15,22 @@ class TaxClassTest < ActiveSupport::TestCase
     record = TaxClass.create!(code: " Physical Book ", name: "Physical book")
     assert_equal "physical_book", record.code
   end
+
+  test "code cannot change after create" do
+    record = tax_class(code: "books")
+    record.code = "other"
+    assert_not record.valid?
+    assert_includes record.errors[:code], "cannot be changed after creation"
+  end
+
+  test "reactivate succeeds when inactive" do
+    actor = actor_user
+    record = tax_class(code: "inactive_tax", active: false)
+    Configuration::Reactivate.call(
+      record: record,
+      actor: actor,
+      audit_action: "tax_classes.reactivate"
+    )
+    assert record.reload.active?
+  end
 end

--- a/test/services/codes/normalizer_test.rb
+++ b/test/services/codes/normalizer_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Codes::NormalizerTest < ActiveSupport::TestCase
+  test "normalizes punctuation whitespace and accents" do
+    assert_equal "used_books_media", Codes::Normalizer.normalize("Used Books & Media")
+    assert_equal "cafe_bakery", Codes::Normalizer.normalize("Café / Bakery")
+  end
+
+  test "rejects blank after normalization" do
+    assert_raises(ArgumentError) { Codes::Normalizer.normalize!("???") }
+  end
+end

--- a/test/services/product_variants/create_and_activation_test.rb
+++ b/test/services/product_variants/create_and_activation_test.rb
@@ -10,14 +10,14 @@ class ProductVariants::CreateAndActivationTest < ActiveSupport::TestCase
     @used_dept = department(code: "used_books", default_tax_class: @tax)
     @klass = merchandise_class(
       code: "book",
-      pricing_method: "fixed",
+      pricing_method: "list_price",
       used_merchandise_allowed: false,
       default_standard_department: @standard_dept,
       default_used_department: @used_dept
     )
     @used_klass = merchandise_class(
       code: "used_book",
-      pricing_method: "fixed",
+      pricing_method: "list_price",
       used_merchandise_allowed: true,
       default_standard_department: @standard_dept,
       default_used_department: @used_dept
@@ -192,6 +192,7 @@ class ProductVariants::CreateAndActivationTest < ActiveSupport::TestCase
     assert_equal @tax.id, standard.tax_class_id
     assert_equal 2_000, standard.regular_price_cents
     assert_equal "quantity", standard.derived_inventory_tracking
+    assert_equal "Standard", standard.name
 
     used = ProductVariants::Create.call(
       product: @product,
@@ -205,6 +206,28 @@ class ProductVariants::CreateAndActivationTest < ActiveSupport::TestCase
     assert_equal @used_dept.id, used.department_id
     assert_equal 1_200, used.regular_price_cents
     assert_equal "individual", used.derived_inventory_tracking
+    assert_equal @like_new.name, used.name
+  end
+
+  test "fixed pricing method does not default from product list price" do
+    fixed = merchandise_class(
+      code: "fixed_book",
+      pricing_method: "fixed",
+      default_standard_department: @standard_dept
+    )
+    category = merchandise_category(name: "Fixed Cat", default_merchandise_class: fixed)
+    product = Products::Create.call(
+      attributes: { name: "Fixed Price Book", status: "draft", merchandise_category: category, list_price_cents: 2_000 },
+      actor: @actor,
+      identifier_mode: "generate"
+    )
+
+    variant = ProductVariants::Create.call(
+      product: product,
+      actor: @actor,
+      attributes: { variant_type: "standard" }
+    )
+    assert_nil variant.regular_price_cents
   end
 
   test "changing class defaults does not mutate existing variants" do

--- a/test/services/product_variants/create_and_activation_test.rb
+++ b/test/services/product_variants/create_and_activation_test.rb
@@ -209,6 +209,20 @@ class ProductVariants::CreateAndActivationTest < ActiveSupport::TestCase
     assert_equal @like_new.name, used.name
   end
 
+  test "blank regular_price_cents from UI still defaults under list_price" do
+    variant = ProductVariants::Create.call(
+      product: @product,
+      actor: @actor,
+      attributes: {
+        variant_type: "standard",
+        merchandise_class_id: @klass.id,
+        regular_price_cents: nil
+      }
+    )
+
+    assert_equal 2_000, variant.regular_price_cents
+  end
+
   test "fixed pricing method does not default from product list price" do
     fixed = merchandise_class(
       code: "fixed_book",


### PR DESCRIPTION
## Summary
- Enforce shared machine-code normalization/immutability, reference-data reactivation, and DB invariants for GL category↔type, buyback implication, supplier-returnable rename, and positive reservation days.
- Make pricing-method-aware variant defaults and product list-price currency UX usable, and add a downloadable merchandise CSV import template with clearer import docs.
- Update Phase 2 schema/authorization docs for the Phase 2.1 contracts. Store schema/form expansion remains deferred per the Phase 2.1 plan.

## Test plan
- [x] `./dev/rails-docker bin/rails db:prepare`
- [x] `./dev/rails-docker bin/rails test`
- [x] `./dev/rails-docker bin/rubocop`
- [x] Smoke admin: create/edit reference codes (immutable after create), deactivate/reactivate GL/tax/dept/merch class/category/condition
- [x] Smoke admin: product form currency list price; merchandise CSV template download and import page docs
- [x] Confirm GL form derives account type from category; merchandise class rejects invalid buyback combinations


Made with [Cursor](https://cursor.com)