### PR TITLE
Implement Phase 2.2 administrative UX foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,18 @@ The Phase 2.1 deliverable is:
 
 Authoritative plan: [phase-2.1-platform-and-merchandise-refinements.md](docs/planning/phase2.1-platform-merchandise-refinement/phase-2.1-platform-and-merchandise-refinements.md).
 
+### Phase 2.2: Administrative UX foundation
+
+Status: implemented (Propshaft design tokens and shell, shared admin partials/helpers, product reference flow with search/filter/pagination, currency form UX via `Money::ParseCents`, Stores and Merchandise Classes adoption).
+
+Phase 2.2 is an HTML/CSS-first presentation pass between merchandise foundation work and Phase 3 inventory. It does not install Hotwire and does not add inventory behavior.
+
+The Phase 2.2 deliverable is:
+
+> An authorized administrator can navigate a consistent administrative shell, manage products with searchable/filterable indexes and dollar-oriented price fields, and use the same presentation patterns on Stores and Merchandise Classes.
+
+Authoritative plan: [phase-2.2-ux-foundation.md](docs/planning/phase2.2-ux-foundation/phase-2.2-ux-foundation.md). Conventions: [UX conventions](docs/ux-conventions.md).
+
 ## Phase 1 authorization model
 
 Permissions are additive and supplied by roles:
@@ -200,6 +212,7 @@ Start with the [documentation index](docs/README.md). Key references include:
 - [Architecture Decision Records](docs/adr/README.md)
 - [Phase 1 plan](docs/planning/phase1-operational-foundation/phase1-plan.md), [schema](docs/planning/phase1-operational-foundation/phase1-schema.md), and [authorization contract](docs/planning/phase1-operational-foundation/phase1-authorization.md)
 - [Phase 2 plan](docs/planning/phase2-financial-classification-and-merchandise-foundation/phase2-plan.md), [schema](docs/planning/phase2-financial-classification-and-merchandise-foundation/phase-2-database-schema.md), and [authorization contract](docs/planning/phase2-financial-classification-and-merchandise-foundation/phase2-authorization.md)
+- [Phase 2.2 UX foundation](docs/planning/phase2.2-ux-foundation/phase-2.2-ux-foundation.md) and [UX conventions](docs/ux-conventions.md)
 - [Development guide](docs/development.md)
 - [Testing and CI](docs/testing.md)
 - [GitHub work management](docs/github-workflow.md)

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,10 +1,421 @@
-/*
- * This is a manifest file that'll be compiled into application.css.
- *
- * With Propshaft, assets are served efficiently without preprocessing steps. You can still include
- * application-wide styles in this file, but keep in mind that CSS precedence will follow the standard
- * cascading order, meaning styles declared later in the document or manifest will override earlier ones,
- * depending on specificity.
- *
- * Consider organizing styles into separate files for maintainability.
- */
+:root {
+  --color-background: #f8fafc;
+  --color-surface: #ffffff;
+  --color-text: #0f172a;
+  --color-text-muted: #64748b;
+  --color-action: #0d6e6e;
+  --color-accent: #7a2e5a;
+  --color-warning: #e09214;
+  --color-border: #e2e8f0;
+  --color-danger: #b91c1c;
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.5rem;
+  --space-6: 2rem;
+  --radius: 0.375rem;
+  --content-max: 72rem;
+  --form-max: 40rem;
+  --font-sans: "Source Sans 3", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 16px;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  color: var(--color-text);
+  background: var(--color-background);
+  line-height: 1.5;
+}
+
+a {
+  color: var(--color-action);
+}
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+summary:focus-visible {
+  outline: 2px solid var(--color-action);
+  outline-offset: 2px;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+  padding: var(--space-3) var(--space-5);
+}
+
+.app-brand {
+  font-weight: 700;
+  color: var(--color-text);
+  text-decoration: none;
+  margin-right: var(--space-4);
+}
+
+.app-header-meta {
+  color: var(--color-text-muted);
+  font-size: 0.875rem;
+  margin-top: var(--space-1);
+}
+
+.app-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-3);
+  align-items: center;
+  margin-top: var(--space-3);
+}
+
+.app-nav a {
+  text-decoration: none;
+  color: var(--color-text);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius);
+}
+
+.app-nav a:hover,
+.app-nav a.is-active {
+  color: var(--color-action);
+  background: color-mix(in srgb, var(--color-action) 10%, transparent);
+}
+
+.app-nav-group {
+  display: contents;
+}
+
+.app-content {
+  width: min(100% - 2rem, var(--content-max));
+  margin: var(--space-5) auto;
+  flex: 1;
+}
+
+.surface {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: var(--space-5);
+}
+
+.page-header {
+  margin-bottom: var(--space-5);
+}
+
+.page-header__title {
+  margin: 0 0 var(--space-2);
+  font-size: 1.75rem;
+  line-height: 1.2;
+}
+
+.page-header__subtitle {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.breadcrumbs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  list-style: none;
+  padding: 0;
+  margin: 0 0 var(--space-3);
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+}
+
+.breadcrumbs a {
+  color: var(--color-action);
+  text-decoration: none;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+  margin: var(--space-4) 0;
+}
+
+.btn,
+button,
+input[type="submit"] {
+  appearance: none;
+  border: 1px solid transparent;
+  border-radius: var(--radius);
+  padding: var(--space-2) var(--space-4);
+  font: inherit;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-action);
+  color: #fff;
+}
+
+.btn:hover,
+button:hover,
+input[type="submit"]:hover {
+  filter: brightness(0.95);
+}
+
+.btn--secondary,
+.button-secondary {
+  background: var(--color-surface);
+  color: var(--color-accent);
+  border-color: var(--color-border);
+}
+
+.btn--danger,
+.button-danger {
+  background: var(--color-danger);
+  color: #fff;
+}
+
+.btn--ghost {
+  background: transparent;
+  color: var(--color-action);
+  border-color: var(--color-border);
+}
+
+.flash {
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius);
+  margin: var(--space-4) auto;
+  width: min(100% - 2rem, var(--content-max));
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+
+.flash--notice {
+  border-color: color-mix(in srgb, var(--color-action) 40%, var(--color-border));
+  color: var(--color-action);
+}
+
+.flash--alert {
+  border-color: color-mix(in srgb, var(--color-danger) 40%, var(--color-border));
+  color: var(--color-danger);
+}
+
+.status-badge {
+  display: inline-block;
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.8125rem;
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  background: var(--color-surface);
+}
+
+.status-badge--active {
+  border-color: color-mix(in srgb, var(--color-action) 50%, var(--color-border));
+  color: var(--color-action);
+}
+
+.status-badge--draft,
+.status-badge--inactive {
+  color: var(--color-text-muted);
+}
+
+.status-badge--discontinued {
+  color: var(--color-danger);
+  border-color: color-mix(in srgb, var(--color-danger) 40%, var(--color-border));
+}
+
+.muted,
+.missing-value {
+  color: var(--color-text-muted);
+}
+
+.definition-list {
+  display: grid;
+  grid-template-columns: minmax(8rem, 12rem) 1fr;
+  gap: var(--space-2) var(--space-4);
+  margin: 0;
+}
+
+.definition-list dt {
+  color: var(--color-text-muted);
+  font-weight: 600;
+}
+
+.definition-list dd {
+  margin: 0;
+}
+
+.section {
+  margin: var(--space-5) 0;
+}
+
+.section__title {
+  margin: 0 0 var(--space-3);
+  font-size: 1.125rem;
+}
+
+.section__help {
+  margin: 0 0 var(--space-3);
+  color: var(--color-text-muted);
+  font-size: 0.9375rem;
+}
+
+.form {
+  max-width: var(--form-max);
+}
+
+.form-field {
+  margin-bottom: var(--space-4);
+}
+
+.form-field label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: var(--space-1);
+}
+
+.form-field input,
+.form-field select,
+.form-field textarea {
+  width: 100%;
+  max-width: 100%;
+  padding: var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  font: inherit;
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+.form-field .field-help,
+.form-field .field-error {
+  display: block;
+  margin-top: var(--space-1);
+  font-size: 0.875rem;
+}
+
+.form-field .field-help {
+  color: var(--color-text-muted);
+}
+
+.form-field .field-error {
+  color: var(--color-danger);
+}
+
+.form-errors {
+  border: 1px solid color-mix(in srgb, var(--color-danger) 45%, var(--color-border));
+  background: color-mix(in srgb, var(--color-danger) 8%, var(--color-surface));
+  color: var(--color-danger);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius);
+  margin-bottom: var(--space-4);
+}
+
+.form-errors h2 {
+  margin: 0 0 var(--space-2);
+  font-size: 1rem;
+}
+
+.form-errors ul {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
+.table-scroll {
+  overflow-x: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  background: var(--color-surface);
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 36rem;
+}
+
+.data-table th,
+.data-table td {
+  text-align: left;
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+  white-space: nowrap;
+}
+
+.data-table th {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  background: color-mix(in srgb, var(--color-background) 80%, var(--color-surface));
+}
+
+.data-table td.numeric,
+.data-table th.numeric {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.empty-state {
+  padding: var(--space-5);
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius);
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+}
+
+.empty-state__title {
+  margin: 0 0 var(--space-2);
+  color: var(--color-text);
+  font-size: 1.125rem;
+}
+
+.technical-details {
+  margin-top: var(--space-5);
+  color: var(--color-text-muted);
+  font-size: 0.875rem;
+}
+
+.technical-details summary {
+  cursor: pointer;
+  color: var(--color-text);
+}
+
+.pagination {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  align-items: center;
+  margin-top: var(--space-4);
+}
+
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  align-items: end;
+  margin-bottom: var(--space-4);
+}
+
+.filters .form-field {
+  margin: 0;
+  min-width: 10rem;
+}
+
+.filters .form-field--grow {
+  flex: 1 1 14rem;
+}

--- a/app/controllers/admin/product_variants_controller.rb
+++ b/app/controllers/admin/product_variants_controller.rb
@@ -22,14 +22,23 @@ module Admin
     end
 
     def create
+      attrs = variant_attributes
+      if @money_error
+        @product_variant = @product.product_variants.build(attrs)
+        @product_variant.errors.add(:regular_price, @money_error)
+        load_form_options
+        render :new, status: :unprocessable_entity
+        return
+      end
+
       @product_variant = ProductVariants::Create.call(
         product: @product,
-        attributes: variant_attributes,
+        attributes: attrs,
         actor: current_user
       )
       redirect_to admin_product_variant_path(@product_variant), notice: "Product variant created."
     rescue ProductVariants::Create::Error => e
-      @product_variant = @product.product_variants.build(variant_attributes)
+      @product_variant = @product.product_variants.build(attrs)
       @product_variant.errors.add(:base, e.message)
       load_form_options
       render :new, status: :unprocessable_entity
@@ -43,6 +52,14 @@ module Admin
     def update
       rescue_stale do
         attrs = product_variant_params
+        if @money_error
+          @product = @product_variant.product
+          @product_variant.errors.add(:regular_price, @money_error)
+          load_form_options
+          render :edit, status: :unprocessable_entity
+          return
+        end
+
         if attrs[:status] == "discontinued"
           @product_variant.errors.add(:status, "use Discontinue instead")
           @product = @product_variant.product
@@ -124,23 +141,30 @@ module Admin
       @tax_classes = TaxClass.assignable.order(:display_order, :code)
     end
 
-    def audit_attribute_keys
-      %w[
-        variant_type name option_value_1 option_value_2 merchandise_condition_id merchandise_class_id
-        department_id tax_class_id regular_price_cents status industry_identifier
-      ]
-    end
-
     def variant_attributes
       product_variant_params.except(:lock_version, :sku).to_h.symbolize_keys
     end
 
     def product_variant_params
+      @money_error = nil
+      @regular_price_raw = params.dig(:product_variant, :regular_price)
       permitted = params.require(:product_variant).permit(
         :variant_type, :name, :option_value_1, :option_value_2, :merchandise_condition_id,
-        :merchandise_class_id, :department_id, :tax_class_id, :regular_price_cents,
+        :merchandise_class_id, :department_id, :tax_class_id, :regular_price, :regular_price_cents,
         :industry_identifier, :status, :lock_version
       )
+
+      if permitted.key?(:regular_price) || params[:product_variant]&.key?(:regular_price)
+        raw = permitted.delete(:regular_price)
+        raw = params.dig(:product_variant, :regular_price) if raw.nil?
+        begin
+          permitted[:regular_price_cents] = Money::ParseCents.call(raw)
+        rescue Money::ParseCents::Error => e
+          @money_error = e.message
+          permitted.delete(:regular_price_cents)
+        end
+      end
+
       %i[name option_value_1 option_value_2 merchandise_condition_id merchandise_class_id department_id tax_class_id
          regular_price_cents industry_identifier].each do |key|
         permitted[key] = nil if permitted[key].blank?

--- a/app/controllers/admin/products_controller.rb
+++ b/app/controllers/admin/products_controller.rb
@@ -10,11 +10,22 @@ module Admin
     before_action :set_product, only: %i[show edit update destroy discontinue]
 
     def index
-      @products = Product.order(:name)
+      @index = Products::AdminIndexQuery.call(
+        q: params[:q],
+        status: params[:status],
+        merchandise_category_id: params[:merchandise_category_id],
+        page: params[:page]
+      )
+      @products = @index.records.includes(:merchandise_category)
+      @variant_counts = ProductVariant.where(product_id: @products.map(&:id)).group(:product_id).count
+      @merchandise_categories = MerchandiseCategory.assignable.order(:display_order, :name)
     end
 
     def show
-      @product_variants = @product.product_variants.order(:sku)
+      @product_variants = @product.product_variants
+        .includes(:merchandise_class, :department, :tax_class, :merchandise_condition)
+        .order(:sku)
+      @recent_audit_events = recent_product_audit_events
     end
 
     def new
@@ -23,15 +34,24 @@ module Admin
     end
 
     def create
+      attrs = product_attributes
+      if @money_error
+        @product = Product.new(attrs)
+        @product.errors.add(:list_price, @money_error)
+        load_form_options
+        render :new, status: :unprocessable_entity
+        return
+      end
+
       @product = Products::Create.call(
-        attributes: product_attributes,
+        attributes: attrs,
         actor: current_user,
         identifier_mode: identifier_mode,
         external_identifier: external_identifier.presence
       )
       redirect_to admin_product_path(@product), notice: "Product created."
     rescue Products::Create::Error => e
-      @product = Product.new(product_attributes)
+      @product = Product.new(attrs)
       @product.errors.add(:base, e.message)
       load_form_options
       render :new, status: :unprocessable_entity
@@ -44,6 +64,11 @@ module Admin
     def update
       rescue_stale do
         attrs = product_params
+        if @money_error
+          render_form_with_money_error(:edit)
+          return
+        end
+
         if attrs[:status] == "discontinued"
           @product.errors.add(:status, "use Discontinue instead")
           load_form_options
@@ -115,11 +140,19 @@ module Admin
       @merchandise_categories = MerchandiseCategory.assignable.order(:display_order, :name)
     end
 
-    def audit_attribute_keys
-      %w[
-        name subtitle description brand_name product_model merchandise_category_id
-        list_price_cents release_date status variant_option_name_1 variant_option_name_2
-      ]
+    def recent_product_audit_events
+      return [] unless effective_permissions.include?("audit_events.view")
+
+      scope = AuditEvent.where(subject_type: "Product", subject_id: @product.id)
+      global_view = Authorization::PermissionEvaluator.allowed?(
+        user: current_user,
+        permission_key: "audit_events.view",
+        store: nil
+      )
+      unless global_view
+        scope = scope.where(store_id: accessible_stores.select(:id))
+      end
+      scope.order(occurred_at: :desc).limit(5).to_a
     end
 
     def identifier_mode
@@ -137,6 +170,8 @@ module Admin
     end
 
     def product_params
+      @money_error = nil
+      @list_price_raw = params.dig(:product, :list_price)
       permitted = params.require(:product).permit(
         :name, :subtitle, :description, :brand_name, :product_model, :merchandise_category_id,
         :list_price, :list_price_cents, :release_date, :status, :variant_option_name_1, :variant_option_name_2,
@@ -144,8 +179,14 @@ module Admin
       )
 
       if permitted.key?(:list_price) || params[:product]&.key?(:list_price)
-        raw = permitted.delete(:list_price).presence || params.dig(:product, :list_price)
-        permitted[:list_price_cents] = raw.blank? ? nil : dollars_to_cents(raw)
+        raw = permitted.delete(:list_price)
+        raw = params.dig(:product, :list_price) if raw.nil?
+        begin
+          permitted[:list_price_cents] = Money::ParseCents.call(raw)
+        rescue Money::ParseCents::Error => e
+          @money_error = e.message
+          permitted.delete(:list_price_cents)
+        end
       end
 
       %i[merchandise_category_id list_price_cents release_date subtitle description brand_name
@@ -155,10 +196,12 @@ module Admin
       permitted
     end
 
-    def dollars_to_cents(raw)
-      (BigDecimal(raw.to_s.strip) * 100).round.to_i
-    rescue ArgumentError
-      raise ActionController::BadRequest, "list price is not a valid amount"
+    def render_form_with_money_error(template)
+      @product ||= Product.new
+      @product.assign_attributes(product_params.except(:list_price_cents, :lock_version)) if params[:product]
+      @product.errors.add(:list_price, @money_error)
+      load_form_options
+      render template, status: :unprocessable_entity
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,63 @@
+# frozen_string_literal: true
+
 module ApplicationHelper
+  STATUS_SCHEMES = {
+    product_variant: {
+      "draft" => "draft",
+      "active" => "active",
+      "discontinued" => "discontinued"
+    }.freeze,
+    configuration: {
+      "active" => "active",
+      "inactive" => "inactive"
+    }.freeze
+  }.freeze
+
+  def format_money_cents(cents, currency_prefix: "$")
+    return missing_value if cents.nil?
+
+    sign = cents.negative? ? "-" : ""
+    absolute = cents.abs
+    dollars = absolute / 100
+    remainder = absolute % 100
+    "#{sign}#{currency_prefix}#{dollars}.#{format("%02d", remainder)}"
+  end
+
+  def money_field_value(cents)
+    return if cents.nil?
+
+    sign = cents.negative? ? "-" : ""
+    absolute = cents.abs
+    "#{sign}#{absolute / 100}.#{format("%02d", absolute % 100)}"
+  end
+
+  def missing_value(label = "Not provided")
+    content_tag(:span, label, class: "missing-value")
+  end
+
+  def format_timestamp(time)
+    return missing_value if time.blank?
+
+    time.in_time_zone.strftime("%Y-%m-%d %H:%M %Z")
+  end
+
+  def format_date(date)
+    return missing_value if date.blank?
+
+    date.to_date.iso8601
+  end
+
+  # scheme: :product_variant or :configuration
+  def status_badge(status, scheme:)
+    mapping = STATUS_SCHEMES.fetch(scheme.to_sym)
+    key = status.to_s
+    raise ArgumentError, "unknown status #{status.inspect} for scheme #{scheme}" unless mapping.key?(key)
+
+    css = mapping.fetch(key)
+    content_tag(:span, key.humanize, class: "status-badge status-badge--#{css}")
+  end
+
+  def configuration_status_badge(active)
+    status_badge(active ? "active" : "inactive", scheme: :configuration)
+  end
 end

--- a/app/services/money/parse_cents.rb
+++ b/app/services/money/parse_cents.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Money
+  # Parses HTML admin currency strings into integer cents.
+  # Import/API/CSV contracts continue to use integer cents directly.
+  class ParseCents
+    class Error < StandardError; end
+
+    def self.call(raw)
+      new(raw).call
+    end
+
+    def initialize(raw)
+      @raw = raw
+    end
+
+    def call
+      return nil if @raw.nil?
+
+      text = @raw.to_s.strip
+      return nil if text.empty?
+
+      normalized = text.delete("$").delete(",").delete(" ")
+      unless normalized.match?(/\A-?\d+(?:\.\d{1,2})?\z/)
+        raise Error, "is not a valid amount"
+      end
+
+      (BigDecimal(normalized) * 100).round.to_i
+    rescue ArgumentError
+      raise Error, "is not a valid amount"
+    end
+  end
+end

--- a/app/services/products/admin_index_query.rb
+++ b/app/services/products/admin_index_query.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module Products
+  class AdminIndexQuery
+    PER_PAGE = 50
+
+    Result = Struct.new(
+      :records, :page, :per_page, :total_count, :total_pages,
+      :q, :status, :merchandise_category_id, :filtered,
+      keyword_init: true
+    )
+
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(scope: Product.all, q: nil, status: nil, merchandise_category_id: nil, page: 1)
+      @scope = scope
+      @q = q.to_s
+      @status = status.to_s.presence
+      @merchandise_category_id = merchandise_category_id.to_s.presence
+      @page = page
+    end
+
+    def call
+      relation = @scope
+      relation = apply_search(relation)
+      relation = relation.where(status: @status) if @status.present?
+      if @merchandise_category_id.present?
+        relation = relation.where(merchandise_category_id: @merchandise_category_id)
+      end
+
+      total_count = relation.except(:order, :select).count
+      total_pages = [ (total_count.to_f / PER_PAGE).ceil, 1 ].max
+      page = parse_page(total_pages)
+      offset = (page - 1) * PER_PAGE
+
+      records = relation.order(name: :asc, id: :asc).offset(offset).limit(PER_PAGE)
+
+      Result.new(
+        records: records,
+        page: page,
+        per_page: PER_PAGE,
+        total_count: total_count,
+        total_pages: total_pages,
+        q: @q.presence,
+        status: @status,
+        merchandise_category_id: @merchandise_category_id,
+        filtered: filtered?
+      )
+    end
+
+    private
+
+    def filtered?
+      @q.present? || @status.present? || @merchandise_category_id.present?
+    end
+
+    def parse_page(total_pages)
+      value = Integer(@page)
+      return 1 if value < 1
+
+      [ value, total_pages ].min
+    rescue ArgumentError, TypeError
+      1
+    end
+
+    def apply_search(relation)
+      return relation if @q.blank?
+
+      name_pattern = "%#{escape_like(@q)}%"
+      identifier_digits = @q.gsub(/[\s-]/, "")
+
+      if identifier_digits.match?(/\A\d+\z/)
+        relation.where(
+          "products.name ILIKE :name ESCAPE '\\' OR products.primary_identifier = :exact OR products.primary_identifier LIKE :prefix ESCAPE '\\'",
+          name: name_pattern,
+          exact: identifier_digits,
+          prefix: "#{escape_like(identifier_digits)}%"
+        )
+      else
+        relation.where("products.name ILIKE :name ESCAPE '\\'", name: name_pattern)
+      end
+    end
+
+    def escape_like(value)
+      value.to_s.gsub(/[\\%_]/) { |char| "\\#{char}" }
+    end
+  end
+end

--- a/app/views/admin/merchandise_classes/_form.html.erb
+++ b/app/views/admin/merchandise_classes/_form.html.erb
@@ -1,36 +1,69 @@
-<%= form_with model: [:admin, merchandise_class] do |form| %>
-  <% if merchandise_class.errors.any? %><ul><% merchandise_class.errors.full_messages.each do |m| %><li><%= m %></li><% end %></ul><% end %>
+<%= form_with model: [:admin, merchandise_class], class: "form" do |form| %>
+  <%= render "shared/form_errors", record: merchandise_class %>
   <%= form.hidden_field :lock_version %>
-  <% if merchandise_class.persisted? %>
-    <p>Code: <code><%= merchandise_class.code %></code> (immutable)</p>
-  <% else %>
-    <p>
-      <%= form.label :code %>
-      <%= form.text_field :code %>
-      <span>Leave blank to generate from the name. Later changes are not allowed.</span>
-    </p>
+
+  <%= render layout: "shared/form_section", locals: { title: "Identity" } do %>
+    <% if merchandise_class.persisted? %>
+      <div class="form-field">
+        <span class="muted">Code</span>
+        <div><code><%= merchandise_class.code %></code> (immutable)</div>
+      </div>
+    <% else %>
+      <div class="form-field">
+        <%= form.label :code %>
+        <%= form.text_field :code %>
+        <span class="field-help">Leave blank to generate from the name. Later changes are not allowed.</span>
+      </div>
+    <% end %>
+    <div class="form-field">
+      <%= form.label :name %>
+      <%= form.text_field :name %>
+    </div>
+    <div class="form-field">
+      <%= form.label :description %>
+      <%= form.text_area :description, rows: 3 %>
+    </div>
+    <div class="form-field">
+      <%= form.label :display_order %>
+      <%= form.number_field :display_order %>
+    </div>
   <% end %>
-  <p><%= form.label :name %><%= form.text_field :name %></p>
-  <p><%= form.label :description %><%= form.text_area :description %></p>
-  <p>
-    <%= form.label :inventory_mode %>
-    <%= form.select :inventory_mode, MerchandiseClass::INVENTORY_MODES.map { |m| [m.humanize, m] } %>
-  </p>
-  <p>
-    <%= form.label :pricing_method %>
-    <%= form.select :pricing_method, MerchandiseClass::PRICING_METHODS.map { |m| [m.humanize, m] } %>
-  </p>
-  <p>
-    <%= form.label :default_standard_department_id, "Default standard department" %>
-    <%= form.select :default_standard_department_id, @departments.map { |d| ["#{d.code} — #{d.name}", d.id] }, include_blank: "None" %>
-  </p>
-  <p>
-    <%= form.label :default_used_department_id, "Default used department" %>
-    <%= form.select :default_used_department_id, @departments.map { |d| ["#{d.code} — #{d.name}", d.id] }, include_blank: "None" %>
-  </p>
-  <p><%= form.check_box :used_merchandise_allowed %><%= form.label :used_merchandise_allowed %></p>
-  <p><%= form.check_box :buyback_allowed %><%= form.label :buyback_allowed, "Buyback allowed (requires used + inventory)" %></p>
-  <p><%= form.check_box :default_supplier_returnable %><%= form.label :default_supplier_returnable, "Default supplier returnable" %></p>
-  <p><%= form.label :display_order %><%= form.number_field :display_order %></p>
-  <p><%= form.submit %></p>
+
+  <%= render layout: "shared/form_section", locals: { title: "Behavior" } do %>
+    <div class="form-field">
+      <%= form.label :inventory_mode %>
+      <%= form.select :inventory_mode, MerchandiseClass::INVENTORY_MODES.map { |m| [m.humanize, m] } %>
+    </div>
+    <div class="form-field">
+      <%= form.label :pricing_method %>
+      <%= form.select :pricing_method, MerchandiseClass::PRICING_METHODS.map { |m| [m.humanize, m] } %>
+    </div>
+    <div class="form-field">
+      <%= form.label :default_standard_department_id, "Default standard department" %>
+      <%= form.select :default_standard_department_id, @departments.map { |d| ["#{d.code} — #{d.name}", d.id] }, include_blank: "None" %>
+    </div>
+    <div class="form-field">
+      <%= form.label :default_used_department_id, "Default used department" %>
+      <%= form.select :default_used_department_id, @departments.map { |d| ["#{d.code} — #{d.name}", d.id] }, include_blank: "None" %>
+    </div>
+    <div class="form-field">
+      <%= form.check_box :used_merchandise_allowed %>
+      <%= form.label :used_merchandise_allowed, "Used merchandise allowed" %>
+    </div>
+    <div class="form-field">
+      <%= form.check_box :buyback_allowed %>
+      <%= form.label :buyback_allowed, "Buyback allowed (requires used + inventory)" %>
+    </div>
+    <div class="form-field">
+      <%= form.check_box :default_supplier_returnable %>
+      <%= form.label :default_supplier_returnable, "Default supplier returnable" %>
+    </div>
+  <% end %>
+
+  <div class="actions">
+    <%= form.submit class: "btn" %>
+    <%= link_to "Cancel",
+          merchandise_class.persisted? ? admin_merchandise_class_path(merchandise_class) : admin_merchandise_classes_path,
+          class: "btn btn--ghost" %>
+  </div>
 <% end %>

--- a/app/views/admin/merchandise_classes/edit.html.erb
+++ b/app/views/admin/merchandise_classes/edit.html.erb
@@ -1,3 +1,11 @@
 <% content_for :title, "Edit merchandise class" %>
-<h1>Edit merchandise class</h1>
+
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Merchandise classes", path: admin_merchandise_classes_path },
+  { name: @merchandise_class.name, path: admin_merchandise_class_path(@merchandise_class) },
+  { name: "Edit" }
+] %>
+
+<%= render "shared/page_header", title: "Edit merchandise class", subtitle: @merchandise_class.code %>
 <%= render "form", merchandise_class: @merchandise_class %>

--- a/app/views/admin/merchandise_classes/index.html.erb
+++ b/app/views/admin/merchandise_classes/index.html.erb
@@ -1,11 +1,27 @@
-<% content_for :title, "Merchandise Classes" %>
-<h1>Merchandise Classes</h1>
-<% if effective_permissions.include?("merchandise_classes.create") %><p><%= link_to "New merchandise class", new_admin_merchandise_class_path %></p><% end %>
-<ul>
-  <% @merchandise_classes.each do |merchandise_class| %>
-    <li>
-      <%= link_to "#{merchandise_class.code} — #{merchandise_class.name}", admin_merchandise_class_path(merchandise_class) %>
-      <%= "inactive" unless merchandise_class.active? %>
-    </li>
-  <% end %>
-</ul>
+<% content_for :title, "Merchandise classes" %>
+
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Merchandise classes" }
+] %>
+
+<%= render "shared/page_header",
+      title: "Merchandise classes",
+      subtitle: "Operational sellability and pricing behavior",
+      actions: (link_to("New merchandise class", new_admin_merchandise_class_path, class: "btn") if effective_permissions.include?("merchandise_classes.create")) %>
+
+<% if @merchandise_classes.empty? %>
+  <%= render "shared/empty_state", title: "No merchandise classes", body: "Create a class to define inventory and pricing behavior." %>
+<% else %>
+  <% rows = @merchandise_classes.map { |klass|
+       [
+         link_to("#{klass.code} — #{klass.name}", admin_merchandise_class_path(klass)),
+         klass.inventory_mode.humanize,
+         klass.pricing_method.humanize,
+         configuration_status_badge(klass.active?)
+       ]
+     } %>
+  <%= render "shared/data_table",
+        headers: ["Class", "Inventory mode", "Pricing method", "Status"],
+        rows: rows %>
+<% end %>

--- a/app/views/admin/merchandise_classes/new.html.erb
+++ b/app/views/admin/merchandise_classes/new.html.erb
@@ -1,3 +1,10 @@
 <% content_for :title, "New merchandise class" %>
-<h1>New merchandise class</h1>
+
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Merchandise classes", path: admin_merchandise_classes_path },
+  { name: "New" }
+] %>
+
+<%= render "shared/page_header", title: "New merchandise class" %>
 <%= render "form", merchandise_class: @merchandise_class %>

--- a/app/views/admin/merchandise_classes/show.html.erb
+++ b/app/views/admin/merchandise_classes/show.html.erb
@@ -1,18 +1,52 @@
 <% content_for :title, @merchandise_class.name %>
-<h1><%= @merchandise_class.code %> — <%= @merchandise_class.name %></h1>
-<p>
-  Inventory: <%= @merchandise_class.inventory_mode %> ·
-  Pricing: <%= @merchandise_class.pricing_method %> ·
-  Order: <%= @merchandise_class.display_order %> ·
-  <%= @merchandise_class.active? ? "active" : "inactive" %>
-</p>
-<% if @merchandise_class.description.present? %><p><%= @merchandise_class.description %></p><% end %>
-<p>
-  <%= link_to "Edit", edit_admin_merchandise_class_path(@merchandise_class) if effective_permissions.include?("merchandise_classes.update") %>
-  <% if effective_permissions.include?("merchandise_classes.deactivate") && @merchandise_class.active? %>
-    <%= button_to "Deactivate", admin_merchandise_class_path(@merchandise_class), method: :delete, form: { data: { turbo_confirm: "Deactivate this merchandise class?" } } %>
-  <% elsif effective_permissions.include?("merchandise_classes.deactivate") && !@merchandise_class.active? %>
-    <%= button_to "Reactivate", reactivate_admin_merchandise_class_path(@merchandise_class), method: :post, params: { lock_version: @merchandise_class.lock_version } %>
-  <% end %>
-</p>
-<p><%= link_to "Back to merchandise classes", admin_merchandise_classes_path %></p>
+
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Merchandise classes", path: admin_merchandise_classes_path },
+  { name: @merchandise_class.name }
+] %>
+
+<% actions = [configuration_status_badge(@merchandise_class.active?)] %>
+<% if effective_permissions.include?("merchandise_classes.update") %>
+  <% actions << link_to("Edit", edit_admin_merchandise_class_path(@merchandise_class), class: "btn btn--secondary") %>
+<% end %>
+<% if effective_permissions.include?("merchandise_classes.deactivate") && @merchandise_class.active? %>
+  <% actions << button_to("Deactivate", admin_merchandise_class_path(@merchandise_class), method: :delete, class: "btn btn--danger") %>
+<% elsif effective_permissions.include?("merchandise_classes.deactivate") && !@merchandise_class.active? %>
+  <% actions << button_to("Reactivate", reactivate_admin_merchandise_class_path(@merchandise_class), method: :post, params: { lock_version: @merchandise_class.lock_version }, class: "btn") %>
+<% end %>
+
+<%= render "shared/page_header",
+      title: @merchandise_class.name,
+      subtitle: @merchandise_class.code,
+      actions: safe_join(actions, " ") %>
+
+<section class="section surface">
+  <%= render "shared/definition_list", rows: [
+        ["Code", @merchandise_class.code],
+        ["Inventory mode", @merchandise_class.inventory_mode.humanize],
+        ["Pricing method", @merchandise_class.pricing_method.humanize],
+        ["Used merchandise allowed", @merchandise_class.used_merchandise_allowed? ? "Yes" : "No"],
+        ["Buyback allowed", @merchandise_class.buyback_allowed? ? "Yes" : "No"],
+        ["Default supplier returnable", @merchandise_class.default_supplier_returnable? ? "Yes" : "No"],
+        ["Default standard department", (
+          if @merchandise_class.default_standard_department
+            link_to("#{@merchandise_class.default_standard_department.code} — #{@merchandise_class.default_standard_department.name}", admin_department_path(@merchandise_class.default_standard_department))
+          end
+        )],
+        ["Default used department", (
+          if @merchandise_class.default_used_department
+            link_to("#{@merchandise_class.default_used_department.code} — #{@merchandise_class.default_used_department.name}", admin_department_path(@merchandise_class.default_used_department))
+          end
+        )],
+        ["Display order", @merchandise_class.display_order],
+        ["Description", @merchandise_class.description]
+      ] %>
+</section>
+
+<%= render "shared/technical_details", rows: [
+      ["ID", @merchandise_class.id],
+      ["Created", format_timestamp(@merchandise_class.created_at)],
+      ["Updated", format_timestamp(@merchandise_class.updated_at)],
+      ["Lock version", @merchandise_class.lock_version]
+    ] %>

--- a/app/views/admin/product_variants/_form.html.erb
+++ b/app/views/admin/product_variants/_form.html.erb
@@ -1,39 +1,82 @@
-<%= form_with model: product_variant.persisted? ? [:admin, product_variant] : [:admin, product, product_variant] do |form| %>
-  <% if product_variant.errors.any? %><ul><% product_variant.errors.full_messages.each do |m| %><li><%= m %></li><% end %></ul><% end %>
+<%= form_with model: product_variant.persisted? ? [:admin, product_variant] : [:admin, product, product_variant], class: "form" do |form| %>
+  <%= render "shared/form_errors", record: product_variant, attribute_ids: { regular_price: "product_variant_regular_price" } %>
   <%= form.hidden_field :lock_version %>
-  <% if product_variant.persisted? %>
-    <p>SKU: <%= product_variant.sku %></p>
-    <p>Type: <%= product_variant.variant_type %></p>
-  <% else %>
-    <p>
-      <%= form.label :variant_type %>
-      <%= form.select :variant_type, ProductVariant::VARIANT_TYPES.map { |t| [t.humanize, t] } %>
-    </p>
+
+  <%= render layout: "shared/form_section", locals: { title: "Identity" } do %>
+    <% if product_variant.persisted? %>
+      <div class="form-field">
+        <span class="muted">SKU</span>
+        <div><code><%= product_variant.sku %></code> (immutable)</div>
+      </div>
+      <div class="form-field">
+        <span class="muted">Type</span>
+        <div><%= product_variant.variant_type.humanize %></div>
+      </div>
+    <% else %>
+      <div class="form-field">
+        <%= form.label :variant_type %>
+        <%= form.select :variant_type, ProductVariant::VARIANT_TYPES.map { |t| [t.humanize, t] } %>
+      </div>
+    <% end %>
+    <div class="form-field">
+      <%= form.label :name %>
+      <%= form.text_field :name %>
+      <span class="field-help">Leave blank on create to use Standard or the used condition name.</span>
+    </div>
+    <div class="form-field">
+      <%= form.label :option_value_1 %>
+      <%= form.text_field :option_value_1 %>
+    </div>
+    <div class="form-field">
+      <%= form.label :option_value_2 %>
+      <%= form.text_field :option_value_2 %>
+    </div>
+    <div class="form-field">
+      <%= form.label :industry_identifier, "Industry identifier" %>
+      <%= form.text_field :industry_identifier %>
+    </div>
   <% end %>
-  <p><%= form.label :name %><%= form.text_field :name %></p>
-  <p><%= form.label :option_value_1 %><%= form.text_field :option_value_1 %></p>
-  <p><%= form.label :option_value_2 %><%= form.text_field :option_value_2 %></p>
-  <p>
-    <%= form.label :merchandise_condition_id, "Condition (used variants only)" %>
-    <%= form.select :merchandise_condition_id, @merchandise_conditions.map { |c| ["#{c.code} — #{c.name}", c.id] }, include_blank: true %>
-  </p>
-  <p>
-    <%= form.label :merchandise_class_id, "Merchandise class" %>
-    <%= form.select :merchandise_class_id, @merchandise_classes.map { |c| ["#{c.code} — #{c.name}", c.id] }, include_blank: "Resolve default" %>
-  </p>
-  <p>
-    <%= form.label :department_id, "Department" %>
-    <%= form.select :department_id, @departments.map { |d| ["#{d.code} — #{d.name}", d.id] }, include_blank: "Resolve default" %>
-  </p>
-  <p>
-    <%= form.label :tax_class_id, "Tax class" %>
-    <%= form.select :tax_class_id, @tax_classes.map { |t| ["#{t.code} — #{t.name}", t.id] }, include_blank: "Resolve default" %>
-  </p>
-  <p><%= form.label :regular_price_cents %><%= form.number_field :regular_price_cents %></p>
-  <p><%= form.label :industry_identifier %><%= form.text_field :industry_identifier %></p>
-  <p>
-    <%= form.label :status %>
-    <%= form.select :status, ProductVariant::STATUSES.reject { |s| s == "discontinued" }.map { |s| [s.humanize, s] } %>
-  </p>
-  <p><%= form.submit %></p>
+
+  <%= render layout: "shared/form_section", locals: { title: "Sellability", help: "Blank class, department, or tax class resolve at create time. Clearing them later does not re-inherit defaults." } do %>
+    <div class="form-field">
+      <%= form.label :merchandise_condition_id, "Condition (used variants only)" %>
+      <%= form.select :merchandise_condition_id, @merchandise_conditions.map { |c| ["#{c.code} — #{c.name}", c.id] }, include_blank: true %>
+    </div>
+    <div class="form-field">
+      <%= form.label :merchandise_class_id, "Merchandise class" %>
+      <%= form.select :merchandise_class_id, @merchandise_classes.map { |c| ["#{c.code} — #{c.name}", c.id] }, include_blank: "Resolve default" %>
+    </div>
+    <div class="form-field">
+      <%= form.label :department_id, "Department" %>
+      <%= form.select :department_id, @departments.map { |d| ["#{d.code} — #{d.name}", d.id] }, include_blank: "Resolve default" %>
+    </div>
+    <div class="form-field">
+      <%= form.label :tax_class_id, "Tax class" %>
+      <%= form.select :tax_class_id, @tax_classes.map { |t| ["#{t.code} — #{t.name}", t.id] }, include_blank: "Resolve default" %>
+    </div>
+  <% end %>
+
+  <%= render layout: "shared/form_section", locals: { title: "Pricing" } do %>
+    <%= render "shared/currency_field",
+          name: "product_variant[regular_price]",
+          id: "product_variant_regular_price",
+          label: "Regular price",
+          value: params.dig(:product_variant, :regular_price).presence || money_field_value(product_variant.regular_price_cents),
+          help: "Enter a currency amount such as 12.50. CSV import continues to use integer cents.",
+          error: product_variant.errors[:regular_price].presence&.to_sentence %>
+  <% end %>
+
+  <%= render layout: "shared/form_section", locals: { title: "Lifecycle" } do %>
+    <div class="form-field">
+      <%= form.label :status %>
+      <%= form.select :status, ProductVariant::STATUSES.reject { |s| s == "discontinued" }.map { |s| [s.humanize, s] } %>
+    </div>
+  <% end %>
+
+  <div class="actions">
+    <%= form.submit class: "btn" %>
+    <%= link_to "Cancel",
+          product_variant.persisted? ? admin_product_variant_path(product_variant) : admin_product_path(product),
+          class: "btn btn--ghost" %>
+  </div>
 <% end %>

--- a/app/views/admin/product_variants/edit.html.erb
+++ b/app/views/admin/product_variants/edit.html.erb
@@ -1,3 +1,15 @@
 <% content_for :title, "Edit product variant" %>
-<h1>Edit variant <%= @product_variant.sku %></h1>
+
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Products", path: admin_products_path },
+  { name: @product.name, path: admin_product_path(@product) },
+  { name: @product_variant.name.presence || @product_variant.sku, path: admin_product_variant_path(@product_variant) },
+  { name: "Edit" }
+] %>
+
+<%= render "shared/page_header",
+      title: "Edit variant",
+      subtitle: @product_variant.sku %>
+
 <%= render "form", product_variant: @product_variant, product: @product %>

--- a/app/views/admin/product_variants/new.html.erb
+++ b/app/views/admin/product_variants/new.html.erb
@@ -1,3 +1,14 @@
 <% content_for :title, "New product variant" %>
-<h1>New variant for <%= @product.name %></h1>
+
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Products", path: admin_products_path },
+  { name: @product.name, path: admin_product_path(@product) },
+  { name: "New variant" }
+] %>
+
+<%= render "shared/page_header",
+      title: "New variant",
+      subtitle: @product.name %>
+
 <%= render "form", product_variant: @product_variant, product: @product %>

--- a/app/views/admin/product_variants/show.html.erb
+++ b/app/views/admin/product_variants/show.html.erb
@@ -1,25 +1,58 @@
-<% content_for :title, @product_variant.sku %>
-<h1><%= @product_variant.sku %></h1>
-<p>
-  Product: <%= link_to @product_variant.product.name, admin_product_path(@product_variant.product) %> ·
-  Type: <%= @product_variant.variant_type %> ·
-  Status: <%= @product_variant.status %> ·
-  Condition: <%= @product_variant.merchandise_condition&.code || "—" %> ·
-  Price cents: <%= @product_variant.regular_price_cents.presence || "—" %>
-</p>
-<p>
-  Class: <%= @product_variant.merchandise_class&.code || "—" %> ·
-  Department: <%= @product_variant.department&.code || "—" %> ·
-  Tax class: <%= @product_variant.tax_class&.code || "—" %> ·
-  Industry ID: <%= @product_variant.industry_identifier.presence || "—" %>
-</p>
-<p>
-  <%= link_to "Edit", edit_admin_product_variant_path(@product_variant) if effective_permissions.include?("product_variants.update") %>
-  <% if effective_permissions.include?("product_variants.discontinue") && @product_variant.status != "discontinued" %>
-    <%= button_to "Discontinue", discontinue_admin_product_variant_path(@product_variant), method: :post, form: { data: { turbo_confirm: "Discontinue this variant?" } } %>
-  <% end %>
-  <% if effective_permissions.include?("product_variants.update") && @product_variant.draft? %>
-    <%= button_to "Delete draft", admin_product_variant_path(@product_variant), method: :delete, form: { data: { turbo_confirm: "Delete this draft variant and retire its identifiers?" } } %>
-  <% end %>
-</p>
-<p><%= link_to "Back to product", admin_product_path(@product_variant.product) %></p>
+<% content_for :title, @product_variant.name.presence || @product_variant.sku %>
+
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Products", path: admin_products_path },
+  { name: @product_variant.product.name, path: admin_product_path(@product_variant.product) },
+  { name: @product_variant.name.presence || @product_variant.sku }
+] %>
+
+<% actions = [status_badge(@product_variant.status, scheme: :product_variant)] %>
+<% if effective_permissions.include?("product_variants.update") %>
+  <% actions << link_to("Edit", edit_admin_product_variant_path(@product_variant), class: "btn btn--secondary") %>
+<% end %>
+<% if effective_permissions.include?("product_variants.discontinue") && @product_variant.status != "discontinued" %>
+  <% actions << button_to("Discontinue", discontinue_admin_product_variant_path(@product_variant), method: :post, class: "btn btn--danger") %>
+<% end %>
+<% if effective_permissions.include?("product_variants.update") && @product_variant.draft? %>
+  <% actions << button_to("Delete draft", admin_product_variant_path(@product_variant), method: :delete, class: "btn btn--danger") %>
+<% end %>
+
+<%= render "shared/page_header",
+      title: @product_variant.name.presence || "Variant",
+      subtitle: "SKU #{@product_variant.sku}",
+      actions: safe_join(actions, " ") %>
+
+<section class="section surface">
+  <%= render "shared/definition_list", rows: [
+        ["Product", link_to(@product_variant.product.name, admin_product_path(@product_variant.product))],
+        ["SKU", @product_variant.sku],
+        ["Type", @product_variant.variant_type.humanize],
+        ["Status", status_badge(@product_variant.status, scheme: :product_variant)],
+        ["Regular price", format_money_cents(@product_variant.regular_price_cents)],
+        ["Merchandise class", (
+          if @product_variant.merchandise_class
+            link_to("#{@product_variant.merchandise_class.code} — #{@product_variant.merchandise_class.name}", admin_merchandise_class_path(@product_variant.merchandise_class))
+          end
+        )],
+        ["Department", (
+          if @product_variant.department
+            link_to("#{@product_variant.department.code} — #{@product_variant.department.name}", admin_department_path(@product_variant.department))
+          end
+        )],
+        ["Tax class", (
+          if @product_variant.tax_class
+            link_to("#{@product_variant.tax_class.code} — #{@product_variant.tax_class.name}", admin_tax_class_path(@product_variant.tax_class))
+          end
+        )],
+        ["Condition", @product_variant.merchandise_condition&.name],
+        ["Industry identifier", @product_variant.industry_identifier]
+      ] %>
+</section>
+
+<%= render "shared/technical_details", rows: [
+      ["ID", @product_variant.id],
+      ["Created", format_timestamp(@product_variant.created_at)],
+      ["Updated", format_timestamp(@product_variant.updated_at)],
+      ["Lock version", @product_variant.lock_version]
+    ] %>

--- a/app/views/admin/products/_form.html.erb
+++ b/app/views/admin/products/_form.html.erb
@@ -1,41 +1,89 @@
-<%= form_with model: [:admin, product] do |form| %>
-  <% if product.errors.any? %><ul><% product.errors.full_messages.each do |m| %><li><%= m %></li><% end %></ul><% end %>
+<%= form_with model: [:admin, product], class: "form" do |form| %>
+  <%= render "shared/form_errors", record: product, attribute_ids: { list_price: "product_list_price" } %>
   <%= form.hidden_field :lock_version %>
-  <% if creating %>
-    <p>
-      <%= form.label :identifier_mode, "Identifier mode" %>
-      <%= select_tag "product[identifier_mode]", options_for_select([["Enter external", "enter"], ["Generate ShelfSense (222)", "generate"]], params.dig(:product, :identifier_mode) || "enter") %>
-    </p>
-    <p>
-      <%= form.label :external_identifier, "External identifier" %>
-      <%= text_field_tag "product[external_identifier]", params.dig(:product, :external_identifier) %>
-    </p>
-  <% else %>
-    <p>Primary identifier: <%= product.primary_identifier %></p>
+
+  <%= render layout: "shared/form_section", locals: { title: "Identity", help: "Enter a manufacturer-assigned identifier or ask ShelfSense to generate a reserved 222 identifier." } do %>
+    <% if creating %>
+      <div class="form-field">
+        <%= label_tag "product_identifier_mode", "Identifier mode" %>
+        <%= select_tag "product[identifier_mode]",
+              options_for_select([["Enter external", "enter"], ["Generate ShelfSense (222)", "generate"]], params.dig(:product, :identifier_mode) || "enter"),
+              id: "product_identifier_mode" %>
+      </div>
+      <div class="form-field">
+        <%= label_tag "product_external_identifier", "External identifier" %>
+        <%= text_field_tag "product[external_identifier]", params.dig(:product, :external_identifier), id: "product_external_identifier" %>
+        <span class="field-help" id="product_external_identifier_help">Required when entering an external identifier. Spaces and hyphens are removed during normalization.</span>
+      </div>
+    <% else %>
+      <div class="form-field">
+        <span class="muted">Primary identifier</span>
+        <div><code><%= product.primary_identifier %></code> (immutable)</div>
+      </div>
+    <% end %>
+
+    <div class="form-field">
+      <%= form.label :name %>
+      <%= form.text_field :name, id: "product_name", required: true, "aria-describedby": product.errors[:name].any? ? "product_name_error" : nil %>
+      <% if product.errors[:name].any? %><span class="field-error" id="product_name_error"><%= product.errors[:name].to_sentence %></span><% end %>
+    </div>
+    <div class="form-field">
+      <%= form.label :subtitle %>
+      <%= form.text_field :subtitle %>
+    </div>
+    <div class="form-field">
+      <%= form.label :description %>
+      <%= form.text_area :description, rows: 4 %>
+    </div>
+    <div class="form-field">
+      <%= form.label :brand_name, "Brand name" %>
+      <%= form.text_field :brand_name %>
+    </div>
+    <div class="form-field">
+      <%= form.label :product_model, "Model" %>
+      <%= form.text_field :product_model %>
+    </div>
+    <div class="form-field">
+      <%= form.label :release_date %>
+      <%= form.date_field :release_date %>
+    </div>
+    <div class="form-field">
+      <%= form.label :variant_option_name_1, "Variant option name 1" %>
+      <%= form.text_field :variant_option_name_1 %>
+    </div>
+    <div class="form-field">
+      <%= form.label :variant_option_name_2, "Variant option name 2" %>
+      <%= form.text_field :variant_option_name_2 %>
+    </div>
   <% end %>
-  <p><%= form.label :name %><%= form.text_field :name %></p>
-  <p><%= form.label :subtitle %><%= form.text_field :subtitle %></p>
-  <p><%= form.label :description %><%= form.text_area :description %></p>
-  <p><%= form.label :brand_name %><%= form.text_field :brand_name %></p>
-  <p><%= form.label :product_model, "Model" %><%= form.text_field :product_model %></p>
-  <p>
-    <%= form.label :merchandise_category_id, "Merchandise category" %>
-    <%= form.select :merchandise_category_id, MerchandiseCategory.options_for_select(@merchandise_categories), include_blank: "None" %>
-    <span>Supplies the default merchandise class for newly created variants. Changing it does not rewrite existing variants. Merchandise class itself is set on each variant.</span>
-  </p>
-  <p>
-    <%= label_tag :list_price, "List price" %>
-    <%= text_field_tag "product[list_price]",
-          params.dig(:product, :list_price).presence || (product.list_price_cents.present? ? format("%.2f", product.list_price_cents / 100.0) : nil),
-          inputmode: "decimal" %>
-    <span>Product-level reference price (currency amount, not cents). Changing it does not rewrite existing variant prices.</span>
-  </p>
-  <p><%= form.label :release_date %><%= form.date_field :release_date %></p>
-  <p>
-    <%= form.label :status %>
-    <%= form.select :status, Product::STATUSES.reject { |s| s == "discontinued" }.map { |s| [s.humanize, s] } %>
-  </p>
-  <p><%= form.label :variant_option_name_1 %><%= form.text_field :variant_option_name_1 %></p>
-  <p><%= form.label :variant_option_name_2 %><%= form.text_field :variant_option_name_2 %></p>
-  <p><%= form.submit %></p>
+
+  <%= render layout: "shared/form_section", locals: { title: "Classification", help: "Merchandise category supplies the default merchandise class for newly created variants. Changing it does not rewrite existing variants." } do %>
+    <div class="form-field">
+      <%= form.label :merchandise_category_id, "Merchandise category" %>
+      <%= form.select :merchandise_category_id, MerchandiseCategory.options_for_select(@merchandise_categories), include_blank: "None" %>
+    </div>
+  <% end %>
+
+  <%= render layout: "shared/form_section", locals: { title: "Pricing", help: "Product-level reference price. Changing it does not rewrite existing variant prices." } do %>
+    <%= render "shared/currency_field",
+          name: "product[list_price]",
+          id: "product_list_price",
+          label: "List price",
+          value: params.dig(:product, :list_price).presence || money_field_value(product.list_price_cents),
+          help: "Enter a currency amount such as 12.50. Stored as integer cents.",
+          error: product.errors[:list_price].presence&.to_sentence %>
+  <% end %>
+
+  <%= render layout: "shared/form_section", locals: { title: "Lifecycle" } do %>
+    <div class="form-field">
+      <%= form.label :status %>
+      <%= form.select :status, Product::STATUSES.reject { |s| s == "discontinued" }.map { |s| [s.humanize, s] } %>
+      <span class="field-help">Use Discontinue on the product page to mark a product discontinued.</span>
+    </div>
+  <% end %>
+
+  <div class="actions">
+    <%= form.submit class: "btn" %>
+    <%= link_to "Cancel", creating ? admin_products_path : admin_product_path(product), class: "btn btn--ghost" %>
+  </div>
 <% end %>

--- a/app/views/admin/products/edit.html.erb
+++ b/app/views/admin/products/edit.html.erb
@@ -1,3 +1,14 @@
 <% content_for :title, "Edit product" %>
-<h1>Edit product</h1>
+
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Products", path: admin_products_path },
+  { name: @product.name, path: admin_product_path(@product) },
+  { name: "Edit" }
+] %>
+
+<%= render "shared/page_header",
+      title: "Edit product",
+      subtitle: @product.primary_identifier %>
+
 <%= render "form", product: @product, creating: false %>

--- a/app/views/admin/products/index.html.erb
+++ b/app/views/admin/products/index.html.erb
@@ -1,11 +1,83 @@
 <% content_for :title, "Products" %>
-<h1>Products</h1>
-<% if effective_permissions.include?("products.create") %><p><%= link_to "New product", new_admin_product_path %></p><% end %>
-<ul>
-  <% @products.each do |product| %>
-    <li>
-      <%= link_to "#{product.primary_identifier} — #{product.name}", admin_product_path(product) %>
-      (<%= product.status %>)
-    </li>
-  <% end %>
-</ul>
+
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Products" }
+] %>
+
+<%= render "shared/page_header",
+      title: "Products",
+      subtitle: "Catalog products and their sellable variants",
+      actions: (
+        if effective_permissions.include?("products.create")
+          link_to("New product", new_admin_product_path, class: "btn")
+        end
+      ) %>
+
+<%= form_with url: admin_products_path, method: :get, local: true, class: "filters" do %>
+  <div class="form-field form-field--grow">
+    <%= label_tag :q, "Search" %>
+    <%= text_field_tag :q, @index.q, placeholder: "Name or identifier" %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :status, "Status" %>
+    <%= select_tag :status,
+          options_for_select([["Any status", ""]] + Product::STATUSES.map { |s| [s.humanize, s] }, @index.status) %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :merchandise_category_id, "Category" %>
+    <%= select_tag :merchandise_category_id,
+          options_for_select([["Any category", ""]] + MerchandiseCategory.options_for_select(@merchandise_categories), @index.merchandise_category_id) %>
+  </div>
+  <div class="form-field">
+    <%= submit_tag "Apply", class: "btn" %>
+  </div>
+<% end %>
+
+<% if @products.empty? && !@index.filtered %>
+  <%= render "shared/empty_state",
+        title: "No products yet",
+        body: "Create a product to start the merchandise catalog.",
+        action: (link_to("New product", new_admin_product_path, class: "btn") if effective_permissions.include?("products.create")) %>
+<% elsif @products.empty? %>
+  <%= render "shared/empty_state",
+        title: "No matching products",
+        body: "Try a different search or clear the filters." %>
+<% else %>
+  <% rows = @products.map { |product|
+       [
+         link_to(product.name, admin_product_path(product)),
+         product.primary_identifier,
+         product.merchandise_category&.path_label || missing_value,
+         (@variant_counts[product.id] || 0),
+         format_money_cents(product.list_price_cents),
+         status_badge(product.status, scheme: :product_variant)
+       ]
+     } %>
+  <%= render "shared/data_table",
+        headers: [
+          "Name",
+          "Primary identifier",
+          "Category",
+          { text: "Variants", class: "numeric" },
+          { text: "List price", class: "numeric" },
+          "Status"
+        ],
+        rows: rows %>
+
+  <div class="pagination">
+    <span class="muted">
+      Page <%= @index.page %> of <%= @index.total_pages %> · <%= @index.total_count %> total
+    </span>
+    <% if @index.page > 1 %>
+      <%= link_to "Previous",
+            admin_products_path(q: @index.q, status: @index.status, merchandise_category_id: @index.merchandise_category_id, page: @index.page - 1),
+            class: "btn btn--ghost" %>
+    <% end %>
+    <% if @index.page < @index.total_pages %>
+      <%= link_to "Next",
+            admin_products_path(q: @index.q, status: @index.status, merchandise_category_id: @index.merchandise_category_id, page: @index.page + 1),
+            class: "btn btn--ghost" %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/admin/products/new.html.erb
+++ b/app/views/admin/products/new.html.erb
@@ -1,3 +1,13 @@
 <% content_for :title, "New product" %>
-<h1>New product</h1>
+
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Products", path: admin_products_path },
+  { name: "New" }
+] %>
+
+<%= render "shared/page_header",
+      title: "New product",
+      subtitle: "Create a catalog product with a primary identifier" %>
+
 <%= render "form", product: @product, creating: true %>

--- a/app/views/admin/products/show.html.erb
+++ b/app/views/admin/products/show.html.erb
@@ -1,33 +1,108 @@
 <% content_for :title, @product.name %>
-<h1><%= @product.name %></h1>
-<p>
-  Identifier: <%= @product.primary_identifier %> ·
-  Status: <%= @product.status %> ·
-  Merchandise category: <%= @product.merchandise_category&.path_label || "—" %> ·
-  List price: <%= @product.list_price_cents.present? ? format("%.2f", @product.list_price_cents / 100.0) : "—" %>
-</p>
-<% if @product.description.present? %><p><%= @product.description %></p><% end %>
 
-<h2>Variants</h2>
-<% if effective_permissions.include?("product_variants.create") %>
-  <p><%= link_to "New variant", new_admin_product_product_variant_path(@product) %></p>
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Products", path: admin_products_path },
+  { name: @product.name }
+] %>
+
+<% actions = [] %>
+<% actions << status_badge(@product.status, scheme: :product_variant) %>
+<% if effective_permissions.include?("products.update") %>
+  <% actions << link_to("Edit", edit_admin_product_path(@product), class: "btn btn--secondary") %>
 <% end %>
-<ul>
-  <% @product_variants.each do |variant| %>
-    <li>
-      <%= link_to "#{variant.sku} — #{variant.name.presence || "unnamed"}", admin_product_variant_path(variant) %>
-      (<%= variant.status %>)
-    </li>
-  <% end %>
-</ul>
+<% if effective_permissions.include?("products.discontinue") && @product.status != "discontinued" %>
+  <% actions << button_to("Discontinue", discontinue_admin_product_path(@product), method: :post, class: "btn btn--danger") %>
+<% end %>
+<% if effective_permissions.include?("products.update") && @product.draft? %>
+  <% actions << button_to("Delete draft", admin_product_path(@product), method: :delete, class: "btn btn--danger") %>
+<% end %>
 
-<p>
-  <%= link_to "Edit", edit_admin_product_path(@product) if effective_permissions.include?("products.update") %>
-  <% if effective_permissions.include?("products.discontinue") && @product.status != "discontinued" %>
-    <%= button_to "Discontinue", discontinue_admin_product_path(@product), method: :post, form: { data: { turbo_confirm: "Discontinue this product?" } } %>
+<%= render "shared/page_header",
+      title: @product.name,
+      subtitle: "Primary identifier #{@product.primary_identifier}",
+      actions: safe_join(actions, " ") %>
+
+<section class="section surface">
+  <%= render "shared/definition_list", rows: [
+        ["Primary identifier", @product.primary_identifier],
+        ["Status", status_badge(@product.status, scheme: :product_variant)],
+        ["List price", format_money_cents(@product.list_price_cents)],
+        ["Merchandise category", (
+          if @product.merchandise_category
+            link_to(@product.merchandise_category.path_label, admin_merchandise_category_path(@product.merchandise_category))
+          end
+        )],
+        ["Subtitle", @product.subtitle],
+        ["Brand", @product.brand_name],
+        ["Model", @product.product_model],
+        ["Release date", format_date(@product.release_date)],
+        ["Variant option 1", @product.variant_option_name_1],
+        ["Variant option 2", @product.variant_option_name_2]
+      ] %>
+  <% if @product.description.present? %>
+    <div class="section">
+      <h2 class="section__title">Description</h2>
+      <p><%= simple_format(@product.description) %></p>
+    </div>
   <% end %>
-  <% if effective_permissions.include?("products.update") && @product.draft? %>
-    <%= button_to "Delete draft", admin_product_path(@product), method: :delete, form: { data: { turbo_confirm: "Delete this draft product and retire its identifier?" } } %>
+</section>
+
+<section class="section">
+  <h2 class="section__title">Variants</h2>
+  <% if effective_permissions.include?("product_variants.create") %>
+    <div class="actions"><%= link_to "New variant", new_admin_product_product_variant_path(@product), class: "btn" %></div>
   <% end %>
-</p>
-<p><%= link_to "Back to products", admin_products_path %></p>
+
+  <% if @product_variants.empty? %>
+    <%= render "shared/empty_state",
+          title: "No variants yet",
+          body: "Add a standard or used variant to make this product sellable." %>
+  <% else %>
+    <% rows = @product_variants.map { |variant|
+         [
+           link_to(variant.name.presence || "Unnamed", admin_product_variant_path(variant)),
+           variant.sku,
+           variant.variant_type.humanize,
+           status_badge(variant.status, scheme: :product_variant),
+           variant.merchandise_class ? "#{variant.merchandise_class.code} — #{variant.merchandise_class.name}" : missing_value,
+           variant.department ? "#{variant.department.code} — #{variant.department.name}" : missing_value,
+           variant.tax_class ? "#{variant.tax_class.code} — #{variant.tax_class.name}" : missing_value,
+           variant.used? ? (variant.merchandise_condition&.name || missing_value) : "—",
+           format_money_cents(variant.regular_price_cents)
+         ]
+       } %>
+    <%= render "shared/data_table",
+          headers: [
+            "Name", "SKU", "Type", "Status", "Class", "Department", "Tax", "Condition",
+            { text: "Regular price", class: "numeric" }
+          ],
+          rows: rows %>
+  <% end %>
+</section>
+
+<% if @recent_audit_events.present? %>
+  <section class="section">
+    <h2 class="section__title">Recent activity</h2>
+    <ul>
+      <% @recent_audit_events.each do |event| %>
+        <li>
+          <%= format_timestamp(event.occurred_at) %> ·
+          <%= event.action %> ·
+          <%= event.outcome %> ·
+          <%= event.actor_label %>
+        </li>
+      <% end %>
+    </ul>
+    <% if effective_permissions.include?("audit_events.view") %>
+      <p><%= link_to "View audit events", admin_audit_events_path(subject_type: "Product") %></p>
+    <% end %>
+  </section>
+<% end %>
+
+<%= render "shared/technical_details", rows: [
+      ["ID", @product.id],
+      ["Created", format_timestamp(@product.created_at)],
+      ["Updated", format_timestamp(@product.updated_at)],
+      ["Lock version", @product.lock_version]
+    ] %>

--- a/app/views/admin/stores/_form.html.erb
+++ b/app/views/admin/stores/_form.html.erb
@@ -1,12 +1,78 @@
-<%= form_with model: [:admin, store] do |form| %>
-  <% if store.errors.any? %><ul><% store.errors.full_messages.each do |m| %><li><%= m %></li><% end %></ul><% end %>
+<%= form_with model: [:admin, store], class: "form" do |form| %>
+  <%= render "shared/form_errors", record: store %>
   <%= form.hidden_field :lock_version %>
-  <p><%= form.label :store_number %><%= form.text_field :store_number %></p>
-  <p><%= form.label :code %><%= form.text_field :code %></p>
-  <p><%= form.label :name %><%= form.text_field :name %></p>
-  <p><%= form.label :country_code %><%= form.text_field :country_code %></p>
-  <p><%= form.label :timezone %><%= form.text_field :timezone %></p>
-  <p><%= form.label :receipt_header %><%= form.text_area :receipt_header %></p>
-  <p><%= form.label :receipt_footer %><%= form.text_area :receipt_footer %></p>
-  <p><%= form.submit %></p>
+
+  <%= render layout: "shared/form_section", locals: { title: "Identity" } do %>
+    <div class="form-field">
+      <%= form.label :store_number %>
+      <%= form.text_field :store_number %>
+    </div>
+    <div class="form-field">
+      <%= form.label :code %>
+      <%= form.text_field :code %>
+    </div>
+    <div class="form-field">
+      <%= form.label :name %>
+      <%= form.text_field :name %>
+    </div>
+    <div class="form-field">
+      <%= form.label :legal_name, "Legal name" %>
+      <%= form.text_field :legal_name %>
+    </div>
+    <div class="form-field">
+      <%= form.label :phone %>
+      <%= form.text_field :phone %>
+    </div>
+    <div class="form-field">
+      <%= form.label :san, "SAN" %>
+      <%= form.text_field :san %>
+    </div>
+  <% end %>
+
+  <%= render layout: "shared/form_section", locals: { title: "Address" } do %>
+    <div class="form-field">
+      <%= form.label :street_address_1, "Street address 1" %>
+      <%= form.text_field :street_address_1 %>
+    </div>
+    <div class="form-field">
+      <%= form.label :street_address_2, "Street address 2" %>
+      <%= form.text_field :street_address_2 %>
+    </div>
+    <div class="form-field">
+      <%= form.label :city %>
+      <%= form.text_field :city %>
+    </div>
+    <div class="form-field">
+      <%= form.label :region_code, "Region" %>
+      <%= form.text_field :region_code %>
+    </div>
+    <div class="form-field">
+      <%= form.label :postal_code, "Postal code" %>
+      <%= form.text_field :postal_code %>
+    </div>
+    <div class="form-field">
+      <%= form.label :country_code, "Country code" %>
+      <%= form.text_field :country_code %>
+    </div>
+    <div class="form-field">
+      <%= form.label :timezone %>
+      <%= form.text_field :timezone %>
+    </div>
+  <% end %>
+
+  <%= render layout: "shared/form_section", locals: { title: "Receipt text", help: "Blank receipt header/footer semantics remain unchanged in this phase." } do %>
+    <div class="form-field">
+      <%= form.label :receipt_header %>
+      <%= form.text_area :receipt_header, rows: 3 %>
+    </div>
+    <div class="form-field">
+      <%= form.label :receipt_footer %>
+      <%= form.text_area :receipt_footer, rows: 3 %>
+    </div>
+  <% end %>
+
+  <div class="actions">
+    <%= form.submit class: "btn" %>
+    <%= link_to "Cancel", store.persisted? ? admin_store_path(store) : admin_stores_path, class: "btn btn--ghost" %>
+  </div>
 <% end %>

--- a/app/views/admin/stores/edit.html.erb
+++ b/app/views/admin/stores/edit.html.erb
@@ -1,3 +1,11 @@
 <% content_for :title, "Edit store" %>
-<h1>Edit store</h1>
+
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Stores", path: admin_stores_path },
+  { name: @store.name, path: admin_store_path(@store) },
+  { name: "Edit" }
+] %>
+
+<%= render "shared/page_header", title: "Edit store", subtitle: @store.code %>
 <%= render "form", store: @store %>

--- a/app/views/admin/stores/index.html.erb
+++ b/app/views/admin/stores/index.html.erb
@@ -1,8 +1,28 @@
 <% content_for :title, "Stores" %>
-<h1>Stores</h1>
-<% if effective_permissions.include?("stores.create") %><p><%= link_to "New store", new_admin_store_path %></p><% end %>
-<ul>
-  <% @stores.each do |store| %>
-    <li><%= link_to "#{store.name} (#{store.code})", admin_store_path(store) %> <%= "inactive" unless store.active? %></li>
-  <% end %>
-</ul>
+
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Stores" }
+] %>
+
+<%= render "shared/page_header",
+      title: "Stores",
+      subtitle: "Organization store locations",
+      actions: (link_to("New store", new_admin_store_path, class: "btn") if effective_permissions.include?("stores.create")) %>
+
+<% if @stores.empty? %>
+  <%= render "shared/empty_state", title: "No stores", body: "Create a store to continue setup." %>
+<% else %>
+  <% rows = @stores.map { |store|
+       [
+         link_to(store.name, admin_store_path(store)),
+         store.code,
+         store.store_number,
+         store.timezone,
+         configuration_status_badge(store.active?)
+       ]
+     } %>
+  <%= render "shared/data_table",
+        headers: ["Name", "Code", "Number", "Timezone", "Status"],
+        rows: rows %>
+<% end %>

--- a/app/views/admin/stores/new.html.erb
+++ b/app/views/admin/stores/new.html.erb
@@ -1,3 +1,10 @@
 <% content_for :title, "New store" %>
-<h1>New store</h1>
+
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Stores", path: admin_stores_path },
+  { name: "New" }
+] %>
+
+<%= render "shared/page_header", title: "New store" %>
 <%= render "form", store: @store %>

--- a/app/views/admin/stores/show.html.erb
+++ b/app/views/admin/stores/show.html.erb
@@ -1,9 +1,46 @@
 <% content_for :title, @store.name %>
-<h1><%= @store.name %></h1>
-<p>Code: <%= @store.code %> · Number: <%= @store.store_number %> · <%= @store.timezone %></p>
-<p>
-  <%= link_to "Edit", edit_admin_store_path(@store) if effective_permissions.include?("stores.manage") %>
-  <% if effective_permissions.include?("stores.deactivate") && @store.active? %>
-    <%= button_to "Deactivate", admin_store_path(@store), method: :delete, form: { data: { turbo_confirm: "Deactivate this store?" } } %>
-  <% end %>
-</p>
+
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Stores", path: admin_stores_path },
+  { name: @store.name }
+] %>
+
+<% actions = [configuration_status_badge(@store.active?)] %>
+<% if effective_permissions.include?("stores.manage") %>
+  <% actions << link_to("Edit", edit_admin_store_path(@store), class: "btn btn--secondary") %>
+<% end %>
+<% if effective_permissions.include?("stores.deactivate") && @store.active? %>
+  <% actions << button_to("Deactivate", admin_store_path(@store), method: :delete, class: "btn btn--danger") %>
+<% end %>
+
+<%= render "shared/page_header",
+      title: @store.name,
+      subtitle: "Store #{@store.store_number} · #{@store.code}",
+      actions: safe_join(actions, " ") %>
+
+<section class="section surface">
+  <%= render "shared/definition_list", rows: [
+        ["Store number", @store.store_number],
+        ["Code", @store.code],
+        ["Legal name", @store.legal_name],
+        ["Phone", @store.phone],
+        ["SAN", @store.san],
+        ["Street address 1", @store.street_address_1],
+        ["Street address 2", @store.street_address_2],
+        ["City", @store.city],
+        ["Region", @store.region_code],
+        ["Postal code", @store.postal_code],
+        ["Country", @store.country_code],
+        ["Timezone", @store.timezone],
+        ["Receipt header", @store.receipt_header],
+        ["Receipt footer", @store.receipt_footer]
+      ] %>
+</section>
+
+<%= render "shared/technical_details", rows: [
+      ["ID", @store.id],
+      ["Created", format_timestamp(@store.created_at)],
+      ["Updated", format_timestamp(@store.updated_at)],
+      ["Lock version", @store.lock_version]
+    ] %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,74 +1,86 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
-    <title><%= content_for(:title) || "ShelfSense" %></title>
+    <title><%= content_for?(:title) ? "#{content_for(:title)} · ShelfSense" : "ShelfSense" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= yield :head %>
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "application" %>
   </head>
   <body>
-    <% if notice.present? %><p class="notice"><%= notice %></p><% end %>
-    <% if alert.present? %><p class="alert"><%= alert %></p><% end %>
-    <% if signed_in? %>
-      <nav>
-        <%= link_to "Home", root_path %>
-        <% if effective_permissions.include?("system_settings.view") %>
-          <%= link_to "Settings", admin_system_settings_path %>
-        <% end %>
-        <% if effective_permissions.include?("stores.view") || effective_permissions.include?("stores.create") %>
-          <%= link_to "Stores", admin_stores_path %>
-        <% end %>
-        <% if effective_permissions.include?("gl_accounts.view") %>
-          <%= link_to "GL Accounts", admin_gl_accounts_path %>
-        <% end %>
-        <% if effective_permissions.include?("tax_classes.view") %>
-          <%= link_to "Tax Classes", admin_tax_classes_path %>
-        <% end %>
-        <% if effective_permissions.include?("departments.view") %>
-          <%= link_to "Departments", admin_departments_path %>
-        <% end %>
-        <% if effective_permissions.include?("merchandise_classes.view") %>
-          <%= link_to "Merchandise classes", admin_merchandise_classes_path %>
-        <% end %>
-        <% if effective_permissions.include?("merchandise_categories.view") %>
-          <%= link_to "Categories", admin_merchandise_categories_path %>
-        <% end %>
-        <% if effective_permissions.include?("merchandise_conditions.view") %>
-          <%= link_to "Conditions", admin_merchandise_conditions_path %>
-        <% end %>
-        <% if effective_permissions.include?("products.view") %>
-          <%= link_to "Products", admin_products_path %>
-        <% end %>
-        <% if effective_permissions.include?("merchandise.lookup") %>
-          <%= link_to "Lookup", new_admin_merchandise_lookup_path %>
-        <% end %>
-        <% if effective_permissions.include?("merchandise.import") %>
-          <%= link_to "Import", new_admin_merchandise_import_path %>
-        <% end %>
-        <% if effective_permissions.include?("users.view") %>
-          <%= link_to "Users", admin_users_path %>
-        <% end %>
+    <div class="app-shell">
+      <%= render "shared/flash" %>
 
-        <% if effective_permissions.include?("roles.view") %>
-          <%= link_to "Roles", admin_roles_path %>
-        <% end %>
-        <% if effective_permissions.include?("users.assign_roles") %>
-          <%= link_to "Role assignments", admin_role_assignments_path %>
-        <% end %>
-        <% if effective_permissions.include?("workstations.view") %>
-          <%= link_to "Workstations", admin_workstations_path %>
-        <% end %>
-        <% if effective_permissions.include?("audit_events.view") %>
-          <%= link_to "Audit", admin_audit_events_path %>
-        <% end %>
-        <% if accessible_stores.many? %>
-          <%= link_to "Switch store", new_store_selection_path %>
-        <% end %>
-        <%= button_to "Sign out", session_path, method: :delete %>
-      </nav>
-    <% end %>
-    <%= yield %>
+      <% if signed_in? %>
+        <header class="app-header">
+          <div>
+            <%= link_to "ShelfSense", root_path, class: "app-brand" %>
+            <% if current_store.present? %>
+              <div class="app-header-meta">Current store: <%= current_store.name %> (<%= current_store.code %>)</div>
+            <% end %>
+          </div>
+          <nav class="app-nav" aria-label="Primary">
+            <%= link_to "Home", root_path %>
+            <% if effective_permissions.include?("system_settings.view") %>
+              <%= link_to "Settings", admin_system_settings_path %>
+            <% end %>
+            <% if effective_permissions.include?("stores.view") || effective_permissions.include?("stores.create") %>
+              <%= link_to "Stores", admin_stores_path %>
+            <% end %>
+            <% if effective_permissions.include?("gl_accounts.view") %>
+              <%= link_to "GL Accounts", admin_gl_accounts_path %>
+            <% end %>
+            <% if effective_permissions.include?("tax_classes.view") %>
+              <%= link_to "Tax Classes", admin_tax_classes_path %>
+            <% end %>
+            <% if effective_permissions.include?("departments.view") %>
+              <%= link_to "Departments", admin_departments_path %>
+            <% end %>
+            <% if effective_permissions.include?("merchandise_classes.view") %>
+              <%= link_to "Merchandise classes", admin_merchandise_classes_path %>
+            <% end %>
+            <% if effective_permissions.include?("merchandise_categories.view") %>
+              <%= link_to "Categories", admin_merchandise_categories_path %>
+            <% end %>
+            <% if effective_permissions.include?("merchandise_conditions.view") %>
+              <%= link_to "Conditions", admin_merchandise_conditions_path %>
+            <% end %>
+            <% if effective_permissions.include?("products.view") %>
+              <%= link_to "Products", admin_products_path %>
+            <% end %>
+            <% if effective_permissions.include?("merchandise.lookup") %>
+              <%= link_to "Lookup", new_admin_merchandise_lookup_path %>
+            <% end %>
+            <% if effective_permissions.include?("merchandise.import") %>
+              <%= link_to "Import", new_admin_merchandise_import_path %>
+            <% end %>
+            <% if effective_permissions.include?("users.view") %>
+              <%= link_to "Users", admin_users_path %>
+            <% end %>
+            <% if effective_permissions.include?("roles.view") %>
+              <%= link_to "Roles", admin_roles_path %>
+            <% end %>
+            <% if effective_permissions.include?("users.assign_roles") %>
+              <%= link_to "Role assignments", admin_role_assignments_path %>
+            <% end %>
+            <% if effective_permissions.include?("workstations.view") %>
+              <%= link_to "Workstations", admin_workstations_path %>
+            <% end %>
+            <% if effective_permissions.include?("audit_events.view") %>
+              <%= link_to "Audit", admin_audit_events_path %>
+            <% end %>
+            <% if accessible_stores.many? %>
+              <%= link_to "Switch store", new_store_selection_path %>
+            <% end %>
+            <%= button_to "Sign out", session_path, method: :delete, class: "btn btn--ghost" %>
+          </nav>
+        </header>
+      <% end %>
+
+      <main class="app-content">
+        <%= yield %>
+      </main>
+    </div>
   </body>
 </html>

--- a/app/views/shared/_actions.html.erb
+++ b/app/views/shared/_actions.html.erb
@@ -1,0 +1,7 @@
+<%#
+  locals:
+    items: optional HTML already built; or yield block content via content
+%>
+<div class="actions">
+  <%= local_assigns[:items] || yield %>
+</div>

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -1,0 +1,22 @@
+<%#
+  locals:
+    crumbs: array of { name:, path: } — last may omit path for current page
+%>
+<% if local_assigns[:crumbs].present? %>
+  <nav aria-label="Breadcrumb">
+    <ol class="breadcrumbs">
+      <% crumbs.each_with_index do |crumb, index| %>
+        <li>
+          <% if crumb[:path].present? && index < crumbs.length - 1 %>
+            <%= link_to crumb[:name], crumb[:path] %>
+          <% else %>
+            <span<%= " aria-current=page" if index == crumbs.length - 1 %>><%= crumb[:name] %></span>
+          <% end %>
+          <% unless index == crumbs.length - 1 %>
+            <span aria-hidden="true"> / </span>
+          <% end %>
+        </li>
+      <% end %>
+    </ol>
+  </nav>
+<% end %>

--- a/app/views/shared/_currency_field.html.erb
+++ b/app/views/shared/_currency_field.html.erb
@@ -1,0 +1,24 @@
+<%#
+  locals:
+    form: optional FormBuilder
+    name:, id:, label:, value:, help: optional, error: optional, required: false
+%>
+<% field_id = local_assigns.fetch(:id, name) %>
+<% described_by = [] %>
+<% described_by << "#{field_id}_help" if local_assigns[:help].present? %>
+<% described_by << "#{field_id}_error" if local_assigns[:error].present? %>
+<div class="form-field">
+  <%= label_tag field_id, label, class: ("required" if local_assigns[:required]) %>
+  <%= text_field_tag name, value,
+        id: field_id,
+        inputmode: "decimal",
+        autocomplete: "off",
+        "aria-invalid": local_assigns[:error].present? ? "true" : nil,
+        "aria-describedby": described_by.presence&.join(" ") %>
+  <% if local_assigns[:help].present? %>
+    <span class="field-help" id="<%= field_id %>_help"><%= help %></span>
+  <% end %>
+  <% if local_assigns[:error].present? %>
+    <span class="field-error" id="<%= field_id %>_error"><%= error %></span>
+  <% end %>
+</div>

--- a/app/views/shared/_data_table.html.erb
+++ b/app/views/shared/_data_table.html.erb
@@ -1,0 +1,36 @@
+<%#
+  locals:
+    headers: array of strings or { text:, class: }
+    rows: array of arrays of cell content (HTML-safe ok)
+    empty: optional HTML when no rows
+%>
+<% if rows.blank? %>
+  <%= local_assigns[:empty] %>
+<% else %>
+  <div class="table-scroll">
+    <table class="data-table">
+      <thead>
+        <tr>
+          <% headers.each do |header| %>
+            <% if header.is_a?(Hash) %>
+              <th class="<%= header[:class] %>"><%= header[:text] %></th>
+            <% else %>
+              <th><%= header %></th>
+            <% end %>
+          <% end %>
+        </tr>
+      </thead>
+      <tbody>
+        <% rows.each do |row| %>
+          <tr>
+            <% row.each_with_index do |cell, index| %>
+              <% header = headers[index] %>
+              <% css = header.is_a?(Hash) ? header[:class] : nil %>
+              <td class="<%= css %>"><%= cell %></td>
+            <% end %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>

--- a/app/views/shared/_definition_list.html.erb
+++ b/app/views/shared/_definition_list.html.erb
@@ -1,0 +1,9 @@
+<%#
+  locals: rows: [[label, value], ...] — value may be HTML-safe
+%>
+<dl class="definition-list">
+  <% rows.each do |label, value| %>
+    <dt><%= label %></dt>
+    <dd><%= value.nil? || value == "" ? missing_value : value %></dd>
+  <% end %>
+</dl>

--- a/app/views/shared/_empty_state.html.erb
+++ b/app/views/shared/_empty_state.html.erb
@@ -1,0 +1,11 @@
+<%#
+  locals:
+    title:, body:, action: optional HTML
+%>
+<div class="empty-state">
+  <h2 class="empty-state__title"><%= title %></h2>
+  <p><%= body %></p>
+  <% if local_assigns[:action].present? %>
+    <div class="actions"><%= action %></div>
+  <% end %>
+</div>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,0 +1,6 @@
+<% if notice.present? %>
+  <div class="flash flash--notice" role="status"><%= notice %></div>
+<% end %>
+<% if alert.present? %>
+  <div class="flash flash--alert" role="alert"><%= alert %></div>
+<% end %>

--- a/app/views/shared/_form_errors.html.erb
+++ b/app/views/shared/_form_errors.html.erb
@@ -1,0 +1,23 @@
+<%#
+  locals:
+    record:
+    attribute_ids: optional hash of attribute => dom id for linking
+%>
+<% if record.errors.any? %>
+  <div class="form-errors" id="form-error-summary" tabindex="-1" autofocus role="alert">
+    <h2><%= pluralize(record.errors.count, "error") %> prevented this form from being saved</h2>
+    <ul>
+      <% record.errors.each do |error| %>
+        <% attr = error.attribute %>
+        <% field_id = local_assigns.dig(:attribute_ids, attr) || "#{record.model_name.param_key}_#{attr}" %>
+        <li>
+          <% if attr == :base %>
+            <%= error.full_message %>
+          <% else %>
+            <a href="#<%= field_id %>"><%= error.full_message %></a>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/shared/_form_section.html.erb
+++ b/app/views/shared/_form_section.html.erb
@@ -1,0 +1,11 @@
+<%#
+  locals:
+    title:, help: optional
+%>
+<section class="section form-section">
+  <h2 class="section__title"><%= title %></h2>
+  <% if local_assigns[:help].present? %>
+    <p class="section__help"><%= help %></p>
+  <% end %>
+  <%= yield %>
+</section>

--- a/app/views/shared/_page_header.html.erb
+++ b/app/views/shared/_page_header.html.erb
@@ -1,0 +1,15 @@
+<%#
+  locals:
+    title: (required)
+    subtitle: optional
+    actions: optional HTML
+%>
+<header class="page-header">
+  <h1 class="page-header__title"><%= title %></h1>
+  <% if local_assigns[:subtitle].present? %>
+    <p class="page-header__subtitle"><%= subtitle %></p>
+  <% end %>
+  <% if local_assigns[:actions].present? %>
+    <div class="actions"><%= actions %></div>
+  <% end %>
+</header>

--- a/app/views/shared/_status_badge.html.erb
+++ b/app/views/shared/_status_badge.html.erb
@@ -1,0 +1,4 @@
+<%#
+  locals: status:, scheme: (:product_variant | :configuration)
+%>
+<%= status_badge(status, scheme: scheme) %>

--- a/app/views/shared/_technical_details.html.erb
+++ b/app/views/shared/_technical_details.html.erb
@@ -1,0 +1,11 @@
+<%#
+  locals:
+    title: optional
+    rows: [[label, value], ...]
+%>
+<details class="technical-details">
+  <summary><%= local_assigns.fetch(:title, "Technical details") %></summary>
+  <div class="section">
+    <%= render "shared/definition_list", rows: rows %>
+  </div>
+</details>

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,8 @@ This directory contains the project’s technical authority, development guidanc
 | [Phase 2 schema](planning/phase2-financial-classification-and-merchandise-foundation/phase-2-database-schema.md) | Phase 2 tables, fields, and constraints |
 | [Phase 2 authorization](planning/phase2-financial-classification-and-merchandise-foundation/phase2-authorization.md) | Phase 2 permission catalog and role grants |
 | [Phase 2.1 refinements](planning/phase2.1-platform-merchandise-refinement/phase-2.1-platform-and-merchandise-refinements.md) | Implemented merchandise correctness and operability patch before inventory |
+| [Phase 2.2 UX foundation](planning/phase2.2-ux-foundation/phase-2.2-ux-foundation.md) | Implemented administrative UX foundation (shell, products reference flow, Stores/Classes adoption) |
+| [UX conventions](ux-conventions.md) | Shared admin page anatomy, partials, currency boundaries, palette, and Hotwire deferral |
 | [Development guide](development.md) | Docker-only local setup, PostgreSQL configuration, application commands, and troubleshooting |
 | [Testing and CI](testing.md) | Active GitHub Actions checks and prerequisites for deferred checks |
 | [GitHub work management](github-workflow.md) | Issues, PRs, milestones, labels, and release tagging |

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -146,6 +146,23 @@ Phase 2.1 hardens merchandise and financial reference-data contracts before inve
 
 Deliverable: an authorized administrator can reactivate core reference data, create products and variants with complete fields and pricing-method-aware defaults, and use a documented CSV import template, with database-enforced merchandise and GL-account invariants.
 
+### Phase 2.2 — Administrative UX foundation
+
+Status: implemented.
+
+Authoritative Phase 2.2 documents:
+
+* [phase-2.2-ux-foundation.md](phase2.2-ux-foundation/phase-2.2-ux-foundation.md) — scope and acceptance criteria  
+* [UX conventions](../ux-conventions.md) — reusable admin presentation patterns  
+
+Phase 2.2 establishes an HTML/CSS-first administrative UX foundation:
+
+* Propshaft design tokens, application shell, and shared partials/helpers  
+* Product reference flow with deterministic search/filters/pagination and dollar currency UX  
+* Stores and Merchandise Classes adoption of shared patterns  
+
+Deliverable: an authorized administrator can navigate a consistent administrative shell, manage products with searchable indexes and dollar-oriented price fields, and use the same presentation patterns on Stores and Merchandise Classes—without Hotwire.
+
 ### Phase 3 — Inventory foundation
 
 Implement:

--- a/docs/planning/phase2.2-ux-foundation/phase-2.2-ux-foundation.md
+++ b/docs/planning/phase2.2-ux-foundation/phase-2.2-ux-foundation.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Implemented
 
 ## Purpose
 
@@ -23,11 +23,12 @@ Phase 2.2 sits after Phase 2.1 (merchandise correctness and operability) and bef
 
 It does not reopen Phase 2 or Phase 2.1 domain decisions, and it does not add Phase 3 inventory behavior. Instead, it establishes the presentation patterns needed to display merchandise, configuration, authorization, audit, and future inventory information clearly.
 
-When this specification is accepted, update:
+Roadmap and documentation indexes updated with this implementation:
 
 - [README.md](../../../README.md) roadmap
 - [docs/README.md](../../README.md) documentation index
 - [docs/planning/README.md](../README.md) planning index
+- [UX conventions](../../ux-conventions.md)
 
 ## Goals
 
@@ -467,7 +468,7 @@ Phase 2.2 should produce concise internal documentation covering:
 
 The documentation should describe intended usage rather than duplicating implementation details that are obvious from helper and partial APIs.
 
-On acceptance of this specification, also update the three roadmap/index documents listed under [Position in the roadmap](#position-in-the-roadmap).
+Roadmap and index documents listed under [Position in the roadmap](#position-in-the-roadmap) are updated with this Implemented status.
 
 ## Acceptance criteria
 

--- a/docs/ux-conventions.md
+++ b/docs/ux-conventions.md
@@ -1,0 +1,86 @@
+# Administrative UX conventions
+
+Status: Implemented (Phase 2.2).
+
+Concise conventions for ShelfSense server-rendered admin screens. Prefer these patterns over inventing parallel markup or CSS.
+
+## Page anatomy
+
+1. **Application shell** — brand, optional current-store label (only when authoritative `current_store` exists), permission-gated nav, flash.
+2. **Breadcrumbs** — caller-supplied crumb arrays via `shared/breadcrumbs`. Do not infer crumbs from controller or route names.
+3. **Page header** — title, optional subtitle, primary actions via `shared/page_header` / `shared/actions`.
+4. **Content** — one primary task or record view inside `.app-content`.
+5. **Technical details** — UUIDs, lock versions, and similar via `shared/technical_details` (`<details>`), never as the first thing users see.
+
+## Shared partials
+
+| Partial | Use when |
+|---|---|
+| `shared/flash` | Layout flash notices/alerts |
+| `shared/page_header` | Title + optional subtitle/actions |
+| `shared/breadcrumbs` | Explicit navigation trail |
+| `shared/actions` | Grouped action links/buttons |
+| `shared/status_badge` | Lifecycle/status chips (prefer helper wrappers) |
+| `shared/definition_list` | Show-page labeled fields |
+| `shared/data_table` | Semantic tables in a horizontally scrollable container |
+| `shared/empty_state` | Empty collections or empty filter results |
+| `shared/form_section` | Grouped form fields (`render layout:`) |
+| `shared/form_errors` | Error summary with links to fields |
+| `shared/currency_field` | Dollar-oriented money inputs |
+| `shared/technical_details` | Subordinate technical metadata |
+
+## Status badges
+
+Use `status_badge(status, scheme:)` (or `configuration_status_badge(active)`).
+
+- `:product_variant` — `draft` / `active` / `discontinued`
+- `:configuration` — `active` / `inactive`
+
+Map colors only from the scheme table. Never infer meaning from arbitrary strings.
+
+## Money
+
+| Boundary | Representation |
+|---|---|
+| HTML admin forms | Dollars (`12.50`, `$12.50`, optionally `1,200.00`) |
+| Persistence / import / API / CSV | Integer cents |
+
+- **Display:** `format_money_cents`, `money_field_value` in helpers (views only).
+- **Parse:** `Money::ParseCents` from controllers/services. Invalid input becomes a **field error**; do not silent-coerce or return `BadRequest` for ordinary typos. Preserve the submitted string for redisplay.
+
+## Forms and validation
+
+- Error summary at the top of the form (`shared/form_errors`), with `autofocus` and links to fields.
+- Associate field errors/help with `aria-describedby`.
+- Cancel returns to show (edit) or index (new).
+- Do not use `data-turbo-confirm`. Turbo/Importmap/Stimulus are not installed. Prefer existing server behavior; if a new consequential action needs confirmation, use a server-rendered confirmation page.
+
+## Tables and empty states
+
+- Tables stay tabular; wrap in the shared scroll container for narrow viewports. Do not reflow to card layouts in this foundation.
+- Distinguish empty collections from empty search/filter results (product index is the reference).
+
+## Color tokens
+
+Defined on `:root` in `application.css`:
+
+| Token | Role |
+|---|---|
+| `--color-background` | Page background (`#F8FAFC`) |
+| `--color-surface` | Surfaces (`#FFFFFF`) |
+| `--color-text` / `--color-text-muted` | Body and secondary text |
+| `--color-action` | Primary actions (`#0D6E6E`) |
+| `--color-accent` | Accent emphasis (`#7A2E5A`) |
+| `--color-warning` | Warnings (`#E09214`) |
+| `--color-border` | Borders (`#E2E8F0`) |
+| `--color-danger` | Destructive actions (`#B91C1C`) |
+
+Keep keyboard focus visible. Do not communicate meaning by color alone (pair badges with text labels).
+
+## Hotwire
+
+Importmap, Turbo, and Stimulus remain deferred. Phase 2.2 is Propshaft CSS + ERB only. Any Hotwire adoption must be a separately accepted change.
+
+## Phase 3 and later
+
+Reuse this shell, partials, helpers, and money/status conventions for inventory screens. Add domain-specific presentation (ledger language, denser operational tables) without inventing a second design system. Search/filter/pagination may expand beyond products when a phase explicitly requires it; keep `per_page` fixed in application code unless a later decision changes that contract.

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ApplicationHelperTest < ActionView::TestCase
+  test "format_money_cents formats signed minor units" do
+    assert_equal "$12.50", format_money_cents(1250)
+    assert_equal "-$0.99", format_money_cents(-99)
+    assert_includes format_money_cents(nil), "Not provided"
+  end
+
+  test "money_field_value uses integer cents without floats" do
+    assert_equal "12.50", money_field_value(1250)
+    assert_equal "-0.99", money_field_value(-99)
+    assert_nil money_field_value(nil)
+  end
+
+  test "status_badge maps product_variant scheme only" do
+    html = status_badge("draft", scheme: :product_variant)
+    assert_includes html, "Draft"
+    assert_includes html, "status-badge--draft"
+
+    assert_raises(ArgumentError) { status_badge("inactive", scheme: :product_variant) }
+  end
+
+  test "status_badge maps configuration scheme only" do
+    html = status_badge("inactive", scheme: :configuration)
+    assert_includes html, "Inactive"
+    assert_includes html, "status-badge--inactive"
+
+    assert_raises(ArgumentError) { status_badge("draft", scheme: :configuration) }
+  end
+
+  test "configuration_status_badge wraps boolean active flag" do
+    assert_includes configuration_status_badge(true), "Active"
+    assert_includes configuration_status_badge(false), "Inactive"
+  end
+end

--- a/test/integration/phase22_product_ux_test.rb
+++ b/test/integration/phase22_product_ux_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Phase22ProductUxTest < ActionDispatch::IntegrationTest
+  setup do
+    @bootstrap = bootstrap!
+    @admin = @bootstrap[:administrator]
+    @actor = @admin
+    @category = merchandise_category(name: "Fiction")
+    @product = Products::Create.call(
+      attributes: {
+        name: "Example Book",
+        status: "draft",
+        merchandise_category: @category,
+        list_price_cents: 1999
+      },
+      actor: @actor,
+      identifier_mode: "generate"
+    )
+  end
+
+  test "product index search filter and currency form round trip" do
+    sign_in_as("admin")
+
+    get admin_products_path, params: { q: "Example", status: "draft", merchandise_category_id: @category.id }
+    assert_response :success
+    assert_match(/Example Book/, response.body)
+    assert_match(/\$19\.99/, response.body)
+
+    get edit_admin_product_path(@product)
+    assert_response :success
+
+    patch admin_product_path(@product), params: {
+      product: {
+        name: "Example Book",
+        status: "draft",
+        merchandise_category_id: @category.id,
+        list_price: "25.50",
+        lock_version: @product.lock_version
+      }
+    }
+    assert_redirected_to admin_product_path(@product)
+    assert_equal 2550, @product.reload.list_price_cents
+
+    patch admin_product_path(@product), params: {
+      product: {
+        name: "Example Book",
+        status: "draft",
+        list_price: "nope",
+        lock_version: @product.lock_version
+      }
+    }
+    assert_response :unprocessable_entity
+    assert_match(/not a valid amount|error/i, response.body)
+    assert_equal 2550, @product.reload.list_price_cents
+  end
+
+  test "variant regular price uses currency parsing" do
+    sign_in_as("admin")
+    tax = tax_class(code: "books")
+    dept = department(code: "new_books", default_tax_class: tax)
+    klass = merchandise_class(code: "book", pricing_method: "fixed", default_standard_department: dept)
+
+    post admin_product_product_variants_path(@product), params: {
+      product_variant: {
+        variant_type: "standard",
+        merchandise_class_id: klass.id,
+        department_id: dept.id,
+        tax_class_id: tax.id,
+        regular_price: "14.00",
+        status: "draft"
+      }
+    }
+    assert_response :redirect
+    variant = @product.product_variants.order(:created_at).last
+    assert_equal 1400, variant.regular_price_cents
+  end
+
+  private
+
+  def sign_in_as(username)
+    delete session_path
+    follow_redirect! while response.redirect?
+    post session_path, params: { session: { username: username, password: "correct-horse-battery" } }
+    follow_redirect! if response.redirect?
+  end
+end

--- a/test/services/money/parse_cents_test.rb
+++ b/test/services/money/parse_cents_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Money::ParseCentsTest < ActiveSupport::TestCase
+  test "parses plain and currency formatted amounts" do
+    assert_equal 1250, Money::ParseCents.call("12.50")
+    assert_equal 1250, Money::ParseCents.call("$12.50")
+    assert_equal 120_000, Money::ParseCents.call("1,200.00")
+    assert_nil Money::ParseCents.call("")
+    assert_nil Money::ParseCents.call(nil)
+  end
+
+  test "rejects invalid amounts" do
+    assert_raises(Money::ParseCents::Error) { Money::ParseCents.call("abc") }
+    assert_raises(Money::ParseCents::Error) { Money::ParseCents.call("12.345") }
+  end
+end

--- a/test/services/products/admin_index_query_test.rb
+++ b/test/services/products/admin_index_query_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Products::AdminIndexQueryTest < ActiveSupport::TestCase
+  setup do
+    @actor = actor_user
+    @alpha = Products::Create.call(
+      attributes: { name: "Alpha Book", status: "active" },
+      actor: @actor,
+      identifier_mode: "generate"
+    )
+    @beta = Products::Create.call(
+      attributes: { name: "Beta Guide", status: "draft" },
+      actor: @actor,
+      identifier_mode: "generate"
+    )
+    @category = merchandise_category(name: "Fiction")
+    @beta.update!(merchandise_category: @category)
+  end
+
+  test "searches by name contains and identifier prefix" do
+    by_name = Products::AdminIndexQuery.call(q: "alpha")
+    assert_equal [ @alpha.id ], by_name.records.map(&:id)
+
+    prefix = @beta.primary_identifier[0, 6]
+    by_id = Products::AdminIndexQuery.call(q: prefix)
+    assert_includes by_id.records.map(&:id), @beta.id
+  end
+
+  test "escapes like wildcards in q" do
+    wild = Products::Create.call(
+      attributes: { name: "100% Cotton", status: "draft" },
+      actor: @actor,
+      identifier_mode: "generate"
+    )
+    result = Products::AdminIndexQuery.call(q: "%")
+    assert_includes result.records.map(&:id), wild.id
+    assert_equal 1, result.records.count { |p| p.name.include?("%") }
+  end
+
+  test "filters status and category conjunctively" do
+    result = Products::AdminIndexQuery.call(
+      status: "draft",
+      merchandise_category_id: @category.id
+    )
+    assert_equal [ @beta.id ], result.records.map(&:id)
+  end
+
+  test "orders by name and id and clamps page" do
+    result = Products::AdminIndexQuery.call(page: 0)
+    assert_equal 1, result.page
+    assert_equal [ @alpha.name, @beta.name ].sort, result.records.map(&:name)
+
+    high = Products::AdminIndexQuery.call(page: 999)
+    assert_equal 1, high.page
+  end
+end


### PR DESCRIPTION
## Summary
- Propshaft design tokens, application shell, and shared admin partials/helpers (no Hotwire)
- Product reference flow with deterministic search/filter/pagination, dollar currency UX via `Money::ParseCents`, and optional audit snippet
- Stores and Merchandise Classes adopt shared patterns; Phase 2.2 marked Implemented with UX conventions docs

## Test plan
- [x] `./dev/rails-docker bin/rails test`
- [x] Spot-check products index: search (`q`), status/category filters, pagination preserves params
- [x] Create/edit product and variant with valid/invalid currency amounts; confirm field errors and redisplay
- [x] Review Stores form/show for legal name, address, phone, SAN
- [x] Review Merchandise Classes index/show/form (immutable code, department links, status badges)
- [x] Confirm keyboard focus rings and destructive vs primary button styling
- [x] Confirm no Importmap/Turbo/Stimulus install in this change


Made with [Cursor](https://cursor.com)