### PR TITLE
Implement Phase 5 operational cash register

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,21 @@ jobs:
       - name: Scan for known security vulnerabilities in gems used
         run: bin/bundler-audit
 
+  scan_js:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Scan pinned JavaScript dependencies
+        run: bin/importmap audit
+
   lint:
     runs-on: ubuntu-latest
     env:
@@ -88,3 +103,37 @@ jobs:
           # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           # REDIS_URL: redis://localhost:6379/0
         run: bin/rails db:test:prepare test
+
+  test_system:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    steps:
+      - name: Install packages
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libpq-dev libvips
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Install Chrome
+        uses: browser-actions/setup-chrome@v1
+
+      - name: Run system tests
+        env:
+          RAILS_ENV: test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/test
+        run: bin/rails db:test:prepare test:system

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres
+        image: postgres:17
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -109,7 +109,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres
+        image: postgres:17
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,7 +210,7 @@ An ADR should include status, context, decision, and consequences. Mark unresolv
 
 Keep README setup instructions executable and current. Development procedures belong in `docs/development.md`; CI coverage and deferred checks belong in `docs/testing.md`. Issue, PR, milestone, and release conventions belong in `docs/github-workflow.md`.
 
-Use Rails-native patterns unless an accepted ADR or an established project pattern requires otherwise. Phase 5 Slice 2 locks Importmap + Turbo + Stimulus for the cashier Register workspace, with system/browser tests required when that UI is implemented ([register-workspace.md](docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md)). Those gems are in the Gemfile; they are not installed until the workspace implementation PR. Admin screens remain server-rendered Rails until a later decision. Do not treat Gemfile presence alone as installation.
+Use Rails-native patterns unless an accepted ADR or an established project pattern requires otherwise. Phase 5 Slice 2 uses Importmap + Turbo + Stimulus for the cashier Register workspace, with system/browser tests ([register-workspace.md](docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md)). Admin screens remain server-rendered Rails until a later decision. Do not add Hotwire to admin chrome as a side effect of POS work.
 
 ## 14. Change discipline
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,7 +210,7 @@ An ADR should include status, context, decision, and consequences. Mark unresolv
 
 Keep README setup instructions executable and current. Development procedures belong in `docs/development.md`; CI coverage and deferred checks belong in `docs/testing.md`. Issue, PR, milestone, and release conventions belong in `docs/github-workflow.md`.
 
-Use Rails-native patterns unless an accepted ADR or an established project pattern requires otherwise. The frontend dependency strategy is not yet settled: do not assume the presence of `importmap-rails`, Turbo, or Stimulus in the Gemfile means those tools have been installed or adopted.
+Use Rails-native patterns unless an accepted ADR or an established project pattern requires otherwise. Phase 5 Slice 2 locks Importmap + Turbo + Stimulus for the cashier Register workspace, with system/browser tests required when that UI is implemented ([register-workspace.md](docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md)). Those gems are in the Gemfile; they are not installed until the workspace implementation PR. Admin screens remain server-rendered Rails until a later decision. Do not treat Gemfile presence alone as installation.
 
 ## 14. Change discipline
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -27,6 +27,7 @@ RUN apt-get update -qq && \
 
 ENV CHROME_BIN=/usr/bin/chromium
 ENV CHROMEDRIVER_PATH=/usr/bin/chromedriver
+ENV SE_CHROMEDRIVER=/usr/bin/chromedriver
 
 RUN groupadd --gid ${APP_GID} ${APP_USER} && \
     useradd --uid ${APP_UID} --gid ${APP_GID} --create-home ${APP_USER}

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -19,8 +19,14 @@ RUN apt-get update -qq && \
       curl \
       ca-certificates \
       tzdata \
-      nano && \
+      nano \
+      chromium \
+      chromium-driver \
+      fonts-liberation && \
     rm -rf /var/lib/apt/lists/*
+
+ENV CHROME_BIN=/usr/bin/chromium
+ENV CHROMEDRIVER_PATH=/usr/bin/chromedriver
 
 RUN groupadd --gid ${APP_GID} ${APP_USER} && \
     useradd --uid ${APP_UID} --gid ${APP_GID} --create-home ${APP_USER}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ShelfSense is an inventory, purchasing, customer-service, and point-of-sale system for independent bookstores. It is designed for one organization operating one or more stores, with a central organization server and store Registers. A future standalone Terminal (ADR-021) may continue ordinary checkout during temporary connectivity loss.
 
-Phases 0–4 are implemented. Phase 5 slice 1 (headless cash accountability and Z finalize) is locked. The next work is the cashier-facing register workspace and receipt/Z screens.
+Phases 0–4 are implemented. Phase 5 slice 1 (headless cash accountability and Z finalize) is implemented. Slice 2 interaction/HTTP contract is locked; the workspace UI is not built yet.
 
 ## Goals
 
@@ -31,7 +31,7 @@ The accepted application scaffold currently uses:
 - Minitest, RuboCop, Brakeman, and Bundler Audit
 - GitHub Actions for continuous integration
 
-The frontend dependency strategy is not yet settled. Importmap, Turbo, and Stimulus gems are present in the scaffold, but Importmap has not been installed or configured. Browser-based system testing is also intentionally deferred. See [Testing and CI](docs/testing.md).
+The cashier Register workspace (Phase 5 Slice 2) locks Importmap + Turbo + Stimulus, with system/browser tests required when that UI is implemented. Those gems are in the Gemfile and are **not installed** until the workspace PR. Admin screens remain server-rendered Rails. See [register-workspace.md](docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md) and [Testing and CI](docs/testing.md).
 
 ## Quick start
 
@@ -200,11 +200,11 @@ Authoritative plan: [phase4-plan.md](docs/planning/phase4-6-point-of-sale/phase4
 
 ### Phase 5: First operational cash register
 
-Status: in progress (slice 1 locked — headless cash accountability and Z finalize). Register workspace and receipt/Z screens follow.
+Status: in progress (slice 1 implemented; slice 2 workspace contract locked, UI not implemented).
 
-Phase 5 turns the Phase 4 completion path into a cashier-usable online Rails register. Opening float, session close snapshots, and finalized Z facts are locked; the register UI stack is not.
+Phase 5 turns the Phase 4 completion path into a cashier-usable online Rails register. Opening float, session close snapshots, and finalized Z facts are implemented. The Register workspace stack is Importmap + Turbo + Stimulus with system tests; gems are not installed until the workspace PR.
 
-Authoritative plan: [phase5-plan.md](docs/planning/phase4-6-point-of-sale/phase5-cash-register/phase5-plan.md). Schema: [phase5-schema.md](docs/planning/phase4-6-point-of-sale/phase5-cash-register/phase5-schema.md).
+Authoritative plan: [phase5-plan.md](docs/planning/phase4-6-point-of-sale/phase5-cash-register/phase5-plan.md). Schema: [phase5-schema.md](docs/planning/phase4-6-point-of-sale/phase5-cash-register/phase5-schema.md). Workspace contract: [register-workspace.md](docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md).
 
 ## Phase 1 authorization model
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ShelfSense is an inventory, purchasing, customer-service, and point-of-sale system for independent bookstores. It is designed for one organization operating one or more stores, with a central organization server and store Registers. A future standalone Terminal (ADR-021) may continue ordinary checkout during temporary connectivity loss.
 
-Phases 0–4 are implemented. Phase 5 slice 1 (headless cash accountability and Z finalize) is implemented. Slice 2 interaction/HTTP contract is locked; the workspace UI is not built yet.
+Phases 0–4 are implemented. Phase 5 slice 1 (headless cash accountability and Z finalize) is implemented. Slice 2 is the cashier Register workspace (Importmap + Turbo + Stimulus).
 
 ## Goals
 
@@ -31,7 +31,7 @@ The accepted application scaffold currently uses:
 - Minitest, RuboCop, Brakeman, and Bundler Audit
 - GitHub Actions for continuous integration
 
-The cashier Register workspace (Phase 5 Slice 2) locks Importmap + Turbo + Stimulus, with system/browser tests required when that UI is implemented. Those gems are in the Gemfile and are **not installed** until the workspace PR. Admin screens remain server-rendered Rails. See [register-workspace.md](docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md) and [Testing and CI](docs/testing.md).
+The cashier Register workspace (Phase 5 Slice 2) uses Importmap + Turbo + Stimulus with system/browser tests. Admin screens remain server-rendered Rails. See [register-workspace.md](docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md) and [Testing and CI](docs/testing.md).
 
 ## Quick start
 
@@ -200,9 +200,9 @@ Authoritative plan: [phase4-plan.md](docs/planning/phase4-6-point-of-sale/phase4
 
 ### Phase 5: First operational cash register
 
-Status: in progress (slice 1 implemented; slice 2 workspace contract locked, UI not implemented).
+Status: in progress (slices 1–2 implemented; slice 3 print and close/Z screens remain).
 
-Phase 5 turns the Phase 4 completion path into a cashier-usable online Rails register. Opening float, session close snapshots, and finalized Z facts are implemented. The Register workspace stack is Importmap + Turbo + Stimulus with system tests; gems are not installed until the workspace PR.
+Phase 5 turns the Phase 4 completion path into a cashier-usable online Rails register. Opening float, session close snapshots, finalized Z facts, and the cashier Register workspace are implemented.
 
 Authoritative plan: [phase5-plan.md](docs/planning/phase4-6-point-of-sale/phase5-cash-register/phase5-plan.md). Schema: [phase5-schema.md](docs/planning/phase4-6-point-of-sale/phase5-cash-register/phase5-schema.md). Workspace contract: [register-workspace.md](docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md).
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -585,5 +585,98 @@ input[type="submit"]:hover {
 }
 
 .pos-receipt__new {
+  margin-top: 0;
+}
+
+.pos-receipt__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
   margin-top: var(--space-5);
+}
+
+.pos-print-only {
+  display: none;
+}
+
+.pos-close,
+.pos-z {
+  width: min(100% - 2rem, 40rem);
+  margin: var(--space-6) auto;
+}
+
+.pos-close__facts,
+.pos-z__facts {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.pos-close__facts div,
+.pos-z__facts div {
+  display: flex;
+  justify-content: space-between;
+}
+
+.pos-close__actions,
+.pos-z__actions,
+.pos-enter__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-5);
+}
+
+.pos-close__field {
+  width: 100%;
+  font-size: 1.25rem;
+  padding: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+@media print {
+  .pos-no-print,
+  .pos-receipt__screen,
+  .pos-receipt__actions {
+    display: none !important;
+  }
+
+  .pos-print-only,
+  .pos-receipt__print {
+    display: block !important;
+  }
+
+  .pos-body,
+  .pos-receipt {
+    width: 72mm;
+    margin: 0;
+    background: #fff;
+    color: #000;
+  }
+
+  .pos-receipt__print-header {
+    font-weight: 700;
+  }
+
+  .pos-receipt__print-lines {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .pos-receipt__print-lines th,
+  .pos-receipt__print-lines td {
+    text-align: left;
+    padding: 0.15rem 0;
+    background: #fff;
+    color: #000;
+  }
+
+  .pos-receipt__print-lines th:last-child,
+  .pos-receipt__print-lines td:last-child {
+    text-align: right;
+  }
+
+  .pos-receipt__print-totals div {
+    display: flex;
+    justify-content: space-between;
+  }
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -419,3 +419,171 @@ input[type="submit"]:hover {
 .filters .form-field--grow {
   flex: 1 1 14rem;
 }
+
+.pos-body {
+  margin: 0;
+  background: var(--color-background);
+}
+
+.pos-shell {
+  min-height: 100vh;
+  display: grid;
+  grid-template-rows: auto 1fr auto auto auto;
+  min-width: 1280px;
+}
+
+.pos-header {
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+  padding: var(--space-3) var(--space-5);
+}
+
+.pos-header__row {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.pos-header__date,
+.pos-date-emphasis {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin-top: var(--space-2);
+}
+
+.pos-banner {
+  margin: var(--space-2) 0 0;
+  padding: var(--space-2) var(--space-3);
+  background: color-mix(in srgb, var(--color-warning) 20%, var(--color-surface));
+  border: 1px solid var(--color-warning);
+}
+
+.pos-main {
+  display: grid;
+  grid-template-columns: 1fr 18rem;
+  min-height: 0;
+}
+
+.pos-basket {
+  overflow: auto;
+  padding: var(--space-3);
+}
+
+.pos-lines {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.pos-lines th,
+.pos-lines td {
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.pos-lines .numeric {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.pos-lines tr.is-selected {
+  background: color-mix(in srgb, var(--color-action) 12%, var(--color-surface));
+  font-weight: 600;
+}
+
+.pos-totals {
+  border-left: 1px solid var(--color-border);
+  padding: var(--space-4);
+  background: var(--color-surface);
+}
+
+.pos-totals__due,
+.pos-totals__change {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin-top: var(--space-4);
+}
+
+.pos-feedback {
+  min-height: 3.5rem;
+  padding: var(--space-3) var(--space-5);
+  border-top: 1px solid var(--color-border);
+  color: var(--color-danger);
+}
+
+.pos-command {
+  padding: var(--space-3) var(--space-5);
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-border);
+}
+
+.pos-command__mode {
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.pos-command__field {
+  width: 100%;
+  font-size: 1.25rem;
+  padding: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.pos-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-5) var(--space-5);
+}
+
+.pos-hidden {
+  display: none;
+}
+
+.pos-overlay {
+  position: fixed;
+  inset: 0;
+  background: color-mix(in srgb, #000 45%, transparent);
+  display: grid;
+  place-items: center;
+}
+
+.pos-overlay[hidden] {
+  display: none;
+}
+
+.pos-overlay__panel {
+  background: var(--color-surface);
+  padding: var(--space-5);
+  border-radius: var(--radius);
+  max-width: 28rem;
+}
+
+.pos-enter,
+.pos-receipt {
+  width: min(100% - 2rem, 40rem);
+  margin: var(--space-6) auto;
+}
+
+.pos-enter__alert {
+  color: var(--color-danger);
+}
+
+.pos-receipt__ref {
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.pos-receipt__totals {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.pos-receipt__totals div {
+  display: flex;
+  justify-content: space-between;
+}
+
+.pos-receipt__new {
+  margin-top: var(--space-5);
+}

--- a/app/controllers/admin/inventory_balances_controller.rb
+++ b/app/controllers/admin/inventory_balances_controller.rb
@@ -64,7 +64,7 @@ module Admin
 
     def set_balance
       @balance = InventoryBalance.find(params[:id])
-      return unless authorize!("inventory.view", store: @balance.store)
+      nil unless authorize!("inventory.view", store: @balance.store)
     end
   end
 end

--- a/app/controllers/admin/inventory_balances_controller.rb
+++ b/app/controllers/admin/inventory_balances_controller.rb
@@ -64,7 +64,7 @@ module Admin
 
     def set_balance
       @balance = InventoryBalance.find(params[:id])
-      throw :abort unless authorize!("inventory.view", store: @balance.store)
+      return unless authorize!("inventory.view", store: @balance.store)
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,6 @@ class ApplicationController < ActionController::Base
   include SessionAuthentication
   include AuthorizesRequests
 
-  allow_browser versions: :modern
+  allow_browser versions: :modern unless Rails.env.test?
   before_action :require_authentication
 end

--- a/app/controllers/concerns/authorizes_requests.rb
+++ b/app/controllers/concerns/authorizes_requests.rb
@@ -59,7 +59,6 @@ module AuthorizesRequests
     else
       redirect_to root_path, alert: "No accessible store is available for your account."
     end
-    throw :abort
   end
 
   def resolve_current_store

--- a/app/controllers/pos/base_controller.rb
+++ b/app/controllers/pos/base_controller.rb
@@ -4,20 +4,10 @@ module Pos
   class BaseController < ApplicationController
     layout "pos"
 
-    before_action :ensure_store_context
+    before_action :require_store_context
     before_action :require_pos_transact!
 
     private
-
-    def ensure_store_context
-      return if current_store.present?
-
-      if accessible_stores.exists?
-        redirect_to new_store_selection_path
-      else
-        redirect_to root_path, alert: "No accessible store is available for your account."
-      end
-    end
 
     def require_pos_transact!
       return if Authorization::PermissionEvaluator.allowed?(

--- a/app/controllers/pos/base_controller.rb
+++ b/app/controllers/pos/base_controller.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Pos
+  class BaseController < ApplicationController
+    layout "pos"
+
+    before_action :ensure_store_context
+    before_action :require_pos_transact!
+
+    private
+
+    def ensure_store_context
+      return if current_store.present?
+
+      if accessible_stores.exists?
+        redirect_to new_store_selection_path
+      else
+        redirect_to root_path, alert: "No accessible store is available for your account."
+      end
+    end
+
+    def require_pos_transact!
+      return if Authorization::PermissionEvaluator.allowed?(
+        user: current_user,
+        permission_key: "pos.transact",
+        store: current_store
+      )
+
+      Audit::Recorder.record!(
+        action: "authorization.denied",
+        outcome: "denied",
+        actor_user: current_user,
+        actor_label: current_user.display_name,
+        store: current_store,
+        reason_code: "pos.transact",
+        metadata: { path: request.fullpath }
+      )
+      redirect_to root_path, alert: "You are not authorized to perform that action."
+    end
+
+    def active_registers
+      current_store.registers.active.order(:register_number)
+    end
+
+    def find_register
+      register_id = params[:register_id].presence || session[:pos_register_id]
+      active_registers.find_by(id: register_id)
+    end
+  end
+end

--- a/app/controllers/pos/closed_sessions_controller.rb
+++ b/app/controllers/pos/closed_sessions_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Pos
+  class ClosedSessionsController < BaseController
+    def show
+      @session_record = PosSession.find_by!(id: params[:id], store_id: current_store.id)
+      Pos::Support.authorize!(current_user, @session_record.store)
+      Pos::Support.require_session_cashier!(current_user, @session_record)
+      if @session_record.open?
+        redirect_to pos_session_close_path(@session_record)
+        return
+      end
+
+      raise ActiveRecord::RecordNotFound unless @session_record.closed?
+
+      @register = @session_record.register
+      @period = @session_record.reporting_period
+      @totals = Pos::SessionTotals.for(@session_record)
+      session[:pos_register_id] = @register.id
+    rescue Pos::Denied
+      raise ActiveRecord::RecordNotFound
+    end
+  end
+end

--- a/app/controllers/pos/completed_transactions_controller.rb
+++ b/app/controllers/pos/completed_transactions_controller.rb
@@ -3,7 +3,7 @@
 module Pos
   class CompletedTransactionsController < BaseController
     def show
-      @transaction = PosTransaction.find(params[:id])
+      @transaction = PosTransaction.find_by!(id: params[:id], store_id: current_store.id)
       raise ActiveRecord::RecordNotFound unless @transaction.completed?
 
       Pos::Support.authorize!(current_user, @transaction.store)

--- a/app/controllers/pos/completed_transactions_controller.rb
+++ b/app/controllers/pos/completed_transactions_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Pos
+  class CompletedTransactionsController < BaseController
+    def show
+      @transaction = PosTransaction.find(params[:id])
+      raise ActiveRecord::RecordNotFound unless @transaction.completed?
+
+      Pos::Support.authorize!(current_user, @transaction.store)
+      Pos::Support.require_transaction_cashier!(current_user, @transaction)
+      @register = @transaction.register
+      @session_record = @transaction.pos_session
+      @period = @transaction.reporting_period
+      @tender = @transaction.pos_tenders.find_by(tender_type: "cash")
+      session[:pos_register_id] = @register.id
+    rescue Pos::Denied
+      raise ActiveRecord::RecordNotFound
+    end
+  end
+end

--- a/app/controllers/pos/enters_controller.rb
+++ b/app/controllers/pos/enters_controller.rb
@@ -16,7 +16,8 @@ module Pos
         store: current_store,
         register: @register,
         actor: current_user,
-        opening_float_cents: float_cents
+        opening_float_cents: float_cents,
+        business_date: params[:confirmed_business_date]
       )
       session[:pos_register_id] = @register.id
       redirect_to pos_register_workspace_path

--- a/app/controllers/pos/enters_controller.rb
+++ b/app/controllers/pos/enters_controller.rb
@@ -11,6 +11,12 @@ module Pos
 
     def create
       @register = active_registers.find(params.require(:register_id))
+      gate = Pos::OpenGate.for(store: current_store, register: @register, actor: current_user)
+      if gate.opening_new_period? && params[:confirmed_business_date].blank?
+        fail_enter("business date confirmation is required")
+        return
+      end
+
       float_cents = parse_opening_float
       result = Pos::EnterRegister.call(
         store: current_store,
@@ -46,6 +52,7 @@ module Pos
     def fail_enter(message)
       @registers = active_registers
       @gate = @register && Pos::OpenGate.for(store: current_store, register: @register, actor: current_user)
+      @opening_float = params[:opening_float]
       flash.now[:alert] = message
       render :show, status: :unprocessable_content
     end

--- a/app/controllers/pos/enters_controller.rb
+++ b/app/controllers/pos/enters_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Pos
+  class EntersController < BaseController
+    def show
+      @registers = active_registers
+      @register = find_register || (@registers.one? ? @registers.first : nil)
+      @gate = Pos::OpenGate.for(store: current_store, register: @register, actor: current_user) if @register
+      @opening_float = params[:opening_float]
+    end
+
+    def create
+      @register = active_registers.find(params.require(:register_id))
+      float_cents = parse_opening_float
+      result = Pos::EnterRegister.call(
+        store: current_store,
+        register: @register,
+        actor: current_user,
+        opening_float_cents: float_cents
+      )
+      session[:pos_register_id] = @register.id
+      redirect_to pos_register_workspace_path
+    rescue ActiveRecord::RecordNotFound
+      redirect_to pos_register_enter_path, alert: "Select an active register."
+    rescue Money::ParseCents::Error => e
+      fail_enter(e.message)
+    rescue Pos::Denied
+      fail_enter("Register #{@register.admin_label} is open for #{Pos::OpenGate.for(store: current_store, register: @register, actor: current_user).occupier&.display_name}.")
+    rescue Pos::Error => e
+      fail_enter(e.message)
+    end
+
+    private
+
+    def parse_opening_float
+      gate = Pos::OpenGate.for(store: current_store, register: @register, actor: current_user)
+      return nil unless gate.needs_opening_float?
+
+      parsed = Money::ParseCents.call(params[:opening_float])
+      raise Pos::Error, "opening float is required" if parsed.nil?
+
+      parsed
+    end
+
+    def fail_enter(message)
+      @registers = active_registers
+      @gate = @register && Pos::OpenGate.for(store: current_store, register: @register, actor: current_user)
+      flash.now[:alert] = message
+      render :show, status: :unprocessable_content
+    end
+  end
+end

--- a/app/controllers/pos/register_closes_controller.rb
+++ b/app/controllers/pos/register_closes_controller.rb
@@ -9,9 +9,15 @@ module Pos
         return
       end
 
-      session_record = actor_open_session(@register)
-      unless session_record
-        redirect_to pos_register_enter_path(register_id: @register.id)
+      session_record = PosSession.find_by!(
+        id: params.require(:session_id),
+        store_id: current_store.id,
+        register: @register,
+        cashier_user: current_user
+      )
+
+      if session_record.closed?
+        redirect_to pos_session_closed_path(session_record)
         return
       end
 
@@ -30,6 +36,8 @@ module Pos
       end
 
       redirect_to pos_session_close_path(session_record)
+    rescue ActionController::ParameterMissing
+      raise ActiveRecord::RecordNotFound
     rescue Pos::Denied
       raise ActiveRecord::RecordNotFound
     rescue Pos::StaleObject, Pos::Error => e
@@ -37,10 +45,6 @@ module Pos
     end
 
     private
-
-    def actor_open_session(register)
-      PosSession.open.find_by(store: current_store, register: register, cashier_user: current_user)
-    end
 
     def nonempty_working?(transaction)
       transaction.pos_transaction_lines.exists? || transaction.pos_tenders.exists?

--- a/app/controllers/pos/register_closes_controller.rb
+++ b/app/controllers/pos/register_closes_controller.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Pos
+  class RegisterClosesController < BaseController
+    def create
+      @register = find_register
+      unless @register
+        redirect_to pos_register_enter_path
+        return
+      end
+
+      session_record = actor_open_session(@register)
+      unless session_record
+        redirect_to pos_register_enter_path(register_id: @register.id)
+        return
+      end
+
+      working = session_record.pos_transactions.working.first
+      if working
+        if nonempty_working?(working)
+          redirect_to pos_register_workspace_path, alert: "Complete or cancel the current sale before closing."
+          return
+        end
+
+        Pos::CancelTransaction.call(
+          transaction: working,
+          actor: current_user,
+          expected_lock_version: working.lock_version
+        )
+      end
+
+      redirect_to pos_session_close_path(session_record)
+    rescue Pos::Denied
+      raise ActiveRecord::RecordNotFound
+    rescue Pos::StaleObject, Pos::Error => e
+      redirect_to pos_register_workspace_path, alert: e.message
+    end
+
+    private
+
+    def actor_open_session(register)
+      PosSession.open.find_by(store: current_store, register: register, cashier_user: current_user)
+    end
+
+    def nonempty_working?(transaction)
+      transaction.pos_transaction_lines.exists? || transaction.pos_tenders.exists?
+    end
+  end
+end

--- a/app/controllers/pos/reporting_period_finalizations_controller.rb
+++ b/app/controllers/pos/reporting_period_finalizations_controller.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Pos
+  class ReportingPeriodFinalizationsController < BaseController
+    def create
+      @period = PosReportingPeriod.find_by!(id: params[:id], store_id: current_store.id)
+      Pos::Support.authorize!(current_user, @period.store)
+
+      if @period.finalized?
+        redirect_to pos_reporting_period_z_path(@period)
+        return
+      end
+
+      Pos::FinalizeReportingPeriod.call(
+        period: @period,
+        actor: current_user,
+        expected_lock_version: params.require(:expected_lock_version)
+      )
+      redirect_to pos_reporting_period_z_path(@period)
+    rescue Pos::Denied
+      raise ActiveRecord::RecordNotFound
+    rescue ActionController::ParameterMissing
+      fail_finalize("expected lock version is required")
+    rescue Pos::StaleObject
+      @period.reload
+      if @period.finalized?
+        redirect_to pos_reporting_period_z_path(@period)
+      else
+        fail_finalize("This reporting period was changed. Reload and try again.")
+      end
+    rescue Pos::Error => e
+      fail_finalize(e.message)
+    end
+
+    private
+
+    def fail_finalize(message)
+      if params[:return_to] == "closed" && params[:session_id].present?
+        render_closed_summary(message)
+      else
+        render_enter(message)
+      end
+    end
+
+    def render_closed_summary(message)
+      @session_record = PosSession.find_by!(id: params[:session_id], store_id: current_store.id)
+      Pos::Support.require_session_cashier!(current_user, @session_record)
+      raise ActiveRecord::RecordNotFound unless @session_record.closed?
+
+      @register = @session_record.register
+      @period = @session_record.reporting_period
+      @totals = Pos::SessionTotals.for(@session_record)
+      flash.now[:alert] = message
+      render "pos/closed_sessions/show", status: :unprocessable_content
+    rescue Pos::Denied
+      raise ActiveRecord::RecordNotFound
+    end
+
+    def render_enter(message)
+      @register = active_registers.find_by(id: params[:register_id]) || @period.register
+      @registers = active_registers
+      @gate = Pos::OpenGate.for(store: current_store, register: @register, actor: current_user)
+      @opening_float = params[:opening_float]
+      flash.now[:alert] = message
+      render "pos/enters/show", status: :unprocessable_content
+    end
+  end
+end

--- a/app/controllers/pos/reporting_period_zs_controller.rb
+++ b/app/controllers/pos/reporting_period_zs_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Pos
+  class ReportingPeriodZsController < BaseController
+    def show
+      @period = PosReportingPeriod.find_by!(id: params[:id], store_id: current_store.id)
+      Pos::Support.authorize!(current_user, @period.store)
+      raise ActiveRecord::RecordNotFound unless @period.finalized?
+
+      @register = @period.register
+    rescue Pos::Denied
+      raise ActiveRecord::RecordNotFound
+    end
+  end
+end

--- a/app/controllers/pos/session_closes_controller.rb
+++ b/app/controllers/pos/session_closes_controller.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+module Pos
+  class SessionClosesController < BaseController
+    before_action :load_session!
+
+    def show
+      return if performed?
+
+      if @session_record.closed?
+        redirect_to pos_session_closed_path(@session_record)
+        return
+      end
+
+      if @session_record.pos_transactions.working.exists?
+        redirect_to pos_register_workspace_path, alert: "Complete or cancel the current sale before closing."
+        return
+      end
+
+      @closing_count = params[:closing_count]
+    end
+
+    def create
+      return if performed?
+
+      if @session_record.closed?
+        redirect_to pos_session_closed_path(@session_record)
+        return
+      end
+
+      count_cents = parse_closing_count
+      Pos::CloseSession.call(
+        session: @session_record,
+        actor: current_user,
+        expected_lock_version: params.require(:expected_lock_version),
+        closing_count_cents: count_cents
+      )
+      redirect_to pos_session_closed_path(@session_record)
+    rescue ActionController::ParameterMissing
+      fail_blind("expected lock version is required")
+    rescue Money::ParseCents::Error => e
+      fail_blind(e.message)
+    rescue Pos::Error => e
+      @session_record.reload
+      if @session_record.closed?
+        redirect_to pos_session_closed_path(@session_record)
+      elsif e.message == "session has a working transaction"
+        redirect_to pos_register_workspace_path, alert: "Complete or cancel the current sale before closing."
+      else
+        fail_blind(e.message)
+      end
+    rescue Pos::StaleObject
+      @session_record.reload
+      if @session_record.closed?
+        redirect_to pos_session_closed_path(@session_record)
+      else
+        fail_blind("This session was changed. Reload and try again.")
+      end
+    end
+
+    def resume_sales
+      return if performed?
+
+      if @session_record.closed?
+        redirect_to pos_session_closed_path(@session_record)
+        return
+      end
+
+      Pos::ResumeOrStartTransaction.call(session: @session_record, actor: current_user)
+      redirect_to pos_register_workspace_path
+    rescue Pos::Denied, Pos::Error => e
+      redirect_to pos_register_enter_path(register_id: @session_record.register_id), alert: e.message
+    end
+
+    private
+
+    def load_session!
+      @session_record = PosSession.find_by!(id: params[:id], store_id: current_store.id)
+      Pos::Support.authorize!(current_user, @session_record.store)
+      Pos::Support.require_session_cashier!(current_user, @session_record)
+      @register = @session_record.register
+      session[:pos_register_id] = @register.id
+    rescue Pos::Denied
+      raise ActiveRecord::RecordNotFound
+    end
+
+    def parse_closing_count
+      parsed = Money::ParseCents.call(params[:closing_count])
+      raise Pos::Error, "closing count is required" if parsed.nil?
+      raise Pos::Error, "closing count must be a non-negative amount" if parsed.negative?
+
+      parsed
+    end
+
+    def fail_blind(message)
+      @closing_count = params[:closing_count]
+      @feedback = message
+      render :show, status: :unprocessable_content
+    end
+  end
+end

--- a/app/controllers/pos/session_closes_controller.rb
+++ b/app/controllers/pos/session_closes_controller.rb
@@ -37,25 +37,13 @@ module Pos
       )
       redirect_to pos_session_closed_path(@session_record)
     rescue ActionController::ParameterMissing
-      fail_blind("expected lock version is required")
+      recover_blind("expected lock version is required")
     rescue Money::ParseCents::Error => e
-      fail_blind(e.message)
+      recover_blind(e.message)
     rescue Pos::Error => e
-      @session_record.reload
-      if @session_record.closed?
-        redirect_to pos_session_closed_path(@session_record)
-      elsif e.message == "session has a working transaction"
-        redirect_to pos_register_workspace_path, alert: "Complete or cancel the current sale before closing."
-      else
-        fail_blind(e.message)
-      end
+      recover_blind(e.message)
     rescue Pos::StaleObject
-      @session_record.reload
-      if @session_record.closed?
-        redirect_to pos_session_closed_path(@session_record)
-      else
-        fail_blind("This session was changed. Reload and try again.")
-      end
+      recover_blind("This session was changed. Reload and try again.")
     end
 
     def resume_sales
@@ -92,10 +80,18 @@ module Pos
       parsed
     end
 
-    def fail_blind(message)
-      @closing_count = params[:closing_count]
-      @feedback = message
-      render :show, status: :unprocessable_content
+    def recover_blind(message)
+      @session_record.reload
+
+      if @session_record.closed?
+        redirect_to pos_session_closed_path(@session_record)
+      elsif @session_record.pos_transactions.working.exists?
+        redirect_to pos_register_workspace_path, alert: "Complete or cancel the current sale before closing."
+      else
+        @closing_count = params[:closing_count]
+        @feedback = message
+        render :show, status: :unprocessable_content
+      end
     end
   end
 end

--- a/app/controllers/pos/workspaces_controller.rb
+++ b/app/controllers/pos/workspaces_controller.rb
@@ -1,0 +1,261 @@
+# frozen_string_literal: true
+
+module Pos
+  class WorkspacesController < BaseController
+    before_action :require_register!
+    before_action :prepare_workspace!, except: %i[show continue]
+    before_action :prepare_session!, only: :continue
+
+    def show
+      @session_record = actor_session
+      unless @session_record
+        redirect_to pos_register_enter_path(register_id: @register.id)
+        return
+      end
+
+      @transaction = @session_record.pos_transactions.working.first
+      unless @transaction
+        redirect_to pos_register_enter_path(register_id: @register.id)
+        return
+      end
+
+      prepare_view_state
+    end
+
+    def merchandise
+      rescue_workspace do
+        @selected_line = Pos::AddMerchandise.call(
+          transaction: @transaction,
+          actor: current_user,
+          expected_lock_version: expected_lock_version,
+          identifier: params.require(:identifier),
+          quantity: 1
+        )
+        @transaction.reload
+        @ui_mode = "sale_entry"
+        respond_workspace
+      end
+    end
+
+    def quantity
+      rescue_workspace do
+        line = find_line!
+        @selected_line = Pos::ChangeQuantity.call(
+          transaction: @transaction,
+          line: line,
+          actor: current_user,
+          expected_lock_version: expected_lock_version,
+          quantity: params.require(:quantity)
+        )
+        @transaction.reload
+        @ui_mode = "sale_entry"
+        respond_workspace
+      end
+    end
+
+    def remove
+      rescue_workspace do
+        line = find_line!
+        previous = previous_line(line)
+        Pos::RemoveWorkingLine.call(
+          transaction: @transaction,
+          line: line,
+          actor: current_user,
+          expected_lock_version: expected_lock_version
+        )
+        @transaction.reload
+        @selected_line = previous && @transaction.pos_transaction_lines.find_by(id: previous.id)
+        @ui_mode = "sale_entry"
+        respond_workspace
+      end
+    end
+
+    def abandon_tender
+      rescue_workspace do
+        Pos::AbandonTender.call(
+          transaction: @transaction,
+          actor: current_user,
+          expected_lock_version: expected_lock_version
+        )
+        @transaction.reload
+        @ui_mode = "sale_entry"
+        respond_workspace
+      end
+    end
+
+    def cancel
+      rescue_workspace do
+        Pos::CancelTransaction.call(
+          transaction: @transaction,
+          actor: current_user,
+          expected_lock_version: expected_lock_version
+        )
+        Pos::ResumeOrStartTransaction.call(session: @session_record, actor: current_user)
+        redirect_to pos_register_workspace_path
+      end
+    end
+
+    def tender
+      rescue_workspace do
+        presented = Money::ParseCents.call(params[:amount_presented])
+        raise Pos::Error, "cash presented is required" if presented.nil?
+
+        Pos::TenderCash.call(
+          transaction: @transaction,
+          actor: current_user,
+          expected_lock_version: expected_lock_version,
+          amount_presented_cents: presented
+        )
+        @transaction.reload
+        mint_or_restore_completion!
+        @ui_mode = "completion_pending"
+        @auto_complete = @completion_status == "pending"
+        respond_workspace
+      end
+    end
+
+    def complete
+      rescue_workspace do
+        @transaction.reload
+        if @transaction.completed?
+          redirect_to pos_completed_transaction_path(@transaction)
+          return
+        end
+
+        result = Pos::CompleteTransaction.call(
+          transaction: @transaction,
+          actor: current_user,
+          operation_id: params.require(:completion_operation_id),
+          expected_lock_version: expected_lock_version,
+          expected_total_cents: params.require(:expected_total_cents),
+          amount_presented_cents: params.require(:amount_presented_cents)
+        )
+        redirect_to pos_completed_transaction_path(result.transaction)
+      end
+    end
+
+    def continue
+      Pos::ResumeOrStartTransaction.call(session: @session_record, actor: current_user)
+      redirect_to pos_register_workspace_path
+    rescue Pos::Denied, Pos::Error => e
+      redirect_to pos_register_enter_path(register_id: @register.id), alert: e.message
+    end
+
+    private
+
+    def require_register!
+      @register = find_register
+      return if @register
+
+      redirect_to pos_register_enter_path
+    end
+
+    def actor_session
+      PosSession.open.find_by(store: current_store, register: @register, cashier_user: current_user)
+    end
+
+    def prepare_session!
+      @session_record = actor_session
+      return if @session_record
+
+      redirect_to pos_register_enter_path(register_id: @register&.id)
+    end
+
+    def prepare_workspace!
+      @session_record = actor_session
+      unless @session_record
+        redirect_to pos_register_enter_path(register_id: @register.id)
+        return
+      end
+
+      @transaction = @session_record.pos_transactions.working.first
+      return if @transaction
+
+      redirect_to pos_register_enter_path(register_id: @register.id)
+    end
+
+    def prepare_view_state
+      @period = @session_record.reporting_period
+      @lines = @transaction.pos_transaction_lines.includes(product_variant: :product)
+      @tender = @transaction.pos_tenders.find_by(tender_type: "cash")
+      @selected_line ||= default_selected_line
+      @feedback ||= nil
+      @command_value ||= nil
+      if @tender
+        mint_or_restore_completion!
+        @ui_mode ||= @completion_status == "failed" ? "completion_failed" : "completion_pending"
+        @auto_complete = @completion_status == "pending" || @completion_status == "in_flight"
+      else
+        @ui_mode ||= "sale_entry"
+        @auto_complete = false
+      end
+    end
+
+    def mint_or_restore_completion!
+      found = Pos::FindCompletionOperation.call(transaction: @transaction, actor: current_user)
+      if found
+        @completion_operation_id = found.id
+        @completion_status = found.status
+      else
+        @completion_operation_id = SecureRandom.uuid_v7
+        @completion_status = "pending"
+      end
+    end
+
+    def respond_workspace
+      prepare_view_state
+      respond_to do |format|
+        format.turbo_stream { render "pos/workspaces/update" }
+        format.html { render :show }
+      end
+    end
+
+    def rescue_workspace
+      yield
+    rescue Pos::Denied
+      redirect_to root_path, alert: "You are not authorized to perform that action."
+    rescue Pos::StaleObject
+      @feedback = "This sale was changed. Reload and try again."
+      @transaction.reload
+      @ui_mode = "sale_entry"
+      respond_workspace
+    rescue Money::ParseCents::Error, Pos::Error => e
+      @feedback = e.message
+      @transaction.reload
+      @command_value = params[:identifier] || params[:quantity] || params[:amount_presented]
+      @ui_mode = e.message.match?(/less than amount due|cash presented/i) ? "tender" : workspace_mode_after_error
+      if @transaction.completed?
+        redirect_to pos_completed_transaction_path(@transaction)
+      else
+        respond_workspace
+      end
+    end
+
+    def workspace_mode_after_error
+      return "completion_failed" if @transaction.pos_tenders.exists?
+
+      "sale_entry"
+    end
+
+    def expected_lock_version
+      params.require(:lock_version)
+    end
+
+    def find_line!
+      @transaction.pos_transaction_lines.find(params.require(:line_id))
+    end
+
+    def default_selected_line
+      id = params[:selected_line_id].presence
+      (id && @transaction.pos_transaction_lines.find_by(id: id)) || @transaction.pos_transaction_lines.last
+    end
+
+    def previous_line(line)
+      lines = @transaction.pos_transaction_lines.to_a
+      index = lines.index { |item| item.id == line.id }
+      return if index.nil? || index.zero?
+
+      lines[index - 1]
+    end
+  end
+end

--- a/app/controllers/pos/workspaces_controller.rb
+++ b/app/controllers/pos/workspaces_controller.rb
@@ -2,9 +2,10 @@
 
 module Pos
   class WorkspacesController < BaseController
-    before_action :require_register!
-    before_action :prepare_workspace!, except: %i[show continue]
+    before_action :require_register!, except: :complete
+    before_action :prepare_workspace!, except: %i[show continue complete]
     before_action :prepare_session!, only: :continue
+    before_action :load_completion_transaction!, only: :complete
 
     def show
       @session_record = actor_session
@@ -23,7 +24,7 @@ module Pos
     end
 
     def merchandise
-      rescue_workspace do
+      rescue_workspace(error_mode: "sale_entry") do
         @selected_line = Pos::AddMerchandise.call(
           transaction: @transaction,
           actor: current_user,
@@ -38,7 +39,7 @@ module Pos
     end
 
     def quantity
-      rescue_workspace do
+      rescue_workspace(error_mode: "quantity") do
         line = find_line!
         @selected_line = Pos::ChangeQuantity.call(
           transaction: @transaction,
@@ -54,7 +55,7 @@ module Pos
     end
 
     def remove
-      rescue_workspace do
+      rescue_workspace(error_mode: "sale_entry") do
         line = find_line!
         previous = previous_line(line)
         Pos::RemoveWorkingLine.call(
@@ -71,7 +72,7 @@ module Pos
     end
 
     def abandon_tender
-      rescue_workspace do
+      rescue_workspace(error_mode: "derive") do
         Pos::AbandonTender.call(
           transaction: @transaction,
           actor: current_user,
@@ -84,7 +85,7 @@ module Pos
     end
 
     def cancel
-      rescue_workspace do
+      rescue_workspace(error_mode: "sale_entry") do
         Pos::CancelTransaction.call(
           transaction: @transaction,
           actor: current_user,
@@ -96,7 +97,7 @@ module Pos
     end
 
     def tender
-      rescue_workspace do
+      rescue_workspace(error_mode: "tender") do
         presented = Money::ParseCents.call(params[:amount_presented])
         raise Pos::Error, "cash presented is required" if presented.nil?
 
@@ -109,15 +110,14 @@ module Pos
         @transaction.reload
         mint_or_restore_completion!
         @ui_mode = "completion_pending"
-        @auto_complete = @completion_status == "pending"
         respond_workspace
       end
     end
 
     def complete
-      rescue_workspace do
-        @transaction.reload
+      rescue_workspace(error_mode: "derive") do
         if @transaction.completed?
+          authorize_completion_transaction!
           redirect_to pos_completed_transaction_path(@transaction)
           return
         end
@@ -174,6 +174,22 @@ module Pos
       redirect_to pos_register_enter_path(register_id: @register.id)
     end
 
+    def load_completion_transaction!
+      @transaction = PosTransaction.find_by!(id: params[:transaction_id], store_id: current_store.id)
+      raise ActiveRecord::RecordNotFound if @transaction.cancelled?
+
+      @session_record = @transaction.pos_session
+      @register = @transaction.register
+      session[:pos_register_id] = @register.id
+    end
+
+    def authorize_completion_transaction!
+      Pos::Support.authorize!(current_user, @transaction.store)
+      Pos::Support.require_transaction_cashier!(current_user, @transaction)
+    rescue Pos::Denied
+      raise ActiveRecord::RecordNotFound
+    end
+
     def prepare_view_state
       @period = @session_record.reporting_period
       @lines = @transaction.pos_transaction_lines.includes(product_variant: :product)
@@ -183,20 +199,49 @@ module Pos
       @command_value ||= nil
       if @tender
         mint_or_restore_completion!
-        @ui_mode ||= @completion_status == "failed" ? "completion_failed" : "completion_pending"
-        @auto_complete = @completion_status == "pending" || @completion_status == "in_flight"
+        apply_completion_view_state
       else
         @ui_mode ||= "sale_entry"
         @auto_complete = false
       end
     end
 
+    def apply_completion_view_state
+      case @completion_status
+      when "pending"
+        @ui_mode ||= "completion_pending"
+        @auto_complete = true
+      when "in_flight"
+        if completion_lease_active?
+          @ui_mode ||= "completion_pending"
+          @auto_complete = false
+          @feedback ||= "Completion is still processing"
+        else
+          @ui_mode ||= "completion_failed"
+          @auto_complete = false
+        end
+      when "failed"
+        @ui_mode ||= "completion_failed"
+        @auto_complete = false
+      else
+        @ui_mode ||= "completion_pending"
+        @auto_complete = false
+      end
+    end
+
+    def completion_lease_active?
+      expires_at = @completion_operation&.lease_expires_at
+      expires_at.present? && expires_at >= Time.current
+    end
+
     def mint_or_restore_completion!
       found = Pos::FindCompletionOperation.call(transaction: @transaction, actor: current_user)
       if found
+        @completion_operation = found
         @completion_operation_id = found.id
         @completion_status = found.status
       else
+        @completion_operation = nil
         @completion_operation_id = SecureRandom.uuid_v7
         @completion_status = "pending"
       end
@@ -210,31 +255,34 @@ module Pos
       end
     end
 
-    def rescue_workspace
+    def rescue_workspace(error_mode: "sale_entry")
       yield
     rescue Pos::Denied
       redirect_to root_path, alert: "You are not authorized to perform that action."
     rescue Pos::StaleObject
-      @feedback = "This sale was changed. Reload and try again."
-      @transaction.reload
-      @ui_mode = "sale_entry"
-      respond_workspace
+      recover_from_workspace_error("This sale was changed. Reload and try again.", error_mode)
     rescue Money::ParseCents::Error, Pos::Error => e
-      @feedback = e.message
-      @transaction.reload
-      @command_value = params[:identifier] || params[:quantity] || params[:amount_presented]
-      @ui_mode = e.message.match?(/less than amount due|cash presented/i) ? "tender" : workspace_mode_after_error
-      if @transaction.completed?
-        redirect_to pos_completed_transaction_path(@transaction)
-      else
-        respond_workspace
-      end
+      recover_from_workspace_error(e.message, error_mode)
     end
 
-    def workspace_mode_after_error
-      return "completion_failed" if @transaction.pos_tenders.exists?
+    def recover_from_workspace_error(message, error_mode)
+      @feedback = message
+      @transaction.reload
+      @command_value = params[:identifier] || params[:quantity] || params[:amount_presented]
+      if @transaction.completed?
+        redirect_to pos_completed_transaction_path(@transaction)
+        return
+      end
 
-      "sale_entry"
+      apply_error_mode(error_mode)
+      respond_workspace
+    end
+
+    def apply_error_mode(error_mode)
+      return if @transaction.pos_tenders.where(tender_type: "cash").exists?
+      return if error_mode == "derive"
+
+      @ui_mode = error_mode
     end
 
     def expected_lock_version

--- a/app/controllers/pos/workspaces_controller.rb
+++ b/app/controllers/pos/workspaces_controller.rb
@@ -21,6 +21,7 @@ module Pos
       end
 
       prepare_view_state
+      @feedback ||= flash[:alert]
     end
 
     def merchandise

--- a/app/helpers/pos_helper.rb
+++ b/app/helpers/pos_helper.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module PosHelper
+  def pos_line_description(line)
+    snapshot = line.merchandise_snapshot
+    if snapshot.is_a?(Hash) && snapshot["description"].present?
+      sku = snapshot["sku"]
+      sku.present? ? "#{snapshot["description"]}  #{sku}" : snapshot["description"]
+    else
+      variant = line.product_variant
+      "#{variant.product.name}  #{variant.sku}"
+    end
+  end
+
+  def pos_mode_label(mode)
+    {
+      "sale_entry" => "SALE ENTRY",
+      "quantity" => "QUANTITY",
+      "tender" => "CASH TENDER",
+      "completion_pending" => "CASH TENDER",
+      "completion_failed" => "CASH TENDER"
+    }.fetch(mode, "SALE ENTRY")
+  end
+end

--- a/app/helpers/pos_helper.rb
+++ b/app/helpers/pos_helper.rb
@@ -29,11 +29,8 @@ module PosHelper
 
   def pos_print_line_description(line)
     snapshot = line.merchandise_snapshot
-    if snapshot.is_a?(Hash) && snapshot["description"].present?
-      snapshot["description"]
-    else
-      pos_line_description(line)
-    end
+    description = snapshot.is_a?(Hash) ? snapshot["description"] : nil
+    description.presence || "Description unavailable"
   end
 
   def pos_padded_store_number(store)

--- a/app/helpers/pos_helper.rb
+++ b/app/helpers/pos_helper.rb
@@ -12,6 +12,38 @@ module PosHelper
     end
   end
 
+  def format_store_timestamp(time, store)
+    return if time.blank?
+
+    zone = ActiveSupport::TimeZone[store.timezone] || ActiveSupport::TimeZone["UTC"]
+    time.in_time_zone(zone).strftime("%Y-%m-%d %H:%M")
+  end
+
+  def pos_receipt_print_header(transaction)
+    Pos::ReceiptIdentity.header(
+      store_number: transaction.store_number_snapshot,
+      register_number: transaction.register_number_snapshot,
+      receipt_sequence: transaction.receipt_sequence
+    )
+  end
+
+  def pos_print_line_description(line)
+    snapshot = line.merchandise_snapshot
+    if snapshot.is_a?(Hash) && snapshot["description"].present?
+      snapshot["description"]
+    else
+      pos_line_description(line)
+    end
+  end
+
+  def pos_padded_store_number(store)
+    Pos::ReceiptIdentity.pad(store.store_number, 3)
+  end
+
+  def pos_padded_register_number(register)
+    Pos::ReceiptIdentity.pad(register.register_number, 2)
+  end
+
   def pos_mode_label(mode)
     {
       "sale_entry" => "SALE ENTRY",

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,0 +1,3 @@
+// Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
+import "@hotwired/turbo-rails"
+import "controllers"

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,2 @@
-// Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
-import "@hotwired/turbo-rails"
-import "controllers"
+// Admin entry point. Do not import Turbo or Stimulus here.
+// The Register workspace boots those from pos.js via the POS layout.

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,0 +1,9 @@
+import { Application } from "@hotwired/stimulus"
+
+const application = Application.start()
+
+// Configure Stimulus development experience
+application.debug = false
+window.Stimulus   = application
+
+export { application }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,0 +1,4 @@
+// Import and register all your controllers from the importmap via controllers/**/*_controller
+import { application } from "controllers/application"
+import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
+eagerLoadControllersFrom("controllers", application)

--- a/app/javascript/controllers/pos_receipt_controller.js
+++ b/app/javascript/controllers/pos_receipt_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  onKeydown(event) {
+    if (event.key === "Enter") event.preventDefault()
+  }
+}

--- a/app/javascript/controllers/pos_receipt_controller.js
+++ b/app/javascript/controllers/pos_receipt_controller.js
@@ -2,6 +2,8 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   onKeydown(event) {
-    if (event.key === "Enter") event.preventDefault()
+    if (event.key !== "Enter") return
+    if (event.target && event.target.closest && event.target.closest("button, [type=submit], a[href]")) return
+    event.preventDefault()
   }
 }

--- a/app/javascript/controllers/pos_receipt_controller.js
+++ b/app/javascript/controllers/pos_receipt_controller.js
@@ -6,4 +6,9 @@ export default class extends Controller {
     if (event.target && event.target.closest && event.target.closest("button, [type=submit], a[href]")) return
     event.preventDefault()
   }
+
+  print(event) {
+    event.preventDefault()
+    window.print()
+  }
 }

--- a/app/javascript/controllers/register_workspace_controller.js
+++ b/app/javascript/controllers/register_workspace_controller.js
@@ -21,15 +21,19 @@ export default class extends Controller {
     "dontCancel",
     "confirmCancel",
     "retry",
+    "abandonButton",
     "quantityButton",
     "tenderButton",
     "removeButton",
-    "cancelButton"
+    "cancelButton",
+    "feedback",
+    "clientRecovery"
   ]
 
   static values = {
     mode: String,
-    autoComplete: Boolean
+    autoComplete: Boolean,
+    workspaceUrl: String
   }
 
   connect() {
@@ -38,6 +42,7 @@ export default class extends Controller {
       this.submitComplete()
       return
     }
+    this.enableReadyActions()
     this.restoreFocus()
   }
 
@@ -106,6 +111,12 @@ export default class extends Controller {
     }
   }
 
+  onSubmitEnd(event) {
+    if (event.detail?.success) return
+    if (!this.inFlight) return
+    this.recoverFromTransportFailure(event.target)
+  }
+
   submitMode() {
     if (this.inFlight) return
     if (this.modeValue === "sale_entry") this.submitMerchandise()
@@ -145,6 +156,7 @@ export default class extends Controller {
   }
 
   enterQuantity() {
+    if (this.inFlight) return
     if (this.modeValue !== "sale_entry" || !this.selectedRow()) return
     const row = this.selectedRow()
     this.setMode("quantity", "QUANTITY")
@@ -162,6 +174,7 @@ export default class extends Controller {
   }
 
   enterTender() {
+    if (this.inFlight) return
     if (this.modeValue !== "sale_entry") return
     if (!this.element.querySelector(".pos-lines tbody tr")) return
     this.setMode("tender", "CASH TENDER")
@@ -178,6 +191,7 @@ export default class extends Controller {
   }
 
   removeSelected() {
+    if (this.inFlight) return
     if (this.modeValue !== "sale_entry" || !this.selectedRow()) return
     this.syncSelectedLine()
     this.beginFlight()
@@ -185,21 +199,19 @@ export default class extends Controller {
   }
 
   escape() {
+    if (this.inFlight) return
     if (this.modeValue === "quantity" || this.modeValue === "tender") {
       this.setMode("sale_entry", "SALE ENTRY")
       this.setFieldLabel("Scan or identifier")
       this.fieldTarget.inputMode = "text"
       this.fieldTarget.value = ""
-      const hasSelection = Boolean(this.selectedRow())
-      const hasLines = Boolean(this.element.querySelector(".pos-lines tbody tr"))
-      this.setActionEnabled("quantityButton", hasSelection)
-      this.setActionEnabled("tenderButton", hasLines)
-      this.setActionEnabled("removeButton", hasSelection)
+      this.enableReadyActions()
       this.fieldTarget.focus()
     }
   }
 
   openOverlay() {
+    if (this.inFlight) return
     const cancel = this.hasCancelButtonTarget ? this.cancelButtonTarget : this.element.querySelector(".pos-actions .btn--danger")
     if (!cancel || cancel.disabled) return
     this.overlayTarget.hidden = false
@@ -220,6 +232,7 @@ export default class extends Controller {
   }
 
   moveSelection(delta) {
+    if (this.inFlight) return
     const rows = Array.from(this.element.querySelectorAll(".pos-lines tbody tr"))
     if (rows.length === 0) return
     const current = rows.findIndex((row) => row.classList.contains("is-selected"))
@@ -251,10 +264,62 @@ export default class extends Controller {
   beginFlight() {
     this.inFlight = true
     if (this.hasFieldTarget) this.fieldTarget.disabled = true
+    this.disableMutationControls()
+  }
+
+  disableMutationControls() {
+    ["quantityButton", "tenderButton", "removeButton", "cancelButton", "retry", "abandonButton"].forEach((name) => {
+      this.setActionEnabled(name, false)
+    })
+  }
+
+  enableReadyActions() {
+    if (this.modeValue === "sale_entry") {
+      const hasSelection = Boolean(this.selectedRow())
+      const hasLines = Boolean(this.element.querySelector(".pos-lines tbody tr"))
+      this.setActionEnabled("quantityButton", hasSelection)
+      this.setActionEnabled("tenderButton", hasLines)
+      this.setActionEnabled("removeButton", hasSelection)
+      this.setActionEnabled("cancelButton", hasLines)
+      return
+    }
+    if (this.modeValue === "completion_failed") {
+      this.setActionEnabled("cancelButton", true)
+      this.setActionEnabled("retry", true)
+      this.setActionEnabled("abandonButton", true)
+    }
+  }
+
+  recoverFromTransportFailure(form) {
+    if (this.hasCompleteFormTarget && form && (form === this.completeFormTarget || this.completeFormTarget.contains(form))) {
+      this.recoverCompleteTransport()
+      return
+    }
+    if (this.workspaceUrlValue) {
+      window.location.assign(this.workspaceUrlValue)
+    }
+  }
+
+  recoverCompleteTransport() {
+    this.inFlight = false
+    if (this.hasFeedbackTarget) {
+      this.feedbackTarget.textContent = "Connection lost. Retry complete does not take Cash again."
+      this.feedbackTarget.setAttribute("role", "alert")
+    }
+    if (this.hasRetryTarget) {
+      this.retryTarget.disabled = false
+      this.retryTarget.focus()
+      return
+    }
+    if (this.hasClientRecoveryTarget) {
+      this.clientRecoveryTarget.hidden = false
+      const button = this.clientRecoveryTarget.querySelector("button")
+      if (button) button.focus()
+    }
   }
 
   restoreFocus() {
-    if (this.hasRetryTarget && (this.modeValue === "completion_failed" || (this.modeValue === "completion_pending" && !this.autoCompleteValue))) {
+    if (this.hasRetryTarget && this.modeValue === "completion_failed") {
       this.retryTarget.focus()
       return
     }

--- a/app/javascript/controllers/register_workspace_controller.js
+++ b/app/javascript/controllers/register_workspace_controller.js
@@ -3,6 +3,9 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = [
     "field",
+    "fieldLabel",
+    "modeLabel",
+    "chrome",
     "overlay",
     "completeForm",
     "tenderForm",
@@ -15,7 +18,13 @@ export default class extends Controller {
     "presentedInput",
     "quantityLineInput",
     "removeLineInput",
-    "dontCancel"
+    "dontCancel",
+    "confirmCancel",
+    "retry",
+    "quantityButton",
+    "tenderButton",
+    "removeButton",
+    "cancelButton"
   ]
 
   static values = {
@@ -34,6 +43,10 @@ export default class extends Controller {
 
   onKeydown(event) {
     if (this.overlayOpen()) {
+      if (event.key === "Tab") {
+        this.trapOverlayTab(event)
+        return
+      }
       event.preventDefault()
       if (event.key === "Escape") this.closeOverlay()
       if (event.key === "F9") this.confirmCancel()
@@ -41,12 +54,14 @@ export default class extends Controller {
     }
 
     if (this.inFlight || this.modeValue === "completion_pending") {
+      if (event.key === "Enter" && this.isActionableControl(event.target)) return
       if (event.key === "Enter" || event.key === "F9") event.preventDefault()
       return
     }
 
     if (this.modeValue === "completion_failed") {
       if (event.key === "Enter") {
+        if (this.isActionableControl(event.target)) return
         event.preventDefault()
         this.submitComplete()
       }
@@ -59,6 +74,7 @@ export default class extends Controller {
     }
 
     if (event.key === "Enter") {
+      if (this.isActionableControl(event.target)) return
       event.preventDefault()
       this.submitMode()
       return
@@ -81,7 +97,7 @@ export default class extends Controller {
     } else if (event.key === "+") {
       event.preventDefault()
       this.enterTender()
-    } else if (event.key === "-") {
+    } else if (event.key === "F8") {
       event.preventDefault()
       this.removeSelected()
     } else if (event.key === "ArrowUp" || event.key === "ArrowDown") {
@@ -130,24 +146,34 @@ export default class extends Controller {
 
   enterQuantity() {
     if (this.modeValue !== "sale_entry" || !this.selectedRow()) return
-    this.modeValue = "quantity"
-    this.element.dataset.registerWorkspaceModeValue = "quantity"
-    const mode = this.element.querySelector(".pos-command__mode")
-    if (mode) mode.textContent = "QUANTITY"
+    const row = this.selectedRow()
+    this.setMode("quantity", "QUANTITY")
+    const description = row.dataset.description || "Selected line"
+    const quantity = row.dataset.quantity || ""
+    this.setFieldLabel(`${description} · Current quantity ${quantity}`)
     this.fieldTarget.disabled = false
-    this.fieldTarget.value = ""
+    this.fieldTarget.inputMode = "numeric"
+    this.fieldTarget.value = quantity
+    this.setActionEnabled("quantityButton", false)
+    this.setActionEnabled("tenderButton", false)
+    this.setActionEnabled("removeButton", false)
     this.fieldTarget.focus()
+    this.fieldTarget.select()
   }
 
   enterTender() {
     if (this.modeValue !== "sale_entry") return
     if (!this.element.querySelector(".pos-lines tbody tr")) return
-    this.modeValue = "tender"
-    this.element.dataset.registerWorkspaceModeValue = "tender"
-    const mode = this.element.querySelector(".pos-command__mode")
-    if (mode) mode.textContent = "CASH TENDER"
+    this.setMode("tender", "CASH TENDER")
+    const due = this.element.querySelector(".pos-totals__due")
+    const dueText = due ? due.textContent.trim() : "Amount due"
+    this.setFieldLabel(`${dueText}. Cash presented`)
     this.fieldTarget.disabled = false
+    this.fieldTarget.inputMode = "decimal"
     this.fieldTarget.value = ""
+    this.setActionEnabled("quantityButton", false)
+    this.setActionEnabled("tenderButton", false)
+    this.setActionEnabled("removeButton", false)
     this.fieldTarget.focus()
   }
 
@@ -160,24 +186,30 @@ export default class extends Controller {
 
   escape() {
     if (this.modeValue === "quantity" || this.modeValue === "tender") {
-      this.modeValue = "sale_entry"
-      this.element.dataset.registerWorkspaceModeValue = "sale_entry"
-      const mode = this.element.querySelector(".pos-command__mode")
-      if (mode) mode.textContent = "SALE ENTRY"
+      this.setMode("sale_entry", "SALE ENTRY")
+      this.setFieldLabel("Scan or identifier")
+      this.fieldTarget.inputMode = "text"
       this.fieldTarget.value = ""
+      const hasSelection = Boolean(this.selectedRow())
+      const hasLines = Boolean(this.element.querySelector(".pos-lines tbody tr"))
+      this.setActionEnabled("quantityButton", hasSelection)
+      this.setActionEnabled("tenderButton", hasLines)
+      this.setActionEnabled("removeButton", hasSelection)
       this.fieldTarget.focus()
     }
   }
 
   openOverlay() {
-    const cancel = this.element.querySelector(".pos-actions .btn--danger")
+    const cancel = this.hasCancelButtonTarget ? this.cancelButtonTarget : this.element.querySelector(".pos-actions .btn--danger")
     if (!cancel || cancel.disabled) return
     this.overlayTarget.hidden = false
+    if (this.hasChromeTarget) this.chromeTarget.inert = true
     this.dontCancelTarget.focus()
   }
 
   closeOverlay() {
     this.overlayTarget.hidden = true
+    if (this.hasChromeTarget) this.chromeTarget.inert = false
     this.restoreFocus()
   }
 
@@ -222,13 +254,51 @@ export default class extends Controller {
   }
 
   restoreFocus() {
-    if (!this.hasFieldTarget) return
-    if (this.modeValue === "completion_failed") {
-      const retry = this.element.querySelector("[data-register-workspace-target='retry']")
-      if (retry) retry.focus()
+    if (this.hasRetryTarget && (this.modeValue === "completion_failed" || (this.modeValue === "completion_pending" && !this.autoCompleteValue))) {
+      this.retryTarget.focus()
       return
     }
+    if (!this.hasFieldTarget) return
     if (this.fieldTarget.disabled) return
     this.fieldTarget.focus()
+  }
+
+  setMode(mode, heading) {
+    this.modeValue = mode
+    this.element.dataset.registerWorkspaceModeValue = mode
+    if (this.hasModeLabelTarget) this.modeLabelTarget.textContent = heading
+  }
+
+  setFieldLabel(text) {
+    if (this.hasFieldLabelTarget) this.fieldLabelTarget.textContent = text
+  }
+
+  setActionEnabled(targetName, enabled) {
+    const has = `has${targetName.charAt(0).toUpperCase()}${targetName.slice(1)}Target`
+    if (!this[has]) return
+    this[`${targetName}Target`].disabled = !enabled
+  }
+
+  isActionableControl(target) {
+    if (!target || !target.closest) return false
+    return Boolean(target.closest("button, [type=submit], a[href], [role=button]"))
+  }
+
+  trapOverlayTab(event) {
+    const controls = this.overlayControls()
+    if (controls.length === 0) return
+    event.preventDefault()
+    const current = controls.indexOf(document.activeElement)
+    let next = current
+    if (event.shiftKey) {
+      next = current <= 0 ? controls.length - 1 : current - 1
+    } else {
+      next = current === controls.length - 1 || current < 0 ? 0 : current + 1
+    }
+    controls[next].focus()
+  }
+
+  overlayControls() {
+    return [this.dontCancelTarget, this.confirmCancelTarget].filter(Boolean)
   }
 }

--- a/app/javascript/controllers/register_workspace_controller.js
+++ b/app/javascript/controllers/register_workspace_controller.js
@@ -1,0 +1,234 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [
+    "field",
+    "overlay",
+    "completeForm",
+    "tenderForm",
+    "merchandiseForm",
+    "quantityForm",
+    "removeForm",
+    "cancelForm",
+    "identifierInput",
+    "quantityInput",
+    "presentedInput",
+    "quantityLineInput",
+    "removeLineInput",
+    "dontCancel"
+  ]
+
+  static values = {
+    mode: String,
+    autoComplete: Boolean
+  }
+
+  connect() {
+    this.inFlight = false
+    if (this.autoCompleteValue) {
+      this.submitComplete()
+      return
+    }
+    this.restoreFocus()
+  }
+
+  onKeydown(event) {
+    if (this.overlayOpen()) {
+      event.preventDefault()
+      if (event.key === "Escape") this.closeOverlay()
+      if (event.key === "F9") this.confirmCancel()
+      return
+    }
+
+    if (this.inFlight || this.modeValue === "completion_pending") {
+      if (event.key === "Enter" || event.key === "F9") event.preventDefault()
+      return
+    }
+
+    if (this.modeValue === "completion_failed") {
+      if (event.key === "Enter") {
+        event.preventDefault()
+        this.submitComplete()
+      }
+      if (event.key === "F9") {
+        event.preventDefault()
+        this.openOverlay()
+      }
+      if (event.key === "Escape") event.preventDefault()
+      return
+    }
+
+    if (event.key === "Enter") {
+      event.preventDefault()
+      this.submitMode()
+      return
+    }
+    if (event.key === "Escape") {
+      event.preventDefault()
+      this.escape()
+      return
+    }
+    if (event.key === "F9") {
+      event.preventDefault()
+      this.openOverlay()
+      return
+    }
+    if (this.modeValue !== "sale_entry") return
+
+    if (event.key === "*") {
+      event.preventDefault()
+      this.enterQuantity()
+    } else if (event.key === "+") {
+      event.preventDefault()
+      this.enterTender()
+    } else if (event.key === "Delete") {
+      event.preventDefault()
+      this.removeSelected()
+    } else if (event.key === "ArrowUp" || event.key === "ArrowDown") {
+      event.preventDefault()
+      this.moveSelection(event.key === "ArrowUp" ? -1 : 1)
+    }
+  }
+
+  submitMode() {
+    if (this.inFlight) return
+    if (this.modeValue === "sale_entry") this.submitMerchandise()
+    else if (this.modeValue === "quantity") this.submitQuantity()
+    else if (this.modeValue === "tender") this.submitTender()
+  }
+
+  submitMerchandise() {
+    const value = this.fieldTarget.value.trim()
+    if (!value) return
+    this.identifierInputTarget.value = value
+    this.beginFlight()
+    this.merchandiseFormTarget.requestSubmit()
+  }
+
+  submitQuantity() {
+    const value = this.fieldTarget.value.trim()
+    if (!value) return
+    this.quantityInputTarget.value = value
+    this.syncSelectedLine()
+    this.beginFlight()
+    this.quantityFormTarget.requestSubmit()
+  }
+
+  submitTender() {
+    const value = this.fieldTarget.value.trim()
+    if (!value) return
+    this.presentedInputTarget.value = value
+    this.beginFlight()
+    this.tenderFormTarget.requestSubmit()
+  }
+
+  submitComplete() {
+    if (this.inFlight) return
+    this.beginFlight()
+    this.completeFormTarget.requestSubmit()
+  }
+
+  enterQuantity() {
+    if (this.modeValue !== "sale_entry" || !this.selectedRow()) return
+    this.modeValue = "quantity"
+    this.element.dataset.registerWorkspaceModeValue = "quantity"
+    const mode = this.element.querySelector(".pos-command__mode")
+    if (mode) mode.textContent = "QUANTITY"
+    this.fieldTarget.disabled = false
+    this.fieldTarget.value = ""
+    this.fieldTarget.focus()
+  }
+
+  enterTender() {
+    if (this.modeValue !== "sale_entry") return
+    if (!this.element.querySelector(".pos-lines tbody tr")) return
+    this.modeValue = "tender"
+    this.element.dataset.registerWorkspaceModeValue = "tender"
+    const mode = this.element.querySelector(".pos-command__mode")
+    if (mode) mode.textContent = "CASH TENDER"
+    this.fieldTarget.disabled = false
+    this.fieldTarget.value = ""
+    this.fieldTarget.focus()
+  }
+
+  removeSelected() {
+    if (this.modeValue !== "sale_entry" || !this.selectedRow()) return
+    this.syncSelectedLine()
+    this.beginFlight()
+    this.removeFormTarget.requestSubmit()
+  }
+
+  escape() {
+    if (this.modeValue === "quantity" || this.modeValue === "tender") {
+      this.modeValue = "sale_entry"
+      this.element.dataset.registerWorkspaceModeValue = "sale_entry"
+      const mode = this.element.querySelector(".pos-command__mode")
+      if (mode) mode.textContent = "SALE ENTRY"
+      this.fieldTarget.value = ""
+      this.fieldTarget.focus()
+    }
+  }
+
+  openOverlay() {
+    const cancel = this.element.querySelector(".pos-actions .btn--danger")
+    if (!cancel || cancel.disabled) return
+    this.overlayTarget.hidden = false
+    this.dontCancelTarget.focus()
+  }
+
+  closeOverlay() {
+    this.overlayTarget.hidden = true
+    this.restoreFocus()
+  }
+
+  confirmCancel() {
+    if (this.overlayTarget.hidden) return
+    this.beginFlight()
+    this.cancelFormTarget.requestSubmit()
+  }
+
+  moveSelection(delta) {
+    const rows = Array.from(this.element.querySelectorAll(".pos-lines tbody tr"))
+    if (rows.length === 0) return
+    const current = rows.findIndex((row) => row.classList.contains("is-selected"))
+    const nextIndex = Math.min(rows.length - 1, Math.max(0, (current < 0 ? 0 : current) + delta))
+    rows.forEach((row, index) => {
+      const selected = index === nextIndex
+      row.classList.toggle("is-selected", selected)
+      row.setAttribute("aria-selected", selected ? "true" : "false")
+    })
+    this.syncSelectedLine()
+  }
+
+  overlayOpen() {
+    return this.hasOverlayTarget && !this.overlayTarget.hidden
+  }
+
+  selectedRow() {
+    return this.element.querySelector(".pos-lines tbody tr.is-selected")
+  }
+
+  syncSelectedLine() {
+    const row = this.selectedRow()
+    if (!row) return
+    const id = row.dataset.lineId
+    if (this.hasQuantityLineInputTarget) this.quantityLineInputTarget.value = id
+    if (this.hasRemoveLineInputTarget) this.removeLineInputTarget.value = id
+  }
+
+  beginFlight() {
+    this.inFlight = true
+    if (this.hasFieldTarget) this.fieldTarget.disabled = true
+  }
+
+  restoreFocus() {
+    if (!this.hasFieldTarget) return
+    if (this.modeValue === "completion_failed") {
+      const retry = this.element.querySelector("[data-register-workspace-target='retry']")
+      if (retry) retry.focus()
+      return
+    }
+    if (this.fieldTarget.disabled) return
+    this.fieldTarget.focus()
+  }
+}

--- a/app/javascript/controllers/register_workspace_controller.js
+++ b/app/javascript/controllers/register_workspace_controller.js
@@ -81,7 +81,7 @@ export default class extends Controller {
     } else if (event.key === "+") {
       event.preventDefault()
       this.enterTender()
-    } else if (event.key === "Delete") {
+    } else if (event.key === "-") {
       event.preventDefault()
       this.removeSelected()
     } else if (event.key === "ArrowUp" || event.key === "ArrowDown") {

--- a/app/javascript/pos.js
+++ b/app/javascript/pos.js
@@ -1,0 +1,2 @@
+import "@hotwired/turbo-rails"
+import "controllers"

--- a/app/services/pos/abandon_tender.rb
+++ b/app/services/pos/abandon_tender.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Pos
+  class AbandonTender
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(transaction:, actor:, expected_lock_version:)
+      @transaction = transaction
+      @actor = actor
+      @expected_lock_version = expected_lock_version
+    end
+
+    def call
+      Pos::Support.authorize!(@actor, @transaction.store)
+      Pos::Support.require_active_context!(@transaction.store, @transaction.register)
+      Pos::Support.require_transaction_cashier!(@actor, @transaction)
+
+      PosTransaction.transaction do
+        transaction = Pos::Support.lock_working_transaction!(@transaction, @expected_lock_version)
+        if Pos::Support.clear_working_tenders!(transaction)
+          transaction.update!(updated_at: Time.current)
+        end
+        transaction
+      end
+    end
+  end
+end

--- a/app/services/pos/add_merchandise.rb
+++ b/app/services/pos/add_merchandise.rb
@@ -25,19 +25,28 @@ module Pos
 
       PosTransaction.transaction do
         transaction = Pos::Support.lock_working_transaction!(@transaction, @expected_lock_version)
-        line = transaction.pos_transaction_lines.build(
-          line_number: next_line_number(transaction),
-          direction: "sale",
-          product_variant: variant,
-          quantity: @quantity,
-          reference_unit_price_cents: variant.regular_price_cents,
-          selling_unit_price_cents: variant.regular_price_cents,
-          tax_class: variant.tax_class,
-          tax_class_code_snapshot: variant.tax_class.code
-        )
-        line.extended_selling_amount_cents = line.selling_unit_price_cents * line.quantity
-        Pos::Support.apply_provisional_tax!(line)
-        line.save!
+        Pos::Support.clear_working_tenders!(transaction)
+        line = compatible_line(transaction, variant)
+        if line
+          line.quantity += @quantity
+          line.recalc_extended!
+          Pos::Support.apply_provisional_tax!(line)
+          line.save!
+        else
+          line = transaction.pos_transaction_lines.build(
+            line_number: next_line_number(transaction),
+            direction: "sale",
+            product_variant: variant,
+            quantity: @quantity,
+            reference_unit_price_cents: variant.regular_price_cents,
+            selling_unit_price_cents: variant.regular_price_cents,
+            tax_class: variant.tax_class,
+            tax_class_code_snapshot: variant.tax_class.code
+          )
+          line.extended_selling_amount_cents = line.selling_unit_price_cents * line.quantity
+          Pos::Support.apply_provisional_tax!(line)
+          line.save!
+        end
         Pos::Support.refresh_totals!(transaction)
         line
       end
@@ -60,6 +69,15 @@ module Pos
       raise Pos::Error, "individually tracked merchandise is not supported" unless variant.derived_inventory_tracking == "quantity"
       raise Pos::Error, "open-price merchandise is not supported" if variant.merchandise_class.pricing_method == "open_price"
       raise Pos::Error, "regular price is required" if variant.regular_price_cents.nil?
+    end
+
+    def compatible_line(transaction, variant)
+      transaction.pos_transaction_lines.find do |line|
+        line.product_variant_id == variant.id &&
+          line.direction == "sale" &&
+          line.selling_unit_price_cents == variant.regular_price_cents &&
+          line.tax_class_id == variant.tax_class_id
+      end
     end
 
     def next_line_number(transaction)

--- a/app/services/pos/cancel_transaction.rb
+++ b/app/services/pos/cancel_transaction.rb
@@ -19,6 +19,7 @@ module Pos
 
       PosTransaction.transaction do
         transaction = Pos::Support.lock_working_transaction!(@transaction, @expected_lock_version)
+        Pos::Support.clear_working_tenders!(transaction)
         transaction.update!(status: "cancelled", cancelled_at: Time.current)
         Audit::Recorder.record!(
           action: "pos.transaction_cancelled",

--- a/app/services/pos/change_quantity.rb
+++ b/app/services/pos/change_quantity.rb
@@ -23,6 +23,7 @@ module Pos
 
       PosTransaction.transaction do
         transaction = Pos::Support.lock_working_transaction!(@transaction, @expected_lock_version)
+        Pos::Support.clear_working_tenders!(transaction)
         line = transaction.pos_transaction_lines.find(@line.id)
         line.quantity = @quantity
         line.recalc_extended!

--- a/app/services/pos/complete_transaction.rb
+++ b/app/services/pos/complete_transaction.rb
@@ -8,6 +8,16 @@ module Pos
       new(**attrs).call
     end
 
+    def self.command_payload(transaction:, operation_id:, expected_lock_version:, expected_total_cents:, amount_presented_cents:)
+      {
+        "transaction_id" => transaction.id.to_s,
+        "operation_id" => operation_id.to_s,
+        "expected_lock_version" => expected_lock_version.to_i,
+        "expected_total_cents" => expected_total_cents.to_i,
+        "amount_presented_cents" => amount_presented_cents.to_i
+      }
+    end
+
     def initialize(transaction:, actor:, operation_id:, expected_lock_version:, expected_total_cents:, amount_presented_cents:)
       @transaction = transaction
       @actor = actor
@@ -49,13 +59,13 @@ module Pos
     private
 
     def command_payload(transaction)
-      {
-        "transaction_id" => transaction.id.to_s,
-        "operation_id" => @operation_id.to_s,
-        "expected_lock_version" => @expected_lock_version,
-        "expected_total_cents" => @expected_total_cents,
-        "amount_presented_cents" => @amount_presented_cents
-      }
+      self.class.command_payload(
+        transaction: transaction,
+        operation_id: @operation_id,
+        expected_lock_version: @expected_lock_version,
+        expected_total_cents: @expected_total_cents,
+        amount_presented_cents: @amount_presented_cents
+      )
     end
 
     def complete_commercially!(transaction, operation)

--- a/app/services/pos/enter_register.rb
+++ b/app/services/pos/enter_register.rb
@@ -8,11 +8,12 @@ module Pos
       new(**attrs).call
     end
 
-    def initialize(store:, register:, actor:, opening_float_cents: nil)
+    def initialize(store:, register:, actor:, opening_float_cents: nil, business_date: nil)
       @store = store
       @register = register
       @actor = actor
       @opening_float_cents = opening_float_cents
+      @business_date = business_date
     end
 
     def call
@@ -48,7 +49,12 @@ module Pos
 
     def existing_or_open_period
       PosReportingPeriod.open.find_by(register: @register) ||
-        Pos::OpenReportingPeriod.call(store: @store, register: @register, actor: @actor)
+        Pos::OpenReportingPeriod.call(
+          store: @store,
+          register: @register,
+          actor: @actor,
+          business_date: @business_date
+        )
     rescue Pos::Error => e
       raise unless e.message.match?(/already has an open reporting period/)
 

--- a/app/services/pos/enter_register.rb
+++ b/app/services/pos/enter_register.rb
@@ -48,17 +48,33 @@ module Pos
     end
 
     def existing_or_open_period
-      PosReportingPeriod.open.find_by(register: @register) ||
-        Pos::OpenReportingPeriod.call(
-          store: @store,
-          register: @register,
-          actor: @actor,
-          business_date: @business_date
-        )
+      existing = PosReportingPeriod.open.find_by(register: @register)
+      if existing
+        require_matching_confirmed_date!(existing)
+        return existing
+      end
+
+      Pos::OpenReportingPeriod.call(
+        store: @store,
+        register: @register,
+        actor: @actor,
+        business_date: @business_date
+      )
     rescue Pos::Error => e
       raise unless e.message.match?(/already has an open reporting period/)
 
       nil
+    end
+
+    def require_matching_confirmed_date!(period)
+      return if @business_date.blank?
+
+      confirmed = @business_date.to_date
+      return if period.business_date == confirmed
+
+      raise Pos::Error, "this register is already open on business date #{period.business_date.iso8601}"
+    rescue ArgumentError, TypeError
+      raise Pos::Error, "business date must match the store calendar date"
     end
 
     def open_session(period)

--- a/app/services/pos/enter_register.rb
+++ b/app/services/pos/enter_register.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module Pos
+  class EnterRegister
+    Result = Struct.new(:session, :transaction, keyword_init: true)
+
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(store:, register:, actor:, opening_float_cents: nil)
+      @store = store
+      @register = register
+      @actor = actor
+      @opening_float_cents = opening_float_cents
+    end
+
+    def call
+      Pos::Support.authorize!(@actor, @store)
+      raise Pos::Error, "register does not belong to store" unless @register.store_id == @store.id
+      Pos::Support.require_active_context!(@store, @register)
+
+      3.times do
+        result = attempt_enter
+        return result if result
+      end
+
+      raise Pos::Error, "could not enter register"
+    end
+
+    private
+
+    def attempt_enter
+      session = PosSession.open.find_by(register: @register)
+      if session
+        Pos::Support.require_session_cashier!(@actor, session)
+        return complete(session)
+      end
+
+      period = existing_or_open_period
+      return if period.nil?
+
+      session = open_session(period)
+      return if session.nil?
+
+      complete(session)
+    end
+
+    def existing_or_open_period
+      PosReportingPeriod.open.find_by(register: @register) ||
+        Pos::OpenReportingPeriod.call(store: @store, register: @register, actor: @actor)
+    rescue Pos::Error => e
+      raise unless e.message.match?(/already has an open reporting period/)
+
+      nil
+    end
+
+    def open_session(period)
+      Pos::OpenSession.call(
+        store: @store,
+        register: @register,
+        actor: @actor,
+        reporting_period: period,
+        opening_float_cents: required_opening_float!
+      )
+    rescue Pos::Error => e
+      raise unless e.message.match?(/already has an open session/)
+
+      nil
+    end
+
+    def complete(session)
+      Result.new(
+        session: session,
+        transaction: Pos::ResumeOrStartTransaction.call(session: session, actor: @actor)
+      )
+    end
+
+    def required_opening_float!
+      raise Pos::Error, "opening float is required" if @opening_float_cents.nil?
+
+      @opening_float_cents
+    end
+  end
+end

--- a/app/services/pos/find_completion_operation.rb
+++ b/app/services/pos/find_completion_operation.rb
@@ -36,7 +36,7 @@ module Pos
         command_type: PosOperation::COMMAND_TYPE,
         source_id: @transaction.register_id,
         status: %w[in_flight failed]
-      )
+      ).order(created_at: :desc, id: :desc)
     end
 
     def payload_matches?(operation, tender)

--- a/app/services/pos/find_completion_operation.rb
+++ b/app/services/pos/find_completion_operation.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Pos
+  class FindCompletionOperation
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(transaction:, actor:)
+      @transaction = transaction
+      @actor = actor
+    end
+
+    def call
+      Pos::Support.authorize!(@actor, @transaction.store)
+      Pos::Support.require_transaction_cashier!(@actor, @transaction)
+      return nil unless @transaction.working?
+
+      tender = cash_tender
+      return nil unless tender
+
+      matching = candidates.select { |operation| payload_matches?(operation, tender) }
+      matching.find { |operation| operation.status == "in_flight" } ||
+        matching.find { |operation| operation.status == "failed" }
+    end
+
+    private
+
+    def cash_tender
+      @transaction.pos_tenders.find_by(tender_type: "cash")
+    end
+
+    def candidates
+      PosOperation.where(
+        pos_transaction_id: @transaction.id,
+        command_type: PosOperation::COMMAND_TYPE,
+        source_id: @transaction.register_id,
+        status: %w[in_flight failed]
+      )
+    end
+
+    def payload_matches?(operation, tender)
+      payload = Pos::CompleteTransaction.command_payload(
+        transaction: @transaction,
+        operation_id: operation.id,
+        expected_lock_version: @transaction.lock_version,
+        expected_total_cents: @transaction.total_cents,
+        amount_presented_cents: tender.amount_presented_cents
+      )
+      operation.command_payload_hash == Idempotency::CanonicalJson.hash(payload)
+    end
+  end
+end

--- a/app/services/pos/open_gate.rb
+++ b/app/services/pos/open_gate.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Pos
+  class OpenGate
+    def self.for(store:, register:, actor:)
+      new(store: store, register: register, actor: actor)
+    end
+
+    def initialize(store:, register:, actor:)
+      @store = store
+      @register = register
+      @actor = actor
+    end
+
+    def session
+      @session ||= PosSession.open.find_by(register: @register)
+    end
+
+    def period
+      @period ||= session&.reporting_period || PosReportingPeriod.open.find_by(register: @register)
+    end
+
+    def occupied?
+      session.present? && session.cashier_user_id != @actor.id
+    end
+
+    def occupier
+      session&.cashier_user
+    end
+
+    def own_session?
+      session.present? && session.cashier_user_id == @actor.id
+    end
+
+    def needs_opening_float?
+      session.nil?
+    end
+
+    def business_date
+      period&.business_date || BusinessDate.for_store(@store)
+    end
+
+    def leftover_period?
+      period.present? && period.business_date != BusinessDate.for_store(@store)
+    end
+
+    def enterable?
+      !occupied?
+    end
+  end
+end

--- a/app/services/pos/open_gate.rb
+++ b/app/services/pos/open_gate.rb
@@ -48,6 +48,10 @@ module Pos
       period.nil?
     end
 
+    def can_finalize_period?
+      period.present? && period.open? && session.nil?
+    end
+
     def enterable?
       !occupied?
     end

--- a/app/services/pos/open_gate.rb
+++ b/app/services/pos/open_gate.rb
@@ -44,6 +44,10 @@ module Pos
       period.present? && period.business_date != BusinessDate.for_store(@store)
     end
 
+    def opening_new_period?
+      period.nil?
+    end
+
     def enterable?
       !occupied?
     end

--- a/app/services/pos/receipt_identity.rb
+++ b/app/services/pos/receipt_identity.rb
@@ -8,6 +8,10 @@ module Pos
       "S#{pad(store_number, 3)}-R#{pad(register_number, 2)}-T#{pad(receipt_sequence, 7)}"
     end
 
+    def header(store_number:, register_number:, receipt_sequence:)
+      "Store: #{pad(store_number, 3)}   Reg: #{pad(register_number, 2)}   Trans: #{pad(receipt_sequence, 7)}"
+    end
+
     def pad(value, min_width)
       digits = value.to_s
       return digits if digits.length >= min_width

--- a/app/services/pos/remove_working_line.rb
+++ b/app/services/pos/remove_working_line.rb
@@ -21,6 +21,7 @@ module Pos
 
       PosTransaction.transaction do
         transaction = Pos::Support.lock_working_transaction!(@transaction, @expected_lock_version)
+        Pos::Support.clear_working_tenders!(transaction)
         transaction.pos_transaction_lines.find(@line.id).destroy!
         Pos::Support.refresh_totals!(transaction)
         transaction

--- a/app/services/pos/resume_or_start_transaction.rb
+++ b/app/services/pos/resume_or_start_transaction.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Pos
+  class ResumeOrStartTransaction
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(session:, actor:, currency_code: "USD")
+      @session = session
+      @actor = actor
+      @currency_code = currency_code
+    end
+
+    def call
+      PosSession.transaction do
+        session = Pos::Support.lock_open_cashier_session!(@session, @actor)
+        session.pos_transactions.working.first ||
+          Pos::Support.create_working_transaction!(session: session, currency_code: @currency_code)
+      end
+    rescue ActiveRecord::RecordNotUnique
+      PosTransaction.working.find_by!(pos_session_id: @session.id)
+    end
+  end
+end

--- a/app/services/pos/session_totals.rb
+++ b/app/services/pos/session_totals.rb
@@ -22,6 +22,10 @@ module Pos
       completed_transactions.sum(:tax_cents)
     end
 
+    def total_cents
+      completed_transactions.sum(:total_cents)
+    end
+
     def cash_tender_cents
       PosTender.joins(:pos_transaction)
                .where(pos_transactions: { pos_session_id: @session.id, status: "completed" })

--- a/app/services/pos/start_transaction.rb
+++ b/app/services/pos/start_transaction.rb
@@ -14,23 +14,15 @@ module Pos
 
     def call
       PosSession.transaction do
-        session = PosSession.lock.find(@session.id)
-        Pos::Support.authorize!(@actor, session.store)
-        Pos::Support.require_active_context!(session.store, session.register)
-        Pos::Support.require_session_cashier!(@actor, session)
-        raise Pos::Error, "session is not open" unless session.open?
-        raise Pos::Error, "reporting period is not open" unless session.reporting_period.open?
+        session = Pos::Support.lock_open_cashier_session!(@session, @actor)
+        if session.pos_transactions.working.exists?
+          raise Pos::Error, "a working transaction already exists"
+        end
 
-        PosTransaction.create!(
-          store: session.store,
-          register: session.register,
-          pos_session: session,
-          reporting_period: session.reporting_period,
-          cashier_user: session.cashier_user,
-          status: "working",
-          currency_code: @currency_code
-        )
+        Pos::Support.create_working_transaction!(session: session, currency_code: @currency_code)
       end
+    rescue ActiveRecord::RecordNotUnique
+      raise Pos::Error, "a working transaction already exists"
     end
   end
 end

--- a/app/services/pos/support.rb
+++ b/app/services/pos/support.rb
@@ -26,6 +26,39 @@ module Pos
       end
     end
 
+    # Assumes the Session is already locked and validated. Not a public bypass of
+    # StartTransaction or ResumeOrStartTransaction.
+    def create_working_transaction!(session:, currency_code:)
+      PosTransaction.create!(
+        store: session.store,
+        register: session.register,
+        pos_session: session,
+        reporting_period: session.reporting_period,
+        cashier_user: session.cashier_user,
+        status: "working",
+        currency_code: currency_code
+      )
+    end
+
+    def lock_open_cashier_session!(session, actor)
+      locked = PosSession.lock.find(session.id)
+      authorize!(actor, locked.store)
+      require_active_context!(locked.store, locked.register)
+      require_session_cashier!(actor, locked)
+      raise Pos::Error, "session is not open" unless locked.open?
+      raise Pos::Error, "reporting period is not open" unless locked.reporting_period.open?
+
+      locked
+    end
+
+    def clear_working_tenders!(transaction)
+      tenders = transaction.pos_tenders
+      return false if tenders.empty?
+
+      tenders.destroy_all
+      true
+    end
+
     def parse_nonnegative_cents!(value, label)
       cents = Integer(value)
       raise Pos::Error, "#{label} must be a non-negative integer" if cents.negative?

--- a/app/services/pos/tender_cash.rb
+++ b/app/services/pos/tender_cash.rb
@@ -28,7 +28,7 @@ module Pos
 
         applied = transaction.total_cents
         change = @amount_presented_cents - applied
-        transaction.pos_tenders.destroy_all
+        Pos::Support.clear_working_tenders!(transaction)
         tender = transaction.pos_tenders.create!(
           tender_type: "cash",
           direction: "payment",

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -6,6 +6,9 @@
     <p>Signed in as <%= current_user.display_name %>.</p>
     <% if current_store %>
       <p>Current store: <%= current_store.admin_label %>.</p>
+      <% if effective_permissions.include?("pos.transact") %>
+        <p><%= link_to "Open register", pos_register_enter_path %></p>
+      <% end %>
     <% elsif accessible_stores.exists? %>
       <p><%= link_to "Select a store", new_store_selection_path %></p>
     <% else %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-turbo="false">
   <head>
     <title><%= content_for?(:title) ? "#{content_for(:title)} · ShelfSense" : "ShelfSense" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
     <%= csp_meta_tag %>
     <%= yield :head %>
     <%= stylesheet_link_tag "application" %>
+    <%= javascript_importmap_tags %>
   </head>
   <body>
     <div class="app-shell">
@@ -81,6 +82,9 @@
             <% end %>
             <% if effective_permissions.include?("audit_events.view") %>
               <%= link_to "Audit", admin_audit_events_path %>
+            <% end %>
+            <% if effective_permissions.include?("pos.transact") && current_store.present? %>
+              <%= link_to "Register", pos_register_enter_path %>
             <% end %>
             <% if accessible_stores.many? %>
               <%= link_to "Switch store", new_store_selection_path %>

--- a/app/views/layouts/pos.html.erb
+++ b/app/views/layouts/pos.html.erb
@@ -7,7 +7,7 @@
     <%= csp_meta_tag %>
     <%= yield :head %>
     <%= stylesheet_link_tag "application" %>
-    <%= javascript_importmap_tags %>
+    <%= javascript_importmap_tags "pos" %>
   </head>
   <body class="pos-body">
     <%= yield %>

--- a/app/views/layouts/pos.html.erb
+++ b/app/views/layouts/pos.html.erb
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title><%= content_for?(:title) ? "#{content_for(:title)} · ShelfSense" : "Register · ShelfSense" %></title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= yield :head %>
+    <%= stylesheet_link_tag "application" %>
+    <%= javascript_importmap_tags %>
+  </head>
+  <body class="pos-body">
+    <%= yield %>
+  </body>
+</html>

--- a/app/views/pos/closed_sessions/show.html.erb
+++ b/app/views/pos/closed_sessions/show.html.erb
@@ -1,0 +1,32 @@
+<% content_for :title, "Session closed" %>
+
+<main class="pos-close">
+  <h1>Session closed</h1>
+
+  <% if flash.now[:alert].present? || alert.present? %>
+    <p class="pos-enter__alert" role="alert"><%= flash.now[:alert] || alert %></p>
+  <% end %>
+
+  <dl class="pos-close__facts">
+    <div><dt>Transactions</dt><dd><%= @totals.completed_transaction_count %></dd></div>
+    <div><dt>Subtotal</dt><dd><%= format_money_cents(@totals.subtotal_cents) %></dd></div>
+    <div><dt>Tax</dt><dd><%= format_money_cents(@totals.tax_cents) %></dd></div>
+    <div><dt>Sales total</dt><dd><%= format_money_cents(@totals.total_cents) %></dd></div>
+    <div><dt>Cash payments</dt><dd><%= format_money_cents(@totals.cash_tender_cents) %></dd></div>
+    <div><dt>Opening float</dt><dd><%= format_money_cents(@session_record.opening_float_cents) %></dd></div>
+    <div><dt>Expected closing Cash</dt><dd><%= format_money_cents(@session_record.closing_expected_cash_cents) %></dd></div>
+    <div><dt>Counted Cash</dt><dd><%= format_money_cents(@session_record.closing_count_cents) %></dd></div>
+    <div><dt>Variance</dt><dd><%= format_money_cents(@session_record.closing_variance_cents) %></dd></div>
+  </dl>
+
+  <div class="pos-close__actions">
+    <%= form_with url: pos_reporting_period_finalize_path(@period), method: :post do %>
+      <%= hidden_field_tag :expected_lock_version, @period.lock_version %>
+      <%= hidden_field_tag :return_to, "closed" %>
+      <%= hidden_field_tag :session_id, @session_record.id %>
+      <%= hidden_field_tag :register_id, @register.id %>
+      <%= submit_tag "Finalize Z", class: "btn" %>
+    <% end %>
+    <%= link_to "Leave period open", pos_register_enter_path(register_id: @register.id), class: "btn btn--secondary" %>
+  </div>
+</main>

--- a/app/views/pos/closed_sessions/show.html.erb
+++ b/app/views/pos/closed_sessions/show.html.erb
@@ -20,13 +20,17 @@
   </dl>
 
   <div class="pos-close__actions">
-    <%= form_with url: pos_reporting_period_finalize_path(@period), method: :post do %>
-      <%= hidden_field_tag :expected_lock_version, @period.lock_version %>
-      <%= hidden_field_tag :return_to, "closed" %>
-      <%= hidden_field_tag :session_id, @session_record.id %>
-      <%= hidden_field_tag :register_id, @register.id %>
-      <%= submit_tag "Finalize Z", class: "btn" %>
+    <% if @period.finalized? %>
+      <%= link_to "View Z", pos_reporting_period_z_path(@period), class: "btn" %>
+    <% else %>
+      <%= form_with url: pos_reporting_period_finalize_path(@period), method: :post do %>
+        <%= hidden_field_tag :expected_lock_version, @period.lock_version %>
+        <%= hidden_field_tag :return_to, "closed" %>
+        <%= hidden_field_tag :session_id, @session_record.id %>
+        <%= hidden_field_tag :register_id, @register.id %>
+        <%= submit_tag "Finalize Z", class: "btn" %>
+      <% end %>
+      <%= link_to "Leave period open", pos_register_enter_path(register_id: @register.id), class: "btn btn--secondary" %>
     <% end %>
-    <%= link_to "Leave period open", pos_register_enter_path(register_id: @register.id), class: "btn btn--secondary" %>
   </div>
 </main>

--- a/app/views/pos/completed_transactions/show.html.erb
+++ b/app/views/pos/completed_transactions/show.html.erb
@@ -1,30 +1,70 @@
 <% content_for :title, "Sale complete" %>
 
 <main class="pos-receipt" data-controller="pos-receipt" data-action="keydown@document->pos-receipt#onKeydown">
-  <header class="pos-header">
-    <div class="pos-header__row">
-      <span>Store  <%= @transaction.store.admin_label %></span>
-      <span>Register  <%= @register.register_number %></span>
-      <span><%= current_user.display_name %></span>
-    </div>
-    <div class="pos-header__date">Business date  <%= @transaction.business_date.iso8601 %></div>
-  </header>
+  <div class="pos-receipt__screen">
+    <header class="pos-header">
+      <div class="pos-header__row">
+        <span>Store  <%= @transaction.store.admin_label %></span>
+        <span>Register  <%= @register.register_number %></span>
+        <span><%= current_user.display_name %></span>
+      </div>
+      <div class="pos-header__date">Business date  <%= @transaction.business_date.iso8601 %></div>
+    </header>
 
-  <h1 tabindex="-1" autofocus>Sale complete</h1>
-  <p class="pos-receipt__ref"><%= @transaction.transaction_reference %></p>
+    <h1 tabindex="-1" autofocus>Sale complete</h1>
+    <p class="pos-receipt__ref"><%= @transaction.transaction_reference %></p>
 
-  <dl class="pos-receipt__totals">
-    <div><dt>Total</dt><dd><%= format_money_cents(@transaction.total_cents) %></dd></div>
-    <div><dt>Cash presented</dt><dd><%= format_money_cents(@tender&.amount_presented_cents) %></dd></div>
-    <div><dt>Change</dt><dd><%= format_money_cents(@tender&.change_cents) %></dd></div>
-  </dl>
+    <dl class="pos-receipt__totals">
+      <div><dt>Total</dt><dd><%= format_money_cents(@transaction.total_cents) %></dd></div>
+      <div><dt>Cash presented</dt><dd><%= format_money_cents(@tender&.amount_presented_cents) %></dd></div>
+      <div><dt>Change</dt><dd><%= format_money_cents(@tender&.change_cents) %></dd></div>
+    </dl>
 
-  <ul class="pos-receipt__lines">
-    <% @transaction.pos_transaction_lines.each do |line| %>
-      <li><%= line.quantity %> × <%= pos_line_description(line) %>  <%= format_money_cents(line.extended_selling_amount_cents) %></li>
-    <% end %>
-    <li>Tax  <%= format_money_cents(@transaction.tax_cents) %></li>
-  </ul>
+    <ul class="pos-receipt__lines">
+      <% @transaction.pos_transaction_lines.each do |line| %>
+        <li><%= line.quantity %> × <%= pos_line_description(line) %>  <%= format_money_cents(line.extended_selling_amount_cents) %></li>
+      <% end %>
+      <li>Tax  <%= format_money_cents(@transaction.tax_cents) %></li>
+    </ul>
+  </div>
 
-  <%= button_to "New sale", pos_register_continue_path, method: :post, class: "btn pos-receipt__new" %>
+  <section class="pos-receipt__print pos-print-only" aria-hidden="true">
+    <p class="pos-receipt__print-header"><%= pos_receipt_print_header(@transaction) %></p>
+    <p><%= @transaction.transaction_reference %></p>
+    <p>Business date  <%= @transaction.business_date.iso8601 %></p>
+    <p>Completed  <%= format_store_timestamp(@transaction.completed_at, @transaction.store) %></p>
+
+    <table class="pos-receipt__print-lines">
+      <thead>
+        <tr>
+          <th>Qty</th>
+          <th>Description</th>
+          <th>Amount</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @transaction.pos_transaction_lines.each do |line| %>
+          <tr>
+            <td><%= line.quantity %></td>
+            <td><%= pos_print_line_description(line) %></td>
+            <td><%= format_money_cents(line.extended_selling_amount_cents) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+    <dl class="pos-receipt__print-totals">
+      <div><dt>Subtotal</dt><dd><%= format_money_cents(@transaction.subtotal_cents) %></dd></div>
+      <div><dt>Tax</dt><dd><%= format_money_cents(@transaction.tax_cents) %></dd></div>
+      <div><dt>Total</dt><dd><%= format_money_cents(@transaction.total_cents) %></dd></div>
+      <div><dt>Cash presented</dt><dd><%= format_money_cents(@tender&.amount_presented_cents) %></dd></div>
+      <div><dt>Change</dt><dd><%= format_money_cents(@tender&.change_cents) %></dd></div>
+    </dl>
+  </section>
+
+  <div class="pos-receipt__actions pos-no-print">
+    <button type="button" class="btn" data-action="pos-receipt#print">Print receipt</button>
+    <%= button_to "New sale", pos_register_continue_path, method: :post, class: "btn pos-receipt__new" %>
+    <%= button_to "Close register", pos_register_close_path, method: :post, class: "btn btn--secondary" %>
+  </div>
 </main>

--- a/app/views/pos/completed_transactions/show.html.erb
+++ b/app/views/pos/completed_transactions/show.html.erb
@@ -3,7 +3,7 @@
 <main class="pos-receipt" data-controller="pos-receipt" data-action="keydown@document->pos-receipt#onKeydown">
   <header class="pos-header">
     <div class="pos-header__row">
-      <span>Store  <%= current_store.admin_label %></span>
+      <span>Store  <%= @transaction.store.admin_label %></span>
       <span>Register  <%= @register.register_number %></span>
       <span><%= current_user.display_name %></span>
     </div>

--- a/app/views/pos/completed_transactions/show.html.erb
+++ b/app/views/pos/completed_transactions/show.html.erb
@@ -65,6 +65,7 @@
   <div class="pos-receipt__actions pos-no-print">
     <button type="button" class="btn" data-action="pos-receipt#print">Print receipt</button>
     <%= button_to "New sale", pos_register_continue_path, method: :post, class: "btn pos-receipt__new" %>
-    <%= button_to "Close register", pos_register_close_path, method: :post, class: "btn btn--secondary" %>
+    <%= button_to "Close register", pos_register_close_path, method: :post,
+          params: { session_id: @session_record.id }, class: "btn btn--secondary" %>
   </div>
 </main>

--- a/app/views/pos/completed_transactions/show.html.erb
+++ b/app/views/pos/completed_transactions/show.html.erb
@@ -1,0 +1,30 @@
+<% content_for :title, "Sale complete" %>
+
+<main class="pos-receipt" data-controller="pos-receipt" data-action="keydown@document->pos-receipt#onKeydown">
+  <header class="pos-header">
+    <div class="pos-header__row">
+      <span>Store  <%= current_store.admin_label %></span>
+      <span>Register  <%= @register.register_number %></span>
+      <span><%= current_user.display_name %></span>
+    </div>
+    <div class="pos-header__date">Business date  <%= @transaction.business_date.iso8601 %></div>
+  </header>
+
+  <h1 tabindex="-1" autofocus>Sale complete</h1>
+  <p class="pos-receipt__ref"><%= @transaction.transaction_reference %></p>
+
+  <dl class="pos-receipt__totals">
+    <div><dt>Total</dt><dd><%= format_money_cents(@transaction.total_cents) %></dd></div>
+    <div><dt>Cash presented</dt><dd><%= format_money_cents(@tender&.amount_presented_cents) %></dd></div>
+    <div><dt>Change</dt><dd><%= format_money_cents(@tender&.change_cents) %></dd></div>
+  </dl>
+
+  <ul class="pos-receipt__lines">
+    <% @transaction.pos_transaction_lines.each do |line| %>
+      <li><%= line.quantity %> × <%= pos_line_description(line) %>  <%= format_money_cents(line.extended_selling_amount_cents) %></li>
+    <% end %>
+    <li>Tax  <%= format_money_cents(@transaction.tax_cents) %></li>
+  </ul>
+
+  <%= button_to "New sale", pos_register_continue_path, method: :post, class: "btn pos-receipt__new" %>
+</main>

--- a/app/views/pos/enters/show.html.erb
+++ b/app/views/pos/enters/show.html.erb
@@ -1,0 +1,59 @@
+<% content_for :title, "Open register" %>
+
+<main class="pos-enter">
+  <h1>Open register</h1>
+  <% if current_store %>
+    <p>Store  <%= current_store.admin_label %></p>
+  <% end %>
+
+  <% if flash.now[:alert].present? || alert.present? %>
+    <p class="pos-enter__alert" role="alert"><%= flash.now[:alert] || alert %></p>
+  <% end %>
+
+  <% if @registers.blank? %>
+    <p>No active register is available in this store.</p>
+  <% else %>
+    <%= form_with url: pos_register_enter_path, method: :get, class: "pos-enter__form" do %>
+      <div class="form-field">
+        <label for="register_id">Register</label>
+        <%= select_tag :register_id,
+              options_from_collection_for_select(@registers, :id, :admin_label, @register&.id),
+              include_blank: (@registers.many? ? "Select a register" : false),
+              autofocus: @register.nil?,
+              onchange: "this.form.requestSubmit()" %>
+      </div>
+      <noscript><%= submit_tag "Select register", class: "btn btn--secondary" %></noscript>
+    <% end %>
+
+    <% if @register && @gate %>
+      <%= form_with url: pos_register_enter_path, method: :post, class: "pos-enter__form" do %>
+        <%= hidden_field_tag :register_id, @register.id %>
+        <% if @gate.occupied? %>
+          <p id="occupied-register" role="alert">
+            Register <%= @register.admin_label %> is open for <%= @gate.occupier.display_name %>.
+          </p>
+        <% else %>
+          <% if @gate.leftover_period? %>
+            <p class="pos-banner" role="status">This register is still on business date <%= @gate.business_date.iso8601 %>.</p>
+          <% end %>
+          <p>
+            <span class="<%= "pos-date-emphasis" if @gate.leftover_period? %>">Business date  <%= @gate.business_date.iso8601 %></span>
+            <% if @gate.own_session? %>
+              (this is your open Session)
+            <% end %>
+          </p>
+          <% if @gate.needs_opening_float? %>
+            <div class="form-field">
+              <label for="opening_float">Opening float</label>
+              <%= text_field_tag :opening_float, @opening_float, inputmode: "decimal", autocomplete: "off", autofocus: true %>
+            </div>
+          <% end %>
+        <% end %>
+
+        <%= submit_tag "Open register",
+              disabled: @gate.occupied?,
+              class: "btn" %>
+      <% end %>
+    <% end %>
+  <% end %>
+</main>

--- a/app/views/pos/enters/show.html.erb
+++ b/app/views/pos/enters/show.html.erb
@@ -53,9 +53,19 @@
           <% end %>
         <% end %>
 
-        <%= submit_tag "Open register",
-              disabled: @gate.occupied?,
-              class: "btn" %>
+        <div class="pos-enter__actions">
+          <%= submit_tag @gate.can_finalize_period? ? "Open session" : "Open register",
+                disabled: @gate.occupied?,
+                class: "btn" %>
+        </div>
+      <% end %>
+      <% if @register && @gate&.can_finalize_period? %>
+        <%= form_with url: pos_reporting_period_finalize_path(@gate.period), method: :post, class: "pos-enter__form" do %>
+          <%= hidden_field_tag :expected_lock_version, @gate.period.lock_version %>
+          <%= hidden_field_tag :return_to, "enter" %>
+          <%= hidden_field_tag :register_id, @register.id %>
+          <%= submit_tag "Finalize Z", class: "btn btn--secondary" %>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/pos/enters/show.html.erb
+++ b/app/views/pos/enters/show.html.erb
@@ -33,6 +33,9 @@
             Register <%= @register.admin_label %> is open for <%= @gate.occupier.display_name %>.
           </p>
         <% else %>
+          <% if @gate.opening_new_period? %>
+            <%= hidden_field_tag :confirmed_business_date, @gate.business_date.iso8601 %>
+          <% end %>
           <% if @gate.leftover_period? %>
             <p class="pos-banner" role="status">This register is still on business date <%= @gate.business_date.iso8601 %>.</p>
           <% end %>

--- a/app/views/pos/reporting_period_zs/show.html.erb
+++ b/app/views/pos/reporting_period_zs/show.html.erb
@@ -1,0 +1,24 @@
+<% content_for :title, "Z report" %>
+
+<main class="pos-z">
+  <h1>Z report</h1>
+  <p>Store  <%= pos_padded_store_number(@period.store) %></p>
+  <p>Register  <%= pos_padded_register_number(@register) %></p>
+  <p>Business date  <%= @period.business_date.iso8601 %></p>
+
+  <dl class="pos-z__facts">
+    <div><dt>Transactions</dt><dd><%= @period.finalized_transaction_count %></dd></div>
+    <div><dt>Subtotal</dt><dd><%= format_money_cents(@period.finalized_subtotal_cents) %></dd></div>
+    <div><dt>Tax</dt><dd><%= format_money_cents(@period.finalized_tax_cents) %></dd></div>
+    <div><dt>Total</dt><dd><%= format_money_cents(@period.finalized_total_cents) %></dd></div>
+    <div><dt>Cash payments</dt><dd><%= format_money_cents(@period.finalized_cash_payment_cents) %></dd></div>
+    <div><dt>Sessions</dt><dd><%= @period.finalized_session_count %></dd></div>
+    <div><dt>Opening floats total</dt><dd><%= format_money_cents(@period.finalized_opening_float_cents_sum) %></dd></div>
+    <div><dt>Expected closing Cash</dt><dd><%= format_money_cents(@period.finalized_closing_expected_cash_cents_sum) %></dd></div>
+    <div><dt>Counted closing Cash</dt><dd><%= format_money_cents(@period.finalized_closing_count_cents_sum) %></dd></div>
+    <div><dt>Closing variance</dt><dd><%= format_money_cents(@period.finalized_closing_variance_cents_sum) %></dd></div>
+  </dl>
+
+  <p>Finalized  <%= format_store_timestamp(@period.closed_at, @period.store) %></p>
+  <p>Finalized by  <%= @period.finalized_by.display_name %></p>
+</main>

--- a/app/views/pos/session_closes/show.html.erb
+++ b/app/views/pos/session_closes/show.html.erb
@@ -1,0 +1,36 @@
+<% content_for :title, "Close register" %>
+
+<main class="pos-close">
+  <header class="pos-header">
+    <div class="pos-header__row">
+      <span>Store  <%= current_store.admin_label %></span>
+      <span>Register  <%= @register.register_number %></span>
+      <span><%= current_user.display_name %></span>
+    </div>
+    <div class="pos-header__date">Business date  <%= @session_record.reporting_period.business_date.iso8601 %></div>
+  </header>
+
+  <h1>Close register</h1>
+  <p>Count all Cash currently in the register.</p>
+
+  <% if @feedback.present? %>
+    <p class="pos-enter__alert" role="alert"><%= @feedback %></p>
+  <% end %>
+
+  <%= form_with url: pos_session_close_path(@session_record), method: :post, class: "pos-close__form" do %>
+    <%= hidden_field_tag :expected_lock_version, @session_record.lock_version %>
+    <div class="form-field">
+      <label for="closing_count">Closing Cash count</label>
+      <%= text_field_tag :closing_count, @closing_count,
+            inputmode: "decimal",
+            autocomplete: "off",
+            autofocus: true,
+            class: "pos-close__field" %>
+    </div>
+    <div class="pos-close__actions">
+      <%= submit_tag "Close session", class: "btn" %>
+    </div>
+  <% end %>
+
+  <%= button_to "Return to sales", pos_session_resume_sales_path(@session_record), method: :post, class: "btn btn--secondary" %>
+</main>

--- a/app/views/pos/workspaces/_surface.html.erb
+++ b/app/views/pos/workspaces/_surface.html.erb
@@ -137,6 +137,9 @@
               disabled>
         Cancel (F9)
       </button>
+      <% if @ui_mode == "sale_entry" && lines.empty? && tender.blank? %>
+        <%= button_to "Close register", pos_register_close_path, method: :post, class: "btn btn--secondary" %>
+      <% end %>
     </div>
 
     <%= form_with url: pos_register_merchandise_path, method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "merchandiseForm", turbo: true } } do %>

--- a/app/views/pos/workspaces/_surface.html.erb
+++ b/app/views/pos/workspaces/_surface.html.erb
@@ -1,0 +1,168 @@
+<%
+  lines = @lines || @transaction.pos_transaction_lines.includes(product_variant: :product)
+  tender = @tender || @transaction.pos_tenders.find_by(tender_type: "cash")
+  selected_id = @selected_line&.id
+  locked = %w[completion_pending completion_failed].include?(@ui_mode)
+  basket_empty = lines.none?
+  merchandise_present = lines.any?
+  cancel_enabled = merchandise_present && @ui_mode != "completion_pending"
+  leftover = @session_record.reporting_period.business_date != BusinessDate.for_store(current_store)
+  amount_due = @transaction.total_cents
+  change_cents = tender&.change_cents
+%>
+
+<div id="pos_workspace"
+     class="pos-shell"
+     data-controller="register-workspace"
+     data-register-workspace-mode-value="<%= @ui_mode %>"
+     data-register-workspace-auto-complete-value="<%= @auto_complete ? "true" : "false" %>"
+     data-action="keydown@document->register-workspace#onKeydown">
+  <header class="pos-header">
+    <div class="pos-header__row">
+      <span>Store  <%= current_store.admin_label %></span>
+      <span>Register  <%= @register.register_number %></span>
+      <span><%= current_user.display_name %></span>
+    </div>
+    <div class="pos-header__date <%= "pos-date-emphasis" if leftover %>">
+      Business date  <%= @session_record.reporting_period.business_date.iso8601 %>
+    </div>
+    <% if leftover %>
+      <p class="pos-banner" role="status">This register is still on business date <%= @session_record.reporting_period.business_date.iso8601 %>.</p>
+    <% end %>
+  </header>
+
+  <div class="pos-main">
+    <div id="pos_basket" class="pos-basket">
+      <table class="pos-lines">
+        <thead>
+          <tr>
+            <th>Qty</th>
+            <th>Description</th>
+            <th class="numeric">Unit</th>
+            <th class="numeric">Ext</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% lines.each do |line| %>
+            <tr class="<%= "is-selected" if line.id == selected_id %>"
+                data-line-id="<%= line.id %>"
+                aria-selected="<%= line.id == selected_id %>">
+              <td><%= line.id == selected_id ? ">" : "" %> <%= line.quantity %></td>
+              <td><%= pos_line_description(line) %></td>
+              <td class="numeric"><%= format_money_cents(line.selling_unit_price_cents) %></td>
+              <td class="numeric"><%= format_money_cents(line.extended_selling_amount_cents) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+
+    <aside id="pos_totals" class="pos-totals">
+      <div>Subtotal  <%= format_money_cents(@transaction.subtotal_cents) %></div>
+      <div>Tax  <%= format_money_cents(@transaction.tax_cents) %></div>
+      <div>Total  <%= format_money_cents(@transaction.total_cents) %></div>
+      <% if tender %>
+        <div>Cash presented  <%= format_money_cents(tender.amount_presented_cents) %></div>
+        <div class="pos-totals__change">CHANGE  <%= format_money_cents(change_cents) %></div>
+      <% else %>
+        <div class="pos-totals__due">Amount due  <%= format_money_cents(amount_due) %></div>
+      <% end %>
+    </aside>
+  </div>
+
+  <div id="pos_feedback" class="pos-feedback" role="<%= @feedback.present? ? "alert" : "status" %>" aria-live="<%= @feedback.present? ? "assertive" : "polite" %>">
+    <% if @ui_mode == "completion_pending" && @feedback.blank? %>
+      Completing sale…
+    <% elsif @feedback.present? %>
+      <%= @feedback %>
+      <% if @ui_mode == "completion_failed" %>
+        Tender is kept. Retry does not take Cash again.
+      <% end %>
+    <% end %>
+  </div>
+
+  <div id="pos_command" class="pos-command">
+    <div class="pos-command__mode"><%= pos_mode_label(@ui_mode) %></div>
+    <% if @ui_mode == "quantity" && @selected_line %>
+      <label for="pos-command-field"><%= pos_line_description(@selected_line) %> · Current quantity <%= @selected_line.quantity %></label>
+    <% elsif @ui_mode == "tender" %>
+      <label for="pos-command-field">Amount due <%= format_money_cents(amount_due) %>. Cash presented</label>
+    <% elsif locked %>
+      <label for="pos-command-field">Cash presented (locked)</label>
+    <% else %>
+      <label for="pos-command-field">Scan or identifier</label>
+    <% end %>
+    <input id="pos-command-field"
+           class="pos-command__field"
+           data-register-workspace-target="field"
+           value="<%= @command_value %>"
+           autocomplete="off"
+           <%= "disabled" if locked || @ui_mode == "completion_pending" %>
+           <%= "autofocus" unless locked || @ui_mode == "completion_failed" %>>
+  </div>
+
+  <div id="pos_actions" class="pos-actions">
+    <% if @ui_mode == "completion_failed" %>
+      <button type="button" class="btn" data-action="register-workspace#submitComplete" data-register-workspace-target="retry" autofocus>Retry complete</button>
+      <%= button_to "Return to sale", pos_register_abandon_tender_path, method: :post, params: { lock_version: @transaction.lock_version }, class: "btn btn--secondary" %>
+    <% else %>
+      <button type="button" class="btn btn--secondary" data-action="register-workspace#enterQuantity" <%= "disabled" unless @selected_line && @ui_mode == "sale_entry" %>>Quantity (*)</button>
+      <button type="button" class="btn btn--secondary" data-action="register-workspace#enterTender" <%= "disabled" unless merchandise_present && @ui_mode == "sale_entry" %>>Tender (+)</button>
+      <button type="button" class="btn btn--secondary" data-action="register-workspace#removeSelected" <%= "disabled" unless @selected_line && @ui_mode == "sale_entry" %>>Remove</button>
+    <% end %>
+    <button type="button"
+            class="btn btn--danger"
+            data-action="register-workspace#openOverlay"
+            <%= "disabled" unless cancel_enabled %>>
+      Cancel (F9)
+    </button>
+  </div>
+
+  <%= form_with url: pos_register_merchandise_path, method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "merchandiseForm", turbo: true } } do %>
+    <%= hidden_field_tag :lock_version, @transaction.lock_version %>
+    <%= hidden_field_tag :selected_line_id, selected_id %>
+    <%= hidden_field_tag :identifier, "", data: { register_workspace_target: "identifierInput" } %>
+  <% end %>
+
+  <%= form_with url: pos_register_quantity_path, method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "quantityForm", turbo: true } } do %>
+    <%= hidden_field_tag :lock_version, @transaction.lock_version %>
+    <%= hidden_field_tag :line_id, selected_id, data: { register_workspace_target: "quantityLineInput" } %>
+    <%= hidden_field_tag :quantity, "", data: { register_workspace_target: "quantityInput" } %>
+  <% end %>
+
+  <%= form_with url: pos_register_remove_path, method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "removeForm", turbo: true } } do %>
+    <%= hidden_field_tag :lock_version, @transaction.lock_version %>
+    <%= hidden_field_tag :line_id, selected_id, data: { register_workspace_target: "removeLineInput" } %>
+  <% end %>
+
+  <%= form_with url: pos_register_tender_path, method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "tenderForm", turbo: true } } do %>
+    <%= hidden_field_tag :lock_version, @transaction.lock_version %>
+    <%= hidden_field_tag :amount_presented, "", data: { register_workspace_target: "presentedInput" } %>
+  <% end %>
+
+  <%= form_with url: pos_register_complete_path, method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "completeForm", turbo: true } } do %>
+    <%= hidden_field_tag :lock_version, @transaction.lock_version %>
+    <%= hidden_field_tag :completion_operation_id, @completion_operation_id %>
+    <%= hidden_field_tag :expected_total_cents, @transaction.total_cents %>
+    <%= hidden_field_tag :amount_presented_cents, tender&.amount_presented_cents %>
+  <% end %>
+
+  <%= form_with url: pos_register_cancel_path, method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "cancelForm", turbo: true } } do %>
+    <%= hidden_field_tag :lock_version, @transaction.lock_version %>
+  <% end %>
+
+  <div class="pos-overlay"
+       id="pos_overlay"
+       hidden
+       data-register-workspace-target="overlay"
+       role="dialog"
+       aria-modal="true"
+       aria-labelledby="pos-cancel-title">
+    <div class="pos-overlay__panel">
+      <h2 id="pos-cancel-title">Cancel this sale?</h2>
+      <p>Lines will not be sold. No receipt. No inventory movement.</p>
+      <button type="button" class="btn btn--secondary" data-action="register-workspace#closeOverlay" data-register-workspace-target="dontCancel">Don't cancel (Esc)</button>
+      <button type="button" class="btn btn--danger" data-action="register-workspace#confirmCancel">Cancel sale (F9)</button>
+    </div>
+  </div>
+</div>

--- a/app/views/pos/workspaces/_surface.html.erb
+++ b/app/views/pos/workspaces/_surface.html.erb
@@ -138,7 +138,8 @@
         Cancel (F9)
       </button>
       <% if @ui_mode == "sale_entry" && lines.empty? && tender.blank? %>
-        <%= button_to "Close register", pos_register_close_path, method: :post, class: "btn btn--secondary" %>
+        <%= button_to "Close register", pos_register_close_path, method: :post,
+              params: { session_id: @session_record.id }, class: "btn btn--secondary" %>
       <% end %>
     </div>
 

--- a/app/views/pos/workspaces/_surface.html.erb
+++ b/app/views/pos/workspaces/_surface.html.erb
@@ -108,7 +108,7 @@
     <% else %>
       <button type="button" class="btn btn--secondary" data-action="register-workspace#enterQuantity" <%= "disabled" unless @selected_line && @ui_mode == "sale_entry" %>>Quantity (*)</button>
       <button type="button" class="btn btn--secondary" data-action="register-workspace#enterTender" <%= "disabled" unless merchandise_present && @ui_mode == "sale_entry" %>>Tender (+)</button>
-      <button type="button" class="btn btn--secondary" data-action="register-workspace#removeSelected" <%= "disabled" unless @selected_line && @ui_mode == "sale_entry" %>>Remove</button>
+      <button type="button" class="btn btn--secondary" data-action="register-workspace#removeSelected" <%= "disabled" unless @selected_line && @ui_mode == "sale_entry" %>>Remove (-)</button>
     <% end %>
     <button type="button"
             class="btn btn--danger"

--- a/app/views/pos/workspaces/_surface.html.erb
+++ b/app/views/pos/workspaces/_surface.html.erb
@@ -3,16 +3,10 @@
   tender = @tender || @transaction.pos_tenders.find_by(tender_type: "cash")
   selected_id = @selected_line&.id
   locked = %w[completion_pending completion_failed].include?(@ui_mode)
-  basket_empty = lines.none?
-  merchandise_present = lines.any?
-  cancel_enabled = merchandise_present && @ui_mode != "completion_pending"
   leftover = @session_record.reporting_period.business_date != BusinessDate.for_store(current_store)
   amount_due = @transaction.total_cents
   change_cents = tender&.change_cents
-  completion_recovery = @ui_mode == "completion_failed" || (@ui_mode == "completion_pending" && !@auto_complete)
-  quantity_enabled = @selected_line && @ui_mode == "sale_entry"
-  tender_enabled = merchandise_present && @ui_mode == "sale_entry"
-  remove_enabled = @selected_line && @ui_mode == "sale_entry"
+  completion_recovery = @ui_mode == "completion_failed"
   command_inputmode =
     if @ui_mode == "quantity"
       "numeric"
@@ -38,7 +32,8 @@
      data-controller="register-workspace"
      data-register-workspace-mode-value="<%= @ui_mode %>"
      data-register-workspace-auto-complete-value="<%= @auto_complete ? "true" : "false" %>"
-     data-action="keydown@document->register-workspace#onKeydown">
+     data-register-workspace-workspace-url-value="<%= pos_register_workspace_path %>"
+     data-action="keydown@document->register-workspace#onKeydown turbo:submit-end->register-workspace#onSubmitEnd">
   <div data-register-workspace-target="chrome">
     <header class="pos-header">
       <div class="pos-header__row">
@@ -95,7 +90,7 @@
       </aside>
     </div>
 
-    <div id="pos_feedback" class="pos-feedback" role="<%= @feedback.present? ? "alert" : "status" %>" aria-live="<%= @feedback.present? ? "assertive" : "polite" %>">
+    <div id="pos_feedback" class="pos-feedback" data-register-workspace-target="feedback" role="<%= @feedback.present? ? "alert" : "status" %>" aria-live="<%= @feedback.present? ? "assertive" : "polite" %>">
       <% if @ui_mode == "completion_pending" && @feedback.blank? %>
         Completing sale…
       <% elsif @feedback.present? %>
@@ -122,17 +117,24 @@
     <div id="pos_actions" class="pos-actions">
       <% if completion_recovery %>
         <button type="button" class="btn" data-action="register-workspace#submitComplete" data-register-workspace-target="retry" autofocus>Retry complete</button>
-        <%= button_to "Return to sale", pos_register_abandon_tender_path, method: :post, params: { lock_version: @transaction.lock_version }, class: "btn btn--secondary" %>
+        <%= button_to "Return to sale", pos_register_abandon_tender_path, method: :post,
+              params: { lock_version: @transaction.lock_version },
+              class: "btn btn--secondary",
+              form: { data: { turbo: true } },
+              data: { register_workspace_target: "abandonButton" } %>
       <% else %>
-        <button type="button" class="btn btn--secondary" data-action="register-workspace#enterQuantity" data-register-workspace-target="quantityButton" <%= "disabled" unless quantity_enabled %>>Quantity (*)</button>
-        <button type="button" class="btn btn--secondary" data-action="register-workspace#enterTender" data-register-workspace-target="tenderButton" <%= "disabled" unless tender_enabled %>>Tender (+)</button>
-        <button type="button" class="btn btn--secondary" data-action="register-workspace#removeSelected" data-register-workspace-target="removeButton" <%= "disabled" unless remove_enabled %>>Remove (F8)</button>
+        <button type="button" class="btn btn--secondary" data-action="register-workspace#enterQuantity" data-register-workspace-target="quantityButton" disabled>Quantity (*)</button>
+        <button type="button" class="btn btn--secondary" data-action="register-workspace#enterTender" data-register-workspace-target="tenderButton" disabled>Tender (+)</button>
+        <button type="button" class="btn btn--secondary" data-action="register-workspace#removeSelected" data-register-workspace-target="removeButton" disabled>Remove (F8)</button>
       <% end %>
+      <div data-register-workspace-target="clientRecovery" hidden>
+        <button type="button" class="btn" data-action="register-workspace#submitComplete">Retry complete</button>
+      </div>
       <button type="button"
               class="btn btn--danger"
               data-action="register-workspace#openOverlay"
               data-register-workspace-target="cancelButton"
-              <%= "disabled" unless cancel_enabled %>>
+              disabled>
         Cancel (F9)
       </button>
     </div>

--- a/app/views/pos/workspaces/_surface.html.erb
+++ b/app/views/pos/workspaces/_surface.html.erb
@@ -9,6 +9,28 @@
   leftover = @session_record.reporting_period.business_date != BusinessDate.for_store(current_store)
   amount_due = @transaction.total_cents
   change_cents = tender&.change_cents
+  completion_recovery = @ui_mode == "completion_failed" || (@ui_mode == "completion_pending" && !@auto_complete)
+  quantity_enabled = @selected_line && @ui_mode == "sale_entry"
+  tender_enabled = merchandise_present && @ui_mode == "sale_entry"
+  remove_enabled = @selected_line && @ui_mode == "sale_entry"
+  command_inputmode =
+    if @ui_mode == "quantity"
+      "numeric"
+    elsif @ui_mode == "tender"
+      "decimal"
+    else
+      "text"
+    end
+  command_label =
+    if @ui_mode == "quantity" && @selected_line
+      "#{pos_line_description(@selected_line)} · Current quantity #{@selected_line.quantity}"
+    elsif @ui_mode == "tender"
+      "Amount due #{format_money_cents(amount_due)}. Cash presented"
+    elsif locked
+      "Cash presented (locked)"
+    else
+      "Scan or identifier"
+    end
 %>
 
 <div id="pos_workspace"
@@ -17,139 +39,137 @@
      data-register-workspace-mode-value="<%= @ui_mode %>"
      data-register-workspace-auto-complete-value="<%= @auto_complete ? "true" : "false" %>"
      data-action="keydown@document->register-workspace#onKeydown">
-  <header class="pos-header">
-    <div class="pos-header__row">
-      <span>Store  <%= current_store.admin_label %></span>
-      <span>Register  <%= @register.register_number %></span>
-      <span><%= current_user.display_name %></span>
-    </div>
-    <div class="pos-header__date <%= "pos-date-emphasis" if leftover %>">
-      Business date  <%= @session_record.reporting_period.business_date.iso8601 %>
-    </div>
-    <% if leftover %>
-      <p class="pos-banner" role="status">This register is still on business date <%= @session_record.reporting_period.business_date.iso8601 %>.</p>
-    <% end %>
-  </header>
+  <div data-register-workspace-target="chrome">
+    <header class="pos-header">
+      <div class="pos-header__row">
+        <span>Store  <%= current_store.admin_label %></span>
+        <span>Register  <%= @register.register_number %></span>
+        <span><%= current_user.display_name %></span>
+      </div>
+      <div class="pos-header__date <%= "pos-date-emphasis" if leftover %>">
+        Business date  <%= @session_record.reporting_period.business_date.iso8601 %>
+      </div>
+      <% if leftover %>
+        <p class="pos-banner" role="status">This register is still on business date <%= @session_record.reporting_period.business_date.iso8601 %>.</p>
+      <% end %>
+    </header>
 
-  <div class="pos-main">
-    <div id="pos_basket" class="pos-basket">
-      <table class="pos-lines">
-        <thead>
-          <tr>
-            <th>Qty</th>
-            <th>Description</th>
-            <th class="numeric">Unit</th>
-            <th class="numeric">Ext</th>
-          </tr>
-        </thead>
-        <tbody>
-          <% lines.each do |line| %>
-            <tr class="<%= "is-selected" if line.id == selected_id %>"
-                data-line-id="<%= line.id %>"
-                aria-selected="<%= line.id == selected_id %>">
-              <td><%= line.id == selected_id ? ">" : "" %> <%= line.quantity %></td>
-              <td><%= pos_line_description(line) %></td>
-              <td class="numeric"><%= format_money_cents(line.selling_unit_price_cents) %></td>
-              <td class="numeric"><%= format_money_cents(line.extended_selling_amount_cents) %></td>
+    <div class="pos-main">
+      <div id="pos_basket" class="pos-basket">
+        <table class="pos-lines">
+          <thead>
+            <tr>
+              <th>Qty</th>
+              <th>Description</th>
+              <th class="numeric">Unit</th>
+              <th class="numeric">Ext</th>
             </tr>
-          <% end %>
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            <% lines.each do |line| %>
+              <tr class="<%= "is-selected" if line.id == selected_id %>"
+                  data-line-id="<%= line.id %>"
+                  data-quantity="<%= line.quantity %>"
+                  data-description="<%= pos_line_description(line) %>"
+                  aria-selected="<%= line.id == selected_id %>">
+                <td><%= line.id == selected_id ? ">" : "" %> <%= line.quantity %></td>
+                <td><%= pos_line_description(line) %></td>
+                <td class="numeric"><%= format_money_cents(line.selling_unit_price_cents) %></td>
+                <td class="numeric"><%= format_money_cents(line.extended_selling_amount_cents) %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+
+      <aside id="pos_totals" class="pos-totals">
+        <div>Subtotal  <%= format_money_cents(@transaction.subtotal_cents) %></div>
+        <div>Tax  <%= format_money_cents(@transaction.tax_cents) %></div>
+        <div>Total  <%= format_money_cents(@transaction.total_cents) %></div>
+        <% if tender %>
+          <div>Cash presented  <%= format_money_cents(tender.amount_presented_cents) %></div>
+          <div class="pos-totals__change">CHANGE  <%= format_money_cents(change_cents) %></div>
+        <% else %>
+          <div class="pos-totals__due">Amount due  <%= format_money_cents(amount_due) %></div>
+        <% end %>
+      </aside>
     </div>
 
-    <aside id="pos_totals" class="pos-totals">
-      <div>Subtotal  <%= format_money_cents(@transaction.subtotal_cents) %></div>
-      <div>Tax  <%= format_money_cents(@transaction.tax_cents) %></div>
-      <div>Total  <%= format_money_cents(@transaction.total_cents) %></div>
-      <% if tender %>
-        <div>Cash presented  <%= format_money_cents(tender.amount_presented_cents) %></div>
-        <div class="pos-totals__change">CHANGE  <%= format_money_cents(change_cents) %></div>
+    <div id="pos_feedback" class="pos-feedback" role="<%= @feedback.present? ? "alert" : "status" %>" aria-live="<%= @feedback.present? ? "assertive" : "polite" %>">
+      <% if @ui_mode == "completion_pending" && @feedback.blank? %>
+        Completing sale…
+      <% elsif @feedback.present? %>
+        <%= @feedback %>
+        <% if @ui_mode == "completion_failed" %>
+          Tender is kept. Retry does not take Cash again.
+        <% end %>
+      <% end %>
+    </div>
+
+    <div id="pos_command" class="pos-command">
+      <div class="pos-command__mode" data-register-workspace-target="modeLabel"><%= pos_mode_label(@ui_mode) %></div>
+      <label for="pos-command-field" data-register-workspace-target="fieldLabel"><%= command_label %></label>
+      <input id="pos-command-field"
+             class="pos-command__field"
+             data-register-workspace-target="field"
+             value="<%= @command_value %>"
+             inputmode="<%= command_inputmode %>"
+             autocomplete="off"
+             <%= "disabled" if locked || @ui_mode == "completion_pending" %>
+             <%= "autofocus" unless locked || @ui_mode == "completion_failed" || completion_recovery %>>
+    </div>
+
+    <div id="pos_actions" class="pos-actions">
+      <% if completion_recovery %>
+        <button type="button" class="btn" data-action="register-workspace#submitComplete" data-register-workspace-target="retry" autofocus>Retry complete</button>
+        <%= button_to "Return to sale", pos_register_abandon_tender_path, method: :post, params: { lock_version: @transaction.lock_version }, class: "btn btn--secondary" %>
       <% else %>
-        <div class="pos-totals__due">Amount due  <%= format_money_cents(amount_due) %></div>
+        <button type="button" class="btn btn--secondary" data-action="register-workspace#enterQuantity" data-register-workspace-target="quantityButton" <%= "disabled" unless quantity_enabled %>>Quantity (*)</button>
+        <button type="button" class="btn btn--secondary" data-action="register-workspace#enterTender" data-register-workspace-target="tenderButton" <%= "disabled" unless tender_enabled %>>Tender (+)</button>
+        <button type="button" class="btn btn--secondary" data-action="register-workspace#removeSelected" data-register-workspace-target="removeButton" <%= "disabled" unless remove_enabled %>>Remove (F8)</button>
       <% end %>
-    </aside>
-  </div>
+      <button type="button"
+              class="btn btn--danger"
+              data-action="register-workspace#openOverlay"
+              data-register-workspace-target="cancelButton"
+              <%= "disabled" unless cancel_enabled %>>
+        Cancel (F9)
+      </button>
+    </div>
 
-  <div id="pos_feedback" class="pos-feedback" role="<%= @feedback.present? ? "alert" : "status" %>" aria-live="<%= @feedback.present? ? "assertive" : "polite" %>">
-    <% if @ui_mode == "completion_pending" && @feedback.blank? %>
-      Completing sale…
-    <% elsif @feedback.present? %>
-      <%= @feedback %>
-      <% if @ui_mode == "completion_failed" %>
-        Tender is kept. Retry does not take Cash again.
-      <% end %>
+    <%= form_with url: pos_register_merchandise_path, method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "merchandiseForm", turbo: true } } do %>
+      <%= hidden_field_tag :lock_version, @transaction.lock_version %>
+      <%= hidden_field_tag :selected_line_id, selected_id %>
+      <%= hidden_field_tag :identifier, "", data: { register_workspace_target: "identifierInput" } %>
+    <% end %>
+
+    <%= form_with url: pos_register_quantity_path, method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "quantityForm", turbo: true } } do %>
+      <%= hidden_field_tag :lock_version, @transaction.lock_version %>
+      <%= hidden_field_tag :line_id, selected_id, data: { register_workspace_target: "quantityLineInput" } %>
+      <%= hidden_field_tag :quantity, "", data: { register_workspace_target: "quantityInput" } %>
+    <% end %>
+
+    <%= form_with url: pos_register_remove_path, method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "removeForm", turbo: true } } do %>
+      <%= hidden_field_tag :lock_version, @transaction.lock_version %>
+      <%= hidden_field_tag :line_id, selected_id, data: { register_workspace_target: "removeLineInput" } %>
+    <% end %>
+
+    <%= form_with url: pos_register_tender_path, method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "tenderForm", turbo: true } } do %>
+      <%= hidden_field_tag :lock_version, @transaction.lock_version %>
+      <%= hidden_field_tag :amount_presented, "", data: { register_workspace_target: "presentedInput" } %>
+    <% end %>
+
+    <%= form_with url: pos_transaction_complete_path(@transaction), method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "completeForm", turbo: true } } do %>
+      <%= hidden_field_tag :lock_version, @transaction.lock_version %>
+      <%= hidden_field_tag :completion_operation_id, @completion_operation_id %>
+      <%= hidden_field_tag :expected_total_cents, @transaction.total_cents %>
+      <%= hidden_field_tag :amount_presented_cents, tender&.amount_presented_cents %>
+    <% end %>
+
+    <%= form_with url: pos_register_cancel_path, method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "cancelForm", turbo: true } } do %>
+      <%= hidden_field_tag :lock_version, @transaction.lock_version %>
     <% end %>
   </div>
-
-  <div id="pos_command" class="pos-command">
-    <div class="pos-command__mode"><%= pos_mode_label(@ui_mode) %></div>
-    <% if @ui_mode == "quantity" && @selected_line %>
-      <label for="pos-command-field"><%= pos_line_description(@selected_line) %> · Current quantity <%= @selected_line.quantity %></label>
-    <% elsif @ui_mode == "tender" %>
-      <label for="pos-command-field">Amount due <%= format_money_cents(amount_due) %>. Cash presented</label>
-    <% elsif locked %>
-      <label for="pos-command-field">Cash presented (locked)</label>
-    <% else %>
-      <label for="pos-command-field">Scan or identifier</label>
-    <% end %>
-    <input id="pos-command-field"
-           class="pos-command__field"
-           data-register-workspace-target="field"
-           value="<%= @command_value %>"
-           autocomplete="off"
-           <%= "disabled" if locked || @ui_mode == "completion_pending" %>
-           <%= "autofocus" unless locked || @ui_mode == "completion_failed" %>>
-  </div>
-
-  <div id="pos_actions" class="pos-actions">
-    <% if @ui_mode == "completion_failed" %>
-      <button type="button" class="btn" data-action="register-workspace#submitComplete" data-register-workspace-target="retry" autofocus>Retry complete</button>
-      <%= button_to "Return to sale", pos_register_abandon_tender_path, method: :post, params: { lock_version: @transaction.lock_version }, class: "btn btn--secondary" %>
-    <% else %>
-      <button type="button" class="btn btn--secondary" data-action="register-workspace#enterQuantity" <%= "disabled" unless @selected_line && @ui_mode == "sale_entry" %>>Quantity (*)</button>
-      <button type="button" class="btn btn--secondary" data-action="register-workspace#enterTender" <%= "disabled" unless merchandise_present && @ui_mode == "sale_entry" %>>Tender (+)</button>
-      <button type="button" class="btn btn--secondary" data-action="register-workspace#removeSelected" <%= "disabled" unless @selected_line && @ui_mode == "sale_entry" %>>Remove (-)</button>
-    <% end %>
-    <button type="button"
-            class="btn btn--danger"
-            data-action="register-workspace#openOverlay"
-            <%= "disabled" unless cancel_enabled %>>
-      Cancel (F9)
-    </button>
-  </div>
-
-  <%= form_with url: pos_register_merchandise_path, method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "merchandiseForm", turbo: true } } do %>
-    <%= hidden_field_tag :lock_version, @transaction.lock_version %>
-    <%= hidden_field_tag :selected_line_id, selected_id %>
-    <%= hidden_field_tag :identifier, "", data: { register_workspace_target: "identifierInput" } %>
-  <% end %>
-
-  <%= form_with url: pos_register_quantity_path, method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "quantityForm", turbo: true } } do %>
-    <%= hidden_field_tag :lock_version, @transaction.lock_version %>
-    <%= hidden_field_tag :line_id, selected_id, data: { register_workspace_target: "quantityLineInput" } %>
-    <%= hidden_field_tag :quantity, "", data: { register_workspace_target: "quantityInput" } %>
-  <% end %>
-
-  <%= form_with url: pos_register_remove_path, method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "removeForm", turbo: true } } do %>
-    <%= hidden_field_tag :lock_version, @transaction.lock_version %>
-    <%= hidden_field_tag :line_id, selected_id, data: { register_workspace_target: "removeLineInput" } %>
-  <% end %>
-
-  <%= form_with url: pos_register_tender_path, method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "tenderForm", turbo: true } } do %>
-    <%= hidden_field_tag :lock_version, @transaction.lock_version %>
-    <%= hidden_field_tag :amount_presented, "", data: { register_workspace_target: "presentedInput" } %>
-  <% end %>
-
-  <%= form_with url: pos_register_complete_path, method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "completeForm", turbo: true } } do %>
-    <%= hidden_field_tag :lock_version, @transaction.lock_version %>
-    <%= hidden_field_tag :completion_operation_id, @completion_operation_id %>
-    <%= hidden_field_tag :expected_total_cents, @transaction.total_cents %>
-    <%= hidden_field_tag :amount_presented_cents, tender&.amount_presented_cents %>
-  <% end %>
-
-  <%= form_with url: pos_register_cancel_path, method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "cancelForm", turbo: true } } do %>
-    <%= hidden_field_tag :lock_version, @transaction.lock_version %>
-  <% end %>
 
   <div class="pos-overlay"
        id="pos_overlay"
@@ -162,7 +182,7 @@
       <h2 id="pos-cancel-title">Cancel this sale?</h2>
       <p>Lines will not be sold. No receipt. No inventory movement.</p>
       <button type="button" class="btn btn--secondary" data-action="register-workspace#closeOverlay" data-register-workspace-target="dontCancel">Don't cancel (Esc)</button>
-      <button type="button" class="btn btn--danger" data-action="register-workspace#confirmCancel">Cancel sale (F9)</button>
+      <button type="button" class="btn btn--danger" data-action="register-workspace#confirmCancel" data-register-workspace-target="confirmCancel">Cancel sale (F9)</button>
     </div>
   </div>
 </div>

--- a/app/views/pos/workspaces/show.html.erb
+++ b/app/views/pos/workspaces/show.html.erb
@@ -1,0 +1,2 @@
+<% content_for :title, "Register #{@register.register_number}" %>
+<%= render "pos/workspaces/surface" %>

--- a/app/views/pos/workspaces/update.turbo_stream.erb
+++ b/app/views/pos/workspaces/update.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "pos_workspace" do %>
+  <%= render "pos/workspaces/surface" %>
+<% end %>

--- a/bin/importmap
+++ b/bin/importmap
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+
+require_relative "../config/application"
+require "importmap/commands"

--- a/config/ci.rb
+++ b/config/ci.rb
@@ -9,10 +9,8 @@ CI.run do
   step "Security: Importmap vulnerability audit", "bin/importmap audit"
   step "Security: Brakeman code analysis", "bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error"
   step "Tests: Rails", "bin/rails test"
+  step "Tests: System", "bin/rails test:system"
   step "Tests: Seeds", "env RAILS_ENV=test bin/rails db:seed:replant"
-
-  # Optional: Run system tests
-  # step "Tests: System", "bin/rails test:system"
 
   # Optional: set a green GitHub commit status to unblock PR merge.
   # Requires the `gh` CLI and `gh extension install basecamp/gh-signoff`.

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,0 +1,7 @@
+# Pin npm packages by running ./bin/importmap
+
+pin "application"
+pin "@hotwired/turbo-rails", to: "turbo.min.js"
+pin "@hotwired/stimulus", to: "stimulus.min.js"
+pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
+pin_all_from "app/javascript/controllers", under: "controllers"

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,6 +1,7 @@
 # Pin npm packages by running ./bin/importmap
 
 pin "application"
+pin "pos"
 pin "@hotwired/turbo-rails", to: "turbo.min.js"
 pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,8 +87,8 @@ Rails.application.routes.draw do
     post "register/abandon_tender", to: "workspaces#abandon_tender"
     post "register/cancel", to: "workspaces#cancel"
     post "register/tender", to: "workspaces#tender"
-    post "register/complete", to: "workspaces#complete"
     post "register/continue", to: "workspaces#continue"
+    post "transactions/:transaction_id/complete", to: "workspaces#complete", as: :transaction_complete
     get "transactions/:id/completed", to: "completed_transactions#show", as: :completed_transaction
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,5 +77,20 @@ Rails.application.routes.draw do
     resource :inventory_reconciliation, only: %i[show], controller: "inventory_reconciliations"
   end
 
+  namespace :pos do
+    get "register/enter", to: "enters#show", as: :register_enter
+    post "register/enter", to: "enters#create"
+    get "register", to: "workspaces#show", as: :register_workspace
+    post "register/merchandise", to: "workspaces#merchandise"
+    post "register/quantity", to: "workspaces#quantity"
+    post "register/remove", to: "workspaces#remove"
+    post "register/abandon_tender", to: "workspaces#abandon_tender"
+    post "register/cancel", to: "workspaces#cancel"
+    post "register/tender", to: "workspaces#tender"
+    post "register/complete", to: "workspaces#complete"
+    post "register/continue", to: "workspaces#continue"
+    get "transactions/:id/completed", to: "completed_transactions#show", as: :completed_transaction
+  end
+
   root "home#show"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,13 @@ Rails.application.routes.draw do
     post "register/continue", to: "workspaces#continue"
     post "transactions/:transaction_id/complete", to: "workspaces#complete", as: :transaction_complete
     get "transactions/:id/completed", to: "completed_transactions#show", as: :completed_transaction
+    post "register/close", to: "register_closes#create", as: :register_close
+    get "sessions/:id/close", to: "session_closes#show", as: :session_close
+    post "sessions/:id/close", to: "session_closes#create"
+    post "sessions/:id/resume_sales", to: "session_closes#resume_sales", as: :session_resume_sales
+    get "sessions/:id/closed", to: "closed_sessions#show", as: :session_closed
+    post "reporting_periods/:id/finalize", to: "reporting_period_finalizations#create", as: :reporting_period_finalize
+    get "reporting_periods/:id/z", to: "reporting_period_zs#show", as: :reporting_period_z
   end
 
   root "home#show"

--- a/db/migrate/20260817120000_add_one_working_transaction_per_session.rb
+++ b/db/migrate/20260817120000_add_one_working_transaction_per_session.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class AddOneWorkingTransactionPerSession < ActiveRecord::Migration[8.1]
+  INDEX_NAME = "index_pos_transactions_one_working_per_session"
+
+  def up
+    duplicates = connection.select_all(<<~SQL.squish)
+      SELECT pos_session_id::text AS pos_session_id, COUNT(*) AS working_count
+      FROM pos_transactions
+      WHERE status = 'working'
+      GROUP BY pos_session_id
+      HAVING COUNT(*) > 1
+    SQL
+
+    if duplicates.any?
+      details = duplicates.map { |row| "#{row.fetch("pos_session_id")} (#{row.fetch("working_count")})" }.join(", ")
+      raise <<~MSG.squish
+        Cannot add #{INDEX_NAME}: these sessions already have more than one working
+        pos_transaction: #{details}. Resolve the duplicates before migrating;
+        do not pick a survivor automatically.
+      MSG
+    end
+
+    add_index :pos_transactions, :pos_session_id,
+              unique: true,
+              where: "status = 'working'",
+              name: INDEX_NAME
+  end
+
+  def down
+    remove_index :pos_transactions, name: INDEX_NAME
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_17_010000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_17_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -34,7 +34,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_17_010000) do
     t.boolean "system_protected", default: false, null: false
     t.timestamptz "updated_at", null: false
     t.index ["code"], name: "index_adjustment_reasons_on_code", unique: true
-    t.check_constraint "direction::text = ANY (ARRAY['increase'::character varying, 'decrease'::character varying, 'either'::character varying]::text[])", name: "adjustment_reasons_direction_valid"
+    t.check_constraint "direction::text = ANY (ARRAY['increase'::character varying::text, 'decrease'::character varying::text, 'either'::character varying::text])", name: "adjustment_reasons_direction_valid"
   end
 
   create_table "audit_events", id: :uuid, default: nil, force: :cascade do |t|
@@ -147,7 +147,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_17_010000) do
     t.timestamptz "updated_at", null: false
     t.index ["source_id", "operation_type", "idempotency_key"], name: "index_idempotency_operations_on_scope_key", unique: true
     t.check_constraint "status::text <> 'in_flight'::text OR lease_expires_at IS NOT NULL", name: "idempotency_operations_in_flight_has_lease"
-    t.check_constraint "status::text = ANY (ARRAY['in_flight'::character varying, 'completed'::character varying, 'failed'::character varying]::text[])", name: "idempotency_operations_status_valid"
+    t.check_constraint "status::text = ANY (ARRAY['in_flight'::character varying::text, 'completed'::character varying::text, 'failed'::character varying::text])", name: "idempotency_operations_status_valid"
   end
 
   create_table "identifier_registry", id: :uuid, default: nil, force: :cascade do |t|
@@ -164,8 +164,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_17_010000) do
     t.index ["product_variant_id"], name: "index_identifier_registry_active_variant_industry", unique: true, where: "(((identifier_kind)::text = 'variant_industry'::text) AND (retired_at IS NULL))"
     t.index ["product_variant_id"], name: "index_identifier_registry_variant_sku", unique: true, where: "((identifier_kind)::text = 'variant_sku'::text)"
     t.index ["value"], name: "index_identifier_registry_on_value", unique: true
-    t.check_constraint "((product_id IS NOT NULL)::integer + (product_variant_id IS NOT NULL)::integer + (inventory_unit_id IS NOT NULL)::integer) <= 1 AND (retired_at IS NOT NULL OR identifier_kind::text = 'product_primary'::text AND product_id IS NOT NULL AND product_variant_id IS NULL AND inventory_unit_id IS NULL OR (identifier_kind::text = ANY (ARRAY['variant_sku'::character varying, 'variant_industry'::character varying]::text[])) AND product_variant_id IS NOT NULL AND product_id IS NULL AND inventory_unit_id IS NULL OR identifier_kind::text = 'inventory_unit'::text AND inventory_unit_id IS NOT NULL AND product_id IS NULL AND product_variant_id IS NULL)", name: "identifier_registry_owner_matches_kind"
-    t.check_constraint "identifier_kind::text = ANY (ARRAY['product_primary'::character varying, 'variant_sku'::character varying, 'variant_industry'::character varying, 'inventory_unit'::character varying]::text[])", name: "identifier_registry_kind_valid"
+    t.check_constraint "((product_id IS NOT NULL)::integer + (product_variant_id IS NOT NULL)::integer + (inventory_unit_id IS NOT NULL)::integer) <= 1 AND (retired_at IS NOT NULL OR identifier_kind::text = 'product_primary'::text AND product_id IS NOT NULL AND product_variant_id IS NULL AND inventory_unit_id IS NULL OR (identifier_kind::text = ANY (ARRAY['variant_sku'::character varying::text, 'variant_industry'::character varying::text])) AND product_variant_id IS NOT NULL AND product_id IS NULL AND inventory_unit_id IS NULL OR identifier_kind::text = 'inventory_unit'::text AND inventory_unit_id IS NOT NULL AND product_id IS NULL AND product_variant_id IS NULL)", name: "identifier_registry_owner_matches_kind"
+    t.check_constraint "identifier_kind::text = ANY (ARRAY['product_primary'::character varying::text, 'variant_sku'::character varying::text, 'variant_industry'::character varying::text, 'inventory_unit'::character varying::text])", name: "identifier_registry_kind_valid"
     t.check_constraint "value::text ~ '^[0-9]{13}$'::text", name: "identifier_registry_value_shape"
   end
 
@@ -244,7 +244,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_17_010000) do
     t.index ["unit_identifier"], name: "index_inventory_units_on_unit_identifier", unique: true
     t.check_constraint "acquisition_cost_cents >= 0 AND carrying_value_cents >= 0", name: "inventory_units_costs_nonnegative"
     t.check_constraint "lifecycle_state::text = 'on_hand'::text AND removed_at IS NULL OR lifecycle_state::text = 'removed'::text AND removed_at IS NOT NULL", name: "inventory_units_removal_consistency"
-    t.check_constraint "lifecycle_state::text = ANY (ARRAY['on_hand'::character varying, 'removed'::character varying]::text[])", name: "inventory_units_lifecycle_valid"
+    t.check_constraint "lifecycle_state::text = ANY (ARRAY['on_hand'::character varying::text, 'removed'::character varying::text])", name: "inventory_units_lifecycle_valid"
     t.check_constraint "regular_price_cents IS NULL OR regular_price_cents >= 0", name: "inventory_units_regular_price_nonnegative"
     t.check_constraint "unit_identifier::text ~ '^[0-9]{13}$'::text", name: "inventory_units_identifier_shape"
   end
@@ -269,7 +269,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_17_010000) do
     t.index ["reversal_of_id"], name: "index_inventory_valuation_entries_on_reversal_of_id", unique: true, where: "(reversal_of_id IS NOT NULL)"
     t.index ["source_type", "source_id", "effect_sequence"], name: "index_inventory_valuation_entries_on_source_effect", unique: true
     t.check_constraint "effect_sequence >= 0", name: "inventory_valuation_entries_effect_sequence_nonnegative"
-    t.check_constraint "valuation_method::text = ANY (ARRAY['moving_average'::character varying, 'specific_identification'::character varying]::text[])", name: "inventory_valuation_entries_method_valid"
+    t.check_constraint "valuation_method::text = ANY (ARRAY['moving_average'::character varying::text, 'specific_identification'::character varying::text])", name: "inventory_valuation_entries_method_valid"
   end
 
   create_table "merchandise_categories", id: :uuid, default: nil, force: :cascade do |t|
@@ -346,7 +346,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_17_010000) do
     t.integer "schema_version", default: 1, null: false
     t.index ["delivery_status", "created_at"], name: "index_outbox_messages_on_delivery_status_and_created_at"
     t.index ["event_type"], name: "index_outbox_messages_on_event_type"
-    t.check_constraint "delivery_status::text = ANY (ARRAY['pending'::character varying, 'delivered'::character varying, 'failed'::character varying]::text[])", name: "outbox_messages_delivery_status_valid"
+    t.check_constraint "delivery_status::text = ANY (ARRAY['pending'::character varying::text, 'delivered'::character varying::text, 'failed'::character varying::text])", name: "outbox_messages_delivery_status_valid"
   end
 
   create_table "permissions", id: :uuid, default: nil, force: :cascade do |t|
@@ -406,7 +406,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_17_010000) do
     t.index ["source_id", "command_type", "idempotency_key"], name: "index_pos_operations_on_scope_key", unique: true
     t.index ["store_id"], name: "index_pos_operations_on_store_id"
     t.check_constraint "status::text = 'in_flight'::text AND lease_expires_at IS NOT NULL AND envelope IS NULL AND envelope_hash IS NULL AND fact_type IS NULL OR status::text = 'failed'::text AND envelope IS NULL AND envelope_hash IS NULL OR status::text = 'completed'::text AND fact_type IS NOT NULL AND schema_version IS NOT NULL AND pos_transaction_id IS NOT NULL AND envelope IS NOT NULL AND envelope_hash IS NOT NULL AND posted_at IS NOT NULL", name: "pos_operations_status_payload_rules"
-    t.check_constraint "status::text = ANY (ARRAY['in_flight'::character varying, 'completed'::character varying, 'failed'::character varying]::text[])", name: "pos_operations_status_valid"
+    t.check_constraint "status::text = ANY (ARRAY['in_flight'::character varying::text, 'completed'::character varying::text, 'failed'::character varying::text])", name: "pos_operations_status_valid"
   end
 
   create_table "pos_reporting_periods", id: :uuid, default: nil, force: :cascade do |t|
@@ -445,7 +445,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_17_010000) do
     t.check_constraint "finalized_total_cents IS NULL OR finalized_total_cents >= 0", name: "pos_reporting_periods_finalized_total_nonnegative"
     t.check_constraint "finalized_transaction_count IS NULL OR finalized_transaction_count >= 0", name: "pos_reporting_periods_finalized_transaction_count_nonnegative"
     t.check_constraint "status::text = 'open'::text AND closed_at IS NULL AND finalized_by_user_id IS NULL AND finalized_transaction_count IS NULL AND finalized_subtotal_cents IS NULL AND finalized_tax_cents IS NULL AND finalized_total_cents IS NULL AND finalized_cash_payment_cents IS NULL AND finalized_session_count IS NULL AND finalized_opening_float_cents_sum IS NULL AND finalized_closing_expected_cash_cents_sum IS NULL AND finalized_closing_count_cents_sum IS NULL AND finalized_closing_variance_cents_sum IS NULL OR status::text = 'finalized'::text AND closed_at IS NOT NULL AND finalized_by_user_id IS NOT NULL AND finalized_transaction_count IS NOT NULL AND finalized_subtotal_cents IS NOT NULL AND finalized_tax_cents IS NOT NULL AND finalized_total_cents IS NOT NULL AND finalized_cash_payment_cents IS NOT NULL AND finalized_session_count IS NOT NULL AND finalized_opening_float_cents_sum IS NOT NULL AND finalized_closing_expected_cash_cents_sum IS NOT NULL AND finalized_closing_count_cents_sum IS NOT NULL AND finalized_closing_variance_cents_sum IS NOT NULL", name: "pos_reporting_periods_closed_at_matches_status"
-    t.check_constraint "status::text = ANY (ARRAY['open'::character varying, 'finalized'::character varying]::text[])", name: "pos_reporting_periods_status_valid"
+    t.check_constraint "status::text = ANY (ARRAY['open'::character varying::text, 'finalized'::character varying::text])", name: "pos_reporting_periods_status_valid"
   end
 
   create_table "pos_sessions", id: :uuid, default: nil, force: :cascade do |t|
@@ -473,7 +473,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_17_010000) do
     t.check_constraint "closing_variance_cents IS NULL OR closing_variance_cents = (closing_count_cents - closing_expected_cash_cents)", name: "pos_sessions_closing_variance_matches_count"
     t.check_constraint "opening_float_cents >= 0", name: "pos_sessions_opening_float_nonnegative"
     t.check_constraint "status::text = 'open'::text AND closed_at IS NULL AND closing_expected_cash_cents IS NULL AND closing_count_cents IS NULL AND closing_variance_cents IS NULL OR status::text = 'closed'::text AND closed_at IS NOT NULL AND closing_expected_cash_cents IS NOT NULL AND closing_count_cents IS NOT NULL AND closing_variance_cents IS NOT NULL", name: "pos_sessions_closed_at_matches_status"
-    t.check_constraint "status::text = ANY (ARRAY['open'::character varying, 'closed'::character varying]::text[])", name: "pos_sessions_status_valid"
+    t.check_constraint "status::text = ANY (ARRAY['open'::character varying::text, 'closed'::character varying::text])", name: "pos_sessions_status_valid"
   end
 
   create_table "pos_tenders", id: :uuid, default: nil, force: :cascade do |t|
@@ -538,13 +538,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_17_010000) do
     t.timestamptz "updated_at", null: false
     t.index ["cashier_user_id"], name: "index_pos_transactions_on_cashier_user_id"
     t.index ["pos_session_id"], name: "index_pos_transactions_on_pos_session_id"
+    t.index ["pos_session_id"], name: "index_pos_transactions_one_working_per_session", unique: true, where: "((status)::text = 'working'::text)"
     t.index ["register_id"], name: "index_pos_transactions_on_register_id"
     t.index ["reporting_period_id"], name: "index_pos_transactions_on_reporting_period_id"
     t.index ["store_id", "register_id", "receipt_sequence"], name: "index_pos_transactions_receipt_identity", unique: true, where: "(receipt_sequence IS NOT NULL)"
     t.index ["store_id"], name: "index_pos_transactions_on_store_id"
     t.index ["transaction_reference"], name: "index_pos_transactions_on_transaction_reference", unique: true, where: "(transaction_reference IS NOT NULL)"
     t.check_constraint "status::text = 'working'::text AND receipt_sequence IS NULL AND store_number_snapshot IS NULL AND register_number_snapshot IS NULL AND occurred_at IS NULL AND business_date IS NULL AND completed_at IS NULL AND cancelled_at IS NULL OR status::text = 'completed'::text AND receipt_sequence IS NOT NULL AND store_number_snapshot IS NOT NULL AND register_number_snapshot IS NOT NULL AND occurred_at IS NOT NULL AND business_date IS NOT NULL AND completed_at IS NOT NULL AND cancelled_at IS NULL OR status::text = 'cancelled'::text AND receipt_sequence IS NULL AND store_number_snapshot IS NULL AND register_number_snapshot IS NULL AND occurred_at IS NULL AND business_date IS NULL AND completed_at IS NULL AND cancelled_at IS NOT NULL", name: "pos_transactions_status_null_rules"
-    t.check_constraint "status::text = ANY (ARRAY['working'::character varying, 'completed'::character varying, 'cancelled'::character varying]::text[])", name: "pos_transactions_status_valid"
+    t.check_constraint "status::text = ANY (ARRAY['working'::character varying::text, 'completed'::character varying::text, 'cancelled'::character varying::text])", name: "pos_transactions_status_valid"
   end
 
   create_table "product_variants", id: :uuid, default: nil, force: :cascade do |t|

--- a/dev/rails-docker
+++ b/dev/rails-docker
@@ -3,7 +3,12 @@ set -euo pipefail
 
 SERVICE="${RAILS_DOCKER_SERVICE:-web}"
 
-if docker compose ps --status running "$SERVICE" | grep -q "$SERVICE"; then
+needs_browser_image() {
+  local joined="$*"
+  [[ "$joined" == *test:system* || "$joined" == *bin/ci* ]]
+}
+
+if ! needs_browser_image "$@" && docker compose ps --status running "$SERVICE" | grep -q "$SERVICE"; then
   docker compose exec "$SERVICE" "$@"
 else
   docker compose run --rm "$SERVICE" "$@"

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ This directory contains the project’s technical authority, development guidanc
 | [Phase 5 cash register plan](planning/phase4-6-point-of-sale/phase5-cash-register/phase5-plan.md) | Phase 5 cash/Z (slice 1 implemented) and register-workspace contract |
 | [Phase 5 cash register schema](planning/phase4-6-point-of-sale/phase5-cash-register/phase5-schema.md) | Implemented session close snapshots and reporting-period Z aggregates |
 | [Phase 5 register workspace](planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md) | Slice 2 open gate, modes, HTTP/retry, focus, completion receipt vs print |
+| [Phase 5 register workspace UX](planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace-ux.md) | Slice 2 low-fidelity wireframes (focus, keys, Turbo regions) |
 | [POS Phases 4–6 plan](planning/phase4-6-point-of-sale/spec.md) | Multi-phase POS sequencing (foundation → cash register → breadth) |
 | [UX conventions](ux-conventions.md) | Shared admin page anatomy, partials, currency boundaries, palette, and Hotwire deferral |
 | [Development guide](development.md) | Docker-only local setup, PostgreSQL configuration, application commands, and troubleshooting |

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,8 +24,9 @@ This directory contains the project’s technical authority, development guidanc
 | [Receipt identity](planning/phase4-6-point-of-sale/phase4-point-of-sale/receipt-identity.md) | Compact `S…-R…-T…` transaction reference and receipt header forms (ADR-006) |
 | [Register identity](planning/phase4-6-point-of-sale/phase4-point-of-sale/register-identity.md) | Register vs Terminal; pre-Phase-4 `workstations`→`registers` rename (ADR-021) |
 | [POS operation and Core facts](planning/phase4-6-point-of-sale/phase4-point-of-sale/operation-and-core-facts.md) | Canonical envelope vs normalized Core dual authority (ADR-020) |
-| [Phase 5 cash register plan](planning/phase4-6-point-of-sale/phase5-cash-register/phase5-plan.md) | Phase 5 cash/Z (slice 1 locked) and register-UI slices |
+| [Phase 5 cash register plan](planning/phase4-6-point-of-sale/phase5-cash-register/phase5-plan.md) | Phase 5 cash/Z (slice 1 implemented) and register-workspace contract |
 | [Phase 5 cash register schema](planning/phase4-6-point-of-sale/phase5-cash-register/phase5-schema.md) | Implemented session close snapshots and reporting-period Z aggregates |
+| [Phase 5 register workspace](planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md) | Slice 2 open gate, modes, HTTP/retry, focus, completion receipt vs print |
 | [POS Phases 4–6 plan](planning/phase4-6-point-of-sale/spec.md) | Multi-phase POS sequencing (foundation → cash register → breadth) |
 | [UX conventions](ux-conventions.md) | Shared admin page anatomy, partials, currency boundaries, palette, and Hotwire deferral |
 | [Development guide](development.md) | Docker-only local setup, PostgreSQL configuration, application commands, and troubleshooting |

--- a/docs/development.md
+++ b/docs/development.md
@@ -135,9 +135,10 @@ Run the Rails test suite:
 ```sh
 ./dev/rails-docker bin/rails test
 ./dev/rails-docker bin/rails test:system
+./dev/rails-docker bin/ci
 ```
 
-System tests require Chromium in the development image. Rebuild after pulling Dockerfile changes: `docker compose build`.
+System tests and `bin/ci` start a throwaway `web` container so they use Chromium from the image even when `docker compose up` is already serving. Rebuild after pulling Dockerfile changes: `docker compose build`. If system tests still fail with “Linux arm64 is not supported yet by chrome”, the running image is stale — rebuild, then rerun `./dev/rails-docker bin/rails test:system`.
 
 Run the other checks enforced by CI:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -134,7 +134,10 @@ Run the Rails test suite:
 
 ```sh
 ./dev/rails-docker bin/rails test
+./dev/rails-docker bin/rails test:system
 ```
+
+System tests require Chromium in the development image. Rebuild after pulling Dockerfile changes: `docker compose build`.
 
 Run the other checks enforced by CI:
 

--- a/docs/planning/phase4-6-point-of-sale/phase4-point-of-sale/phase4-schema.md
+++ b/docs/planning/phase4-6-point-of-sale/phase4-point-of-sale/phase4-schema.md
@@ -172,6 +172,7 @@ One row for working and completed (or cancelled) commercial state.
 - Completed and cancelled rows are application-readonly (`readonly?`); no generic update/delete of completed facts. Child lines, tenders, and tax components are readonly when the parent is not working. Completed `pos_operations` are readonly.
 - Cancelled working transactions create no receipt and no Inventory effect.
 - No Phase 4 `inventory_unit_id` on the header.
+- At most one `working` row per Session: partial unique index `index_pos_transactions_one_working_per_session` on `(pos_session_id) WHERE status = 'working'`. `StartTransaction` rejects a second working row. `ResumeOrStartTransaction` resumes or creates.
 
 ---
 
@@ -400,6 +401,7 @@ Do not invent a POS-only domain `source_type` string unless a global inventory A
 - Partial unique `(register_id) WHERE status = 'open'` on `pos_reporting_periods`.
 - Partial unique `(register_id) WHERE status = 'open'` on `pos_sessions`.
 - Unique `(store_id, register_id, receipt_sequence)` where sequence is not null.
+- Partial unique `(pos_session_id) WHERE status = 'working'` on `pos_transactions` (`index_pos_transactions_one_working_per_session`). Completed and cancelled history does not block a later working row.
 - Unique `(store_id, register_number)` on `registers`.
 - Unique `(pos_transaction_id, line_number)` on lines; CHECK `quantity > 0`.
 - Unique `(pos_transaction_line_id, store_tax_id)` on tax components; nonnegative CHECKs on basis/tax cents.

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/README.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/README.md
@@ -1,12 +1,13 @@
 # Phase 5 — First Operational Cash Register
 
-**Status:** Slice 1 (headless cash / Z) locked. Register workspace and receipt/Z screens are later slices.
+**Status:** Slice 1 (headless cash / Z) implemented. Slice 2 HTTP/interaction contract locked; workspace UI not implemented.
 
 | Document | Purpose |
 |---|---|
 | [phase5-plan.md](phase5-plan.md) | Scope, locked decisions, slices, acceptance |
 | [phase5-schema.md](phase5-schema.md) | Session cash columns and reporting-period Z snapshots |
+| [register-workspace.md](register-workspace.md) | Slice 2 open gate, modes, HTTP/retry, focus, completion receipt vs print |
 
 Parent multi-phase sequencing: [../spec.md](../spec.md). Phase 4 completion kernel: [../phase4-point-of-sale/](../phase4-point-of-sale/).
 
-Where this packet and `../spec.md` §5 disagree on cash columns, expected-cash formula, Z snapshots, or authorization, **prefer this packet**.
+Where this packet and `../spec.md` disagree on cash columns, expected-cash formula, Z snapshots, authorization, or the register workspace interaction contract, **prefer this packet**.

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/README.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/README.md
@@ -1,12 +1,13 @@
 # Phase 5 — First Operational Cash Register
 
-**Status:** Slice 1 (headless cash / Z) implemented. Slice 2 HTTP/interaction contract locked; workspace UI not implemented.
+**Status:** Slice 1 (headless cash / Z) implemented. Slice 2 HTTP/domain contract locked; interaction wireframes drafted; workspace UI not implemented.
 
 | Document | Purpose |
 |---|---|
 | [phase5-plan.md](phase5-plan.md) | Scope, locked decisions, slices, acceptance |
 | [phase5-schema.md](phase5-schema.md) | Session cash columns and reporting-period Z snapshots |
 | [register-workspace.md](register-workspace.md) | Slice 2 open gate, modes, HTTP/retry, focus, completion receipt vs print |
+| [register-workspace-ux.md](register-workspace-ux.md) | Slice 2 low-fidelity wireframes (focus, Enter/Escape, shortcuts, Turbo regions) |
 
 Parent multi-phase sequencing: [../spec.md](../spec.md). Phase 4 completion kernel: [../phase4-point-of-sale/](../phase4-point-of-sale/).
 

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/README.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/README.md
@@ -1,6 +1,6 @@
 # Phase 5 — First Operational Cash Register
 
-**Status:** Slice 1 (headless cash / Z) implemented. Slice 2 HTTP/domain contract locked; interaction wireframes drafted; workspace UI not implemented.
+**Status:** Slice 1 (headless cash / Z) implemented. Slice 2 Register workspace implemented. Slice 3 print and close/Z screens remain.
 
 | Document | Purpose |
 |---|---|

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/README.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/README.md
@@ -1,6 +1,6 @@
 # Phase 5 — First Operational Cash Register
 
-**Status:** Slice 1 (headless cash / Z) implemented. Slice 2 Register workspace implemented. Slice 3 print and close/Z screens remain.
+**Status:** Slice 1 (headless cash / Z) implemented. Slice 2 Register workspace implemented. Slice 3 print and close/Z screens implemented.
 
 | Document | Purpose |
 |---|---|
@@ -8,6 +8,8 @@
 | [phase5-schema.md](phase5-schema.md) | Session cash columns and reporting-period Z snapshots |
 | [register-workspace.md](register-workspace.md) | Slice 2 open gate, modes, HTTP/retry, focus, completion receipt vs print |
 | [register-workspace-ux.md](register-workspace-ux.md) | Slice 2 low-fidelity wireframes (focus, Enter/Escape, shortcuts, Turbo regions) |
+| [close-z-screens.md](close-z-screens.md) | Slice 3 print, blind close, enter-gate Z, HTTP/auth/retry |
+| [close-z-screens-ux.md](close-z-screens-ux.md) | Slice 3 low-fidelity frames (receipt, blind count, closed Session, Z) |
 
 Parent multi-phase sequencing: [../spec.md](../spec.md). Phase 4 completion kernel: [../phase4-point-of-sale/](../phase4-point-of-sale/).
 

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/close-z-screens-ux.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/close-z-screens-ux.md
@@ -1,0 +1,110 @@
+# Phase 5 Slice 3 — Close / Z wireframes
+
+**Status:** Low-fidelity frames for Slice 3 print, blind close, closed Session, and finalized Z. HTTP/domain contract stays in [close-z-screens.md](close-z-screens.md).
+
+Do not reuse admin chrome. Money display uses `format_money_cents`; money entry uses decimal strings parsed by `Money::ParseCents`.
+
+---
+
+## Frame 1 — Completed receipt
+
+On-screen confirmation. Printed header format is **not** required here.
+
+```text
+Store 1 · Register 2 · Cashier
+Business date 2026-08-17
+
+SALE COMPLETE
+S001-R02-T0000123
+
+Total             $41.99
+Cash presented    $50.00
+Change              $8.01
+
+[ Print receipt ] [ New sale ] [ Close register ]
+```
+
+| Annotation | Meaning |
+|---|---|
+| Focused element | Heading / first action in tab order. Document Enter is a no-op |
+| Next Enter | Nothing. Scanner must not print, start a new sale, or close |
+| Visible equivalents | Print receipt, New sale, Close register |
+| Print | `window.print()` only; `@media print` hides these actions and POS chrome |
+| Printed identity | `Store: 001   Reg: 02   Trans: 0000123` from transaction snapshots |
+
+---
+
+## Frame 2 — Blind close
+
+```text
+Store 1 · Register 2
+Business date 2026-08-17
+
+CLOSE REGISTER
+
+Count all Cash currently in the register.
+
+Closing Cash count
+[____________________]   [FOCUS]
+
+[ Close session ]
+[ Return to sales ]
+```
+
+No expected amount, variance, opening float, Cash sales, or tender/period totals may appear anywhere — including hidden fields and `data-*` attributes.
+
+| Annotation | Meaning |
+|---|---|
+| Focused element | Closing Cash count |
+| Next Enter | Submit count |
+| Escape / Return to sales | `ResumeOrStartTransaction` → workspace `SALE_ENTRY` |
+| Hidden fields | Session `lock_version` only |
+
+---
+
+## Frame 3 — Closed Session
+
+```text
+SESSION CLOSED
+
+Transactions               14
+Sales total            $241.99
+Cash payments          $241.99
+
+Opening float          $100.00
+Expected Cash          $341.99
+Counted Cash           $340.99
+Variance                -$1.00
+
+[ Finalize Z ]
+[ Leave period open ]
+```
+
+Cash figures are persisted `closing_*` snapshots. Leave period open returns to the enter gate for this Register.
+
+---
+
+## Frame 4 — Finalized Z
+
+```text
+Z REPORT
+Store 001 · Register 02
+Business date 2026-08-17
+
+Transactions               42
+Subtotal             $1,125.00
+Tax                     $72.44
+Total                $1,197.44
+Cash payments        $1,197.44
+
+Sessions                   2
+Opening floats total  $200.00
+Expected closing Cash $1,397.44
+Counted closing Cash  $1,395.44
+Variance                -$2.00
+
+Finalized 18:42
+Finalized by Alex Rivera
+```
+
+Store and Register numbers are the period's identity, not editable names. Session-custody lines are sums of independent Session intervals, not one drawer. Values are persisted `finalized_*` fields. No `Z #123`.

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/close-z-screens.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/close-z-screens.md
@@ -57,7 +57,7 @@ Invariants:
 | Print lifecycle | No `printed_at`, print status, print job, printer record, or acknowledgement |
 | Print failure | Cannot undo or alter a completed transaction |
 | Receipt identity | Printed header uses `store_number_snapshot`, `register_number_snapshot`, and `receipt_sequence` |
-| Close initiation | Separate POST before blind count |
+| Close initiation | Separate POST before blind count; `session_id` is the Session represented by the page |
 | Working transaction cleanup | Empty working transaction may be explicitly cancelled during close initiation |
 | Nonempty sale | Must be completed or cancelled before close begins |
 | GET behavior | No GET may cancel a transaction, close a Session, or finalize a Reporting Period |
@@ -131,7 +131,7 @@ Store: 003   Reg: 02   Trans: 0018427
 
 Values come from the completed transaction snapshots, not current Store/Register configuration. The compact reference may also appear.
 
-Render from completed facts: Store / Reg / Trans, transaction reference, business date, completed timestamp (Store IANA zone), line snapshots, subtotal, tax, total, Cash presented, change.
+Render from completed facts: Store / Reg / Trans, transaction reference, business date, completed timestamp (Store IANA zone), line snapshots, subtotal, tax, total, Cash presented, change. Printed line descriptions use the completed merchandise snapshot only. If that snapshot is missing, render `Description unavailable` — do not substitute current Product metadata.
 
 The ordinary on-screen completion screen does not have to adopt the printed header format.
 
@@ -150,13 +150,21 @@ Do not expose it in `QUANTITY`, `TENDER`, completion-pending, completion-failed,
 
 ```text
 POST /pos/register/close
+  session_id = <Session represented by this page>
 ```
 
-resolves the actor's open Session for the selected Register:
+The POST is bound to that Session. Do not resolve “whatever open Session this cashier currently has on the Register.” A stale receipt or workspace for Session A must not cancel or close Session B.
+
+Load:
+
+```text
+id + current_store + selected Register + Session cashier
+```
 
 | Condition | Result |
 |---|---|
-| No open Session for actor | Redirect enter |
+| Missing / wrong Store / wrong cashier / wrong Register | Not found |
+| Named Session is closed | Redirect that Session's closed summary; never fall forward to a newer Session |
 | Working transaction with merchandise or tender | Reject, return workspace, "Complete or cancel the current sale before closing." |
 | Empty working transaction | `CancelTransaction`, then redirect blind-count GET |
 | No working transaction | Redirect blind-count GET |
@@ -196,11 +204,14 @@ POST /pos/sessions/:id/close
 
 parses the count and calls `Pos::CloseSession`. No Cash calculation belongs in the controller.
 
-| Error | Result |
+Every blind-count error recovery reloads the Session first:
+
+| Authoritative state | Result |
 |---|---|
-| Invalid count | Re-render blind count; preserve entered value; reveal no expected/variance |
-| Stale `lock_version` and Session still open | Reload Session; re-render blind count; preserve typed count; stay blind |
-| Session already closed | Authorize; redirect closed summary; do not call `CloseSession` again |
+| Session already closed | Redirect closed summary; do not call `CloseSession` again |
+| Working transaction exists | Redirect workspace, "Complete or cancel the current sale before closing." |
+| Still open, no working transaction, invalid count | Re-render blind count; preserve entered value; reveal no expected/variance |
+| Still open, no working transaction, stale `lock_version` | Re-render blind count; preserve typed count; stay blind |
 
 ```text
 POST /pos/sessions/:id/resume_sales
@@ -225,10 +236,15 @@ Commercial totals may be exposed through `Pos::SessionTotals` (optional `total_c
 Actions:
 
 ```text
-[ Finalize Z ]   [ Leave period open ]
+period open
+→ Finalize Z
+→ Leave period open
+
+period finalized
+→ View Z
 ```
 
-Leave period open redirects to `GET /pos/register/enter?register_id=...` (Reporting Period open, Session none).
+Leave period open redirects to `GET /pos/register/enter?register_id=...` (Reporting Period open, Session none). View Z is `GET` of the existing finalized Z.
 
 ---
 

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/close-z-screens.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/close-z-screens.md
@@ -1,0 +1,364 @@
+# Phase 5 Slice 3 — Receipt print + blind close / Z
+
+**Status:** Implemented. HTTP/domain contract for Slice 3 print, blind close, and Z screens.
+
+**Authority:** Cashier-facing print, blind Session close, and immutable Z screens. Domain close and finalize remain in Slice 1 (`Pos::CloseSession`, `Pos::FinalizeReportingPeriod`, `Pos::SessionTotals`, `Pos::PeriodTotals`). Selling workspace and on-screen completion remain in [register-workspace.md](register-workspace.md). Receipt identity remains in [receipt-identity.md](../phase4-point-of-sale/receipt-identity.md).
+
+Companions: [phase5-plan.md](phase5-plan.md), [close-z-screens-ux.md](close-z-screens-ux.md).
+
+**Governing principle:** presentation and workflow only. Transaction completion is already authoritative, Session close already owns Cash accountability, and Reporting Period finalization already owns Z snapshots. Slice 3 exposes those boundaries without duplicating their business logic.
+
+No new cash-accountability model, permission, printer abstraction, Z number, or drawer is introduced.
+
+---
+
+## 1. Objective
+
+> Can a cashier complete a Cash sale, optionally print its receipt, close the Register with a genuinely blind Cash count, review the frozen Session close result, and finalize an immutable Z?
+
+```text
+completed sale
+    ↓
+receipt confirmation
+    ├── Print receipt
+    ├── New sale
+    └── Close register
+             ↓
+       blind cash count
+             ↓
+       close Session
+             ↓
+       reveal expected / count / variance
+             ↓
+       Finalize Z
+             ↓
+       immutable Z
+```
+
+Invariants:
+
+* Cash count is entered before expected Cash or variance is exposed.
+* `CloseSession` remains authoritative for expected Cash and variance.
+* Session close and Reporting Period finalization remain separate actions.
+* Closed Session Cash figures are persisted snapshots.
+* Finalized Z figures are persisted snapshots.
+* Receipt printing happens only after commercial completion and cannot affect completion.
+* No GET may cancel a transaction, close a Session, or finalize a Reporting Period.
+
+---
+
+## 2. Locked decisions
+
+| Topic | Decision |
+|---|---|
+| Printing | Browser print is the only supported Phase 5 path |
+| Print trigger | Explicit **Print receipt** action; never automatic on receipt GET |
+| Print authority | Completed immutable transaction facts and receipt snapshots |
+| Print lifecycle | No `printed_at`, print status, print job, printer record, or acknowledgement |
+| Print failure | Cannot undo or alter a completed transaction |
+| Receipt identity | Printed header uses `store_number_snapshot`, `register_number_snapshot`, and `receipt_sequence` |
+| Close initiation | Separate POST before blind count |
+| Working transaction cleanup | Empty working transaction may be explicitly cancelled during close initiation |
+| Nonempty sale | Must be completed or cancelled before close begins |
+| GET behavior | No GET may cancel a transaction, close a Session, or finalize a Reporting Period |
+| Blind close | Count screen contains no expected Cash, variance, opening float, Cash sales, or equivalent derivable values |
+| Closing count | Nonnegative integer cents; `$0.00` is valid |
+| Session close | Existing `Pos::CloseSession`; count in, expected/variance server-derived |
+| Close snapshots | `closing_expected_cash_cents`, `closing_count_cents`, `closing_variance_cents` are authoritative after close |
+| Close vs Z | Closing a Session does not automatically finalize the Reporting Period |
+| Z finalization | Explicit POST through `Pos::FinalizeReportingPeriod` |
+| Z snapshots | Render persisted `finalized_*` fields after finalization |
+| Period with no Session | If an open period has no open Session, the enter gate offers **Finalize Z** or **Open session** |
+| Unused period Z | A period with zero Sessions may be finalized as an all-zero Z (Slice 1 empty-Z rule) |
+| Leave period open | Returns to the enter gate for that Register |
+| Authorization | Close flow: Session cashier + `pos.transact`; Z: `pos.transact` at current Store |
+| Permissions | No new permission key |
+| Period lock on enter Finalize Z | Hidden `expected_lock_version` is the period's `lock_version` |
+| Stale period while still open | Re-render the page they posted from; do not finalize; do not show `finalized_*` |
+| Open session vs Finalize Z | HTTP loser is a re-rendered enter/error, not a 500 |
+| Display timezone | Printed completion time and Z finalized-at use the Store IANA zone (ADR-007) |
+| Z header numbers | Period's Store/Register identity (`store_number` / `register_number`), not editable names |
+| Z number | Deferred |
+| Drawer model | Deferred |
+| Denomination counting | Deferred |
+| Direct printer integration | Deferred |
+
+---
+
+## 3. Routes
+
+```text
+POST /pos/register/close
+GET  /pos/sessions/:id/close
+POST /pos/sessions/:id/close
+POST /pos/sessions/:id/resume_sales
+GET  /pos/sessions/:id/closed
+POST /pos/reporting_periods/:id/finalize
+GET  /pos/reporting_periods/:id/z
+```
+
+Every ID is resolved against `current_store`, following the Slice 2 completed-receipt pattern.
+
+---
+
+## 4. Receipt printing
+
+The Slice 2 completed receipt gains three ordinary actions:
+
+```text
+[ Print receipt ]   [ New sale ]   [ Close register ]
+```
+
+Reached only by explicit completed transaction identity:
+
+```text
+GET /pos/transactions/:id/completed
+```
+
+No printing occurs automatically when this page loads. Document Enter remains a no-op. Scanner input must not print, start a new sale, or close the Register.
+
+**Print receipt** invokes `window.print()` from a small Stimulus action. The browser's native print dialog is the entire Phase 5 print transport.
+
+Do not add `printer_id`, `printed_at`, `print_status`, print jobs, or ESC/POS integration.
+
+### Printed identity and contents
+
+Printed header follows [receipt-identity.md](../phase4-point-of-sale/receipt-identity.md):
+
+```text
+Store: 003   Reg: 02   Trans: 0018427
+```
+
+Values come from the completed transaction snapshots, not current Store/Register configuration. The compact reference may also appear.
+
+Render from completed facts: Store / Reg / Trans, transaction reference, business date, completed timestamp (Store IANA zone), line snapshots, subtotal, tax, total, Cash presented, change.
+
+The ordinary on-screen completion screen does not have to adopt the printed header format.
+
+`@media print` hides POS chrome and the three actions, uses a narrow monochrome receipt format, and avoids reliance on background colors.
+
+---
+
+## 5. Close-register entry and initiation
+
+Close Register is available from:
+
+1. The completed receipt (no working transaction).
+2. Empty `SALE_ENTRY` only: working status, zero lines, no working tender, UI mode `SALE_ENTRY`.
+
+Do not expose it in `QUANTITY`, `TENDER`, completion-pending, completion-failed, or a merchandised basket. Scanner Enter must never activate Close Register.
+
+```text
+POST /pos/register/close
+```
+
+resolves the actor's open Session for the selected Register:
+
+| Condition | Result |
+|---|---|
+| No open Session for actor | Redirect enter |
+| Working transaction with merchandise or tender | Reject, return workspace, "Complete or cancel the current sale before closing." |
+| Empty working transaction | `CancelTransaction`, then redirect blind-count GET |
+| No working transaction | Redirect blind-count GET |
+
+The empty working ticket is disposed of **before** `CloseSession`. Do not weaken `CloseSession`; it continues to reject any working transaction.
+
+Repeat initiate after empty-ticket cancellation is workflow-idempotent: no working transaction remains, so the POST redirects to the same blind-count GET.
+
+---
+
+## 6. Blind count
+
+```text
+GET /pos/sessions/:id/close
+```
+
+is read-only. Require current Store, `pos.transact`, and Session cashier.
+
+| Lifecycle | Result |
+|---|---|
+| Session open + no working transaction | Render blind count |
+| Session open + working transaction | Redirect workspace; do not cancel |
+| Session already closed | Redirect closed Session summary |
+| Wrong Store / wrong cashier / unauthorized | Not found / deny |
+
+GET must never dispose of a working transaction.
+
+The page may display Store, Register, business date, cashier, the count field, **Close session**, and **Return to sales**.
+
+Before the count is submitted, the response must **not contain** expected Cash, variance, opening float, Cash sales, tender totals, transaction totals, or period totals — including visible text, hidden inputs, `data-*` attributes, JavaScript variables, and Turbo metadata.
+
+Closing count: `inputmode="decimal"`, autofocus, parse through `Money::ParseCents`, submit integer cents. `$0.00` is valid; blank, negative, and malformed decimals are invalid. Enter submits the count. Hidden `expected_lock_version` is the **Session** `lock_version`. Do not send expected Cash or variance.
+
+```text
+POST /pos/sessions/:id/close
+```
+
+parses the count and calls `Pos::CloseSession`. No Cash calculation belongs in the controller.
+
+| Error | Result |
+|---|---|
+| Invalid count | Re-render blind count; preserve entered value; reveal no expected/variance |
+| Stale `lock_version` and Session still open | Reload Session; re-render blind count; preserve typed count; stay blind |
+| Session already closed | Authorize; redirect closed summary; do not call `CloseSession` again |
+
+```text
+POST /pos/sessions/:id/resume_sales
+```
+
+invokes `Pos::ResumeOrStartTransaction` and redirects to `GET /pos/register`. No `closing` Session status is needed.
+
+---
+
+## 7. Closed Session summary
+
+```text
+GET /pos/sessions/:id/closed
+```
+
+Session must be closed. Authorization remains current Store, `pos.transact`, and Session cashier.
+
+Only now expose opening float, Cash payments, expected closing Cash, counted Cash, and variance. Cash-close fields are read from persisted `closing_*` columns. Do not recompute expected Cash after close.
+
+Commercial totals may be exposed through `Pos::SessionTotals` (optional `total_cents` helper). Do not calculate business totals in the controller.
+
+Actions:
+
+```text
+[ Finalize Z ]   [ Leave period open ]
+```
+
+Leave period open redirects to `GET /pos/register/enter?register_id=...` (Reporting Period open, Session none).
+
+---
+
+## 8. Enter gate with an open period and no Session
+
+Required for same-day leftover Sessions and leftover periods:
+
+```text
+Register has open Reporting Period
+Register has no open Session
+```
+
+The enter gate presents **Finalize Z** and **Open session**. If the period's business date differs from the Store's current calculated business date, the leftover banner remains conspicuous. Do not limit Z access only to prior-day periods. A period with zero Sessions may be finalized as an all-zero Z.
+
+**Open session** uses the existing Reporting Period, collects a new opening float, opens a Session, and resumes/starts a working transaction. Do not ask the cashier to confirm a new business date.
+
+**Finalize Z** from enter POSTs the period's `expected_lock_version`. Authorization is Store + `pos.transact` (not Session cashier).
+
+| Finalize outcome | Result |
+|---|---|
+| Period open, versions match | `FinalizeReportingPeriod`, redirect Z |
+| Period already finalized | Authorize; redirect existing Z; no second audit |
+| Stale `lock_version` and period still open | Re-render the page they posted from (enter or closed summary); do not show `finalized_*` |
+| Open session vs finalize race | HTTP loser is a re-rendered enter/error, not a 500 |
+
+---
+
+## 9. Finalized Z
+
+```text
+GET /pos/reporting_periods/:id/z
+```
+
+Authorization: current Store + `pos.transact`. Period must be finalized. This screen is immutable.
+
+Phase 5 has no Z sequence number. Identity:
+
+```text
+Z Report
+Store 003
+Register 02
+Business date 2026-08-17
+Finalized 2026-08-17 18:42
+Finalized by Alex Rivera
+```
+
+Store and Register numbers come from the period's Store/Register identity. Finalized-at uses the Store IANA zone.
+
+Render persisted `finalized_*` commercial and Session-custody snapshots only. After finalization, the Z page must not re-query live transaction/session facts as its reporting authority.
+
+Session-custody wording reflects independent Session custody intervals (sums), not one drawer's values.
+
+---
+
+## 10. Authorization matrix
+
+| Action | Store scope | `pos.transact` | Session cashier |
+|---|---:|---:|---:|
+| Print completed receipt | yes | yes | transaction cashier |
+| Initiate close | yes | yes | yes |
+| Blind-count GET | yes | yes | yes |
+| Blind-count POST | yes | yes | yes |
+| Closed Session summary | yes | yes | yes |
+| Return to sales | yes | yes | yes |
+| Finalize Z | yes | yes | no |
+| Finalized Z GET | yes | yes | no |
+
+---
+
+## 11. UI / keyboard
+
+Slice 3 does not need another complex client-side state machine.
+
+| Screen | Enter | Notes |
+|---|---|---|
+| Completed receipt | no-op | Print / New sale / Close register are explicit buttons |
+| Blind count | submit count | Autofocus the count field; do not reuse scanner-key handling |
+| Closed Session / Z | ordinary submit | Turbo/Stimulus optional except the print action |
+
+---
+
+## 12. Acceptance
+
+Slice 3 is complete when:
+
+1. A completed Cash transaction can be printed through one explicit browser-print path.
+2. Printed receipt identity uses completed transaction number snapshots and the accepted `Store / Reg / Trans` format.
+3. Printing cannot alter or reverse a completed transaction.
+4. A cashier can initiate close from a completed receipt or an empty `SALE_ENTRY`.
+5. Close initiation explicitly disposes of an empty working transaction but refuses a nonempty sale.
+6. Refreshing any GET in the close flow performs no commercial mutation.
+7. The closing-count page reveals no value from which expected Cash or variance can be learned.
+8. `$0.00` is accepted as a valid closing count.
+9. `CloseSession` alone derives and persists expected Cash and variance.
+10. Closed Session UI displays persisted `closing_*` values.
+11. Closing a Session does not automatically finalize its Reporting Period.
+12. Leaving the period open returns to the Register enter gate.
+13. An open Reporting Period with no Session can be finalized or resumed with a new Session from that gate, including an unused (zero-session) period.
+14. Finalization uses only `FinalizeReportingPeriod`.
+15. Finalized Z UI renders persisted `finalized_*` fields.
+16. Multi-Session Z language represents sums of independent Session custody intervals rather than a single drawer.
+17. Close/finalize lost-response retries resolve to the already-closed/finalized immutable result.
+18. Authorization follows the locked Session-cashier vs Store-level Z boundary.
+19. Stale still-open period finalize stays on enter/closed-summary and reveals no `finalized_*`.
+20. Display timestamps use the Store IANA zone.
+21. No new persistence model, permission, printer abstraction, Z number, or drawer model is introduced.
+22. All Phase 4/5 unit, integration, concurrency, and required browser tests pass.
+
+---
+
+## 13. Out of this contract
+
+```text
+direct printer / ESC-POS integration
+printer configuration
+print acknowledgement/history
+receipt email/SMS
+receipt search UI
+denomination counting
+cash drawer hardware
+drawer/till entities
+paid-in / paid-out
+cash transfers
+manager approval workflow
+dedicated Z-finalize permission
+Z numbering
+Z printing
+X reports
+reopen Session
+reopen/fix finalized Z
+offline POS
+returns / discounts / post-void
+```

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/phase5-plan.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/phase5-plan.md
@@ -1,6 +1,6 @@
 # Phase 5 — First Operational Cash Register
 
-**Status:** Slice 1 implemented (headless cash accountability and Z finalize). Slice 2 interaction/HTTP contract locked in [register-workspace.md](register-workspace.md); workspace UI is not implemented. Register UX wireframes and Hotwire install are later Slice 2 steps.
+**Status:** Slice 1 implemented (headless cash accountability and Z finalize). Slice 2 HTTP/domain contract locked in [register-workspace.md](register-workspace.md). Interaction wireframes drafted in [register-workspace-ux.md](register-workspace-ux.md). Workspace UI is not implemented.
 
 **Authority**
 
@@ -8,6 +8,7 @@
 |---|---|
 | [Phase 5 schema](phase5-schema.md) | Session cash columns and period Z snapshots |
 | [Register workspace](register-workspace.md) | Slice 2 open gate, modes, HTTP/retry, focus, completion receipt vs print |
+| [Register workspace UX](register-workspace-ux.md) | Slice 2 low-fidelity wireframes (focus, keys, Turbo regions) |
 | [Phase 4 plan](../phase4-point-of-sale/phase4-plan.md) | Completion, receipt allocation, inventory posting |
 | [Receipt identity](../phase4-point-of-sale/receipt-identity.md) | Compact reference and print header form ([ADR-006](../../../adr/ADR-006-receipt-numbering.md)) |
 | [Phases 4–6 plan](../spec.md) | Broader sequencing; this packet supersedes conflicting §5 cash/Z and §5.4–5.11 workspace detail |
@@ -116,19 +117,19 @@ Slice 1 answers the cash-accountability half without screens. Slice 2 is the cas
 - Audit + immutability + concurrency tests
 - No POS screens
 
-### Slice 2 — Register workspace (contract locked; UI not implemented)
+### Slice 2 — Register workspace (HTTP/domain locked; wireframes drafted; UI not implemented)
 
-Authority: [register-workspace.md](register-workspace.md).
+Authority: [register-workspace.md](register-workspace.md). Interaction: [register-workspace-ux.md](register-workspace-ux.md).
 
 - Rails + Importmap + Turbo + Stimulus; system/browser tests required when the workspace is implemented
 - Open gate: confirm calculated business date, opening float, resume or open period/session for the cashier's register
-- At most one working transaction per Session; GET workspace is read-only; `ResumeOrStartTransaction` on POST enter/continue
+- At most one working transaction per Session; GET workspace is read-only (working + tender restores completion-pending; no working transaction → enter; never infer a receipt); `ResumeOrStartTransaction` on POST enter/continue/cancel; `AbandonTender` on Return to sale
 - Persistent primary scan/input; keyboard-first ephemeral `SALE_ENTRY` / `QUANTITY` / `TENDER`
 - Rescan of a compatible SKU increments the existing line in `AddMerchandise`
 - `POST tender` then `POST complete` (not one combined endpoint); completion retry does not re-tender
-- Basket mutation clears working tenders
+- Basket mutation and Return to sale (`AbandonTender`) clear working tenders; Cancel disabled on an empty basket
 - On-screen completion receipt/confirmation from completed facts; no print in this slice
-- Low-fidelity UX wireframes (`register-workspace-ux.md`) before Hotwire implementation
+- Low-fidelity UX wireframes: [register-workspace-ux.md](register-workspace-ux.md) (drafted; review before Hotwire)
 
 ### Slice 3 — Print + close / Z screens
 
@@ -198,7 +199,7 @@ Phase 5 does not introduce session-close or Z-finalize outbox events.
 3. SessionTotals / PeriodTotals (preview vs snapshot)
 4. OpenSession (period lock) / CloseSession (blind) / FinalizeReportingPeriod
 5. Headless and concurrency tests
-6. Slice 2 — lock workspace contract (done) → UX wireframes → domain invariants → Hotwire workspace + system tests
+6. Slice 2 — lock workspace contract (done) → UX wireframes (drafted) → domain invariants → Hotwire workspace + system tests
 7. Slice 3 — receipt print + blind close / Z screens
 ```
 

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/phase5-plan.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/phase5-plan.md
@@ -1,15 +1,16 @@
 # Phase 5 — First Operational Cash Register
 
-**Status:** Slice 1 locked (headless cash accountability and Z finalize). Register UI stack is **not** locked.
+**Status:** Slice 1 implemented (headless cash accountability and Z finalize). Slice 2 interaction/HTTP contract locked in [register-workspace.md](register-workspace.md); workspace UI is not implemented. Register UX wireframes and Hotwire install are later Slice 2 steps.
 
 **Authority**
 
 | Document | Role |
 |---|---|
 | [Phase 5 schema](phase5-schema.md) | Session cash columns and period Z snapshots |
+| [Register workspace](register-workspace.md) | Slice 2 open gate, modes, HTTP/retry, focus, completion receipt vs print |
 | [Phase 4 plan](../phase4-point-of-sale/phase4-plan.md) | Completion, receipt allocation, inventory posting |
 | [Receipt identity](../phase4-point-of-sale/receipt-identity.md) | Compact reference and print header form ([ADR-006](../../../adr/ADR-006-receipt-numbering.md)) |
-| [Phases 4–6 plan](../spec.md) | Broader sequencing; this packet supersedes conflicting §5 cash/Z detail |
+| [Phases 4–6 plan](../spec.md) | Broader sequencing; this packet supersedes conflicting §5 cash/Z and §5.4–5.11 workspace detail |
 | Accepted ADRs | ADR-006, ADR-007, ADR-008, ADR-009, ADR-011, ADR-012, ADR-013, ADR-019, ADR-020, ADR-021 |
 
 Phase 4 is a headless Cash sale. Phase 5 turns that path into a cashier-usable online Rails register. No Terminal table (ADR-021). Offline sales stay out.
@@ -56,7 +57,7 @@ Deliver the minimum shift lifecycle:
 
 > Can a cashier operate an ordinary Cash register through open → sell → close → Z using the Phase 4 completion path?
 
-Slice 1 answers the cash-accountability half without screens. Slices 2–3 add the register workspace and receipt/Z presentation.
+Slice 1 answers the cash-accountability half without screens. Slice 2 is the cashier-facing ordinary sale path plus on-screen completion receipt/confirmation. Slice 3 is printing plus blind close / Z screens.
 
 ---
 
@@ -91,9 +92,14 @@ Slice 1 answers the cash-accountability half without screens. Slices 2–3 add t
 | Drawer table | Deferred (POS-DEC-016). Cash custody is session-scoped |
 | Paid-in / paid-out / transfer | Out of Phase 5 |
 | Outbox | No session-close or Z-finalize outbox events unless a concrete consumer appears. Audit and immutable snapshots are sufficient |
-| UI stack | **Not locked.** Slice 2 locks the UI stack **and** its browser-level testing strategy together. Do not install Importmap / Turbo / Stimulus in slice 1 |
-| Input modes (slice 2) | `SALE_ENTRY`, `QUANTITY`, `TENDER` are **ephemeral UI modes**, not persisted transaction states |
-| Controllers (slices 2–3) | Call Phase 4/5 services only. No receipt allocation or inventory mutation in controllers |
+| UI stack | Rails + Importmap + Turbo + Stimulus for the Register workspace. System/browser tests are required. Not installed until the workspace implementation PR. Contract: [register-workspace.md](register-workspace.md) |
+| Input modes (slice 2) | `SALE_ENTRY`, `QUANTITY`, `TENDER` are **ephemeral UI modes**, not persisted transaction states. Completion-pending after successful `TenderCash` is locked input, not a fourth named mode |
+| One working transaction | Partial unique index `UNIQUE (pos_session_id) WHERE status = 'working'`. `ResumeOrStartTransaction` is the service boundary. GET never creates a transaction |
+| Rescan | Compatible SKU increments the existing line inside `AddMerchandise` |
+| Tender vs complete | Separate `POST tender` and `POST complete`. Completion retries must not call `TenderCash` again |
+| Basket vs tender | `AddMerchandise`, `ChangeQuantity`, and `RemoveWorkingLine` clear working tenders in the same transaction |
+| Slice 2 receipt | On-screen completion receipt/confirmation from immutable completed facts. Print is Slice 3 |
+| Controllers (slices 2–3) | Call Phase 4/5 services only. No receipt allocation or inventory mutation in controllers or Stimulus |
 | Print (slice 3) | Render from immutable completed facts. Proposed path: browser print. Printer failure must not undo completion |
 
 ---
@@ -110,20 +116,23 @@ Slice 1 answers the cash-accountability half without screens. Slices 2–3 add t
 - Audit + immutability + concurrency tests
 - No POS screens
 
-### Slice 2 — Register workspace
+### Slice 2 — Register workspace (contract locked; UI not implemented)
 
-Lock the UI stack and browser-testing strategy in the same change.
+Authority: [register-workspace.md](register-workspace.md).
 
-- If the workspace stays conventional server-rendered Rails, request/integration tests plus manual UX acceptance may suffice.
-- If it adopts Turbo/Stimulus or other meaningful client-side behavior, revisit “system tests deferred.”
-- Confirm the calculated store business date (no free-form date field).
-- Persistent scan/input workspace; quantity correction; working-line removal; cancel.
-- Cash tender and complete through Phase 4 services.
-- Keyboard-first ordinary path using ephemeral `SALE_ENTRY` / `QUANTITY` / `TENDER` modes.
+- Rails + Importmap + Turbo + Stimulus; system/browser tests required when the workspace is implemented
+- Open gate: confirm calculated business date, opening float, resume or open period/session for the cashier's register
+- At most one working transaction per Session; GET workspace is read-only; `ResumeOrStartTransaction` on POST enter/continue
+- Persistent primary scan/input; keyboard-first ephemeral `SALE_ENTRY` / `QUANTITY` / `TENDER`
+- Rescan of a compatible SKU increments the existing line in `AddMerchandise`
+- `POST tender` then `POST complete` (not one combined endpoint); completion retry does not re-tender
+- Basket mutation clears working tenders
+- On-screen completion receipt/confirmation from completed facts; no print in this slice
+- Low-fidelity UX wireframes (`register-workspace-ux.md`) before Hotwire implementation
 
-### Slice 3 — Receipt + close / Z screens
+### Slice 3 — Print + close / Z screens
 
-- Receipt from completed facts; header form in [receipt-identity.md](../phase4-point-of-sale/receipt-identity.md)
+- Print path for the Slice 2 completion receipt; header form in [receipt-identity.md](../phase4-point-of-sale/receipt-identity.md)
 - Print prompt; one supported path; failure does not undo completion
 - Session totals: closed sessions show persisted close snapshots
 - Blind count first; then reveal expected and variance
@@ -189,7 +198,7 @@ Phase 5 does not introduce session-close or Z-finalize outbox events.
 3. SessionTotals / PeriodTotals (preview vs snapshot)
 4. OpenSession (period lock) / CloseSession (blind) / FinalizeReportingPeriod
 5. Headless and concurrency tests
-6. Slice 2 — UI stack + testing strategy + register workspace
+6. Slice 2 — lock workspace contract (done) → UX wireframes → domain invariants → Hotwire workspace + system tests
 7. Slice 3 — receipt print + blind close / Z screens
 ```
 
@@ -216,6 +225,8 @@ A headless scenario can:
 15. `CloseSession` receives only count; expected/variance are server-derived.
 16. Multi-session Z aggregates independent session snapshots (`closing_variance_cents_sum == SUM(session.closing_variance_cents)`) without treating them as one drawer.
 
+Slice 2 acceptance lives in [register-workspace.md](register-workspace.md) §9.
+
 ---
 
 ## 9. Phase 5 acceptance (all slices)
@@ -226,4 +237,4 @@ A cashier can complete [spec.md §5.16](../spec.md) (business date through final
 
 ## 10. Out of Phase 5
 
-Returns, discounts, approvals, suspend/recall, post-void, card / stored value, paid-ins / paid-outs / transfers, drawers, offline Terminal, customer display, Z numbering, close/Z outbox events, a dedicated finalize permission, Hotwire unless slice 2 accepts it together with a browser-testing strategy.
+Returns, discounts, approvals, suspend/recall, post-void, card / stored value, paid-ins / paid-outs / transfers, drawers, offline Terminal, customer display, Z numbering, close/Z outbox events, a dedicated finalize permission.

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/phase5-plan.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/phase5-plan.md
@@ -1,6 +1,6 @@
 # Phase 5 — First Operational Cash Register
 
-**Status:** Slice 1 implemented (headless cash accountability and Z finalize). Slice 2 Register workspace implemented ([register-workspace.md](register-workspace.md)). Interaction wireframes in [register-workspace-ux.md](register-workspace-ux.md). Slice 3 print and close/Z screens remain.
+**Status:** Slice 1 implemented (headless cash accountability and Z finalize). Slice 2 Register workspace implemented; HTTP/browser hardening in progress ([register-workspace.md](register-workspace.md)). Interaction wireframes in [register-workspace-ux.md](register-workspace-ux.md). Slice 3 print and close/Z screens remain.
 
 **Authority**
 
@@ -97,7 +97,7 @@ Slice 1 answers the cash-accountability half without screens. Slice 2 is the cas
 | Input modes (slice 2) | `SALE_ENTRY`, `QUANTITY`, `TENDER` are **ephemeral UI modes**, not persisted transaction states. Completion-pending after successful `TenderCash` is locked input, not a fourth named mode |
 | One working transaction | Partial unique index `UNIQUE (pos_session_id) WHERE status = 'working'`. `StartTransaction` rejects a second working row. `ResumeOrStartTransaction` is the UI-safe boundary. GET never creates a transaction |
 | Rescan | Compatible SKU increments the existing line inside `AddMerchandise` |
-| Tender vs complete | Separate `POST tender` and `POST complete`. Completion retries must not call `TenderCash` again. GET workspace recovery matches a completion operation from **persisted** working transaction + Cash tender |
+| Tender vs complete | Separate `POST tender` and `POST /pos/transactions/:id/complete`. Completion retries must not call `TenderCash` again. GET workspace recovery matches a completion operation from **persisted** working transaction + Cash tender. Unexpired `in_flight` does not auto-submit |
 | Basket vs tender | Shared `clear_working_tenders!` (destroy only; no extra aggregate `save!`). `AddMerchandise`, `ChangeQuantity`, `RemoveWorkingLine`, `AbandonTender`, and `CancelTransaction` clear working tenders in the same database transaction. `AbandonTender` does not bump `lock_version` when there is no tender. Cancelled lines remain; cancelled rows must not keep a provisional Cash tender. Empty-basket cancel is a Slice 2 UI disable; the service may still cancel an empty working transaction |
 | Slice 2 receipt | On-screen completion receipt/confirmation from immutable completed facts. Print is Slice 3 |
 | Controllers (slices 2–3) | Call Phase 4/5 services only. No receipt allocation or inventory mutation in controllers or Stimulus |
@@ -117,20 +117,20 @@ Slice 1 answers the cash-accountability half without screens. Slice 2 is the cas
 - Audit + immutability + concurrency tests
 - No POS screens
 
-### Slice 2 — Register workspace (implemented)
+### Slice 2 — Register workspace (implemented; HTTP/browser hardening in progress)
 
-Authority: [register-workspace.md](register-workspace.md). Interaction: [register-workspace-ux.md](register-workspace-ux.md).
+Authority: [register-workspace.md](register-workspace.md). Interaction: [register-workspace-ux.md](register-workspace-ux.md). Slice 3 remains unimplemented.
 
-- Rails + Importmap + Turbo + Stimulus; system/browser tests required when the workspace is implemented
-- Open gate: confirm calculated business date, opening float, resume or open period/session for the cashier's register
+- Rails + Importmap + Turbo + Stimulus; system/browser tests required
+- Open gate: POST `confirmed_business_date` when opening a new period; opening float; resume or open period/session for the cashier's register
 - At most one working transaction per Session; GET workspace is read-only (working + tender restores completion-pending; no working transaction → enter; never infer a receipt); `ResumeOrStartTransaction` on POST enter/continue/cancel; `AbandonTender` on Return to sale
-- Persistent primary scan/input; keyboard-first ephemeral `SALE_ENTRY` / `QUANTITY` / `TENDER`
+- Persistent primary scan/input; keyboard-first ephemeral `SALE_ENTRY` / `QUANTITY` / `TENDER`; F8 removes the selected line
 - Rescan of a compatible SKU increments the existing line in `AddMerchandise`
-- `POST tender` then `POST complete` (not one combined endpoint); completion retry does not re-tender
+- `POST tender` then `POST /pos/transactions/:id/complete`; unexpired `in_flight` does not auto-submit; completion retry does not re-tender
 - Basket mutation, Return to sale (`AbandonTender`), and `CancelTransaction` clear working tenders; Slice 2 disables Cancel on an empty basket (`CancelTransaction` may still cancel empty)
-- Domain (headless PR, no UI): unique working transaction + preflight; `StartTransaction` stays start-only; `ResumeOrStartTransaction`; `AddMerchandise` rescan merge; `clear_working_tenders!`; `AbandonTender`; `CancelTransaction` tender discard; `FindCompletionOperation` from persisted settlement (re-tender must not restore the old failed operation)
+- Domain: unique working transaction + preflight; `StartTransaction` stays start-only; `ResumeOrStartTransaction`; `AddMerchandise` rescan merge; `clear_working_tenders!`; `AbandonTender`; `CancelTransaction` tender discard; `FindCompletionOperation` from persisted settlement (newest `in_flight`, else newest `failed`)
 - On-screen completion receipt/confirmation from completed facts; no print in this slice
-- Low-fidelity UX wireframes: [register-workspace-ux.md](register-workspace-ux.md) (drafted; review before Hotwire)
+- Low-fidelity UX wireframes: [register-workspace-ux.md](register-workspace-ux.md)
 
 ### Slice 3 — Print + close / Z screens
 

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/phase5-plan.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/phase5-plan.md
@@ -95,10 +95,10 @@ Slice 1 answers the cash-accountability half without screens. Slice 2 is the cas
 | Outbox | No session-close or Z-finalize outbox events unless a concrete consumer appears. Audit and immutable snapshots are sufficient |
 | UI stack | Rails + Importmap + Turbo + Stimulus for the Register workspace. System/browser tests are required. Not installed until the workspace implementation PR. Contract: [register-workspace.md](register-workspace.md) |
 | Input modes (slice 2) | `SALE_ENTRY`, `QUANTITY`, `TENDER` are **ephemeral UI modes**, not persisted transaction states. Completion-pending after successful `TenderCash` is locked input, not a fourth named mode |
-| One working transaction | Partial unique index `UNIQUE (pos_session_id) WHERE status = 'working'`. `ResumeOrStartTransaction` is the service boundary. GET never creates a transaction |
+| One working transaction | Partial unique index `UNIQUE (pos_session_id) WHERE status = 'working'`. `StartTransaction` rejects a second working row. `ResumeOrStartTransaction` is the UI-safe boundary. GET never creates a transaction |
 | Rescan | Compatible SKU increments the existing line inside `AddMerchandise` |
-| Tender vs complete | Separate `POST tender` and `POST complete`. Completion retries must not call `TenderCash` again |
-| Basket vs tender | `AddMerchandise`, `ChangeQuantity`, `RemoveWorkingLine`, `AbandonTender`, and `CancelTransaction` clear working tenders in the same database transaction. Cancelled lines remain; cancelled rows must not keep a provisional Cash tender |
+| Tender vs complete | Separate `POST tender` and `POST complete`. Completion retries must not call `TenderCash` again. GET workspace recovery matches a completion operation from **persisted** working transaction + Cash tender |
+| Basket vs tender | Shared `clear_working_tenders!` (destroy only; no extra aggregate `save!`). `AddMerchandise`, `ChangeQuantity`, `RemoveWorkingLine`, `AbandonTender`, and `CancelTransaction` clear working tenders in the same database transaction. `AbandonTender` does not bump `lock_version` when there is no tender. Cancelled lines remain; cancelled rows must not keep a provisional Cash tender. Empty-basket cancel is a Slice 2 UI disable; the service may still cancel an empty working transaction |
 | Slice 2 receipt | On-screen completion receipt/confirmation from immutable completed facts. Print is Slice 3 |
 | Controllers (slices 2–3) | Call Phase 4/5 services only. No receipt allocation or inventory mutation in controllers or Stimulus |
 | Print (slice 3) | Render from immutable completed facts. Proposed path: browser print. Printer failure must not undo completion |
@@ -127,8 +127,8 @@ Authority: [register-workspace.md](register-workspace.md). Interaction: [registe
 - Persistent primary scan/input; keyboard-first ephemeral `SALE_ENTRY` / `QUANTITY` / `TENDER`
 - Rescan of a compatible SKU increments the existing line in `AddMerchandise`
 - `POST tender` then `POST complete` (not one combined endpoint); completion retry does not re-tender
-- Basket mutation, Return to sale (`AbandonTender`), and `CancelTransaction` clear working tenders; Cancel disabled on an empty basket
-- Domain (before Hotwire): unique working transaction; `ResumeOrStartTransaction`; `AddMerchandise` rescan merge; tender invalidation on basket/`AbandonTender`/`CancelTransaction`; `CancelTransaction` test with a Cash tender (tenders gone, status cancelled, expected Cash unchanged)
+- Basket mutation, Return to sale (`AbandonTender`), and `CancelTransaction` clear working tenders; Slice 2 disables Cancel on an empty basket (`CancelTransaction` may still cancel empty)
+- Domain (headless PR, no UI): unique working transaction + preflight; `StartTransaction` stays start-only; `ResumeOrStartTransaction`; `AddMerchandise` rescan merge; `clear_working_tenders!`; `AbandonTender`; `CancelTransaction` tender discard; `FindCompletionOperation` from persisted settlement (re-tender must not restore the old failed operation)
 - On-screen completion receipt/confirmation from completed facts; no print in this slice
 - Low-fidelity UX wireframes: [register-workspace-ux.md](register-workspace-ux.md) (drafted; review before Hotwire)
 
@@ -227,7 +227,7 @@ A headless scenario can:
 15. `CloseSession` receives only count; expected/variance are server-derived.
 16. Multi-session Z aggregates independent session snapshots (`closing_variance_cents_sum == SUM(session.closing_variance_cents)`) without treating them as one drawer.
 
-Slice 2 acceptance lives in [register-workspace.md](register-workspace.md) §9.
+Slice 2 acceptance lives in [register-workspace.md](register-workspace.md) §10.
 
 ---
 

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/phase5-plan.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/phase5-plan.md
@@ -1,6 +1,6 @@
 # Phase 5 — First Operational Cash Register
 
-**Status:** Slice 1 implemented (headless cash accountability and Z finalize). Slice 2 Register workspace implemented; HTTP/browser hardening in progress ([register-workspace.md](register-workspace.md)). Interaction wireframes in [register-workspace-ux.md](register-workspace-ux.md). Slice 3 print and close/Z screens remain.
+**Status:** Slice 1 implemented (headless cash accountability and Z finalize). Slice 2 Register workspace implemented ([register-workspace.md](register-workspace.md)). Slice 3 print and close/Z screens implemented ([close-z-screens.md](close-z-screens.md); wireframes in [close-z-screens-ux.md](close-z-screens-ux.md)).
 
 **Authority**
 
@@ -9,6 +9,8 @@
 | [Phase 5 schema](phase5-schema.md) | Session cash columns and period Z snapshots |
 | [Register workspace](register-workspace.md) | Slice 2 open gate, modes, HTTP/retry, focus, completion receipt vs print |
 | [Register workspace UX](register-workspace-ux.md) | Slice 2 low-fidelity wireframes (focus, keys, Turbo regions) |
+| [Close / Z screens](close-z-screens.md) | Slice 3 print, blind close, enter-gate Z, HTTP/auth/retry |
+| [Close / Z UX](close-z-screens-ux.md) | Slice 3 low-fidelity frames (receipt, blind count, closed Session, Z) |
 | [Phase 4 plan](../phase4-point-of-sale/phase4-plan.md) | Completion, receipt allocation, inventory posting |
 | [Receipt identity](../phase4-point-of-sale/receipt-identity.md) | Compact reference and print header form ([ADR-006](../../../adr/ADR-006-receipt-numbering.md)) |
 | [Phases 4–6 plan](../spec.md) | Broader sequencing; this packet supersedes conflicting §5 cash/Z and §5.4–5.11 workspace detail |
@@ -101,7 +103,7 @@ Slice 1 answers the cash-accountability half without screens. Slice 2 is the cas
 | Basket vs tender | Shared `clear_working_tenders!` (destroy only; no extra aggregate `save!`). `AddMerchandise`, `ChangeQuantity`, `RemoveWorkingLine`, `AbandonTender`, and `CancelTransaction` clear working tenders in the same database transaction. `AbandonTender` does not bump `lock_version` when there is no tender. Cancelled lines remain; cancelled rows must not keep a provisional Cash tender. Empty-basket cancel is a Slice 2 UI disable; the service may still cancel an empty working transaction |
 | Slice 2 receipt | On-screen completion receipt/confirmation from immutable completed facts. Print is Slice 3 |
 | Controllers (slices 2–3) | Call Phase 4/5 services only. No receipt allocation or inventory mutation in controllers or Stimulus |
-| Print (slice 3) | Render from immutable completed facts. Proposed path: browser print. Printer failure must not undo completion |
+| Print (slice 3) | Browser `window.print()` only; explicit Print receipt action; never print on GET. Failure must not undo completion. Contract: [close-z-screens.md](close-z-screens.md) |
 
 ---
 
@@ -134,11 +136,17 @@ Authority: [register-workspace.md](register-workspace.md). Interaction: [registe
 
 ### Slice 3 — Print + close / Z screens
 
-- Print path for the Slice 2 completion receipt; header form in [receipt-identity.md](../phase4-point-of-sale/receipt-identity.md)
-- Print prompt; one supported path; failure does not undo completion
-- Session totals: closed sessions show persisted close snapshots
-- Blind count first; then reveal expected and variance
-- Finalize and show basic immutable Z from persisted snapshots
+Authority: [close-z-screens.md](close-z-screens.md). Interaction: [close-z-screens-ux.md](close-z-screens-ux.md).
+
+- Print the Slice 2 completion receipt through one explicit browser-print path; header form in [receipt-identity.md](../phase4-point-of-sale/receipt-identity.md)
+- Close Register from the completed receipt or empty `SALE_ENTRY`; initiate POST may cancel an empty working ticket and must not weaken `CloseSession`
+- Blind count GET is read-only and contains no expected Cash, variance, opening float, or tender totals
+- Closed Session UI shows persisted `closing_*` snapshots; close does not finalize the period
+- Enter gate with an open period and no Session offers Finalize Z or Open session (including unused all-zero Z)
+- Finalize through `FinalizeReportingPeriod` only; Z UI renders persisted `finalized_*` fields
+- No new permission, printer model, Z number, or drawer
+
+Slice 3 acceptance lives in [close-z-screens.md](close-z-screens.md) §12.
 
 ---
 
@@ -201,7 +209,7 @@ Phase 5 does not introduce session-close or Z-finalize outbox events.
 4. OpenSession (period lock) / CloseSession (blind) / FinalizeReportingPeriod
 5. Headless and concurrency tests
 6. Slice 2 — lock workspace contract (done) → UX wireframes (drafted) → domain invariants (done) → Hotwire workspace + system tests (done)
-7. Slice 3 — receipt print + blind close / Z screens
+7. Slice 3 — lock close/Z contract (done) → UX wireframes (done) → receipt print + blind close / Z screens (done)
 ```
 
 ---

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/phase5-plan.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/phase5-plan.md
@@ -98,7 +98,7 @@ Slice 1 answers the cash-accountability half without screens. Slice 2 is the cas
 | One working transaction | Partial unique index `UNIQUE (pos_session_id) WHERE status = 'working'`. `ResumeOrStartTransaction` is the service boundary. GET never creates a transaction |
 | Rescan | Compatible SKU increments the existing line inside `AddMerchandise` |
 | Tender vs complete | Separate `POST tender` and `POST complete`. Completion retries must not call `TenderCash` again |
-| Basket vs tender | `AddMerchandise`, `ChangeQuantity`, and `RemoveWorkingLine` clear working tenders in the same transaction |
+| Basket vs tender | `AddMerchandise`, `ChangeQuantity`, `RemoveWorkingLine`, `AbandonTender`, and `CancelTransaction` clear working tenders in the same database transaction. Cancelled lines remain; cancelled rows must not keep a provisional Cash tender |
 | Slice 2 receipt | On-screen completion receipt/confirmation from immutable completed facts. Print is Slice 3 |
 | Controllers (slices 2–3) | Call Phase 4/5 services only. No receipt allocation or inventory mutation in controllers or Stimulus |
 | Print (slice 3) | Render from immutable completed facts. Proposed path: browser print. Printer failure must not undo completion |
@@ -127,7 +127,8 @@ Authority: [register-workspace.md](register-workspace.md). Interaction: [registe
 - Persistent primary scan/input; keyboard-first ephemeral `SALE_ENTRY` / `QUANTITY` / `TENDER`
 - Rescan of a compatible SKU increments the existing line in `AddMerchandise`
 - `POST tender` then `POST complete` (not one combined endpoint); completion retry does not re-tender
-- Basket mutation and Return to sale (`AbandonTender`) clear working tenders; Cancel disabled on an empty basket
+- Basket mutation, Return to sale (`AbandonTender`), and `CancelTransaction` clear working tenders; Cancel disabled on an empty basket
+- Domain (before Hotwire): unique working transaction; `ResumeOrStartTransaction`; `AddMerchandise` rescan merge; tender invalidation on basket/`AbandonTender`/`CancelTransaction`; `CancelTransaction` test with a Cash tender (tenders gone, status cancelled, expected Cash unchanged)
 - On-screen completion receipt/confirmation from completed facts; no print in this slice
 - Low-fidelity UX wireframes: [register-workspace-ux.md](register-workspace-ux.md) (drafted; review before Hotwire)
 

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/phase5-plan.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/phase5-plan.md
@@ -119,9 +119,9 @@ Slice 1 answers the cash-accountability half without screens. Slice 2 is the cas
 - Audit + immutability + concurrency tests
 - No POS screens
 
-### Slice 2 — Register workspace (implemented; HTTP/browser hardening in progress)
+### Slice 2 — Register workspace (implemented)
 
-Authority: [register-workspace.md](register-workspace.md). Interaction: [register-workspace-ux.md](register-workspace-ux.md). Slice 3 remains unimplemented.
+Authority: [register-workspace.md](register-workspace.md). Interaction: [register-workspace-ux.md](register-workspace-ux.md).
 
 - Rails + Importmap + Turbo + Stimulus; system/browser tests required
 - Open gate: POST `confirmed_business_date` when opening a new period; opening float; resume or open period/session for the cashier's register

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/phase5-plan.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/phase5-plan.md
@@ -1,6 +1,6 @@
 # Phase 5 — First Operational Cash Register
 
-**Status:** Slice 1 implemented (headless cash accountability and Z finalize). Slice 2 HTTP/domain contract locked in [register-workspace.md](register-workspace.md). Interaction wireframes drafted in [register-workspace-ux.md](register-workspace-ux.md). Workspace UI is not implemented.
+**Status:** Slice 1 implemented (headless cash accountability and Z finalize). Slice 2 Register workspace implemented ([register-workspace.md](register-workspace.md)). Interaction wireframes in [register-workspace-ux.md](register-workspace-ux.md). Slice 3 print and close/Z screens remain.
 
 **Authority**
 
@@ -93,7 +93,7 @@ Slice 1 answers the cash-accountability half without screens. Slice 2 is the cas
 | Drawer table | Deferred (POS-DEC-016). Cash custody is session-scoped |
 | Paid-in / paid-out / transfer | Out of Phase 5 |
 | Outbox | No session-close or Z-finalize outbox events unless a concrete consumer appears. Audit and immutable snapshots are sufficient |
-| UI stack | Rails + Importmap + Turbo + Stimulus for the Register workspace. System/browser tests are required. Not installed until the workspace implementation PR. Contract: [register-workspace.md](register-workspace.md) |
+| UI stack | Rails + Importmap + Turbo + Stimulus for the Register workspace. System/browser tests are required. Contract: [register-workspace.md](register-workspace.md) |
 | Input modes (slice 2) | `SALE_ENTRY`, `QUANTITY`, `TENDER` are **ephemeral UI modes**, not persisted transaction states. Completion-pending after successful `TenderCash` is locked input, not a fourth named mode |
 | One working transaction | Partial unique index `UNIQUE (pos_session_id) WHERE status = 'working'`. `StartTransaction` rejects a second working row. `ResumeOrStartTransaction` is the UI-safe boundary. GET never creates a transaction |
 | Rescan | Compatible SKU increments the existing line inside `AddMerchandise` |
@@ -117,7 +117,7 @@ Slice 1 answers the cash-accountability half without screens. Slice 2 is the cas
 - Audit + immutability + concurrency tests
 - No POS screens
 
-### Slice 2 — Register workspace (HTTP/domain locked; wireframes drafted; UI not implemented)
+### Slice 2 — Register workspace (implemented)
 
 Authority: [register-workspace.md](register-workspace.md). Interaction: [register-workspace-ux.md](register-workspace-ux.md).
 
@@ -200,7 +200,7 @@ Phase 5 does not introduce session-close or Z-finalize outbox events.
 3. SessionTotals / PeriodTotals (preview vs snapshot)
 4. OpenSession (period lock) / CloseSession (blind) / FinalizeReportingPeriod
 5. Headless and concurrency tests
-6. Slice 2 — lock workspace contract (done) → UX wireframes (drafted) → domain invariants → Hotwire workspace + system tests
+6. Slice 2 — lock workspace contract (done) → UX wireframes (drafted) → domain invariants (done) → Hotwire workspace + system tests (done)
 7. Slice 3 — receipt print + blind close / Z screens
 ```
 

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/phase5-plan.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/phase5-plan.md
@@ -126,7 +126,7 @@ Authority: [register-workspace.md](register-workspace.md). Interaction: [registe
 - At most one working transaction per Session; GET workspace is read-only (working + tender restores completion-pending; no working transaction → enter; never infer a receipt); `ResumeOrStartTransaction` on POST enter/continue/cancel; `AbandonTender` on Return to sale
 - Persistent primary scan/input; keyboard-first ephemeral `SALE_ENTRY` / `QUANTITY` / `TENDER`; F8 removes the selected line
 - Rescan of a compatible SKU increments the existing line in `AddMerchandise`
-- `POST tender` then `POST /pos/transactions/:id/complete`; unexpired `in_flight` does not auto-submit; completion retry does not re-tender
+- `POST tender` then `POST /pos/transactions/:id/complete`; unexpired `in_flight` does not auto-submit and exposes no Retry / Return to sale; completion retry does not re-tender
 - Basket mutation, Return to sale (`AbandonTender`), and `CancelTransaction` clear working tenders; Slice 2 disables Cancel on an empty basket (`CancelTransaction` may still cancel empty)
 - Domain: unique working transaction + preflight; `StartTransaction` stays start-only; `ResumeOrStartTransaction`; `AddMerchandise` rescan merge; `clear_working_tenders!`; `AbandonTender`; `CancelTransaction` tender discard; `FindCompletionOperation` from persisted settlement (newest `in_flight`, else newest `failed`)
 - On-screen completion receipt/confirmation from completed facts; no print in this slice

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace-ux.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace-ux.md
@@ -17,7 +17,7 @@ Each frame annotates:
 | Annotation | Meaning |
 |---|---|
 | Focused element | Where the caret is. `[FOCUS]` in the drawing |
-| Selected line | Which basket row QUANTITY / Delete apply to. `>` in the drawing |
+| Selected line | Which basket row QUANTITY / `-` apply to. `>` in the drawing |
 | Next Enter | What Enter submits |
 | Escape | What Escape does |
 | Shortcuts | Keys that do something **on this frame** |
@@ -49,7 +49,7 @@ Frames 3–7 share this skeleton. Open gate (1–2) and the completed receipt (8
 +--------------------------------------+---------------------------+
 |  pos_feedback   fixed height — errors must not move the field    |
 |  pos_command    mode name + label + one primary field  [FOCUS]   |
-|  pos_actions    Quantity (*)  Tender (+)  Remove  Cancel (F9)    |
+|  pos_actions    Quantity (*)  Tender (+)  Remove (-)  Cancel (F9)|
 +------------------------------------------------------------------+
 |  pos_overlay   cancel confirmation only; absent unless open      |
 +------------------------------------------------------------------+
@@ -254,7 +254,7 @@ No manager takeover in Slice 2. If the store has only this occupied register, th
 |  [                                    ] [FOCUS]                  |
 |                                                                  |
 |  Quantity (*)          Tender (+)     (disabled)                 |
-|  Remove                Cancel (F9)    (disabled)                 |
+|  Remove (-)            Cancel (F9)    (disabled)                 |
 +------------------------------------------------------------------+
 ```
 
@@ -281,7 +281,7 @@ Quantity / Remove idle (no selected line). Tender idle (no merchandise). **Cance
 |  [                                    ] [FOCUS]                  |
 |                                                                  |
 |  Quantity (*)          Tender (+)                                |
-|  Remove                Cancel (F9)                               |
+|  Remove (-)            Cancel (F9)                               |
 +------------------------------------------------------------------+
 ```
 
@@ -291,14 +291,14 @@ Quantity / Remove idle (no selected line). Tender idle (no merchandise). **Cance
 | Selected line | Line returned by last `AddMerchandise` (here the pen). ArrowUp / ArrowDown move selection without leaving the field |
 | Next Enter | Non-empty identifier → `POST merchandise` (`AddMerchandise`). Empty Enter is a no-op. Digits alone are an identifier, not quantity |
 | Escape | Clear the field; stay `SALE_ENTRY` |
-| Shortcuts | `*` quantity (if a line is selected); `+` tender (if merchandise exists); Delete remove selected; F9 cancel overlay; arrows move selection |
-| Visible equivalents | **Quantity (\*)**, **Tender (+)**, **Remove**, **Cancel (F9)** |
+| Shortcuts | `*` quantity (if a line is selected); `+` tender (if merchandise exists); `-` remove selected; F9 cancel overlay; arrows move selection |
+| Visible equivalents | **Quantity (\*)**, **Tender (+)**, **Remove (-)**, **Cancel (F9)** |
 | Error location | `pos_feedback` in the reserved strip above the field (unknown identifier, unsupported merchandise, stale `lock_version`). Basket unchanged. Field coordinates do not change |
 | Turbo region(s) | Streams: `pos_basket`, `pos_totals`, `pos_feedback`, `pos_actions`; `lock_version` in `pos_command`. Focus stays in the field |
 
 Rescan of a compatible SKU increments that line in `AddMerchandise`; the response selects **that** line. Same SKU with a different price/tax context is a new line.
 
-`*` with no selected line is a no-op. `+` with no merchandise is a no-op. Delete with no selected line is a no-op.
+`*` with no selected line is a no-op. `+` with no merchandise is a no-op. `-` with no selected line is a no-op. Delete is native text editing in the command field.
 
 ### 3c. Unknown identifier (error)
 
@@ -336,7 +336,7 @@ Same chrome. Primary field label becomes **Quantity**. Browser state only; trans
 |  [ 2                                  ] [FOCUS]                  |
 |                                                                  |
 |  Quantity (*)          Tender (+)     (idle while in QUANTITY)   |
-|  Remove                Cancel (F9)                               |
+|  Remove (-)            Cancel (F9)                               |
 +------------------------------------------------------------------+
 ```
 
@@ -348,9 +348,9 @@ Pre-fill the selected line's current quantity so Enter without typing is a no-op
 | Selected line | Unchanged (the line QUANTITY applies to). Arrows do not change selection in this mode |
 | Next Enter | `POST quantity` (`ChangeQuantity`, absolute). Success → `SALE_ENTRY`, field cleared, that line still selected |
 | Escape | Abandon; no POST; `SALE_ENTRY`; restore scan label; keep selection |
-| Shortcuts | Enter, Escape, F9 (cancel overlay). `*` / `+` / Delete / arrows ignored while in QUANTITY |
+| Shortcuts | Enter, Escape, F9 (cancel overlay). `*` / `+` / `-` / arrows ignored while in QUANTITY |
 | Visible equivalents | Field itself is the confirm target; **Cancel (F9)** still visible. No separate “OK” required; a visible **Update quantity** next to the field is allowed |
-| Error location | `pos_feedback` in the reserved strip. Quantity `0` is invalid (do not remove from here — Escape, then Delete in `SALE_ENTRY`). Non-numeric: field error, stay QUANTITY. Field does not jump |
+| Error location | `pos_feedback` in the reserved strip. Quantity `0` is invalid (do not remove from here — Escape, then `-` in `SALE_ENTRY`). Non-numeric: field error, stay QUANTITY. Field does not jump |
 | Turbo region(s) | Success streams: `pos_basket`, `pos_totals`, `pos_feedback`, `pos_actions`, `pos_command` (back to scan label). Failure: `pos_feedback` only |
 
 Basket mutation clears any working tender (none expected in this mode).
@@ -381,17 +381,17 @@ Before `TenderCash` succeeds. Same chrome. Primary field label becomes **Cash pr
 |  [                                    ] [FOCUS]                  |
 |                                                                  |
 |  Quantity (*)          Tender (+)     (idle)                     |
-|  Remove                Cancel (F9)                               |
+|  Remove (-)            Cancel (F9)                               |
 +------------------------------------------------------------------+
 ```
 
 | Annotation | |
 |---|---|
 | Focused element | Cash presented |
-| Selected line | Last selected line remains visually selected but is inactive (no Delete / QUANTITY until Escape back to `SALE_ENTRY`) |
+| Selected line | Last selected line remains visually selected but is inactive (no `-` / QUANTITY until Escape back to `SALE_ENTRY`) |
 | Next Enter | `POST tender` only (`TenderCash`). Does **not** complete. On success → frame 6 (Stimulus then `POST complete`) |
 | Escape | Return to `SALE_ENTRY` without tendering; keep basket |
-| Shortcuts | Enter, Escape, F9. `*` / `+` / Delete / arrows ignored |
+| Shortcuts | Enter, Escape, F9. `*` / `+` / `-` / arrows ignored |
 | Visible equivalents | **Charge cash** / **Tender** next to the field; **Cancel (F9)** |
 | Error location | `pos_feedback` in the reserved strip |
 | Turbo region(s) | Success: streams (or morph) into frame 6 — `pos_totals` (change), `pos_command` (disabled), `pos_feedback`, hidden `completion_operation_id`. Failure: `pos_feedback`; field keeps the submitted string |
@@ -439,7 +439,7 @@ Not a fourth named mode. Working transaction **plus** Cash tender. Input locked.
 |  Cash presented (locked)                                         |
 |  [                                    ] (disabled)               |
 |                                                                  |
-|  Quantity (*)  Tender (+)  Remove      (disabled)                |
+|  Quantity (*)  Tender (+)  Remove (-)  (disabled)                |
 |  Cancel (F9)                           (disabled while in flight)|
 +------------------------------------------------------------------+
 ```
@@ -477,7 +477,7 @@ Same layout as 6a, with `pos_feedback` and controls re-enabled for retry / retur
 | Focused element | **Retry complete** |
 | Next Enter | `POST complete` with the **same** `completion_operation_id`, `expected_lock_version`, totals, and presented amount |
 | Escape | Does not silently dump to `SALE_ENTRY`. Use **Return to sale** (`POST abandon_tender`) |
-| Shortcuts | Enter = retry; F9 = cancel overlay. `*` / `+` / Delete ignored |
+| Shortcuts | Enter = retry; F9 = cancel overlay. `*` / `+` / `-` ignored |
 | Visible equivalents | **Retry complete**, **Return to sale**, **Cancel (F9)** |
 | Error location | `pos_feedback` in the reserved strip (inventory, tax, network, stale `lock_version`) |
 | Turbo region(s) | Retry success: full-page that transaction's receipt. Retry failure: `pos_feedback`. Return to sale: `POST abandon_tender` → `SALE_ENTRY` with no working tender. Cancel: overlay → `POST cancel` (`CancelTransaction` discards the tender, then `ResumeOrStartTransaction`) → empty `SALE_ENTRY` |
@@ -517,7 +517,7 @@ No caret in an input. Do not put `[FOCUS]` on a text field. Proposed: focus **Do
 | Selected line | Unchanged underneath; inactive |
 | Next Enter | **Ignored** (barcodes end in Enter) |
 | Escape | Abort overlay; restore prior mode and focus (scan / quantity / cash / retry) |
-| Shortcuts | F9 confirms cancel (`POST cancel`). Alphanumeric keys ignored. `*` / `+` / Delete ignored |
+| Shortcuts | F9 confirms cancel (`POST cancel`). Alphanumeric keys ignored. `*` / `+` / `-` ignored |
 | Visible equivalents | **Don't cancel (Esc)**, **Cancel sale (F9)** |
 | Error location | If `POST cancel` fails, close overlay, `pos_feedback` on the underlying frame, restore focus to primary |
 | Turbo region(s) | Overlay is Stimulus until confirm. Success: `CancelTransaction` discards working tenders, then full-page `SALE_ENTRY` after `ResumeOrStartTransaction`. Do not land on a prior receipt |
@@ -577,7 +577,7 @@ Do **not** default-focus **New sale**. Slice 2: **Enter does nothing** on this p
 | Selected line | n/a (completed lines are a summary, not a working selection) |
 | Next Enter | **No-op.** Does not `POST continue`. Scanner Enter cannot start a sale or drop a barcode |
 | Escape | no-op (do not cancel a completed sale) |
-| Shortcuts | No `*` / `+` / Delete / F9. New sale uses the visible control (optional dedicated non-Enter key) |
+| Shortcuts | No `*` / `+` / `-` / F9. New sale uses the visible control (optional dedicated non-Enter key) |
 | Visible equivalents | **New sale** (prominent). No print control |
 | Error location | If continue fails (session closed, occupancy): message on this page; do not create a working transaction on GET |
 | Turbo region(s) | Full page. Not a Turbo Frame inside the selling surface — a scan must not be interpretable as `AddMerchandise` |
@@ -604,12 +604,12 @@ Render from completed transaction facts (`transaction_reference`, total, Cash pr
 | Escape | Cancel overlay | Abort |
 | `*` | `SALE_ENTRY` only | Quantity (no-op if no selected line) |
 | `+` | `SALE_ENTRY` only | Tender (no-op if no merchandise) |
-| Delete | `SALE_ENTRY` only | Remove selected line |
+| `-` | `SALE_ENTRY` only | Remove selected line |
 | ArrowUp / ArrowDown | `SALE_ENTRY` only | Move selected line |
 | F9 | Selling surface, not in-flight complete, basket has lines | Open cancel overlay |
 | F9 | Cancel overlay | Confirm cancel |
 
-Intercept `*` and `+` on keydown in `SALE_ENTRY` so they never become identifier text. Do not intercept letter keys.
+Intercept `*`, `+`, and `-` on keydown in `SALE_ENTRY` so they never become identifier text. Do not intercept letter keys. Delete is native text editing.
 
 ---
 

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace-ux.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace-ux.md
@@ -480,7 +480,7 @@ Same layout as 6a, with `pos_feedback` and controls re-enabled for retry / retur
 | Shortcuts | Enter = retry; F9 = cancel overlay. `*` / `+` / Delete ignored |
 | Visible equivalents | **Retry complete**, **Return to sale**, **Cancel (F9)** |
 | Error location | `pos_feedback` in the reserved strip (inventory, tax, network, stale `lock_version`) |
-| Turbo region(s) | Retry success: full-page that transaction's receipt. Retry failure: `pos_feedback`. Return to sale: `POST abandon_tender` → `SALE_ENTRY` with no working tender. Cancel: overlay → `POST cancel` → `ResumeOrStartTransaction` → empty `SALE_ENTRY` |
+| Turbo region(s) | Retry success: full-page that transaction's receipt. Retry failure: `pos_feedback`. Return to sale: `POST abandon_tender` → `SALE_ENTRY` with no working tender. Cancel: overlay → `POST cancel` (`CancelTransaction` discards the tender, then `ResumeOrStartTransaction`) → empty `SALE_ENTRY` |
 
 Do not `POST tender` again from this frame. Changing Cash presented: **Return to sale** (clears tender) then `+` / Tender (new `TenderCash`, new token). Refresh after Return to sale stays `SALE_ENTRY`.
 
@@ -520,7 +520,7 @@ No caret in an input. Do not put `[FOCUS]` on a text field. Proposed: focus **Do
 | Shortcuts | F9 confirms cancel (`POST cancel`). Alphanumeric keys ignored. `*` / `+` / Delete ignored |
 | Visible equivalents | **Don't cancel (Esc)**, **Cancel sale (F9)** |
 | Error location | If `POST cancel` fails, close overlay, `pos_feedback` on the underlying frame, restore focus to primary |
-| Turbo region(s) | Overlay is Stimulus until confirm. Success: full-page `SALE_ENTRY` after `ResumeOrStartTransaction`. Do not land on a prior receipt |
+| Turbo region(s) | Overlay is Stimulus until confirm. Success: `CancelTransaction` discards working tenders, then full-page `SALE_ENTRY` after `ResumeOrStartTransaction`. Do not land on a prior receipt |
 
 First F9 opens this overlay. Second F9 confirms. There is no `Y` confirm.
 
@@ -569,15 +569,15 @@ The browser may retain the transaction id it was completing so a lost redirect c
 +------------------------------------------------------------------+
 ```
 
-Do **not** default-focus **New sale** as a control a scanner Enter would activate.
+Do **not** default-focus **New sale**. Slice 2: **Enter does nothing** on this page (no identifier buffer). **New sale** is an explicit control (click, or a dedicated non-Enter shortcut — which key is wireframe-validatable). A later slice may add “scan on receipt → start new sale and add that identifier”; do not implement that orchestration now.
 
 | Annotation | |
 |---|---|
 | Focused element | A non-activating target (heading or status). **New sale** is prominent and in tab order |
 | Selected line | n/a (completed lines are a summary, not a working selection) |
-| Next Enter | Keyboard Enter with **no** preceding identifier characters → `POST continue`. Identifier characters (scanner digits) then Enter → **do not** submit New sale and must not discard the identifier into a new sale. Slice 2 does not auto-start a transaction and add that SKU |
+| Next Enter | **No-op.** Does not `POST continue`. Scanner Enter cannot start a sale or drop a barcode |
 | Escape | no-op (do not cancel a completed sale) |
-| Shortcuts | No `*` / `+` / Delete / F9 |
+| Shortcuts | No `*` / `+` / Delete / F9. New sale uses the visible control (optional dedicated non-Enter key) |
 | Visible equivalents | **New sale** (prominent). No print control |
 | Error location | If continue fails (session closed, occupancy): message on this page; do not create a working transaction on GET |
 | Turbo region(s) | Full page. Not a Turbo Frame inside the selling surface — a scan must not be interpretable as `AddMerchandise` |
@@ -597,7 +597,7 @@ Render from completed transaction facts (`transaction_reference`, total, Cash pr
 | Enter | Completion-pending in flight | Ignored |
 | Enter | Completion error | Retry complete |
 | Enter | Cancel overlay | **Ignored** |
-| Enter | Completed receipt | Keyboard Enter with empty identifier buffer → `POST continue`. Scanner digits then Enter do **not** submit New sale |
+| Enter | Completed receipt | **Ignored** (New sale is the explicit control) |
 | Escape | `SALE_ENTRY` | Clear field |
 | Escape | `QUANTITY` / `TENDER` | Back to `SALE_ENTRY` |
 | Escape | Completion-pending | No silent return |
@@ -634,10 +634,10 @@ These are the interaction questions this pass is for:
 9. Feedback placement in the reserved strip, not a top-of-page admin flash.
 10. Does feedback appear without moving the command field?
 11. Does a long basket scroll independently while command/totals remain fixed?
-12. Return to sale discards the persisted tender (`POST abandon_tender`).
-13. What happens if the cashier scans while the completed receipt is displayed? (Slice 2: do not submit New sale / drop the identifier.)
+12. Return to sale discards the persisted tender (`POST abandon_tender`). Cancel from 6b also discards the tender (`CancelTransaction`).
+13. Completed receipt: Enter is a no-op; New sale is explicit. (Later: scan-on-receipt → new sale + add SKU.) Dedicated non-Enter New sale shortcut?
 14. Is the current mode unmistakable at a glance?
 
-HTTP/domain items 1–4 from the contract pass (no latest-receipt inference; restore matching `operation_id`; `AbandonTender`; empty-basket Cancel disabled) are **locked**, not open UX questions.
+HTTP/domain locks (not open UX questions): no latest-receipt inference; restore matching `operation_id`; `AbandonTender`; empty-basket Cancel disabled; `CancelTransaction` clears working tenders.
 
-Accepting this document (with any of items 1–5, 7, 14 adjusted) is what makes Slice 2 interaction locked enough to implement domain invariants, then Hotwire.
+Accepting this document (with any of items 1–5, 7, 13–14 adjusted) is what makes Slice 2 interaction locked enough to implement domain invariants, then Hotwire.

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace-ux.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace-ux.md
@@ -17,7 +17,7 @@ Each frame annotates:
 | Annotation | Meaning |
 |---|---|
 | Focused element | Where the caret is. `[FOCUS]` in the drawing |
-| Selected line | Which basket row QUANTITY / `-` apply to. `>` in the drawing |
+| Selected line | Which basket row QUANTITY / F8 apply to. `>` in the drawing |
 | Next Enter | What Enter submits |
 | Escape | What Escape does |
 | Shortcuts | Keys that do something **on this frame** |
@@ -49,7 +49,7 @@ Frames 3–7 share this skeleton. Open gate (1–2) and the completed receipt (8
 +--------------------------------------+---------------------------+
 |  pos_feedback   fixed height — errors must not move the field    |
 |  pos_command    mode name + label + one primary field  [FOCUS]   |
-|  pos_actions    Quantity (*)  Tender (+)  Remove (-)  Cancel (F9)|
+|  pos_actions    Quantity (*)  Tender (+)  Remove (F8) Cancel (F9)|
 +------------------------------------------------------------------+
 |  pos_overlay   cancel confirmation only; absent unless open      |
 +------------------------------------------------------------------+
@@ -254,7 +254,7 @@ No manager takeover in Slice 2. If the store has only this occupied register, th
 |  [                                    ] [FOCUS]                  |
 |                                                                  |
 |  Quantity (*)          Tender (+)     (disabled)                 |
-|  Remove (-)            Cancel (F9)    (disabled)                 |
+|  Remove (F8)           Cancel (F9)    (disabled)                 |
 +------------------------------------------------------------------+
 ```
 
@@ -281,7 +281,7 @@ Quantity / Remove idle (no selected line). Tender idle (no merchandise). **Cance
 |  [                                    ] [FOCUS]                  |
 |                                                                  |
 |  Quantity (*)          Tender (+)                                |
-|  Remove (-)            Cancel (F9)                               |
+|  Remove (F8)           Cancel (F9)                               |
 +------------------------------------------------------------------+
 ```
 
@@ -291,14 +291,14 @@ Quantity / Remove idle (no selected line). Tender idle (no merchandise). **Cance
 | Selected line | Line returned by last `AddMerchandise` (here the pen). ArrowUp / ArrowDown move selection without leaving the field |
 | Next Enter | Non-empty identifier → `POST merchandise` (`AddMerchandise`). Empty Enter is a no-op. Digits alone are an identifier, not quantity |
 | Escape | Clear the field; stay `SALE_ENTRY` |
-| Shortcuts | `*` quantity (if a line is selected); `+` tender (if merchandise exists); `-` remove selected; F9 cancel overlay; arrows move selection |
-| Visible equivalents | **Quantity (\*)**, **Tender (+)**, **Remove (-)**, **Cancel (F9)** |
+| Shortcuts | `*` quantity (if a line is selected); `+` tender (if merchandise exists); F8 remove selected; F9 cancel overlay; arrows move selection |
+| Visible equivalents | **Quantity (\*)**, **Tender (+)**, **Remove (F8)**, **Cancel (F9)** |
 | Error location | `pos_feedback` in the reserved strip above the field (unknown identifier, unsupported merchandise, stale `lock_version`). Basket unchanged. Field coordinates do not change |
 | Turbo region(s) | Streams: `pos_basket`, `pos_totals`, `pos_feedback`, `pos_actions`; `lock_version` in `pos_command`. Focus stays in the field |
 
 Rescan of a compatible SKU increments that line in `AddMerchandise`; the response selects **that** line. Same SKU with a different price/tax context is a new line.
 
-`*` with no selected line is a no-op. `+` with no merchandise is a no-op. `-` with no selected line is a no-op. Delete is native text editing in the command field.
+`*` with no selected line is a no-op. `+` with no merchandise is a no-op. F8 with no selected line is a no-op. Delete is native text editing in the command field. Hyphens are identifier text.
 
 ### 3c. Unknown identifier (error)
 
@@ -336,7 +336,7 @@ Same chrome. Primary field label becomes **Quantity**. Browser state only; trans
 |  [ 2                                  ] [FOCUS]                  |
 |                                                                  |
 |  Quantity (*)          Tender (+)     (idle while in QUANTITY)   |
-|  Remove (-)            Cancel (F9)                               |
+|  Remove (F8)           Cancel (F9)                               |
 +------------------------------------------------------------------+
 ```
 
@@ -348,9 +348,9 @@ Pre-fill the selected line's current quantity so Enter without typing is a no-op
 | Selected line | Unchanged (the line QUANTITY applies to). Arrows do not change selection in this mode |
 | Next Enter | `POST quantity` (`ChangeQuantity`, absolute). Success → `SALE_ENTRY`, field cleared, that line still selected |
 | Escape | Abandon; no POST; `SALE_ENTRY`; restore scan label; keep selection |
-| Shortcuts | Enter, Escape, F9 (cancel overlay). `*` / `+` / `-` / arrows ignored while in QUANTITY |
+| Shortcuts | Enter, Escape, F9 (cancel overlay). `*` / `+` / F8 / arrows ignored while in QUANTITY |
 | Visible equivalents | Field itself is the confirm target; **Cancel (F9)** still visible. No separate “OK” required; a visible **Update quantity** next to the field is allowed |
-| Error location | `pos_feedback` in the reserved strip. Quantity `0` is invalid (do not remove from here — Escape, then `-` in `SALE_ENTRY`). Non-numeric: field error, stay QUANTITY. Field does not jump |
+| Error location | `pos_feedback` in the reserved strip. Quantity `0` is invalid (do not remove from here — Escape, then F8 in `SALE_ENTRY`). Non-numeric: field error, stay QUANTITY. Field does not jump |
 | Turbo region(s) | Success streams: `pos_basket`, `pos_totals`, `pos_feedback`, `pos_actions`, `pos_command` (back to scan label). Failure: `pos_feedback` only |
 
 Basket mutation clears any working tender (none expected in this mode).
@@ -381,17 +381,17 @@ Before `TenderCash` succeeds. Same chrome. Primary field label becomes **Cash pr
 |  [                                    ] [FOCUS]                  |
 |                                                                  |
 |  Quantity (*)          Tender (+)     (idle)                     |
-|  Remove (-)            Cancel (F9)                               |
+|  Remove (F8)           Cancel (F9)                               |
 +------------------------------------------------------------------+
 ```
 
 | Annotation | |
 |---|---|
 | Focused element | Cash presented |
-| Selected line | Last selected line remains visually selected but is inactive (no `-` / QUANTITY until Escape back to `SALE_ENTRY`) |
+| Selected line | Last selected line remains visually selected but is inactive (no F8 / QUANTITY until Escape back to `SALE_ENTRY`) |
 | Next Enter | `POST tender` only (`TenderCash`). Does **not** complete. On success → frame 6 (Stimulus then `POST complete`) |
 | Escape | Return to `SALE_ENTRY` without tendering; keep basket |
-| Shortcuts | Enter, Escape, F9. `*` / `+` / `-` / arrows ignored |
+| Shortcuts | Enter, Escape, F9. `*` / `+` / F8 / arrows ignored |
 | Visible equivalents | **Charge cash** / **Tender** next to the field; **Cancel (F9)** |
 | Error location | `pos_feedback` in the reserved strip |
 | Turbo region(s) | Success: streams (or morph) into frame 6 — `pos_totals` (change), `pos_command` (disabled), `pos_feedback`, hidden `completion_operation_id`. Failure: `pos_feedback`; field keeps the submitted string |
@@ -439,7 +439,7 @@ Not a fourth named mode. Working transaction **plus** Cash tender. Input locked.
 |  Cash presented (locked)                                         |
 |  [                                    ] (disabled)               |
 |                                                                  |
-|  Quantity (*)  Tender (+)  Remove (-)  (disabled)                |
+|  Quantity (*)  Tender (+)  Remove (F8) (disabled)                |
 |  Cancel (F9)                           (disabled while in flight)|
 +------------------------------------------------------------------+
 ```
@@ -477,7 +477,7 @@ Same layout as 6a, with `pos_feedback` and controls re-enabled for retry / retur
 | Focused element | **Retry complete** |
 | Next Enter | `POST complete` with the **same** `completion_operation_id`, `expected_lock_version`, totals, and presented amount |
 | Escape | Does not silently dump to `SALE_ENTRY`. Use **Return to sale** (`POST abandon_tender`) |
-| Shortcuts | Enter = retry; F9 = cancel overlay. `*` / `+` / `-` ignored |
+| Shortcuts | Enter = retry; F9 = cancel overlay. `*` / `+` / F8 ignored |
 | Visible equivalents | **Retry complete**, **Return to sale**, **Cancel (F9)** |
 | Error location | `pos_feedback` in the reserved strip (inventory, tax, network, stale `lock_version`) |
 | Turbo region(s) | Retry success: full-page that transaction's receipt. Retry failure: `pos_feedback`. Return to sale: `POST abandon_tender` → `SALE_ENTRY` with no working tender. Cancel: overlay → `POST cancel` (`CancelTransaction` discards the tender, then `ResumeOrStartTransaction`) → empty `SALE_ENTRY` |
@@ -517,7 +517,7 @@ No caret in an input. Do not put `[FOCUS]` on a text field. Proposed: focus **Do
 | Selected line | Unchanged underneath; inactive |
 | Next Enter | **Ignored** (barcodes end in Enter) |
 | Escape | Abort overlay; restore prior mode and focus (scan / quantity / cash / retry) |
-| Shortcuts | F9 confirms cancel (`POST cancel`). Alphanumeric keys ignored. `*` / `+` / `-` ignored |
+| Shortcuts | F9 confirms cancel (`POST cancel`). Alphanumeric keys ignored. `*` / `+` / F8 ignored |
 | Visible equivalents | **Don't cancel (Esc)**, **Cancel sale (F9)** |
 | Error location | If `POST cancel` fails, close overlay, `pos_feedback` on the underlying frame, restore focus to primary |
 | Turbo region(s) | Overlay is Stimulus until confirm. Success: `CancelTransaction` discards working tenders, then full-page `SALE_ENTRY` after `ResumeOrStartTransaction`. Do not land on a prior receipt |
@@ -577,7 +577,7 @@ Do **not** default-focus **New sale**. Slice 2: **Enter does nothing** on this p
 | Selected line | n/a (completed lines are a summary, not a working selection) |
 | Next Enter | **No-op.** Does not `POST continue`. Scanner Enter cannot start a sale or drop a barcode |
 | Escape | no-op (do not cancel a completed sale) |
-| Shortcuts | No `*` / `+` / `-` / F9. New sale uses the visible control (optional dedicated non-Enter key) |
+| Shortcuts | No `*` / `+` / F8 / F9. New sale uses the visible control (optional dedicated non-Enter key) |
 | Visible equivalents | **New sale** (prominent). No print control |
 | Error location | If continue fails (session closed, occupancy): message on this page; do not create a working transaction on GET |
 | Turbo region(s) | Full page. Not a Turbo Frame inside the selling surface — a scan must not be interpretable as `AddMerchandise` |
@@ -604,12 +604,12 @@ Render from completed transaction facts (`transaction_reference`, total, Cash pr
 | Escape | Cancel overlay | Abort |
 | `*` | `SALE_ENTRY` only | Quantity (no-op if no selected line) |
 | `+` | `SALE_ENTRY` only | Tender (no-op if no merchandise) |
-| `-` | `SALE_ENTRY` only | Remove selected line |
+| F8 | `SALE_ENTRY` only | Remove selected line |
 | ArrowUp / ArrowDown | `SALE_ENTRY` only | Move selected line |
 | F9 | Selling surface, not in-flight complete, basket has lines | Open cancel overlay |
 | F9 | Cancel overlay | Confirm cancel |
 
-Intercept `*`, `+`, and `-` on keydown in `SALE_ENTRY` so they never become identifier text. Do not intercept letter keys. Delete is native text editing.
+Intercept `*` and `+` on keydown in `SALE_ENTRY` so they never become identifier text. Do not intercept letter keys or hyphen. Delete is native text editing. F8 removes the selected line.
 
 ---
 

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace-ux.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace-ux.md
@@ -1,0 +1,643 @@
+# Phase 5 Slice 2 — Register workspace wireframes
+
+**Status:** Draft. Low-fidelity interaction proposal. Not implemented. Does not change the HTTP/domain contract in [register-workspace.md](register-workspace.md).
+
+**Purpose:** Validate where the cashier's eyes are, where keyboard focus is, and what the next keystroke does — before Hotwire. Bindings, layout, error placement, and completion-pending presentation are **wireframe-validatable**; changing them here is not an architectural reversal.
+
+HTTP, GET-does-not-mutate, one working transaction, tender/complete split, Rails-issued `completion_operation_id`, and the Slice 2 vs Slice 3 receipt split stay in [register-workspace.md](register-workspace.md).
+
+Do not reuse admin chrome ([ux-conventions.md](../../../ux-conventions.md)). This is a dedicated POS layout. Money display uses `format_money_cents`; money entry uses decimal strings parsed by `Money::ParseCents`.
+
+---
+
+## How to read these frames
+
+Each frame annotates:
+
+| Annotation | Meaning |
+|---|---|
+| Focused element | Where the caret is. `[FOCUS]` in the drawing |
+| Selected line | Which basket row QUANTITY / Delete apply to. `>` in the drawing |
+| Next Enter | What Enter submits |
+| Escape | What Escape does |
+| Shortcuts | Keys that do something **on this frame** |
+| Visible equivalents | Focusable controls for those shortcuts (keyboard-first, not keyboard-only) |
+| Error location | Where the cashier sees failure without hunting |
+| Turbo region(s) | What a successful response replaces. Full-page visits are named as such |
+
+`[FOCUS]` is the only focused control. Visible action buttons are in tab order **after** the primary field. After every successful action and recoverable error, focus returns to the primary field unless the cancel overlay is open.
+
+In-flight (any mutating POST waiting): primary field disabled; a second Enter must not queue another mutation.
+
+Hidden fields (not drawn): `lock_version`; on completion-pending, `completion_operation_id`, `expected_total_cents`, `amount_presented_cents`. Stimulus does not recompute those.
+
+---
+
+## Shared selling chrome
+
+Frames 3–7 share this skeleton. Open gate (1–2) and the completed receipt (8) do **not** include the scan field.
+
+```text
++------------------------------------------------------------------+
+|  pos_header                                                      |
+|  Store  Downtown            Register  2            Alex Rivera   |
+|  Business date  2026-08-17                                       |
++--------------------------------------+---------------------------+
+|  pos_basket  (scrolls)               |  pos_totals  (fixed)      |
+|  lines                               |  subtotal / tax / total   |
+|                                      |  (amount due is largest)  |
++--------------------------------------+---------------------------+
+|  pos_feedback   fixed height — errors must not move the field    |
+|  pos_command    mode name + label + one primary field  [FOCUS]   |
+|  pos_actions    Quantity (*)  Tender (+)  Remove  Cancel (F9)    |
++------------------------------------------------------------------+
+|  pos_overlay   cancel confirmation only; absent unless open      |
++------------------------------------------------------------------+
+```
+
+**Header hierarchy (proposed):** store and register first, cashier on the right, **business date on its own line** and visually heavier than the names. If the period date is not today, `pos_header` adds a full-width banner (see 1c) so a leftover period cannot be missed.
+
+**Stationary command area.** `pos_command` occupies a fixed location. `pos_feedback` reserves a stable height (empty when there is no message). Errors and status must not cause the primary input to jump. System-testable.
+
+**Visible mode indicator.** The same physical field means identifier, quantity, or money. Show the mode name in the command area, not only a changed label:
+
+```text
+SALE ENTRY
+Scan or identifier
+[________________________]
+
+QUANTITY
+Blue gel pen · Current quantity 2
+[ 2______________________]
+
+CASH TENDER
+Amount due $18.36
+Cash presented
+[________________________]
+```
+
+**Primary field stays in the same place** in `SALE_ENTRY`, `QUANTITY`, and `TENDER`. Completion-pending keeps that field visible but disabled.
+
+**Totals stay on the right** and do not scroll. Amount due is the largest figure on the selling surface. After a successful `TenderCash`, that slot becomes **CHANGE**. Label presented cash as **Cash presented**, never bare “Cash” ($20 presented vs $18.36 applied).
+
+**Basket is the scrolling region.** Header, totals, command, feedback, and actions stay put. New/rescanned line becomes selected and is scrolled into view. ArrowUp/ArrowDown keep the selected row visible.
+
+**Line table columns (proposed):** qty, description (name + identifier), unit price, extended. Selected row uses a leading `>` plus a semantic selected state; do not rely on color alone.
+
+**Minimum viewport for system tests:** `1280×720`. Do not discover later that the fixed chrome only fits a developer monitor.
+
+**Accessibility:** [register-workspace.md](register-workspace.md) §9 (`alert` / `aria-live`, selected row, dialog, `disabled`).
+
+**Turbo mapping**
+
+| Region | Updates when |
+|---|---|
+| `pos_header` | Rarely (enter/resume). Not on scan |
+| `pos_basket` | Add / quantity / remove / rescan merge |
+| `pos_totals` | Same as basket; also after tender (change) |
+| `pos_command` | Mode label, enabled/disabled, in-flight |
+| `pos_feedback` | Every error and recoverable status |
+| `pos_actions` | Enable/disable by mode (Tender when merchandise exists; Quantity/Remove when a line is selected; Cancel disabled when the basket is empty or complete is in flight) |
+| `pos_overlay` | Cancel open/close (client-side until confirm POST) |
+
+Merchandise / quantity / remove / tender responses are Turbo Streams that replace `pos_basket`, `pos_totals`, `pos_feedback`, `pos_actions`, and refresh `lock_version` in `pos_command`. Focus restoration is Stimulus, not a full-page visit.
+
+`POST complete` success is a **full-page** visit to `GET /pos/transactions/:id/completed`. `POST continue` / `POST cancel` / `POST abandon_tender` return to `SALE_ENTRY` (cancel and continue via `ResumeOrStartTransaction`; abandon tender stays on the same working transaction).
+
+---
+
+## 1. Open gate — no Session
+
+`GET enter` (read-only). `POST enter` creates period (if needed) and Session, then `ResumeOrStartTransaction`, then redirects to the workspace.
+
+### 1a. No open period (confirm today's date + opening float)
+
+```text
++------------------------------------------------------------------+
+|  Open register                                                   |
+|  Store  Downtown                                                 |
++------------------------------------------------------------------+
+|                                                                  |
+|  Register                                                        |
+|  [ 2 — Front  v ]                                                |
+|                                                                  |
+|  Business date                                                   |
+|  2026-08-17            (calculated; not editable)                |
+|                                                                  |
+|  Opening float                                                   |
+|  $[ 100.00          ]  [FOCUS]                                   |
+|                                                                  |
+|  [ Open register ]                                               |
+|                                                                  |
++------------------------------------------------------------------+
+```
+
+| Annotation | |
+|---|---|
+| Focused element | Opening float (if only one register). Register select if more than one register and none chosen yet |
+| Selected line | n/a |
+| Next Enter | `POST enter` (confirm date by submitting; collect float; open period + Session) |
+| Escape | no-op on this page (or leave to store selection if that control is present — not a POS overlay) |
+| Shortcuts | Enter submits. No `*` / `+` / F9 |
+| Visible equivalents | **Open register** button |
+| Error location | `form_errors` summary at top of this form, plus field error on float / register. Invalid money stays in the field |
+| Turbo region(s) | Full page. Success: redirect `GET workspace`. Failure: re-render this page |
+
+Opening float is required, integer cents ≥ 0, zero allowed. Shown only because this POST will **create** a Session.
+
+If the store has one active register, the select is omitted (or read-only); focus starts on float.
+
+### 1b. Open period exists, no Session (do not re-confirm a new date)
+
+Same form as 1a, except business date is the **period's** date (read-only) and the submit label stays **Open register**. Opening float still required (new Session).
+
+### 1c. Period date is not today
+
+Same as 1b, plus a banner in the page header:
+
+```text
+|  This register's reporting period is 2026-08-16 — not today.     |
+|  Slice 2 resumes it. Close / Z is Slice 3.                       |
+```
+
+Do not offer a date override. Do not open a second period.
+
+### 1d. Resume the actor's own open Session
+
+No opening float (must not change `opening_float_cents`).
+
+```text
++------------------------------------------------------------------+
+|  Open register                                                   |
+|  Store  Downtown                                                 |
++------------------------------------------------------------------+
+|                                                                  |
+|  Register                                                        |
+|  2 — Front                         (this is your open Session)   |
+|                                                                  |
+|  Business date                                                   |
+|  2026-08-17                                                      |
+|                                                                  |
+|  [ Continue ]                      [FOCUS]                       |
+|                                                                  |
++------------------------------------------------------------------+
+```
+
+| Annotation | |
+|---|---|
+| Focused element | **Continue** |
+| Next Enter | `POST enter` → resume Session → `ResumeOrStartTransaction` → workspace |
+| Escape | no-op |
+| Visible equivalents | **Continue** |
+| Error location | Top of this form (occupied race after reload: switch to frame 2) |
+| Turbo region(s) | Full page → workspace |
+
+---
+
+## 2. Open gate — occupied Register
+
+`GET enter` deny. Not a workspace overlay. `POST enter` for this register also denies.
+
+```text
++------------------------------------------------------------------+
+|  Open register                                                   |
+|  Store  Downtown                                                 |
++------------------------------------------------------------------+
+|                                                                  |
+|  Register                                                        |
+|  [ 2 — Front  v ]                  [FOCUS]                       |
+|                                                                  |
+|  Register 2 is open for Jordan Blake.                            |
+|  You cannot enter this Session.                                  |
+|                                                                  |
+|  Choose a different register, or wait until that Session closes. |
+|                                                                  |
+|  [ Open register ]                 (disabled while 2 is selected)|
+|                                                                  |
++------------------------------------------------------------------+
+```
+
+| Annotation | |
+|---|---|
+| Focused element | Register select (cashier can pick another) |
+| Selected line | n/a |
+| Next Enter | If another register is selected and available, `POST enter` for that register. If the occupied one is still selected, Enter does not submit |
+| Escape | no-op |
+| Shortcuts | none of the selling-surface keys |
+| Visible equivalents | Register select; **Open register** enabled only when the selected register is enterable |
+| Error location | Body of this page (the deny sentence). Not a flash on the selling surface |
+| Turbo region(s) | Full page. Changing the select may be a GET (`?register_id=`) so the deny/float/continue state stays read-only until POST |
+
+No manager takeover in Slice 2. If the store has only this occupied register, the cashier cannot enter POS; keep the deny visible.
+
+---
+
+## 3. SALE_ENTRY
+
+`GET workspace` with a working transaction and no Cash tender. Ordinary selling surface.
+
+### 3a. Empty basket (after enter / continue / cancel+resume)
+
+```text
++------------------------------------------------------------------+
+|  Downtown            Register  2                    Alex Rivera  |
+|  Business date  2026-08-17                                       |
++--------------------------------------+---------------------------+
+|                                      |  Subtotal         $0.00   |
+|  Scan to add a line.                 |  Tax              $0.00   |
+|                                      |                           |
+|                                      |  Amount due       $0.00   |
++--------------------------------------+---------------------------+
+|  pos_feedback  (fixed height; empty)                             |
+|  SALE ENTRY                                                      |
+|  Scan or identifier                                              |
+|  [                                    ] [FOCUS]                  |
+|                                                                  |
+|  Quantity (*)          Tender (+)     (disabled)                 |
+|  Remove                Cancel (F9)    (disabled)                 |
++------------------------------------------------------------------+
+```
+
+Quantity / Remove idle (no selected line). Tender idle (no merchandise). **Cancel disabled** — cancel+resume of an empty ticket has no useful effect and still blocks `CloseSession`. Slice 3 can dispose of leftover empty working transactions on leave/close.
+
+### 3b. With lines (selected line = last added / last changed)
+
+```text
++------------------------------------------------------------------+
+|  Downtown            Register  2                    Alex Rivera  |
+|  Business date  2026-08-17                                       |
++--------------------------------------+---------------------------+
+|  Qty  Description              Unit      Ext                     |
+|    1  Graphite notebook        $12.00    $12.00                  |
+|  > 2  Blue gel pen   012345    $2.50     $5.00                   |
+|                                      |  Subtotal        $17.00   |
+|                                      |  Tax              $1.36   |
+|                                      |                           |
+|                                      |  Amount due      $18.36   |
++--------------------------------------+---------------------------+
+|  pos_feedback  (fixed height; empty)                             |
+|  SALE ENTRY                                                      |
+|  Scan or identifier                                              |
+|  [                                    ] [FOCUS]                  |
+|                                                                  |
+|  Quantity (*)          Tender (+)                                |
+|  Remove                Cancel (F9)                               |
++------------------------------------------------------------------+
+```
+
+| Annotation | |
+|---|---|
+| Focused element | Scan or identifier (cleared after each successful add) |
+| Selected line | Line returned by last `AddMerchandise` (here the pen). ArrowUp / ArrowDown move selection without leaving the field |
+| Next Enter | Non-empty identifier → `POST merchandise` (`AddMerchandise`). Empty Enter is a no-op. Digits alone are an identifier, not quantity |
+| Escape | Clear the field; stay `SALE_ENTRY` |
+| Shortcuts | `*` quantity (if a line is selected); `+` tender (if merchandise exists); Delete remove selected; F9 cancel overlay; arrows move selection |
+| Visible equivalents | **Quantity (\*)**, **Tender (+)**, **Remove**, **Cancel (F9)** |
+| Error location | `pos_feedback` in the reserved strip above the field (unknown identifier, unsupported merchandise, stale `lock_version`). Basket unchanged. Field coordinates do not change |
+| Turbo region(s) | Streams: `pos_basket`, `pos_totals`, `pos_feedback`, `pos_actions`; `lock_version` in `pos_command`. Focus stays in the field |
+
+Rescan of a compatible SKU increments that line in `AddMerchandise`; the response selects **that** line. Same SKU with a different price/tax context is a new line.
+
+`*` with no selected line is a no-op. `+` with no merchandise is a no-op. Delete with no selected line is a no-op.
+
+### 3c. Unknown identifier (error)
+
+Same as 3b, with `pos_feedback`:
+
+```text
+|  pos_feedback                                                    |
+|  No sellable item for “XYZ999”.                                  |
+|  SALE ENTRY                                                      |
+|  Scan or identifier                                              |
+|  [ XYZ999                             ] [FOCUS]                  |
+```
+
+Preserve the submitted string. Do not clear the basket. The primary field stays at the same coordinates as 3b.
+
+---
+
+## 4. QUANTITY
+
+Same chrome. Primary field label becomes **Quantity**. Browser state only; transaction stays `working`.
+
+```text
++------------------------------------------------------------------+
+|  Downtown            Register  2                    Alex Rivera  |
+|  Business date  2026-08-17                                       |
++--------------------------------------+---------------------------+
+|  Qty  Description              Unit      Ext                     |
+|    1  Graphite notebook        $12.00    $12.00                  |
+|  > 2  Blue gel pen   012345    $2.50     $5.00                   |
+|                                      |  Amount due      $18.36   |
++--------------------------------------+---------------------------+
+|  pos_feedback  (fixed height; empty)                             |
+|  QUANTITY                                                        |
+|  Blue gel pen · Current quantity 2                               |
+|  [ 2                                  ] [FOCUS]                  |
+|                                                                  |
+|  Quantity (*)          Tender (+)     (idle while in QUANTITY)   |
+|  Remove                Cancel (F9)                               |
++------------------------------------------------------------------+
+```
+
+Pre-fill the selected line's current quantity so Enter without typing is a no-op-or-confirm of the same value (implementation may confirm the same quantity; it must not blank the field).
+
+| Annotation | |
+|---|---|
+| Focused element | Quantity field (same DOM node as scan, new label). Select-all on entry so a scanner-or-type replacement is easy |
+| Selected line | Unchanged (the line QUANTITY applies to). Arrows do not change selection in this mode |
+| Next Enter | `POST quantity` (`ChangeQuantity`, absolute). Success → `SALE_ENTRY`, field cleared, that line still selected |
+| Escape | Abandon; no POST; `SALE_ENTRY`; restore scan label; keep selection |
+| Shortcuts | Enter, Escape, F9 (cancel overlay). `*` / `+` / Delete / arrows ignored while in QUANTITY |
+| Visible equivalents | Field itself is the confirm target; **Cancel (F9)** still visible. No separate “OK” required; a visible **Update quantity** next to the field is allowed |
+| Error location | `pos_feedback` in the reserved strip. Quantity `0` is invalid (do not remove from here — Escape, then Delete in `SALE_ENTRY`). Non-numeric: field error, stay QUANTITY. Field does not jump |
+| Turbo region(s) | Success streams: `pos_basket`, `pos_totals`, `pos_feedback`, `pos_actions`, `pos_command` (back to scan label). Failure: `pos_feedback` only |
+
+Basket mutation clears any working tender (none expected in this mode).
+
+---
+
+## 5. TENDER
+
+Before `TenderCash` succeeds. Same chrome. Primary field label becomes **Cash presented**.
+
+```text
++------------------------------------------------------------------+
+|  Downtown            Register  2                    Alex Rivera  |
+|  Business date  2026-08-17                                       |
++--------------------------------------+---------------------------+
+|  Qty  Description              Unit      Ext                     |
+|    1  Graphite notebook        $12.00    $12.00                  |
+|    2  Blue gel pen   012345    $2.50     $5.00                   |
+|                                      |  Subtotal        $17.00   |
+|                                      |  Tax              $1.36   |
+|                                      |                           |
+|                                      |  Amount due      $18.36   |
++--------------------------------------+---------------------------+
+|  pos_feedback  (fixed height; empty)                             |
+|  CASH TENDER                                                     |
+|  Amount due $18.36                                               |
+|  Cash presented                                                  |
+|  [                                    ] [FOCUS]                  |
+|                                                                  |
+|  Quantity (*)          Tender (+)     (idle)                     |
+|  Remove                Cancel (F9)                               |
++------------------------------------------------------------------+
+```
+
+| Annotation | |
+|---|---|
+| Focused element | Cash presented |
+| Selected line | Last selected line remains visually selected but is inactive (no Delete / QUANTITY until Escape back to `SALE_ENTRY`) |
+| Next Enter | `POST tender` only (`TenderCash`). Does **not** complete. On success → frame 6 (Stimulus then `POST complete`) |
+| Escape | Return to `SALE_ENTRY` without tendering; keep basket |
+| Shortcuts | Enter, Escape, F9. `*` / `+` / Delete / arrows ignored |
+| Visible equivalents | **Charge cash** / **Tender** next to the field; **Cancel (F9)** |
+| Error location | `pos_feedback` in the reserved strip |
+| Turbo region(s) | Success: streams (or morph) into frame 6 — `pos_totals` (change), `pos_command` (disabled), `pos_feedback`, hidden `completion_operation_id`. Failure: `pos_feedback`; field keeps the submitted string |
+
+### 5b. Insufficient Cash
+
+Stay in `TENDER`. Example `pos_feedback`:
+
+```text
+|  pos_feedback                                                    |
+|  Cash presented must cover $18.36.                               |
+|  CASH TENDER                                                     |
+|  Amount due $18.36                                               |
+|  Cash presented                                                  |
+|  [ 10.00                              ] [FOCUS]                  |
+```
+
+No split tender. Cashier edits the amount and Enter retries `POST tender` only.
+
+---
+
+## 6. Completion-pending / recoverable completion error
+
+Not a fourth named mode. Working transaction **plus** Cash tender. Input locked. Retry is `POST complete` only.
+
+### 6a. In flight (ordinary path after successful `TenderCash`)
+
+```text
++------------------------------------------------------------------+
+|  Downtown            Register  2                    Alex Rivera  |
+|  Business date  2026-08-17                                       |
++--------------------------------------+---------------------------+
+|  Qty  Description              Unit      Ext                     |
+|    1  Graphite notebook        $12.00    $12.00                  |
+|    2  Blue gel pen   012345    $2.50     $5.00                   |
+|                                      |  Subtotal        $17.00   |
+|                                      |  Tax              $1.36   |
+|                                      |  Total           $18.36   |
+|                                      |  Cash presented  $20.00   |
+|                                      |                           |
+|                                      |  CHANGE           $1.64   |
++--------------------------------------+---------------------------+
+|  pos_feedback  Completing sale…                                  |
+|  CASH TENDER                                                     |
+|  Cash presented (locked)                                         |
+|  [                                    ] (disabled)               |
+|                                                                  |
+|  Quantity (*)  Tender (+)  Remove      (disabled)                |
+|  Cancel (F9)                           (disabled while in flight)|
++------------------------------------------------------------------+
+```
+
+| Annotation | |
+|---|---|
+| Focused element | None that can type. Caret must not sit in a field a scanner can fill. Optional: focus a non-editable **Completing** status so Enter is swallowed |
+| Selected line | Inactive |
+| Next Enter | Ignored while `POST complete` is in flight |
+| Escape | Does **not** return to `SALE_ENTRY` |
+| Shortcuts | None while in flight. F9 disabled |
+| Visible equivalents | None active until a response |
+| Error location | n/a until failure |
+| Turbo region(s) | Success: **full-page** redirect to `GET /pos/transactions/:id/completed`. GET workspace refresh while still working+tender re-renders this frame and **restores** a matching `in_flight`/`failed` `completion_operation_id` if one exists; mints only if complete was never started. If that transaction is already completed: redirect to **that** id's receipt |
+
+Eyes: **CHANGE** is the largest figure (give the customer cash). Stimulus issues `POST complete` automatically after tender success, reusing the Rails token.
+
+### 6b. Recoverable complete failure (inventory, network, unresolved tax, stale lock after showing this frame)
+
+Same layout as 6a, with `pos_feedback` and controls re-enabled for retry / return / cancel:
+
+```text
+|                                      |  CHANGE           $1.64   |
++--------------------------------------+---------------------------+
+|  pos_feedback                                                    |
+|  Could not complete — inventory short for Blue gel pen.          |
+|  Tender is kept. Retry does not take Cash again.                 |
+|                                                                  |
+|  [ Retry complete ] [FOCUS]     [ Return to sale ]               |
+|  Cancel (F9)                     (enabled)                       |
+```
+
+| Annotation | |
+|---|---|
+| Focused element | **Retry complete** |
+| Next Enter | `POST complete` with the **same** `completion_operation_id`, `expected_lock_version`, totals, and presented amount |
+| Escape | Does not silently dump to `SALE_ENTRY`. Use **Return to sale** (`POST abandon_tender`) |
+| Shortcuts | Enter = retry; F9 = cancel overlay. `*` / `+` / Delete ignored |
+| Visible equivalents | **Retry complete**, **Return to sale**, **Cancel (F9)** |
+| Error location | `pos_feedback` in the reserved strip (inventory, tax, network, stale `lock_version`) |
+| Turbo region(s) | Retry success: full-page that transaction's receipt. Retry failure: `pos_feedback`. Return to sale: `POST abandon_tender` → `SALE_ENTRY` with no working tender. Cancel: overlay → `POST cancel` → `ResumeOrStartTransaction` → empty `SALE_ENTRY` |
+
+Do not `POST tender` again from this frame. Changing Cash presented: **Return to sale** (clears tender) then `+` / Tender (new `TenderCash`, new token). Refresh after Return to sale stays `SALE_ENTRY`.
+
+If `POST complete` hits an already-completed transaction (lost response): **full-page** `GET /pos/transactions/:id/completed` for **that** id.
+
+---
+
+## 7. Cancel confirmation
+
+The only overlay. No text field. Opens over frames 3b–5 and 6b (not 3a — Cancel disabled; not 6a; not 8; not the open gate). Real dialog; background inert.
+
+```text
++------------------------------------------------------------------+
+|  Downtown            Register  2                    Alex Rivera  |
+|  … selling surface dimmed; not focusable …                       |
+|                                                                  |
+|           +----------------------------------------+             |
+|           |  Cancel this sale?                     |             |
+|           |                                        |             |
+|           |  Lines will not be sold.               |             |
+|           |  No receipt. No inventory movement.    |             |
+|           |                                        |             |
+|           |  [ Don't cancel  Esc ]                 |             |
+|           |  [ Cancel sale   F9  ]                 |             |
+|           +----------------------------------------+             |
++------------------------------------------------------------------+
+```
+
+No caret in an input. Do not put `[FOCUS]` on a text field. Proposed: focus **Don't cancel** so a stray Enter does nothing useful if it were honored — and **Enter is ignored** regardless.
+
+| Annotation | |
+|---|---|
+| Focused element | **Don't cancel** (no input). Scanner keystrokes must not land anywhere typed |
+| Selected line | Unchanged underneath; inactive |
+| Next Enter | **Ignored** (barcodes end in Enter) |
+| Escape | Abort overlay; restore prior mode and focus (scan / quantity / cash / retry) |
+| Shortcuts | F9 confirms cancel (`POST cancel`). Alphanumeric keys ignored. `*` / `+` / Delete ignored |
+| Visible equivalents | **Don't cancel (Esc)**, **Cancel sale (F9)** |
+| Error location | If `POST cancel` fails, close overlay, `pos_feedback` on the underlying frame, restore focus to primary |
+| Turbo region(s) | Overlay is Stimulus until confirm. Success: full-page `SALE_ENTRY` after `ResumeOrStartTransaction`. Do not land on a prior receipt |
+
+First F9 opens this overlay. Second F9 confirms. There is no `Y` confirm.
+
+---
+
+## 8. Completed receipt / confirmation
+
+Immutable completed facts only. No print in Slice 2. No scan field.
+
+Reached only with an **explicit** completed transaction identity:
+
+```text
+successful CompleteTransaction
+  → redirect GET /pos/transactions/:id/completed
+replayed CompleteTransaction
+  → redirect to that same id
+explicit completed receipt URL
+  → render that transaction
+GET workspace with no working transaction
+  → GET enter
+  (does not infer a receipt from the Session's completed sales)
+```
+
+The browser may retain the transaction id it was completing so a lost redirect can still request that receipt. The server does not guess “latest completed.”
+
+```text
++------------------------------------------------------------------+
+|  Downtown            Register  2                    Alex Rivera  |
+|  Business date  2026-08-17                                       |
++------------------------------------------------------------------+
+|                                                                  |
+|  Sale complete                                                   |
+|                                                                  |
+|  S003-R02-T0018427                                               |
+|                                                                  |
+|  Total                         $18.36                            |
+|  Cash presented                $20.00                            |
+|  Change                         $1.64                            |
+|                                                                  |
+|  1 × Graphite notebook         $12.00                            |
+|  2 × Blue gel pen               $5.00                            |
+|  Tax                            $1.36                            |
+|                                                                  |
+|  [ New sale ]                                                    |
+|                                                                  |
++------------------------------------------------------------------+
+```
+
+Do **not** default-focus **New sale** as a control a scanner Enter would activate.
+
+| Annotation | |
+|---|---|
+| Focused element | A non-activating target (heading or status). **New sale** is prominent and in tab order |
+| Selected line | n/a (completed lines are a summary, not a working selection) |
+| Next Enter | Keyboard Enter with **no** preceding identifier characters → `POST continue`. Identifier characters (scanner digits) then Enter → **do not** submit New sale and must not discard the identifier into a new sale. Slice 2 does not auto-start a transaction and add that SKU |
+| Escape | no-op (do not cancel a completed sale) |
+| Shortcuts | No `*` / `+` / Delete / F9 |
+| Visible equivalents | **New sale** (prominent). No print control |
+| Error location | If continue fails (session closed, occupancy): message on this page; do not create a working transaction on GET |
+| Turbo region(s) | Full page. Not a Turbo Frame inside the selling surface — a scan must not be interpretable as `AddMerchandise` |
+
+Render from completed transaction facts (`transaction_reference`, total, Cash presented, change, concise lines/tax). Never from leftover working browser state. Technical UUID stays out of the cashier's primary view. **Cash presented** is the physical amount ($20), not the applied payment ($18.36).
+
+---
+
+## Keyboard map (proposed; wireframe-validatable)
+
+| Key | Where it applies | Action |
+|---|---|---|
+| Enter | Open gate | Submit enter / continue |
+| Enter | `SALE_ENTRY` | Add merchandise |
+| Enter | `QUANTITY` | Set absolute quantity |
+| Enter | `TENDER` | `POST tender` only |
+| Enter | Completion-pending in flight | Ignored |
+| Enter | Completion error | Retry complete |
+| Enter | Cancel overlay | **Ignored** |
+| Enter | Completed receipt | Keyboard Enter with empty identifier buffer → `POST continue`. Scanner digits then Enter do **not** submit New sale |
+| Escape | `SALE_ENTRY` | Clear field |
+| Escape | `QUANTITY` / `TENDER` | Back to `SALE_ENTRY` |
+| Escape | Completion-pending | No silent return |
+| Escape | Cancel overlay | Abort |
+| `*` | `SALE_ENTRY` only | Quantity (no-op if no selected line) |
+| `+` | `SALE_ENTRY` only | Tender (no-op if no merchandise) |
+| Delete | `SALE_ENTRY` only | Remove selected line |
+| ArrowUp / ArrowDown | `SALE_ENTRY` only | Move selected line |
+| F9 | Selling surface, not in-flight complete, basket has lines | Open cancel overlay |
+| F9 | Cancel overlay | Confirm cancel |
+
+Intercept `*` and `+` on keydown in `SALE_ENTRY` so they never become identifier text. Do not intercept letter keys.
+
+---
+
+## Out of these wireframes
+
+Print prompt, blind close, Z screens (Slice 3). Split tender, discounts, returns, suspend/recall, drawers, customer display, mobile layout, polished visual design. Admin shell.
+
+---
+
+## What to validate in review
+
+These are the interaction questions this pass is for:
+
+1. Primary field at the **bottom** (same place in every selling mode) vs top.
+2. Totals on the **right**, with amount due / change as the largest figure.
+3. **F9** as cancel (open, then confirm) vs another non-letter key.
+4. Leftover period: banner copy and weight enough to be unmissable?
+5. Completion-pending: huge **CHANGE**, locked field, auto-`POST complete` — or should the cashier press Enter once more to complete?
+6. Recoverable complete error: focus on **Retry complete**; Escape does not return to sale.
+7. Cancel-overlay scanner safety (Enter ignored; second F9 confirms).
+8. Occupied register: stay on `GET enter` with register select, not a workspace modal.
+9. Feedback placement in the reserved strip, not a top-of-page admin flash.
+10. Does feedback appear without moving the command field?
+11. Does a long basket scroll independently while command/totals remain fixed?
+12. Return to sale discards the persisted tender (`POST abandon_tender`).
+13. What happens if the cashier scans while the completed receipt is displayed? (Slice 2: do not submit New sale / drop the identifier.)
+14. Is the current mode unmistakable at a glance?
+
+HTTP/domain items 1–4 from the contract pass (no latest-receipt inference; restore matching `operation_id`; `AbandonTender`; empty-basket Cancel disabled) are **locked**, not open UX questions.
+
+Accepting this document (with any of items 1–5, 7, 14 adjusted) is what makes Slice 2 interaction locked enough to implement domain invariants, then Hotwire.

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace-ux.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace-ux.md
@@ -451,7 +451,7 @@ Not a fourth named mode. Working transaction **plus** Cash tender. Input locked.
 | Next Enter | Ignored while `POST complete` is in flight |
 | Escape | Does **not** return to `SALE_ENTRY` |
 | Shortcuts | None while in flight. F9 disabled |
-| Visible equivalents | None active until a response |
+| Visible equivalents | None active until a response. Unexpired `in_flight` on refresh: “Completion is still processing”; no Retry, no Return to sale, Cancel disabled |
 | Error location | n/a until failure |
 | Turbo region(s) | Success: **full-page** redirect to `GET /pos/transactions/:id/completed`. GET workspace refresh while still working+tender re-renders this frame and **restores** a matching `in_flight`/`failed` `completion_operation_id` if one exists; mints only if complete was never started. If that transaction is already completed: redirect to **that** id's receipt |
 

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md
@@ -4,7 +4,7 @@
 
 **Authority:** Cashier-facing online Register workspace: open gate, ephemeral UI modes, HTTP commands, focus/retry rules, and the Slice 2 vs Slice 3 receipt split. Domain completion, tax, inventory posting, and receipt identity remain in the [Phase 4 packet](../phase4-point-of-sale/). Cash/Z snapshots remain in [phase5-schema.md](phase5-schema.md).
 
-Companions: [phase5-plan.md](phase5-plan.md), [register-workspace-ux.md](register-workspace-ux.md), [receipt-identity.md](../phase4-point-of-sale/receipt-identity.md). Low-fidelity wireframes in `register-workspace-ux.md` (review before Hotwire). Changing a key binding or layout in that pass is not an architectural reversal.
+Companions: [phase5-plan.md](phase5-plan.md), [register-workspace-ux.md](register-workspace-ux.md), [close-z-screens.md](close-z-screens.md), [receipt-identity.md](../phase4-point-of-sale/receipt-identity.md). Low-fidelity wireframes in `register-workspace-ux.md` (review before Hotwire). Changing a key binding or layout in that pass is not an architectural reversal.
 
 Where this document and [spec.md](../spec.md) §5.4–5.11 disagree, **prefer this document**.
 
@@ -64,11 +64,11 @@ Do not install Importmap / Turbo / Stimulus in a docs-only change.
 
 ## 2. Slice 2 vs Slice 3
 
-| Slice 2 | Slice 3 |
+| Slice 2 | Slice 3 ([close-z-screens.md](close-z-screens.md)) |
 |---|---|
 | Open gate, selling workspace, on-screen **completion receipt/confirmation** | Receipt **print** path, blind session close, Z finalize screens |
 | Render completion confirmation from **immutable completed transaction facts** | Print representation of those same facts |
-| No print controls | One supported print path; printer failure does not undo completion |
+| No print controls in the Slice 2 contract | One supported print path; printer failure does not undo completion |
 
 Slice 2 completion receipt minimum:
 
@@ -460,4 +460,6 @@ System tests (when the workspace is implemented) must cover at least: scan → f
 
 ## 11. Out of this contract
 
-Close session UI, blind count, Z screens, receipt print, split tender, discounts, returns, suspend/recall, drawers, Terminal, new permissions, close/Z outbox, polished visual design, mobile POS, customer display.
+Split tender, discounts, returns, suspend/recall, drawers, Terminal, new permissions, close/Z outbox, polished visual design, mobile POS, customer display.
+
+Receipt print, blind close, and Z screens are Slice 3: [close-z-screens.md](close-z-screens.md).

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md
@@ -1,0 +1,326 @@
+# Phase 5 Slice 2 — Register workspace contract
+
+**Status:** Locked (interaction and HTTP/domain contract). Not yet implemented.
+
+**Authority:** Cashier-facing online Register workspace: open gate, ephemeral UI modes, HTTP commands, focus/retry rules, and the Slice 2 vs Slice 3 receipt split. Domain completion, tax, inventory posting, and receipt identity remain in the [Phase 4 packet](../phase4-point-of-sale/). Cash/Z snapshots remain in [phase5-schema.md](phase5-schema.md).
+
+Companions: [phase5-plan.md](phase5-plan.md), [receipt-identity.md](../phase4-point-of-sale/receipt-identity.md). Low-fidelity wireframes belong in `register-workspace-ux.md` (not in this change; write before Hotwire).
+
+Where this document and [spec.md](../spec.md) §5.4–5.11 disagree, **prefer this document**.
+
+**Governing UX principle:** where are the cashier's eyes, where is keyboard focus, and what will the next keystroke do?
+
+---
+
+## 1. Locked stack and testing
+
+| Topic | Decision |
+|---|---|
+| Client | Rails-native online POS. No Terminal table (ADR-021). No scanner API; scanners are keyboard input ending in Enter |
+| UI stack | Importmap + Turbo + Stimulus. Gems are in the Gemfile; they are **not installed** until the workspace implementation PR |
+| Layout | Dedicated POS layout. Do not reuse admin chrome for the selling surface (it would steal scan focus) |
+| Permission | `pos.transact` at the current store. Session cashier for session/transaction commands (`require_session_cashier!` / `require_transaction_cashier!`) |
+| Controllers | Orchestrate Phase 4/5 services only. No receipt allocation, inventory posting, tax calculation, or commercial total mutation in controllers or Stimulus |
+| Browser tests | Meaningful client-side POS behavior **requires** system/browser tests. Request tests cannot prove focus, scanner Enter, Escape, or duplicate-submit prevention |
+| Keyboard-first | Ordinary sale path requires no mouse. Every shortcut has a visible, focusable control |
+| Money entry | Decimal strings via `Money::ParseCents`. Never binary floats |
+
+Do not install Importmap / Turbo / Stimulus in a docs-only change.
+
+---
+
+## 2. Slice 2 vs Slice 3
+
+| Slice 2 | Slice 3 |
+|---|---|
+| Open gate, selling workspace, on-screen **completion receipt/confirmation** | Receipt **print** path, blind session close, Z finalize screens |
+| Render completion confirmation from **immutable completed transaction facts** | Print representation of those same facts |
+| No print controls | One supported print path; printer failure does not undo completion |
+
+Slice 2 completion receipt minimum:
+
+```text
+transaction_reference
+completed total
+Cash presented
+change
+completed lines / tax (concise)
+prominent continue / new sale
+```
+
+Never render the confirmation from leftover working browser state.
+
+---
+
+## 3. Open gate
+
+Requires `current_store` and `pos.transact`. If no current store, redirect to existing store selection. Cashier picks an **active register** in that store (auto-select if only one).
+
+| Request | Mutates? | Role |
+|---|---|---|
+| `GET enter` | no | Open-gate form: register pick, date, float when needed, occupied-register deny |
+| `POST enter` | yes | Resolve period/session and `ResumeOrStartTransaction`; redirect to workspace |
+| `GET workspace` | no | Selling surface for an existing working transaction |
+
+Authoritative resolve (also after a uniqueness race: **reload state and apply these rules**; do not surface a raw unique-index exception):
+
+```text
+Register has open Session for actor
+  → resume it
+  → show that Session's period business_date read-only
+  → do not collect opening float
+
+Register has open Session for a different cashier
+  → GET enter shows deny (not a workspace overlay)
+  → POST enter denies
+
+Register has no open Session:
+  use the existing open period if one exists
+    (do not re-confirm a date; use the period's business_date)
+  otherwise open a period for BusinessDate.for_store(...) (confirm; no override)
+  then open Session (opening float required, integer cents >= 0, zero allowed)
+```
+
+Opening float is collected **only when this POST will create a Session**. Resuming the actor's open Session must not change `opening_float_cents`. Float is not a paid-in and not a Cash tender.
+
+**Yesterday’s open period:** one open period per register. If it is still open, resume it and show **that** `business_date`. Do not open a second period because the calendar rolled. Make a non-today date unmissable in the header. Slice 3 is how a leftover period is Z’d. Slice 2 has no “please Z first” wizard.
+
+---
+
+## 4. One working transaction
+
+```sql
+UNIQUE (pos_session_id) WHERE status = 'working'
+```
+
+`StartTransaction` rejects if a working row exists while it holds the session lock.
+
+Controllers must not `find || StartTransaction`. Use `Pos::ResumeOrStartTransaction`:
+
+```text
+lock Session
+authorize actor
+require actor == Session cashier
+require Session and period open
+
+if working transaction exists
+  return it
+else
+  create through the same StartTransaction rules
+end
+```
+
+**GET never creates transactions.** Refresh, prefetch, crawlers, and the back button must not mutate commercial state.
+
+```text
+GET workspace
+  → render the existing working transaction
+  → if it already has a Cash tender: restore completion-pending (do not create)
+  → if none (including back from completion receipt): redirect to GET enter
+  → do not create
+
+POST enter / POST continue
+  → ResumeOrStartTransaction
+  → redirect to workspace
+```
+
+Two browser tabs: last writer wins via `lock_version`. The stale tab shows an error and reloads. Slice 2 does not sync tabs.
+
+Empty working transactions created on enter/continue **block** `CloseSession` (existing Slice 1 gate). Do not auto-cancel on GET. Cashiers cancel in the workspace; Slice 3 may later auto-cancel empty leftovers.
+
+---
+
+## 5. HTTP contract
+
+Stimulus may make `POST tender` then `POST complete` feel like one Enter. They are **not** one controller action.
+
+```text
+GET enter
+  → read only (open-gate form)
+
+POST enter
+  → resolve/open period
+  → resolve/open Session
+  → ResumeOrStartTransaction
+  → redirect workspace
+
+GET workspace
+  → read only
+  → if the working transaction already has a Cash tender: restore completion-pending
+    (show change; retry is POST complete only; do not treat as empty SALE_ENTRY)
+  → if none (including back from completion receipt): redirect to GET enter
+  → do not create
+
+POST merchandise     → AddMerchandise; clear working tenders
+POST quantity        → ChangeQuantity; clear working tenders
+POST remove          → RemoveWorkingLine; clear working tenders
+POST cancel          → CancelTransaction (after explicit confirmation)
+
+POST tender
+  → TenderCash
+  → return change + new lock_version
+  → do not complete
+
+POST complete
+  → CompleteTransaction
+  → caller supplies a UUIDv7 operation_id generated at this completion attempt
+  → stable operation_id and post-tender expected_lock_version
+  → retries hit only this endpoint with the same payload
+  → redirect to completion receipt
+
+GET completed receipt
+  → immutable completed facts only
+  → session/transaction cashier only
+  → if the transaction is not completed: not found (do not complete on GET)
+
+POST continue
+  → ResumeOrStartTransaction
+  → redirect workspace
+```
+
+Direct unauthorized requests must fail, including a second cashier operating another cashier's Session.
+
+---
+
+## 6. Tender vs complete (blocker)
+
+`TenderCash` destroys/recreates the Cash tender and advances `lock_version`. `CompleteTransaction` includes that post-tender `expected_lock_version` in its idempotency command hash. Re-running `TenderCash` on a completion retry changes the hash and raises `PayloadMismatch`.
+
+Ordinary cashier Enter in `TENDER`:
+
+```text
+disable input
+POST tender (expected_lock_version = v5)
+  → change + lock_version = v6
+POST complete (
+    operation_id = A,
+    expected_lock_version = v6,
+    expected_total_cents from the tender response,
+    amount_presented_cents from the tender response
+  )
+  → GET completion receipt
+```
+
+Completion retry:
+
+```text
+POST complete again
+operation_id = A
+expected_lock_version = v6
+same command payload
+```
+
+Do **not** re-tender.
+
+### `operation_id` lifetime
+
+- The workspace generates a UUIDv7 at the **first** `POST complete` after a successful `TenderCash` (identifier at origin). Put it in the complete request; do not let the server silently mint a different id on retry.
+- Reuse that id only for retries of that same post-tender payload (`expected_lock_version`, expected total, amount presented).
+- Refresh after `TenderCash` but before a successful complete: restore completion-pending from the persisted tender. If Stimulus lost the in-memory id and no complete has succeeded, mint a **new** UUIDv7 for the next `POST complete` (a new attempt). Do not reuse an id whose payload would no longer match.
+- Any new `TenderCash` (changed presented amount, or re-tender after returning to sale entry) mints a **new** `operation_id`.
+- After `TenderCash` succeeds, do not `POST tender` again unless the cashier is changing the presented amount. That requires leaving completion-pending (explicit return to `SALE_ENTRY` after a recoverable complete failure, or Escape **before** `TenderCash` succeeded). Then a new `TenderCash` and a new `operation_id`.
+- Stimulus sends `expected_total_cents` and `amount_presented_cents` from the **last tender response**, not a client-side recompute.
+- Abandoned `in_flight` leases expire in 2 minutes (`PosOperation::LEASE_DURATION`). Do not reuse an old id after a new tender.
+
+If completion fails recoverably: keep the working transaction **and** the tender; show a completion error; offer retry complete. Explicit return to `SALE_ENTRY` is allowed; the next merchandise mutation clears the tender. Changing Cash presented after a failed complete requires a new `TenderCash` and a new `operation_id`.
+
+F9 / cancel is disabled while a `POST complete` is in flight. After a recoverable complete failure, cancel is allowed (`CancelTransaction`).
+
+Working-command in-flight guard: a second Enter must not fire `AddMerchandise` (or another mutation) before the first response refreshes `lock_version`.
+
+Presented amount less than amount due: `TenderCash` rejects; remain in `TENDER`; preserve/edit the amount; focus the primary amount input. No split tender in Phase 5.
+
+---
+
+## 7. Ephemeral UI modes
+
+UI mode is **browser state**. Authoritative transaction status remains `working` / `completed` / `cancelled`.
+
+One primary POS input. Autofocus on load. After every successful action and recoverable error, focus returns there unless a confirmation overlay is open. Overlays must restore focus to the primary input.
+
+Quantity and tender **reuse that same primary field** with a changed label. The only overlay is **cancel confirmation**. Occupied-register deny lives on `GET enter`, not on the selling surface.
+
+Intercept `*` and `+` on keydown so they never become identifier text. Do not intercept letter keys such as `T`.
+
+`*` with no selected line is a no-op (stay `SALE_ENTRY`). `+` with no merchandise is a no-op. QUANTITY with no selected line is not entered.
+
+| Mode | Enter | Escape | Other |
+|---|---|---|---|
+| `SALE_ENTRY` | identifier → `AddMerchandise`. Empty Enter is a no-op. Digits alone are an identifier, not quantity | clear input; stay `SALE_ENTRY` | `*` → `QUANTITY` if a line is selected; `+` → `TENDER` if merchandise exists; Delete removes selected line |
+| `QUANTITY` | `ChangeQuantity` on selected line → `SALE_ENTRY` | abandon → `SALE_ENTRY` | quantity `0` is invalid (service requires positive); Delete is not used here — Escape then Delete in `SALE_ENTRY` |
+| `TENDER` (before `TenderCash` succeeds) | `POST tender` only | → `SALE_ENTRY` | insufficient Cash: remain `TENDER` |
+| completion pending (`TenderCash` succeeded, including GET workspace restore) | not a fourth named mode; input locked until complete response | do not silently return to `SALE_ENTRY` | retry is `POST complete` only; explicit return-to-sale control is allowed after a recoverable complete failure |
+
+Keyboard map (shortcuts; each has a visible control):
+
+| Key | Action |
+|---|---|
+| Enter | confirm current mode; **ignored** on the cancel overlay |
+| Escape | back out where the table allows; on cancel overlay, abort confirm |
+| `*` | `QUANTITY` (no-op if no selected line) |
+| `+` | `TENDER` (no-op if no merchandise) |
+| Delete | `RemoveWorkingLine` on the selected line in `SALE_ENTRY` |
+| ArrowUp / ArrowDown | move selected line (in `SALE_ENTRY`) |
+| F9 | open cancel confirmation (disabled while `POST complete` is in flight) |
+| F9 again | confirm cancel (**not** Enter, **not** `Y` — barcodes may contain letters) |
+
+Cancel overlay: no text field (so a scan cannot type into it). Ignore Enter and alphanumeric keys. Visible Confirm (activates on second F9) and Don't cancel (Escape). Abort restores the prior mode and focus.
+
+Selected line defaults to the line **returned** by the last `AddMerchandise`, or the last changed line. After `RemoveWorkingLine`, select the previous remaining line, or none if the basket is empty. Arrow keys move selection. QUANTITY and Delete apply to the selected line.
+
+---
+
+## 8. Merchandise commands
+
+Phase 5 UI sells only standard quantity-tracked merchandise (existing `AddMerchandise` validations).
+
+**Rescan merge** happens in `AddMerchandise` after the working-transaction lock, not in Stimulus. Compatible line:
+
+```text
+same product_variant_id
+same direction
+same selling_unit_price_cents
+same tax_class_id
+same relevant pricing basis
+```
+
+Phase 5 has no discounts or price overrides, so unit price + tax class is the pricing basis. Increment quantity by the scanned amount (default 1). QUANTITY mode sets **absolute** quantity via `ChangeQuantity`.
+
+`AddMerchandise` returns the **resulting line** in both cases (new line or incremented line) so the UI always selects that line.
+
+Same variant with a different price/tax context becomes a separate line.
+
+**Basket mutation invalidates working tenders.** `AddMerchandise`, `ChangeQuantity`, and `RemoveWorkingLine` clear existing working tenders in the same database transaction. The cashier must re-enter `TENDER` after changing the basket.
+
+Inventory shortage is a **completion** error (Phase 4 posts on complete, not on add-line). The scan path will not catch oversell.
+
+Cancel: explicit confirmation overlay (see keyboard map). Escape / Don't cancel returns to the prior mode and focus. Scanner Enter must not confirm.
+
+---
+
+## 9. Slice 2 acceptance (contract)
+
+A cashier can:
+
+1. Enter the Register workspace only with an open reporting period and open Session belonging to them (open gate creates or resumes).
+2. See the period's business date; cannot edit it.
+3. Scan/type a sellable identifier and press Enter to add merchandise.
+4. Continue scanning without manually restoring focus.
+5. Scan the same compatible SKU again and increment the existing line.
+6. Change quantity and remove a working line using keyboard-only interaction (visible controls also exist).
+7. Cancel with explicit confirmation that scanner Enter cannot submit (second F9 confirms; Enter ignored).
+8. Enter Cash presented; insufficient Cash stays in `TENDER`; valid settlement calls `TenderCash` then `CompleteTransaction` as two HTTP requests.
+9. Retry completion without calling `TenderCash` again; one receipt and one inventory posting.
+10. Refresh the workspace and resume the same working transaction (GET does not create another). If a Cash tender is already on the working transaction, restore completion-pending rather than empty `SALE_ENTRY`.
+11. See a completion receipt/confirmation from completed facts, then continue to a fresh `SALE_ENTRY`.
+12. Receive inline feedback for unknown identifier, unsupported merchandise, stale `lock_version`, unresolved tax, insufficient Cash, inventory failure on complete, and recoverable completion/network errors, with the working transaction preserved.
+13. Be denied when a second cashier attempts to operate another cashier's Session.
+14. Never mutate receipt, inventory, tax, or totals in controller or Stimulus code.
+
+System tests (when the workspace is implemented) must cover at least: scan → focus restored → rescan increment; quantity mode; tender then complete; Escape; double Enter; insufficient Cash; refresh/re-entry; refresh with an existing tender restores completion-pending; completion retry without re-tender; cancel overlay ignores Enter and confirms on second F9.
+
+---
+
+## 10. Out of this contract
+
+Close session UI, blind count, Z screens, receipt print, split tender, discounts, returns, suspend/recall, drawers, Terminal, new permissions, close/Z outbox, polished visual design, mobile POS, customer display.

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md
@@ -1,14 +1,45 @@
 # Phase 5 Slice 2 — Register workspace contract
 
-**Status:** Locked (interaction and HTTP/domain contract). Not yet implemented.
+**Status:** HTTP/domain contract locked. Interaction details provisionally accepted pending Slice 2 UX wireframes (`register-workspace-ux.md`). Not yet implemented.
 
 **Authority:** Cashier-facing online Register workspace: open gate, ephemeral UI modes, HTTP commands, focus/retry rules, and the Slice 2 vs Slice 3 receipt split. Domain completion, tax, inventory posting, and receipt identity remain in the [Phase 4 packet](../phase4-point-of-sale/). Cash/Z snapshots remain in [phase5-schema.md](phase5-schema.md).
 
-Companions: [phase5-plan.md](phase5-plan.md), [receipt-identity.md](../phase4-point-of-sale/receipt-identity.md). Low-fidelity wireframes belong in `register-workspace-ux.md` (not in this change; write before Hotwire).
+Companions: [phase5-plan.md](phase5-plan.md), [register-workspace-ux.md](register-workspace-ux.md), [receipt-identity.md](../phase4-point-of-sale/receipt-identity.md). Low-fidelity wireframes in `register-workspace-ux.md` (review before Hotwire). Changing a key binding or layout in that pass is not an architectural reversal.
 
 Where this document and [spec.md](../spec.md) §5.4–5.11 disagree, **prefer this document**.
 
 **Governing UX principle:** where are the cashier's eyes, where is keyboard focus, and what will the next keystroke do?
+
+### Actually locked
+
+```text
+Hotwire + system/browser tests
+dedicated POS layout
+one working transaction
+GET does not mutate
+ResumeOrStartTransaction
+rescan merge in AddMerchandise
+basket mutation clears tender
+AbandonTender (return to sale)
+TenderCash / CompleteTransaction split
+completion retry semantics (no re-tender)
+Rails-issued completion operation_id (restore matching in_flight/failed)
+lost-complete recovery by explicit transaction id (not latest-in-session)
+cancel disabled when the basket is empty
+Slice 2 vs Slice 3 boundary
+```
+
+### Wireframe-validatable
+
+```text
+* / + / Delete / F9 bindings
+header hierarchy
+line-table layout and selected-line styling
+where errors appear
+how completion-pending looks
+visible button arrangement
+receipt confirmation layout
+```
 
 ---
 
@@ -60,7 +91,7 @@ Requires `current_store` and `pos.transact`. If no current store, redirect to ex
 |---|---|---|
 | `GET enter` | no | Open-gate form: register pick, date, float when needed, occupied-register deny |
 | `POST enter` | yes | Resolve period/session and `ResumeOrStartTransaction`; redirect to workspace |
-| `GET workspace` | no | Selling surface for an existing working transaction |
+| `GET workspace` | no | Selling surface: `SALE_ENTRY` or completion-pending (never creates; never infers a receipt) |
 
 Authoritative resolve (also after a uniqueness race: **reload state and apply these rules**; do not surface a raw unique-index exception):
 
@@ -113,20 +144,29 @@ end
 **GET never creates transactions.** Refresh, prefetch, crawlers, and the back button must not mutate commercial state.
 
 ```text
-GET workspace
-  → render the existing working transaction
-  → if it already has a Cash tender: restore completion-pending (do not create)
-  → if none (including back from completion receipt): redirect to GET enter
-  → do not create
+GET workspace (never create)
+  → find the Session's existing working transaction for this cashier
+
+  if working transaction exists
+    if it has a Cash tender
+      → render completion-pending
+        (restore or issue completion_operation_id — see §6)
+    otherwise
+      → render SALE_ENTRY
+  else
+    → redirect GET enter
+    (do not infer a receipt from the Session's completed sales)
 
 POST enter / POST continue
   → ResumeOrStartTransaction
   → redirect to workspace
 ```
 
+Completed receipts are reached only with an **explicit** transaction identity: redirect after successful or replayed `CompleteTransaction`, or `GET /pos/transactions/:id/completed`. `GET workspace` never guesses “latest completed.”
+
 Two browser tabs: last writer wins via `lock_version`. The stale tab shows an error and reloads. Slice 2 does not sync tabs.
 
-Empty working transactions created on enter/continue **block** `CloseSession` (existing Slice 1 gate). Do not auto-cancel on GET. Cashiers cancel in the workspace; Slice 3 may later auto-cancel empty leftovers.
+Empty working transactions created on enter/continue **block** `CloseSession` (existing Slice 1 gate). Do not auto-cancel on GET. **Cancel is disabled** while the working transaction has no lines (cancel+resume of an empty ticket is a no-op that still blocks close). After `CancelTransaction` of a sale that had lines, immediately `ResumeOrStartTransaction` (same as `POST continue`) so the cashier returns to empty `SALE_ENTRY`. Slice 3 may dispose of leftover empty working transactions on leave/close.
 
 ---
 
@@ -145,31 +185,42 @@ POST enter
   → redirect workspace
 
 GET workspace
-  → read only
-  → if the working transaction already has a Cash tender: restore completion-pending
-    (show change; retry is POST complete only; do not treat as empty SALE_ENTRY)
-  → if none (including back from completion receipt): redirect to GET enter
-  → do not create
+  → read only; never create
+  → find the Session's existing working transaction for this cashier
+  → if working + Cash tender: render completion-pending
+       (restore matching completion_operation_id if one exists; otherwise mint)
+  → if working, no tender: render SALE_ENTRY
+  → if no working transaction: redirect GET enter
+       (never infer a completed receipt)
 
 POST merchandise     → AddMerchandise; clear working tenders
 POST quantity        → ChangeQuantity; clear working tenders
 POST remove          → RemoveWorkingLine; clear working tenders
-POST cancel          → CancelTransaction (after explicit confirmation)
+POST abandon_tender
+  → Pos::AbandonTender (lock working transaction; require transaction cashier;
+    destroy working tender; advance lock_version)
+  → render SALE_ENTRY
+POST cancel
+  → allowed only when the working transaction has at least one line
+  → CancelTransaction (after explicit confirmation)
+  → ResumeOrStartTransaction
+  → redirect workspace (SALE_ENTRY)
 
 POST tender
   → TenderCash
-  → return change + new lock_version
+  → return change_cents, lock_version, expected_total_cents, amount_presented_cents,
+    completion_operation_id (SecureRandom.uuid_v7)
   → do not complete
 
 POST complete
-  → CompleteTransaction
-  → caller supplies a UUIDv7 operation_id generated at this completion attempt
-  → stable operation_id and post-tender expected_lock_version
-  → retries hit only this endpoint with the same payload
-  → redirect to completion receipt
+  → CompleteTransaction using the Rails-issued completion_operation_id as operation_id
+  → retries hit only this endpoint with the same payload and same operation_id
+  → if the transaction is already completed: redirect to GET /pos/transactions/:id/completed
+    (lost-response / replay; do not create a second completion)
+  → otherwise redirect to GET /pos/transactions/:id/completed
 
-GET completed receipt
-  → immutable completed facts only
+GET /pos/transactions/:id/completed
+  → that transaction's immutable completed facts only
   → session/transaction cashier only
   → if the transaction is not completed: not found (do not complete on GET)
 
@@ -192,13 +243,14 @@ Ordinary cashier Enter in `TENDER`:
 disable input
 POST tender (expected_lock_version = v5)
   → change + lock_version = v6
+  → completion_operation_id = A   (Rails: SecureRandom.uuid_v7)
 POST complete (
     operation_id = A,
     expected_lock_version = v6,
     expected_total_cents from the tender response,
     amount_presented_cents from the tender response
   )
-  → GET completion receipt
+  → GET /pos/transactions/:id/completed
 ```
 
 Completion retry:
@@ -214,17 +266,53 @@ Do **not** re-tender.
 
 ### `operation_id` lifetime
 
-- The workspace generates a UUIDv7 at the **first** `POST complete` after a successful `TenderCash` (identifier at origin). Put it in the complete request; do not let the server silently mint a different id on retry.
-- Reuse that id only for retries of that same post-tender payload (`expected_lock_version`, expected total, amount presented).
-- Refresh after `TenderCash` but before a successful complete: restore completion-pending from the persisted tender. If Stimulus lost the in-memory id and no complete has succeeded, mint a **new** UUIDv7 for the next `POST complete` (a new attempt). Do not reuse an id whose payload would no longer match.
-- Any new `TenderCash` (changed presented amount, or re-tender after returning to sale entry) mints a **new** `operation_id`.
-- After `TenderCash` succeeds, do not `POST tender` again unless the cashier is changing the presented amount. That requires leaving completion-pending (explicit return to `SALE_ENTRY` after a recoverable complete failure, or Escape **before** `TenderCash` succeeded). Then a new `TenderCash` and a new `operation_id`.
-- Stimulus sends `expected_total_cents` and `amount_presented_cents` from the **last tender response**, not a client-side recompute.
-- Abandoned `in_flight` leases expire in 2 minutes (`PosOperation::LEASE_DURATION`). Do not reuse an old id after a new tender.
+Rails issues the UUIDv7. Stimulus treats `completion_operation_id` as an opaque token. Do not add a JavaScript UUIDv7 implementation for this.
 
-If completion fails recoverably: keep the working transaction **and** the tender; show a completion error; offer retry complete. Explicit return to `SALE_ENTRY` is allowed; the next merchandise mutation clears the tender. Changing Cash presented after a failed complete requires a new `TenderCash` and a new `operation_id`.
+```text
+POST tender succeeds
+  → response includes completion_operation_id = SecureRandom.uuid_v7
+     (mint only; CompleteTransaction has not run yet)
+POST complete
+  → operation_id = that token, unchanged on retries
+GET workspace while working + tender (refresh)
+  → look for an existing pos.complete_transaction for this transaction
+     whose command payload matches the current tender
+       (expected_lock_version, expected_total_cents, amount_presented_cents)
+  → matching in_flight or failed attempt
+       → restore that operation_id; Retry complete uses the same command
+  → no completion operation was ever started
+       → mint a new completion_operation_id
+  → transaction already completed
+       → redirect GET /pos/transactions/:id/completed for that id
+```
 
-F9 / cancel is disabled while a `POST complete` is in flight. After a recoverable complete failure, cancel is allowed (`CancelTransaction`).
+Do **not** unconditionally mint a new id on refresh. Minting B while A is `in_flight` is a second completion attempt for the same sale.
+
+- Reuse the token only for retries of that same post-tender payload (`expected_lock_version`, expected total, amount presented).
+- A new `TenderCash` (changed presented amount, or re-tender after `AbandonTender`) returns a **new** `completion_operation_id`.
+- After `TenderCash` succeeds, do not `POST tender` again unless the cashier is changing the presented amount. That requires `POST abandon_tender` (Return to sale) or Escape **before** `TenderCash` succeeded. Then a new `TenderCash` and a new token.
+- Stimulus sends `expected_total_cents` and `amount_presented_cents` from the **last tender / completion-pending render**, not a client-side recompute.
+- Abandoned `in_flight` leases expire in 2 minutes (`PosOperation::LEASE_DURATION`). Do not reuse an old token after a new tender.
+
+If completion fails recoverably: keep the working transaction **and** the tender; show a completion error; offer retry complete with the **same** token. **Return to sale** is `POST abandon_tender`, then `SALE_ENTRY` with no working tender. Changing Cash presented after a failed complete: Return to sale, then `+` / Tender (new `TenderCash`, new token).
+
+### Lost complete response
+
+Phase 4 already prevents a second commercial effect. Recovery must reference **that** transaction, not “latest completed in this Session”:
+
+```text
+working transaction + Cash tender  → completion-pending (restore operation_id per above)
+POST complete / retry for an already-completed transaction
+  → GET /pos/transactions/:id/completed for that id
+GET /pos/transactions/:id/completed
+  → that transaction's receipt
+GET workspace, no working transaction
+  → GET enter
+```
+
+The browser may retain the transaction id it was completing (so a lost redirect can still request that receipt). The server must not infer a receipt from other completed sales in the Session.
+
+F9 / cancel is disabled while a `POST complete` is in flight. After a recoverable complete failure, cancel is allowed (`CancelTransaction`) if the basket has lines.
 
 Working-command in-flight guard: a second Enter must not fire `AddMerchandise` (or another mutation) before the first response refreshes `lock_version`.
 
@@ -249,9 +337,9 @@ Intercept `*` and `+` on keydown so they never become identifier text. Do not in
 | `SALE_ENTRY` | identifier → `AddMerchandise`. Empty Enter is a no-op. Digits alone are an identifier, not quantity | clear input; stay `SALE_ENTRY` | `*` → `QUANTITY` if a line is selected; `+` → `TENDER` if merchandise exists; Delete removes selected line |
 | `QUANTITY` | `ChangeQuantity` on selected line → `SALE_ENTRY` | abandon → `SALE_ENTRY` | quantity `0` is invalid (service requires positive); Delete is not used here — Escape then Delete in `SALE_ENTRY` |
 | `TENDER` (before `TenderCash` succeeds) | `POST tender` only | → `SALE_ENTRY` | insufficient Cash: remain `TENDER` |
-| completion pending (`TenderCash` succeeded, including GET workspace restore) | not a fourth named mode; input locked until complete response | do not silently return to `SALE_ENTRY` | retry is `POST complete` only; explicit return-to-sale control is allowed after a recoverable complete failure |
+| completion pending (`TenderCash` succeeded, including GET workspace restore) | not a fourth named mode; input locked until complete response | do not silently return to `SALE_ENTRY` | retry is `POST complete` only; **Return to sale** is `POST abandon_tender` |
 
-Keyboard map (shortcuts; each has a visible control):
+Keyboard map (shortcuts; each has a visible control). Bindings are **wireframe-validatable**; F9 is the current proposal, not an architectural lock.
 
 | Key | Action |
 |---|---|
@@ -261,7 +349,7 @@ Keyboard map (shortcuts; each has a visible control):
 | `+` | `TENDER` (no-op if no merchandise) |
 | Delete | `RemoveWorkingLine` on the selected line in `SALE_ENTRY` |
 | ArrowUp / ArrowDown | move selected line (in `SALE_ENTRY`) |
-| F9 | open cancel confirmation (disabled while `POST complete` is in flight) |
+| F9 | open cancel confirmation (disabled while `POST complete` is in flight, and while the basket has no lines) |
 | F9 again | confirm cancel (**not** Enter, **not** `Y` — barcodes may contain letters) |
 
 Cancel overlay: no text field (so a scan cannot type into it). Ignore Enter and alphanumeric keys. Visible Confirm (activates on second F9) and Don't cancel (Escape). Abort restores the prior mode and focus.
@@ -290,15 +378,32 @@ Phase 5 has no discounts or price overrides, so unit price + tax class is the pr
 
 Same variant with a different price/tax context becomes a separate line.
 
-**Basket mutation invalidates working tenders.** `AddMerchandise`, `ChangeQuantity`, and `RemoveWorkingLine` clear existing working tenders in the same database transaction. The cashier must re-enter `TENDER` after changing the basket.
+**Basket mutation and Return to sale invalidate working tenders.** `AddMerchandise`, `ChangeQuantity`, and `RemoveWorkingLine` clear existing working tenders in the same database transaction. **Return to sale** is `Pos::AbandonTender` (`POST abandon_tender`): lock the working transaction, require the transaction cashier, destroy the working tender, advance `lock_version`, render `SALE_ENTRY`. After that, GET workspace is `SALE_ENTRY` (no hidden tender). The cashier must re-enter `TENDER` to settle.
 
 Inventory shortage is a **completion** error (Phase 4 posts on complete, not on add-line). The scan path will not catch oversell.
 
-Cancel: explicit confirmation overlay (see keyboard map). Escape / Don't cancel returns to the prior mode and focus. Scanner Enter must not confirm.
+Cancel: explicit confirmation overlay (see keyboard map). Disabled when the working transaction has no lines. Escape / Don't cancel returns to the prior mode and focus. Scanner Enter must not confirm.
 
 ---
 
-## 9. Slice 2 acceptance (contract)
+## 9. Accessibility (locked)
+
+Not a visual redesign. Lock these before Stimulus is written:
+
+```text
+pos_feedback errors     → role="alert" (or equivalent assertive live region)
+ordinary status         → aria-live="polite"
+selected basket row     → semantic selected state, not color alone
+cancel overlay          → real dialog; background inert / non-focusable;
+                          focus restored to the primary field when closed
+disabled actions        → actual disabled state (empty-basket Cancel, in-flight complete)
+```
+
+Custom key handling must not undermine these semantics.
+
+---
+
+## 10. Slice 2 acceptance (contract)
 
 A cashier can:
 
@@ -308,19 +413,20 @@ A cashier can:
 4. Continue scanning without manually restoring focus.
 5. Scan the same compatible SKU again and increment the existing line.
 6. Change quantity and remove a working line using keyboard-only interaction (visible controls also exist).
-7. Cancel with explicit confirmation that scanner Enter cannot submit (second F9 confirms; Enter ignored).
+7. Cancel a sale that has lines with explicit confirmation that scanner Enter cannot submit (second F9 confirms; Enter ignored). Cancel is disabled on an empty basket.
 8. Enter Cash presented; insufficient Cash stays in `TENDER`; valid settlement calls `TenderCash` then `CompleteTransaction` as two HTTP requests.
-9. Retry completion without calling `TenderCash` again; one receipt and one inventory posting.
-10. Refresh the workspace and resume the same working transaction (GET does not create another). If a Cash tender is already on the working transaction, restore completion-pending rather than empty `SALE_ENTRY`.
-11. See a completion receipt/confirmation from completed facts, then continue to a fresh `SALE_ENTRY`.
-12. Receive inline feedback for unknown identifier, unsupported merchandise, stale `lock_version`, unresolved tax, insufficient Cash, inventory failure on complete, and recoverable completion/network errors, with the working transaction preserved.
-13. Be denied when a second cashier attempts to operate another cashier's Session.
-14. Never mutate receipt, inventory, tax, or totals in controller or Stimulus code.
+9. Retry completion without calling `TenderCash` again; one receipt and one inventory posting. Refresh while working+tender restores a matching `in_flight`/`failed` `operation_id` rather than minting a second attempt.
+10. Refresh the workspace and resume the same working transaction (GET does not create another). Working + Cash tender restores completion-pending. No working transaction redirects to the enter gate — never to an inferred “latest” receipt.
+11. See a completion receipt/confirmation from completed facts at `GET /pos/transactions/:id/completed`, then continue to a fresh `SALE_ENTRY`. A lost complete response or complete retry against an already-completed transaction routes to **that** id's receipt. Scanner input on the receipt must not submit New sale.
+12. Return to sale after a recoverable complete failure via `AbandonTender` (persisted tender is gone; GET workspace stays `SALE_ENTRY`).
+13. Receive inline feedback for unknown identifier, unsupported merchandise, stale `lock_version`, unresolved tax, insufficient Cash, inventory failure on complete, and recoverable completion/network errors, with the working transaction preserved.
+14. Be denied when a second cashier attempts to operate another cashier's Session.
+15. Never mutate receipt, inventory, tax, or totals in controller or Stimulus code.
 
-System tests (when the workspace is implemented) must cover at least: scan → focus restored → rescan increment; quantity mode; tender then complete; Escape; double Enter; insufficient Cash; refresh/re-entry; refresh with an existing tender restores completion-pending; completion retry without re-tender; cancel overlay ignores Enter and confirms on second F9.
+System tests (when the workspace is implemented) must cover at least: scan → focus restored → rescan increment; quantity mode; tender then complete; Escape; double Enter; insufficient Cash; refresh/re-entry; refresh with an existing tender restores completion-pending and the matching `operation_id`; completion retry without re-tender; complete succeeds / response lost / retry of that transaction's complete shows that receipt; GET workspace with no working transaction goes to enter; Return to sale clears the tender; empty-basket Cancel is disabled; cancel overlay ignores Enter and confirms on second F9; completed-receipt scanner Enter does not start New sale and drop the identifier; `pos_feedback` does not move the primary field.
 
 ---
 
-## 10. Out of this contract
+## 11. Out of this contract
 
 Close session UI, blind count, Z screens, receipt print, split tender, discounts, returns, suspend/recall, drawers, Terminal, new permissions, close/Z outbox, polished visual design, mobile POS, customer display.

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md
@@ -1,6 +1,6 @@
 # Phase 5 Slice 2 — Register workspace contract
 
-**Status:** HTTP/domain contract locked. Interaction details provisionally accepted pending Slice 2 UX wireframes (`register-workspace-ux.md`). Not yet implemented.
+**Status:** HTTP/domain contract locked. Register workspace implemented (Importmap + Turbo + Stimulus).
 
 **Authority:** Cashier-facing online Register workspace: open gate, ephemeral UI modes, HTTP commands, focus/retry rules, and the Slice 2 vs Slice 3 receipt split. Domain completion, tax, inventory posting, and receipt identity remain in the [Phase 4 packet](../phase4-point-of-sale/). Cash/Z snapshots remain in [phase5-schema.md](phase5-schema.md).
 
@@ -50,7 +50,7 @@ completed-receipt New sale shortcut (not Enter)
 | Topic | Decision |
 |---|---|
 | Client | Rails-native online POS. No Terminal table (ADR-021). No scanner API; scanners are keyboard input ending in Enter |
-| UI stack | Importmap + Turbo + Stimulus. Gems are in the Gemfile; they are **not installed** until the workspace implementation PR |
+| UI stack | Importmap + Turbo + Stimulus. Gems are installed for the Register workspace |
 | Layout | Dedicated POS layout. Do not reuse admin chrome for the selling surface (it would steal scan focus) |
 | Permission | `pos.transact` at the current store. Session cashier for session/transaction commands (`require_session_cashier!` / `require_transaction_cashier!`) |
 | Controllers | Orchestrate Phase 4/5 services only. No receipt allocation, inventory posting, tax calculation, or commercial total mutation in controllers or Stimulus |

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md
@@ -111,8 +111,11 @@ Register has no open Session:
   use the existing open period if one exists
     (do not re-confirm a date; use the period's business_date)
   otherwise open a period for BusinessDate.for_store(...) (confirm; no override).
-    POST the displayed date as `confirmed_business_date`. `EnterRegister` passes it to
-    `OpenReportingPeriod`. If the store calendar date has changed since GET, reject and re-render.
+    POST the displayed date as `confirmed_business_date` (required at the enter HTTP
+    boundary when no period exists). `EnterRegister` passes it to `OpenReportingPeriod`
+    only when creating a period. If the store calendar date has changed since GET, reject
+    and re-render. If another request opened a period first, the confirmed date must match
+    that period's `business_date` or the gate re-renders.
   then open Session (opening float required, integer cents >= 0, zero allowed)
 ```
 
@@ -294,8 +297,9 @@ GET workspace while working + tender (refresh)
        (newest in_flight, else newest failed; recompute CanonicalJson.hash with that row’s id as operation_id)
        → restore that operation_id
        → pending (no row yet): auto-complete
-       → failed or expired in_flight: Retry complete, no auto-submit
-       → unexpired in_flight: “Completion is still processing”; do not immediately POST again
+       → failed or expired in_flight: Retry complete, Return to sale, Cancel
+       → unexpired in_flight: “Completion is still processing”; no Retry, no Return to sale,
+         Cancel disabled; do not immediately POST again
   → no matching completion operation
        → mint a new completion_operation_id
   → transaction already completed

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md
@@ -21,6 +21,7 @@ ResumeOrStartTransaction
 rescan merge in AddMerchandise
 basket mutation clears tender
 AbandonTender (return to sale)
+CancelTransaction clears working tenders
 TenderCash / CompleteTransaction split
 completion retry semantics (no re-tender)
 Rails-issued completion operation_id (restore matching in_flight/failed)
@@ -39,6 +40,7 @@ where errors appear
 how completion-pending looks
 visible button arrangement
 receipt confirmation layout
+completed-receipt New sale shortcut (not Enter)
 ```
 
 ---
@@ -202,7 +204,11 @@ POST abandon_tender
   → render SALE_ENTRY
 POST cancel
   → allowed only when the working transaction has at least one line
-  → CancelTransaction (after explicit confirmation)
+  → CancelTransaction (after explicit confirmation):
+       lock working transaction
+       clear working tenders
+       status = cancelled, cancelled_at = Time.current
+       (keep cancelled lines)
   → ResumeOrStartTransaction
   → redirect workspace (SALE_ENTRY)
 
@@ -378,11 +384,22 @@ Phase 5 has no discounts or price overrides, so unit price + tax class is the pr
 
 Same variant with a different price/tax context becomes a separate line.
 
-**Basket mutation and Return to sale invalidate working tenders.** `AddMerchandise`, `ChangeQuantity`, and `RemoveWorkingLine` clear existing working tenders in the same database transaction. **Return to sale** is `Pos::AbandonTender` (`POST abandon_tender`): lock the working transaction, require the transaction cashier, destroy the working tender, advance `lock_version`, render `SALE_ENTRY`. After that, GET workspace is `SALE_ENTRY` (no hidden tender). The cashier must re-enter `TENDER` to settle.
+**Basket mutation, Return to sale, and Cancel invalidate working tenders.** `AddMerchandise`, `ChangeQuantity`, and `RemoveWorkingLine` clear existing working tenders in the same database transaction. **Return to sale** is `Pos::AbandonTender` (`POST abandon_tender`): lock the working transaction, require the transaction cashier, destroy the working tender, advance `lock_version`, render `SALE_ENTRY`. After that, GET workspace is `SALE_ENTRY` (no hidden tender). The cashier must re-enter `TENDER` to settle.
+
+**`CancelTransaction` clears working tenders** in the same database transaction, under the working-transaction lock, before marking the transaction cancelled. Keep cancelled lines (minimal cancellation activity). Do not leave a cancelled row with a provisional Cash tender. Share the same clear-tender helper as basket mutation and `AbandonTender`. Completed tenders are never touched (`lock_working_transaction!` already forbids that).
+
+Exit paths:
+
+```text
+basket edit     → tender invalidated
+Return to sale  → tender abandoned
+Cancel          → tender discarded
+Complete        → tender becomes completed immutable fact
+```
 
 Inventory shortage is a **completion** error (Phase 4 posts on complete, not on add-line). The scan path will not catch oversell.
 
-Cancel: explicit confirmation overlay (see keyboard map). Disabled when the working transaction has no lines. Escape / Don't cancel returns to the prior mode and focus. Scanner Enter must not confirm.
+Cancel: explicit confirmation overlay (see keyboard map). Disabled when the working transaction has no lines. Escape / Don't cancel returns to the prior mode and focus. Scanner Enter must not confirm. Cancel from the recoverable completion-error screen (working + tender) uses this same `CancelTransaction` rule.
 
 ---
 
@@ -413,17 +430,17 @@ A cashier can:
 4. Continue scanning without manually restoring focus.
 5. Scan the same compatible SKU again and increment the existing line.
 6. Change quantity and remove a working line using keyboard-only interaction (visible controls also exist).
-7. Cancel a sale that has lines with explicit confirmation that scanner Enter cannot submit (second F9 confirms; Enter ignored). Cancel is disabled on an empty basket.
+7. Cancel a sale that has lines with explicit confirmation that scanner Enter cannot submit (second F9 confirms; Enter ignored). Cancel is disabled on an empty basket. `CancelTransaction` discards any working tender before marking the sale cancelled.
 8. Enter Cash presented; insufficient Cash stays in `TENDER`; valid settlement calls `TenderCash` then `CompleteTransaction` as two HTTP requests.
 9. Retry completion without calling `TenderCash` again; one receipt and one inventory posting. Refresh while working+tender restores a matching `in_flight`/`failed` `operation_id` rather than minting a second attempt.
 10. Refresh the workspace and resume the same working transaction (GET does not create another). Working + Cash tender restores completion-pending. No working transaction redirects to the enter gate — never to an inferred “latest” receipt.
-11. See a completion receipt/confirmation from completed facts at `GET /pos/transactions/:id/completed`, then continue to a fresh `SALE_ENTRY`. A lost complete response or complete retry against an already-completed transaction routes to **that** id's receipt. Scanner input on the receipt must not submit New sale.
+11. See a completion receipt/confirmation from completed facts at `GET /pos/transactions/:id/completed`, then continue to a fresh `SALE_ENTRY` via the **New sale** control. Enter on the receipt is a no-op (scanner-safe). A lost complete response or complete retry against an already-completed transaction routes to **that** id's receipt.
 12. Return to sale after a recoverable complete failure via `AbandonTender` (persisted tender is gone; GET workspace stays `SALE_ENTRY`).
 13. Receive inline feedback for unknown identifier, unsupported merchandise, stale `lock_version`, unresolved tax, insufficient Cash, inventory failure on complete, and recoverable completion/network errors, with the working transaction preserved.
 14. Be denied when a second cashier attempts to operate another cashier's Session.
 15. Never mutate receipt, inventory, tax, or totals in controller or Stimulus code.
 
-System tests (when the workspace is implemented) must cover at least: scan → focus restored → rescan increment; quantity mode; tender then complete; Escape; double Enter; insufficient Cash; refresh/re-entry; refresh with an existing tender restores completion-pending and the matching `operation_id`; completion retry without re-tender; complete succeeds / response lost / retry of that transaction's complete shows that receipt; GET workspace with no working transaction goes to enter; Return to sale clears the tender; empty-basket Cancel is disabled; cancel overlay ignores Enter and confirms on second F9; completed-receipt scanner Enter does not start New sale and drop the identifier; `pos_feedback` does not move the primary field.
+System tests (when the workspace is implemented) must cover at least: scan → focus restored → rescan increment; quantity mode; tender then complete; Escape; double Enter; insufficient Cash; refresh/re-entry; refresh with an existing tender restores completion-pending and the matching `operation_id`; completion retry without re-tender; complete succeeds / response lost / retry of that transaction's complete shows that receipt; GET workspace with no working transaction goes to enter; Return to sale clears the tender; cancel of a working sale with a Cash tender leaves no tenders on the cancelled row; empty-basket Cancel is disabled; cancel overlay ignores Enter and confirms on second F9; completed-receipt Enter does not start New sale; `pos_feedback` does not move the primary field.
 
 ---
 

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md
@@ -33,7 +33,7 @@ Slice 2 vs Slice 3 boundary
 ### Wireframe-validatable
 
 ```text
-* / + / Delete / F9 bindings
+* / + / - / F9 bindings
 header hierarchy
 line-table layout and selected-line styling
 where errors appear
@@ -334,14 +334,14 @@ One primary POS input. Autofocus on load. After every successful action and reco
 
 Quantity and tender **reuse that same primary field** with a changed label. The only overlay is **cancel confirmation**. Occupied-register deny lives on `GET enter`, not on the selling surface.
 
-Intercept `*` and `+` on keydown so they never become identifier text. Do not intercept letter keys such as `T`.
+Intercept `*`, `+`, and `-` on keydown so they never become identifier text. Do not intercept letter keys such as `T`. Delete is native text editing, not a line-removal shortcut.
 
-`*` with no selected line is a no-op (stay `SALE_ENTRY`). `+` with no merchandise is a no-op. QUANTITY with no selected line is not entered.
+`*` with no selected line is a no-op (stay `SALE_ENTRY`). `+` with no merchandise is a no-op. `-` with no selected line is a no-op. QUANTITY with no selected line is not entered.
 
 | Mode | Enter | Escape | Other |
 |---|---|---|---|
-| `SALE_ENTRY` | identifier → `AddMerchandise`. Empty Enter is a no-op. Digits alone are an identifier, not quantity | clear input; stay `SALE_ENTRY` | `*` → `QUANTITY` if a line is selected; `+` → `TENDER` if merchandise exists; Delete removes selected line |
-| `QUANTITY` | `ChangeQuantity` on selected line → `SALE_ENTRY` | abandon → `SALE_ENTRY` | quantity `0` is invalid (service requires positive); Delete is not used here — Escape then Delete in `SALE_ENTRY` |
+| `SALE_ENTRY` | identifier → `AddMerchandise`. Empty Enter is a no-op. Digits alone are an identifier, not quantity | clear input; stay `SALE_ENTRY` | `*` → `QUANTITY` if a line is selected; `+` → `TENDER` if merchandise exists; `-` removes selected line |
+| `QUANTITY` | `ChangeQuantity` on selected line → `SALE_ENTRY` | abandon → `SALE_ENTRY` | quantity `0` is invalid (service requires positive); `-` is not used here — Escape then `-` in `SALE_ENTRY` |
 | `TENDER` (before `TenderCash` succeeds) | `POST tender` only | → `SALE_ENTRY` | insufficient Cash: remain `TENDER` |
 | completion pending (`TenderCash` succeeded, including GET workspace restore) | not a fourth named mode; input locked until complete response | do not silently return to `SALE_ENTRY` | retry is `POST complete` only; **Return to sale** is `POST abandon_tender` |
 
@@ -353,14 +353,14 @@ Keyboard map (shortcuts; each has a visible control). Bindings are **wireframe-v
 | Escape | back out where the table allows; on cancel overlay, abort confirm |
 | `*` | `QUANTITY` (no-op if no selected line) |
 | `+` | `TENDER` (no-op if no merchandise) |
-| Delete | `RemoveWorkingLine` on the selected line in `SALE_ENTRY` |
+| `-` | `RemoveWorkingLine` on the selected line in `SALE_ENTRY` |
 | ArrowUp / ArrowDown | move selected line (in `SALE_ENTRY`) |
 | F9 | open cancel confirmation (disabled while `POST complete` is in flight, and while the basket has no lines) |
 | F9 again | confirm cancel (**not** Enter, **not** `Y` — barcodes may contain letters) |
 
 Cancel overlay: no text field (so a scan cannot type into it). Ignore Enter and alphanumeric keys. Visible Confirm (activates on second F9) and Don't cancel (Escape). Abort restores the prior mode and focus.
 
-Selected line defaults to the line **returned** by the last `AddMerchandise`, or the last changed line. After `RemoveWorkingLine`, select the previous remaining line, or none if the basket is empty. Arrow keys move selection. QUANTITY and Delete apply to the selected line.
+Selected line defaults to the line **returned** by the last `AddMerchandise`, or the last changed line. After `RemoveWorkingLine`, select the previous remaining line, or none if the basket is empty. Arrow keys move selection. QUANTITY and `-` apply to the selected line.
 
 ---
 

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md
@@ -26,7 +26,7 @@ TenderCash / CompleteTransaction split
 completion retry semantics (no re-tender)
 Rails-issued completion operation_id (restore matching in_flight/failed)
 lost-complete recovery by explicit transaction id (not latest-in-session)
-cancel disabled when the basket is empty
+cancel disabled when the basket is empty (UI only)
 Slice 2 vs Slice 3 boundary
 ```
 
@@ -126,21 +126,19 @@ Opening float is collected **only when this POST will create a Session**. Resumi
 UNIQUE (pos_session_id) WHERE status = 'working'
 ```
 
-`StartTransaction` rejects if a working row exists while it holds the session lock.
+`StartTransaction` rejects if a working row exists while it holds the session lock. **Start means start** — do not give it resume semantics.
 
-Controllers must not `find || StartTransaction`. Use `Pos::ResumeOrStartTransaction`:
+Controllers must not `find || StartTransaction`. Use `Pos::ResumeOrStartTransaction` (UI-safe boundary). Both services share an internal create kernel after the Session is already locked and validated; Resume must not call Start (duplicated orchestration / second lock acquisition).
 
 ```text
-lock Session
-authorize actor
-require actor == Session cashier
-require Session and period open
+StartTransaction
+  → lock + authorize + validate
+  → reject if a working transaction exists
+  → create
 
-if working transaction exists
-  return it
-else
-  create through the same StartTransaction rules
-end
+ResumeOrStartTransaction
+  → lock + authorize + validate
+  → return existing working transaction or create
 ```
 
 **GET never creates transactions.** Refresh, prefetch, crawlers, and the back button must not mutate commercial state.
@@ -152,7 +150,7 @@ GET workspace (never create)
   if working transaction exists
     if it has a Cash tender
       → render completion-pending
-        (restore or issue completion_operation_id — see §6)
+        (restore matching completion_operation_id from persisted settlement — see §6)
     otherwise
       → render SALE_ENTRY
   else
@@ -168,7 +166,7 @@ Completed receipts are reached only with an **explicit** transaction identity: r
 
 Two browser tabs: last writer wins via `lock_version`. The stale tab shows an error and reloads. Slice 2 does not sync tabs.
 
-Empty working transactions created on enter/continue **block** `CloseSession` (existing Slice 1 gate). Do not auto-cancel on GET. **Cancel is disabled** while the working transaction has no lines (cancel+resume of an empty ticket is a no-op that still blocks close). After `CancelTransaction` of a sale that had lines, immediately `ResumeOrStartTransaction` (same as `POST continue`) so the cashier returns to empty `SALE_ENTRY`. Slice 3 may dispose of leftover empty working transactions on leave/close.
+Empty working transactions created on enter/continue **block** `CloseSession` (existing Slice 1 gate). Do not auto-cancel on GET. Slice 2 **disables the Cancel control** while the working transaction has no lines (cancel+resume of an empty ticket is a no-op that still blocks close). `CancelTransaction` itself **may** cancel an empty working transaction — Slice 3 may need that to dispose of leftovers before close. After `CancelTransaction` of a sale that had lines, immediately `ResumeOrStartTransaction` (same as `POST continue`) so the cashier returns to empty `SALE_ENTRY`.
 
 ---
 
@@ -190,7 +188,7 @@ GET workspace
   → read only; never create
   → find the Session's existing working transaction for this cashier
   → if working + Cash tender: render completion-pending
-       (restore matching completion_operation_id if one exists; otherwise mint)
+       (restore matching completion_operation_id from persisted settlement — see §6)
   → if working, no tender: render SALE_ENTRY
   → if no working transaction: redirect GET enter
        (never infer a completed receipt)
@@ -200,13 +198,14 @@ POST quantity        → ChangeQuantity; clear working tenders
 POST remove          → RemoveWorkingLine; clear working tenders
 POST abandon_tender
   → Pos::AbandonTender (lock working transaction; require transaction cashier;
-    destroy working tender; advance lock_version)
+    destroy working tender; advance lock_version only if a tender was removed)
   → render SALE_ENTRY
 POST cancel
-  → allowed only when the working transaction has at least one line
+  → workspace UI: only when the working transaction has at least one line
+    (CancelTransaction may still cancel an empty working transaction)
   → CancelTransaction (after explicit confirmation):
        lock working transaction
-       clear working tenders
+       clear working tenders (shared helper; no extra aggregate save)
        status = cancelled, cancelled_at = Time.current
        (keep cancelled lines)
   → ResumeOrStartTransaction
@@ -281,12 +280,13 @@ POST tender succeeds
 POST complete
   → operation_id = that token, unchanged on retries
 GET workspace while working + tender (refresh)
-  → look for an existing pos.complete_transaction for this transaction
-     whose command payload matches the current tender
-       (expected_lock_version, expected_total_cents, amount_presented_cents)
-  → matching in_flight or failed attempt
+  → FindCompletionOperation against persisted settlement
+       (transaction.lock_version, transaction.total_cents,
+        Cash tender amount_presented_cents — not browser-supplied values)
+  → matching in_flight or failed pos.complete_transaction
+       (recompute CanonicalJson.hash with that row’s id as operation_id)
        → restore that operation_id; Retry complete uses the same command
-  → no completion operation was ever started
+  → no matching completion operation
        → mint a new completion_operation_id
   → transaction already completed
        → redirect GET /pos/transactions/:id/completed for that id
@@ -297,10 +297,10 @@ Do **not** unconditionally mint a new id on refresh. Minting B while A is `in_fl
 - Reuse the token only for retries of that same post-tender payload (`expected_lock_version`, expected total, amount presented).
 - A new `TenderCash` (changed presented amount, or re-tender after `AbandonTender`) returns a **new** `completion_operation_id`.
 - After `TenderCash` succeeds, do not `POST tender` again unless the cashier is changing the presented amount. That requires `POST abandon_tender` (Return to sale) or Escape **before** `TenderCash` succeeded. Then a new `TenderCash` and a new token.
-- Stimulus sends `expected_total_cents` and `amount_presented_cents` from the **last tender / completion-pending render**, not a client-side recompute.
+- Stimulus sends `expected_total_cents` and `amount_presented_cents` from the **last tender / completion-pending render**, not a client-side recompute. Recovery on GET workspace uses **persisted** transaction + tender, not those browser fields.
 - Abandoned `in_flight` leases expire in 2 minutes (`PosOperation::LEASE_DURATION`). Do not reuse an old token after a new tender.
 
-If completion fails recoverably: keep the working transaction **and** the tender; show a completion error; offer retry complete with the **same** token. **Return to sale** is `POST abandon_tender`, then `SALE_ENTRY` with no working tender. Changing Cash presented after a failed complete: Return to sale, then `+` / Tender (new `TenderCash`, new token).
+If completion fails recoverably: keep the working transaction **and** the tender; show a completion error; offer retry complete with the **same** token. **Return to sale** is `POST abandon_tender`, then `SALE_ENTRY` with no working tender (`lock_version` advances only if a tender was removed). Changing Cash presented after a failed complete: Return to sale, then `+` / Tender (new `TenderCash`, new token).
 
 ### Lost complete response
 
@@ -318,7 +318,7 @@ GET workspace, no working transaction
 
 The browser may retain the transaction id it was completing (so a lost redirect can still request that receipt). The server must not infer a receipt from other completed sales in the Session.
 
-F9 / cancel is disabled while a `POST complete` is in flight. After a recoverable complete failure, cancel is allowed (`CancelTransaction`) if the basket has lines.
+F9 / cancel is disabled while a `POST complete` is in flight. After a recoverable complete failure, the workspace allows cancel if the basket has lines. `CancelTransaction` may still cancel an empty working transaction (Slice 3).
 
 Working-command in-flight guard: a second Enter must not fire `AddMerchandise` (or another mutation) before the first response refreshes `lock_version`.
 
@@ -384,9 +384,9 @@ Phase 5 has no discounts or price overrides, so unit price + tax class is the pr
 
 Same variant with a different price/tax context becomes a separate line.
 
-**Basket mutation, Return to sale, and Cancel invalidate working tenders.** `AddMerchandise`, `ChangeQuantity`, and `RemoveWorkingLine` clear existing working tenders in the same database transaction. **Return to sale** is `Pos::AbandonTender` (`POST abandon_tender`): lock the working transaction, require the transaction cashier, destroy the working tender, advance `lock_version`, render `SALE_ENTRY`. After that, GET workspace is `SALE_ENTRY` (no hidden tender). The cashier must re-enter `TENDER` to settle.
+**Basket mutation, Return to sale, and Cancel invalidate working tenders.** Share one helper (`clear_working_tenders!`): destroy working tenders only — do **not** `save!` the aggregate (basket commands persist via `refresh_totals!`). `AddMerchandise`, `ChangeQuantity`, and `RemoveWorkingLine` clear then mutate in the same database transaction. **Return to sale** is `Pos::AbandonTender` (`POST abandon_tender`): lock the working transaction, require the transaction cashier, destroy the working tender, advance `lock_version` **only if a tender was removed**, render `SALE_ENTRY`. After that, GET workspace is `SALE_ENTRY` (no hidden tender). The cashier must re-enter `TENDER` to settle.
 
-**`CancelTransaction` clears working tenders** in the same database transaction, under the working-transaction lock, before marking the transaction cancelled. Keep cancelled lines (minimal cancellation activity). Do not leave a cancelled row with a provisional Cash tender. Share the same clear-tender helper as basket mutation and `AbandonTender`. Completed tenders are never touched (`lock_working_transaction!` already forbids that).
+**`CancelTransaction` clears working tenders** in the same database transaction, under the working-transaction lock, before marking the transaction cancelled. Keep cancelled lines (minimal cancellation activity). Do not leave a cancelled row with a provisional Cash tender. Completed tenders are never touched (`lock_working_transaction!` already forbids that). The service **may** cancel an empty working transaction.
 
 Exit paths:
 
@@ -399,7 +399,7 @@ Complete        → tender becomes completed immutable fact
 
 Inventory shortage is a **completion** error (Phase 4 posts on complete, not on add-line). The scan path will not catch oversell.
 
-Cancel: explicit confirmation overlay (see keyboard map). Disabled when the working transaction has no lines. Escape / Don't cancel returns to the prior mode and focus. Scanner Enter must not confirm. Cancel from the recoverable completion-error screen (working + tender) uses this same `CancelTransaction` rule.
+Cancel: explicit confirmation overlay (see keyboard map). Slice 2 **disables the control** when the working transaction has no lines; that is operator UX, not a `CancelTransaction` invariant. Escape / Don't cancel returns to the prior mode and focus. Scanner Enter must not confirm. Cancel from the recoverable completion-error screen (working + tender) uses this same `CancelTransaction` rule.
 
 ---
 
@@ -430,9 +430,9 @@ A cashier can:
 4. Continue scanning without manually restoring focus.
 5. Scan the same compatible SKU again and increment the existing line.
 6. Change quantity and remove a working line using keyboard-only interaction (visible controls also exist).
-7. Cancel a sale that has lines with explicit confirmation that scanner Enter cannot submit (second F9 confirms; Enter ignored). Cancel is disabled on an empty basket. `CancelTransaction` discards any working tender before marking the sale cancelled.
+7. Cancel a sale that has lines with explicit confirmation that scanner Enter cannot submit (second F9 confirms; Enter ignored). Slice 2 disables Cancel on an empty basket; `CancelTransaction` may still cancel an empty working transaction. The service discards any working tender before marking the sale cancelled.
 8. Enter Cash presented; insufficient Cash stays in `TENDER`; valid settlement calls `TenderCash` then `CompleteTransaction` as two HTTP requests.
-9. Retry completion without calling `TenderCash` again; one receipt and one inventory posting. Refresh while working+tender restores a matching `in_flight`/`failed` `operation_id` rather than minting a second attempt.
+9. Retry completion without calling `TenderCash` again; one receipt and one inventory posting. Refresh while working+tender restores a matching `in_flight`/`failed` `operation_id` from **persisted** settlement rather than minting a second attempt.
 10. Refresh the workspace and resume the same working transaction (GET does not create another). Working + Cash tender restores completion-pending. No working transaction redirects to the enter gate — never to an inferred “latest” receipt.
 11. See a completion receipt/confirmation from completed facts at `GET /pos/transactions/:id/completed`, then continue to a fresh `SALE_ENTRY` via the **New sale** control. Enter on the receipt is a no-op (scanner-safe). A lost complete response or complete retry against an already-completed transaction routes to **that** id's receipt.
 12. Return to sale after a recoverable complete failure via `AbandonTender` (persisted tender is gone; GET workspace stays `SALE_ENTRY`).

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md
@@ -33,7 +33,7 @@ Slice 2 vs Slice 3 boundary
 ### Wireframe-validatable
 
 ```text
-* / + / - / F9 bindings
+* / + / F8 / F9 bindings
 header hierarchy
 line-table layout and selected-line styling
 where errors appear
@@ -110,7 +110,9 @@ Register has open Session for a different cashier
 Register has no open Session:
   use the existing open period if one exists
     (do not re-confirm a date; use the period's business_date)
-  otherwise open a period for BusinessDate.for_store(...) (confirm; no override)
+  otherwise open a period for BusinessDate.for_store(...) (confirm; no override).
+    POST the displayed date as `confirmed_business_date`. `EnterRegister` passes it to
+    `OpenReportingPeriod`. If the store calendar date has changed since GET, reject and re-render.
   then open Session (opening float required, integer cents >= 0, zero allowed)
 ```
 
@@ -217,16 +219,19 @@ POST tender
     completion_operation_id (SecureRandom.uuid_v7)
   → do not complete
 
-POST complete
+POST /pos/transactions/:transaction_id/complete
+  → load that transaction for the current store (not “the session’s working row”)
   → CompleteTransaction using the Rails-issued completion_operation_id as operation_id
   → retries hit only this endpoint with the same payload and same operation_id
-  → if the transaction is already completed: redirect to GET /pos/transactions/:id/completed
-    (lost-response / replay; do not create a second completion)
-  → otherwise redirect to GET /pos/transactions/:id/completed
+  → if the transaction is already completed: authorize Store + cashier, redirect to GET /pos/transactions/:id/completed
+    (lost-response / replay; do not create a second completion; do not redirect to enter)
+  → if working: CompleteTransaction, then redirect to GET /pos/transactions/:id/completed
+  → cancelled / other store / unknown id: not found
 
 GET /pos/transactions/:id/completed
-  → that transaction's immutable completed facts only
+  → that transaction's immutable completed facts only, loaded as id + current_store
   → session/transaction cashier only
+  → header uses the transaction's Store
   → if the transaction is not completed: not found (do not complete on GET)
 
 POST continue
@@ -250,6 +255,7 @@ POST tender (expected_lock_version = v5)
   → change + lock_version = v6
   → completion_operation_id = A   (Rails: SecureRandom.uuid_v7)
 POST complete (
+    /pos/transactions/:transaction_id/complete
     operation_id = A,
     expected_lock_version = v6,
     expected_total_cents from the tender response,
@@ -262,6 +268,7 @@ Completion retry:
 
 ```text
 POST complete again
+/pos/transactions/:transaction_id/complete
 operation_id = A
 expected_lock_version = v6
 same command payload
@@ -284,8 +291,11 @@ GET workspace while working + tender (refresh)
        (transaction.lock_version, transaction.total_cents,
         Cash tender amount_presented_cents — not browser-supplied values)
   → matching in_flight or failed pos.complete_transaction
-       (recompute CanonicalJson.hash with that row’s id as operation_id)
-       → restore that operation_id; Retry complete uses the same command
+       (newest in_flight, else newest failed; recompute CanonicalJson.hash with that row’s id as operation_id)
+       → restore that operation_id
+       → pending (no row yet): auto-complete
+       → failed or expired in_flight: Retry complete, no auto-submit
+       → unexpired in_flight: “Completion is still processing”; do not immediately POST again
   → no matching completion operation
        → mint a new completion_operation_id
   → transaction already completed
@@ -309,7 +319,7 @@ Phase 4 already prevents a second commercial effect. Recovery must reference **t
 ```text
 working transaction + Cash tender  → completion-pending (restore operation_id per above)
 POST complete / retry for an already-completed transaction
-  → GET /pos/transactions/:id/completed for that id
+  → GET /pos/transactions/:id/completed for that id (transaction-scoped complete; never infer via the working-row lookup)
 GET /pos/transactions/:id/completed
   → that transaction's receipt
 GET workspace, no working transaction
@@ -334,14 +344,14 @@ One primary POS input. Autofocus on load. After every successful action and reco
 
 Quantity and tender **reuse that same primary field** with a changed label. The only overlay is **cancel confirmation**. Occupied-register deny lives on `GET enter`, not on the selling surface.
 
-Intercept `*`, `+`, and `-` on keydown so they never become identifier text. Do not intercept letter keys such as `T`. Delete is native text editing, not a line-removal shortcut.
+Intercept `*` and `+` on keydown so they never become identifier text. Do not intercept letter keys such as `T` or hyphen. Delete is native text editing. F8 removes the selected line in `SALE_ENTRY`.
 
-`*` with no selected line is a no-op (stay `SALE_ENTRY`). `+` with no merchandise is a no-op. `-` with no selected line is a no-op. QUANTITY with no selected line is not entered.
+`*` with no selected line is a no-op (stay `SALE_ENTRY`). `+` with no merchandise is a no-op. F8 with no selected line is a no-op. QUANTITY with no selected line is not entered.
 
 | Mode | Enter | Escape | Other |
 |---|---|---|---|
-| `SALE_ENTRY` | identifier → `AddMerchandise`. Empty Enter is a no-op. Digits alone are an identifier, not quantity | clear input; stay `SALE_ENTRY` | `*` → `QUANTITY` if a line is selected; `+` → `TENDER` if merchandise exists; `-` removes selected line |
-| `QUANTITY` | `ChangeQuantity` on selected line → `SALE_ENTRY` | abandon → `SALE_ENTRY` | quantity `0` is invalid (service requires positive); `-` is not used here — Escape then `-` in `SALE_ENTRY` |
+| `SALE_ENTRY` | identifier → `AddMerchandise`. Empty Enter is a no-op. Digits alone are an identifier, not quantity | clear input; stay `SALE_ENTRY` | `*` → `QUANTITY` if a line is selected; `+` → `TENDER` if merchandise exists; F8 removes selected line |
+| `QUANTITY` | `ChangeQuantity` on selected line → `SALE_ENTRY` | abandon → `SALE_ENTRY` | quantity `0` is invalid (service requires positive); F8 is not used here — Escape then F8 in `SALE_ENTRY` |
 | `TENDER` (before `TenderCash` succeeds) | `POST tender` only | → `SALE_ENTRY` | insufficient Cash: remain `TENDER` |
 | completion pending (`TenderCash` succeeded, including GET workspace restore) | not a fourth named mode; input locked until complete response | do not silently return to `SALE_ENTRY` | retry is `POST complete` only; **Return to sale** is `POST abandon_tender` |
 
@@ -349,18 +359,18 @@ Keyboard map (shortcuts; each has a visible control). Bindings are **wireframe-v
 
 | Key | Action |
 |---|---|
-| Enter | confirm current mode; **ignored** on the cancel overlay |
+| Enter | confirm current mode; **ignored** on the cancel overlay; when focus is on a visible button, Enter activates that button |
 | Escape | back out where the table allows; on cancel overlay, abort confirm |
 | `*` | `QUANTITY` (no-op if no selected line) |
 | `+` | `TENDER` (no-op if no merchandise) |
-| `-` | `RemoveWorkingLine` on the selected line in `SALE_ENTRY` |
+| F8 | `RemoveWorkingLine` on the selected line in `SALE_ENTRY` |
 | ArrowUp / ArrowDown | move selected line (in `SALE_ENTRY`) |
 | F9 | open cancel confirmation (disabled while `POST complete` is in flight, and while the basket has no lines) |
 | F9 again | confirm cancel (**not** Enter, **not** `Y` — barcodes may contain letters) |
 
-Cancel overlay: no text field (so a scan cannot type into it). Ignore Enter and alphanumeric keys. Visible Confirm (activates on second F9) and Don't cancel (Escape). Abort restores the prior mode and focus.
+Cancel overlay: no text field (so a scan cannot type into it). Ignore Enter and alphanumeric keys. Visible Confirm (activates on second F9) and Don't cancel (Escape). The selling chrome behind the overlay is `inert`; Tab stays in the dialog. Abort restores the prior mode and focus.
 
-Selected line defaults to the line **returned** by the last `AddMerchandise`, or the last changed line. After `RemoveWorkingLine`, select the previous remaining line, or none if the basket is empty. Arrow keys move selection. QUANTITY and `-` apply to the selected line.
+Selected line defaults to the line **returned** by the last `AddMerchandise`, or the last changed line. After `RemoveWorkingLine`, select the previous remaining line, or none if the basket is empty. Arrow keys move selection. QUANTITY and F8 apply to the selected line.
 
 ---
 

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md
@@ -50,7 +50,7 @@ completed-receipt New sale shortcut (not Enter)
 | Topic | Decision |
 |---|---|
 | Client | Rails-native online POS. No Terminal table (ADR-021). No scanner API; scanners are keyboard input ending in Enter |
-| UI stack | Importmap + Turbo + Stimulus. Gems are installed for the Register workspace |
+| UI stack | Importmap + Turbo + Stimulus. Gems are installed for the Register workspace. The POS layout loads `pos.js`; the admin layout loads `application.js` without Turbo and sets `data-turbo="false"` |
 | Layout | Dedicated POS layout. Do not reuse admin chrome for the selling surface (it would steal scan focus) |
 | Permission | `pos.transact` at the current store. Session cashier for session/transaction commands (`require_session_cashier!` / `require_transaction_cashier!`) |
 | Controllers | Orchestrate Phase 4/5 services only. No receipt allocation, inventory posting, tax calculation, or commercial total mutation in controllers or Stimulus |

--- a/docs/planning/phase4-6-point-of-sale/spec.md
+++ b/docs/planning/phase4-6-point-of-sale/spec.md
@@ -776,7 +776,7 @@ Recalculate:
 * tax;
 * total.
 
-Basket mutations (`AddMerchandise`, `ChangeQuantity`, `RemoveWorkingLine`) clear any working tender in the same transaction.
+Basket mutations (`AddMerchandise`, `ChangeQuantity`, `RemoveWorkingLine`), Return to sale (`AbandonTender`), and `CancelTransaction` clear any working tender in the same transaction.
 
 Phase 5 has no approval requirement because price/discount-controlled actions are not yet exposed.
 
@@ -798,6 +798,7 @@ Cancellation:
 
 * requires explicit confirmation that scanner Enter cannot submit (second F9 confirms; Enter ignored);
 * is disabled when the working transaction has no lines;
+* clears any working tenders in the same database transaction before marking the sale cancelled (keep cancelled lines);
 * then `ResumeOrStartTransaction` so the cashier returns to `SALE_ENTRY`;
 * creates no completed commercial facts;
 * creates no receipt;
@@ -825,7 +826,7 @@ Insufficient Cash stays in `TENDER`. No split tender in Phase 5.
 
 # 5.11 Receipt rendering and printing
 
-Slice 2: on-screen **completion receipt/confirmation** from immutable completed transaction facts (`transaction_reference`, total, Cash presented, change, concise lines). No print controls.
+Slice 2: on-screen **completion receipt/confirmation** from immutable completed transaction facts (`transaction_reference`, total, Cash presented, change, concise lines). No print controls. Enter on this page is a no-op; **New sale** is an explicit control ([register-workspace-ux.md](phase5-cash-register/register-workspace-ux.md) frame 8).
 
 Slice 3: the first supported **print** path for those same facts.
 

--- a/docs/planning/phase4-6-point-of-sale/spec.md
+++ b/docs/planning/phase4-6-point-of-sale/spec.md
@@ -705,32 +705,36 @@ It belongs to Cash custody/accountability.
 
 # 5.4 Keyboard/scanner Register workspace
 
-Build a dedicated Rails POS workspace.
+Authority: [register-workspace.md](phase5-cash-register/register-workspace.md). That packet supersedes this section where they disagree.
+
+Build a dedicated Rails POS workspace (Importmap + Turbo + Stimulus; dedicated POS layout, not admin chrome).
 
 Ordinary path:
 
 ```text
 scan
-→ line added
+→ line added (compatible rescan increments the existing line)
 → scan
 → quantity correction if needed
-→ tender
-→ complete
+→ tender (TenderCash)
+→ complete (CompleteTransaction; separate HTTP request)
+→ on-screen completion receipt/confirmation
 → next transaction
 ```
 
-without requiring a mouse.
+without requiring a mouse. Every shortcut has a visible control.
 
 ### Required UX behavior
 
 * persistent transaction workspace;
-* primary scan/input control;
-* automatic focus;
-* Enter confirms;
-* Escape backs out where safe;
-* focus returns to scan target after ordinary operations;
-* completed transaction resets workspace;
-* errors preserve current transaction.
+* one primary scan/input control; autofocus; scanners are keyboard input ending in Enter;
+* Enter confirms the current ephemeral mode;
+* Escape backs out where [register-workspace.md](phase5-cash-register/register-workspace.md) allows;
+* focus returns to the primary input after ordinary operations;
+* GET workspace never creates a transaction; refresh resumes the same working transaction;
+* at most one working transaction per Session (`ResumeOrStartTransaction` on POST enter/continue);
+* completed sale shows an on-screen confirmation from immutable facts, then continue starts a fresh working transaction;
+* errors preserve the current working transaction.
 
 ---
 
@@ -744,7 +748,7 @@ QUANTITY
 TENDER
 ```
 
-Additional modes are Phase 6.
+UI modes are ephemeral browser state. Authoritative status remains `working` / `completed` / `cancelled`. After `TenderCash` succeeds, input is locked for `CompleteTransaction` retry (not a fourth named mode). Additional named modes are Phase 6.
 
 ---
 
@@ -758,17 +762,21 @@ Standard quantity-tracked merchandise
 
 No individually tracked, non-inventory, or open-ring lines yet.
 
+`AddMerchandise` merges a compatible rescan (same variant, direction, unit price, tax class) by incrementing quantity and returns the resulting line.
+
 ---
 
 # 5.7 Quantity correction
 
-Allow quantity change before completion.
+Allow quantity change before completion via `ChangeQuantity` (absolute quantity; `0` is invalid — remove the line instead).
 
 Recalculate:
 
 * extended price;
 * tax;
 * total.
+
+Basket mutations (`AddMerchandise`, `ChangeQuantity`, `RemoveWorkingLine`) clear any working tender in the same transaction.
 
 Phase 5 has no approval requirement because price/discount-controlled actions are not yet exposed.
 
@@ -788,6 +796,7 @@ Allow an open transaction to be cancelled.
 
 Cancellation:
 
+* requires explicit confirmation that scanner Enter cannot submit (second F9 confirms; Enter ignored);
 * creates no completed commercial facts;
 * creates no receipt;
 * posts no Inventory movement.
@@ -798,7 +807,7 @@ Preserve minimal cancellation activity where the transaction had meaningful work
 
 # 5.10 Cash tender UI
 
-Provide a focused Cash dialog/interface.
+Provide a focused Cash interface. `TenderCash` and `CompleteTransaction` are **two HTTP requests**. Completion retries must not call `TenderCash` again ([register-workspace.md](phase5-cash-register/register-workspace.md) §6).
 
 Example:
 
@@ -808,19 +817,21 @@ Cash received:    [20.00]
 Change:            $2.76
 ```
 
-Completion uses the same Phase 4 settlement/completion services.
+Insufficient Cash stays in `TENDER`. No split tender in Phase 5.
 
 ---
 
 # 5.11 Receipt rendering and printing
 
-Add the first operational receipt.
+Slice 2: on-screen **completion receipt/confirmation** from immutable completed transaction facts (`transaction_reference`, total, Cash presented, change, concise lines). No print controls.
 
-Required:
+Slice 3: the first supported **print** path for those same facts.
+
+Required (print, Slice 3):
 
 * render from immutable completed transaction facts;
-* permanent receipt number;
-* print prompt after completion;
+* permanent receipt number / transaction reference ([receipt-identity.md](phase4-point-of-sale/receipt-identity.md));
+* print prompt after the cashier can already see the on-screen confirmation;
 * one supported print path;
 * printer failure does not undo completion.
 

--- a/docs/planning/phase4-6-point-of-sale/spec.md
+++ b/docs/planning/phase4-6-point-of-sale/spec.md
@@ -705,7 +705,7 @@ It belongs to Cash custody/accountability.
 
 # 5.4 Keyboard/scanner Register workspace
 
-Authority: [register-workspace.md](phase5-cash-register/register-workspace.md). That packet supersedes this section where they disagree.
+Authority: [register-workspace.md](phase5-cash-register/register-workspace.md). Interaction wireframes: [register-workspace-ux.md](phase5-cash-register/register-workspace-ux.md). That packet supersedes this section where they disagree.
 
 Build a dedicated Rails POS workspace (Importmap + Turbo + Stimulus; dedicated POS layout, not admin chrome).
 
@@ -731,7 +731,7 @@ without requiring a mouse. Every shortcut has a visible control.
 * Enter confirms the current ephemeral mode;
 * Escape backs out where [register-workspace.md](phase5-cash-register/register-workspace.md) allows;
 * focus returns to the primary input after ordinary operations;
-* GET workspace never creates a transaction; refresh resumes the same working transaction;
+* GET workspace never creates a transaction; working + tender restores completion-pending (and a matching completion `operation_id` if one exists); no working transaction redirects to the enter gate (never infers a “latest” receipt);
 * at most one working transaction per Session (`ResumeOrStartTransaction` on POST enter/continue);
 * completed sale shows an on-screen confirmation from immutable facts, then continue starts a fresh working transaction;
 * errors preserve the current working transaction.
@@ -797,6 +797,8 @@ Allow an open transaction to be cancelled.
 Cancellation:
 
 * requires explicit confirmation that scanner Enter cannot submit (second F9 confirms; Enter ignored);
+* is disabled when the working transaction has no lines;
+* then `ResumeOrStartTransaction` so the cashier returns to `SALE_ENTRY`;
 * creates no completed commercial facts;
 * creates no receipt;
 * posts no Inventory movement.
@@ -807,7 +809,7 @@ Preserve minimal cancellation activity where the transaction had meaningful work
 
 # 5.10 Cash tender UI
 
-Provide a focused Cash interface. `TenderCash` and `CompleteTransaction` are **two HTTP requests**. Completion retries must not call `TenderCash` again ([register-workspace.md](phase5-cash-register/register-workspace.md) §6).
+Provide a focused Cash interface. `TenderCash` and `CompleteTransaction` are **two HTTP requests**. Rails issues `completion_operation_id` on a successful tender (Stimulus treats it as opaque). Refresh of completion-pending **restores** a matching `in_flight`/`failed` operation rather than minting a second attempt. Completion retries must not call `TenderCash` again ([register-workspace.md](phase5-cash-register/register-workspace.md) §6). Return to sale is `AbandonTender` (clears the persisted tender). A lost complete response or `POST complete` against an already-completed transaction opens **that** sale's immutable receipt by id.
 
 Example:
 

--- a/docs/planning/phase4-6-point-of-sale/spec.md
+++ b/docs/planning/phase4-6-point-of-sale/spec.md
@@ -797,7 +797,7 @@ Allow an open transaction to be cancelled.
 Cancellation:
 
 * requires explicit confirmation that scanner Enter cannot submit (second F9 confirms; Enter ignored);
-* is disabled when the working transaction has no lines;
+* Slice 2 disables the Cancel control when the working transaction has no lines (`CancelTransaction` may still cancel an empty working transaction);
 * clears any working tenders in the same database transaction before marking the sale cancelled (keep cancelled lines);
 * then `ResumeOrStartTransaction` so the cashier returns to `SALE_ENTRY`;
 * creates no completed commercial facts;
@@ -810,7 +810,7 @@ Preserve minimal cancellation activity where the transaction had meaningful work
 
 # 5.10 Cash tender UI
 
-Provide a focused Cash interface. `TenderCash` and `CompleteTransaction` are **two HTTP requests**. Rails issues `completion_operation_id` on a successful tender (Stimulus treats it as opaque). Refresh of completion-pending **restores** a matching `in_flight`/`failed` operation rather than minting a second attempt. Completion retries must not call `TenderCash` again ([register-workspace.md](phase5-cash-register/register-workspace.md) §6). Return to sale is `AbandonTender` (clears the persisted tender). A lost complete response or `POST complete` against an already-completed transaction opens **that** sale's immutable receipt by id.
+Provide a focused Cash interface. `TenderCash` and `CompleteTransaction` are **two HTTP requests**. Rails issues `completion_operation_id` on a successful tender (Stimulus treats it as opaque). Refresh of completion-pending **restores** a matching `in_flight`/`failed` operation from **persisted** settlement rather than minting a second attempt. Completion retries must not call `TenderCash` again ([register-workspace.md](phase5-cash-register/register-workspace.md) §6). Return to sale is `AbandonTender` (clears the persisted tender; no `lock_version` bump when there is none). A lost complete response or `POST complete` against an already-completed transaction opens **that** sale's immutable receipt by id.
 
 Example:
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,74 +4,37 @@ ShelfSense uses GitHub Actions to run the checks that the application currently 
 
 - Rails security analysis with Brakeman
 - Ruby dependency auditing with Bundler Audit
+- JavaScript dependency auditing with `bin/importmap audit`
 - Ruby style checks with RuboCop
 - The Rails test suite with PostgreSQL
-
-Two Rails-generated checks have been removed from CI because the application does not yet contain the code or configuration they require. They should be restored when the corresponding features are introduced.
+- Register workspace system tests with headless Chrome
 
 ## System tests
 
-### Why the CI job was removed
+System tests live under `test/system/` and use Selenium with headless Chrome. Locally they must run inside Docker:
 
-The generated system-test job ran:
+```sh
+docker compose build
+./dev/rails-docker bin/rails test:system
+```
+
+`Dockerfile.dev` installs Chromium and chromedriver. Chrome runs as the `rails` user with `--no-sandbox`. The minimum viewport is `1280×720`.
+
+CI runs system tests as a separate job after installing Chrome:
 
 ```sh
 bin/rails db:test:prepare test:system
 ```
-
-ShelfSense does not currently have a `test/system/` directory or any browser-based system tests. Rails therefore attempted to load the nonexistent `test/system` path and failed with a `LoadError`. Keeping that job would make CI fail without testing any application behavior.
-
-This removal does not disable the regular Rails test suite. CI continues to run:
-
-```sh
-bin/rails db:test:prepare test
-```
-
-### When to restore it
-
-Restore a separate system-test job when ShelfSense has user workflows that require browser-level verification and at least one real system test has been added. Before restoring the job:
-
-1. Add `test/application_system_test_case.rb`.
-2. Add at least one test under `test/system/`.
-3. Select and configure a supported browser driver, such as Selenium with headless Chrome.
-4. Confirm the tests pass locally with `./dev/rails-docker bin/rails test:system`.
-5. Ensure the CI runner installs any browser or operating-system packages required by the driver.
-
-The restored CI command can then be:
-
-```sh
-bin/rails db:test:prepare test:system
-```
-
-A separate job is preferable because browser tests usually require additional dependencies and run more slowly than unit, model, request, and integration tests.
 
 ## JavaScript dependency audit
 
-### Why the CI job was removed
-
-The generated JavaScript audit job ran:
+Importmap pins live in `config/importmap.rb`. CI runs:
 
 ```sh
 bin/importmap audit
 ```
 
-ShelfSense does not currently have the files produced by installing and configuring Importmap for Rails, including `bin/importmap` and `config/importmap.rb`. It also has no pinned importmap dependencies to audit. The job consequently failed with “No such file or directory” before performing a security check.
-
 Ruby dependency security remains covered by `bin/bundler-audit`.
-
-### When to restore or replace it
-
-Add JavaScript dependency auditing when the application adopts a JavaScript dependency mechanism.
-
-If ShelfSense adopts Importmap:
-
-1. Install and configure `importmap-rails`.
-2. Confirm `bin/importmap` and `config/importmap.rb` are committed.
-3. Add the application's JavaScript pins.
-4. Verify `./dev/rails-docker bin/importmap audit` locally.
-5. Restore a CI job that runs `bin/importmap audit`.
-
-If ShelfSense instead adopts npm, Yarn, pnpm, Bun, or another package manager, do not restore the importmap command. Add the audit command appropriate to the chosen package manager and ensure CI installs dependencies from the committed lockfile.
 
 ## Maintenance rule
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -16,9 +16,10 @@ System tests live under `test/system/` and use Selenium with headless Chrome. Lo
 ```sh
 docker compose build
 ./dev/rails-docker bin/rails test:system
+./dev/rails-docker bin/ci
 ```
 
-`Dockerfile.dev` installs Chromium and chromedriver. Chrome runs as the `rails` user with `--no-sandbox`. The minimum viewport is `1280×720`.
+`Dockerfile.dev` installs Chromium and chromedriver and sets `SE_CHROMEDRIVER` so Selenium uses that binary instead of downloading Google Chrome (which is unavailable on Linux ARM64). `./dev/rails-docker` starts a throwaway `web` container for `test:system` and `bin/ci` even when the app server is already up, so those commands see the image packages rather than a stale server container. Rebuild after pulling Dockerfile changes: `docker compose build`. Chrome runs as the `rails` user with `--no-sandbox`. The minimum viewport is `1280×720`.
 
 CI runs system tests as a separate job after installing Chrome:
 

--- a/docs/ux-conventions.md
+++ b/docs/ux-conventions.md
@@ -79,7 +79,7 @@ Keep keyboard focus visible. Do not communicate meaning by color alone (pair bad
 
 ## Hotwire
 
-Admin screens remain Propshaft CSS + ERB (Phase 2.2). Phase 5 Slice 2 uses Importmap + Turbo + Stimulus for the cashier Register workspace only ([register-workspace.md](planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md)). Do not add Hotwire to admin chrome as a side effect of POS work.
+Admin screens remain Propshaft CSS + ERB (Phase 2.2). The admin layout loads `application.js` (no Turbo/Stimulus) and sets `data-turbo="false"` so admin forms stay full-page POSTs. Phase 5 Slice 2 uses Importmap + Turbo + Stimulus for the cashier Register workspace only (`pos.js` via the POS layout; [register-workspace.md](planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md)). Do not add Hotwire to admin chrome as a side effect of POS work.
 
 ## Phase 3 and later
 

--- a/docs/ux-conventions.md
+++ b/docs/ux-conventions.md
@@ -79,7 +79,7 @@ Keep keyboard focus visible. Do not communicate meaning by color alone (pair bad
 
 ## Hotwire
 
-Admin screens remain Propshaft CSS + ERB (Phase 2.2). Phase 5 Slice 2 locks Importmap + Turbo + Stimulus for the cashier Register workspace only ([register-workspace.md](planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md)). Those gems are not installed until the workspace implementation PR. Do not add Hotwire to admin chrome in the same change.
+Admin screens remain Propshaft CSS + ERB (Phase 2.2). Phase 5 Slice 2 uses Importmap + Turbo + Stimulus for the cashier Register workspace only ([register-workspace.md](planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md)). Do not add Hotwire to admin chrome as a side effect of POS work.
 
 ## Phase 3 and later
 

--- a/docs/ux-conventions.md
+++ b/docs/ux-conventions.md
@@ -79,7 +79,7 @@ Keep keyboard focus visible. Do not communicate meaning by color alone (pair bad
 
 ## Hotwire
 
-Importmap, Turbo, and Stimulus remain deferred. Phase 2.2 is Propshaft CSS + ERB only. Any Hotwire adoption must be a separately accepted change.
+Admin screens remain Propshaft CSS + ERB (Phase 2.2). Phase 5 Slice 2 locks Importmap + Turbo + Stimulus for the cashier Register workspace only ([register-workspace.md](planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md)). Those gems are not installed until the workspace implementation PR. Do not add Hotwire to admin chrome in the same change.
 
 ## Phase 3 and later
 

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  driven_by :selenium, using: :headless_chrome, screen_size: [ 1280, 720 ] do |options|
+    binary = ENV["CHROME_BIN"].presence ||
+      %w[/usr/bin/chromium /usr/bin/chromium-browser /usr/bin/google-chrome].find { |path| File.exist?(path) }
+    options.binary = binary if binary.present?
+    options.add_argument("--headless=new")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--disable-dev-shm-usage")
+    options.add_argument("--disable-gpu")
+  end
+end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -3,10 +3,20 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  CHROME_BINARIES = %w[/usr/bin/chromium /usr/bin/chromium-browser /usr/bin/google-chrome].freeze
+  CHROMEDRIVERS = %w[/usr/bin/chromedriver /usr/lib/chromium/chromedriver].freeze
+
+  chrome_bin = ENV["CHROME_BIN"].presence || CHROME_BINARIES.find { |path| File.executable?(path) }
+  chromedriver = ENV["SE_CHROMEDRIVER"].presence || ENV["CHROMEDRIVER_PATH"].presence ||
+    CHROMEDRIVERS.find { |path| File.executable?(path) }
+
+  if chromedriver.present? && File.executable?(chromedriver)
+    ENV["SE_CHROMEDRIVER"] ||= chromedriver
+    Selenium::WebDriver::Chrome::Service.driver_path = chromedriver
+  end
+
   driven_by :selenium, using: :headless_chrome, screen_size: [ 1280, 720 ] do |options|
-    binary = ENV["CHROME_BIN"].presence ||
-      %w[/usr/bin/chromium /usr/bin/chromium-browser /usr/bin/google-chrome].find { |path| File.exist?(path) }
-    options.binary = binary if binary.present?
+    options.binary = chrome_bin if chrome_bin.present?
     options.add_argument("--headless=new")
     options.add_argument("--no-sandbox")
     options.add_argument("--disable-dev-shm-usage")

--- a/test/helpers/pos_helper_test.rb
+++ b/test/helpers/pos_helper_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PosHelperTest < ActionView::TestCase
+  test "print line description uses the completed snapshot only" do
+    line = PosTransactionLine.new(merchandise_snapshot: { "description" => "Snapshot Book", "sku" => "OLD" })
+    assert_equal "Snapshot Book", pos_print_line_description(line)
+  end
+
+  test "print line description does not fall back to live product metadata" do
+    product = Product.new(name: "Live Product Name")
+    variant = ProductVariant.new(sku: "LIVE-SKU", product: product)
+    line = PosTransactionLine.new(merchandise_snapshot: {}, product_variant: variant)
+
+    assert_equal "Description unavailable", pos_print_line_description(line)
+    refute_includes pos_print_line_description(line), "Live Product Name"
+  end
+end

--- a/test/integration/inventory_adjustment_identifier_test.rb
+++ b/test/integration/inventory_adjustment_identifier_test.rb
@@ -60,6 +60,16 @@ class InventoryAdjustmentIdentifierTest < ActionDispatch::IntegrationTest
     @shrinkage = AdjustmentReason.find_by!(code: "shrinkage")
   end
 
+  test "adjustment form is a full page post without turbo" do
+    sign_in_as("admin")
+
+    get new_admin_inventory_adjustment_path
+    assert_response :success
+    assert_select "html[data-turbo=false]"
+    assert_select "script[type=module]", text: /import "application"/
+    assert_select "script[type=module]", text: /import "pos"/, count: 0
+  end
+
   test "posts quantity adjustment using variant SKU" do
     sign_in_as("admin")
 

--- a/test/integration/inventory_store_authz_test.rb
+++ b/test/integration/inventory_store_authz_test.rb
@@ -98,6 +98,13 @@ class InventoryStoreAuthzTest < ActionDispatch::IntegrationTest
     assert_not @east_adjustment.reload.reversed?
   end
 
+  test "store-scoped manager cannot show another store's balance" do
+    sign_in_as("manager")
+
+    get admin_inventory_balance_path(@east_balance)
+    assert_redirected_to root_path
+  end
+
   test "rebuild is denied for another store" do
     sign_in_as("manager")
 

--- a/test/integration/pos_close_z_test.rb
+++ b/test/integration/pos_close_z_test.rb
@@ -1,0 +1,445 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PosCloseZTest < ActionDispatch::IntegrationTest
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    @tax = tax_class(code: "physical_book", name: "Physical book")
+    StoreTaxes::Create.call(
+      store: @store,
+      actor: @actor,
+      name: "Illinois State",
+      rate_percent: "5.000",
+      calculation_order: 1,
+      applies_by_tax_class_id: { @tax.id => true }
+    )
+    @variant = pos_sellable_variant(actor: @actor, tax_class: @tax)
+    open_quantity_stock(store: @store, variant: @variant, actor: @actor, quantity: 10)
+    @register = Register.create!(store: @store, register_number: 1, name: "Front")
+    sign_in_as("admin")
+  end
+
+  test "completed receipt exposes print and close without mutating on get" do
+    transaction = complete_http_sale(opening_float: "100.00")
+    get pos_completed_transaction_path(transaction)
+    assert_response :success
+    assert_select "button", text: "Print receipt"
+    assert_match "New sale", response.body
+    assert_match "Close register", response.body
+    assert_match "Store: 001   Reg: 01   Trans:", response.body
+    assert_match "Example Book", response.body
+    assert_select ".pos-print-only"
+    assert_select ".pos-no-print"
+    assert transaction.reload.completed?
+    assert_equal 1, PosTransaction.completed.where(id: transaction.id).count
+  end
+
+  test "empty sale entry can initiate close and cancel the empty ticket" do
+    post pos_register_enter_path, params: enter_params(opening_float: "100.00")
+    follow_redirect!
+    assert_match "Close register", response.body
+    transaction = PosTransaction.working.find_by!(register: @register)
+    session_record = transaction.pos_session
+
+    post pos_register_close_path
+    assert_redirected_to pos_session_close_path(session_record)
+    assert transaction.reload.cancelled?
+    follow_redirect!
+    assert_response :success
+    assert_match "Closing Cash count", response.body
+    refute_includes response.body, "Expected"
+    refute_includes response.body, "Opening float"
+    refute_includes response.body, "$100.00"
+    refute_includes response.body, "Variance"
+    refute_includes response.body, "Cash payments"
+    assert_select "input[name='expected_lock_version'][value='#{session_record.reload.lock_version}']"
+  end
+
+  test "nonempty sale cannot initiate close" do
+    post pos_register_enter_path, params: enter_params
+    transaction = PosTransaction.working.find_by!(register: @register)
+    post pos_register_merchandise_path, params: { identifier: @variant.sku, lock_version: transaction.lock_version }
+    get pos_register_workspace_path
+    assert_no_match "Close register", response.body
+
+    post pos_register_close_path
+    assert_redirected_to pos_register_workspace_path
+    follow_redirect!
+    assert_match "Complete or cancel the current sale before closing.", response.body
+    assert transaction.reload.working?
+  end
+
+  test "repeating initiate close after empty cancel still reaches the count screen" do
+    post pos_register_enter_path, params: enter_params
+    session_record = PosSession.open.find_by!(register: @register)
+    post pos_register_close_path
+    assert_redirected_to pos_session_close_path(session_record)
+    post pos_register_close_path
+    assert_redirected_to pos_session_close_path(session_record)
+    assert_equal 0, session_record.pos_transactions.working.count
+  end
+
+  test "get close does not cancel a merchandised working transaction" do
+    post pos_register_enter_path, params: enter_params
+    transaction = PosTransaction.working.find_by!(register: @register)
+    post pos_register_merchandise_path, params: { identifier: @variant.sku, lock_version: transaction.lock_version }
+    session_record = transaction.pos_session
+
+    get pos_session_close_path(session_record)
+    assert_redirected_to pos_register_workspace_path
+    assert transaction.reload.working?
+    assert_equal 1, transaction.pos_transaction_lines.count
+  end
+
+  test "zero dollars closes and reveals persisted snapshots" do
+    complete_http_sale(opening_float: "100.00")
+    session_record = PosSession.open.find_by!(register: @register)
+    post pos_register_close_path
+    follow_redirect!
+
+    post pos_session_close_path(session_record), params: {
+      closing_count: "0.00",
+      expected_lock_version: session_record.lock_version
+    }
+    assert_redirected_to pos_session_closed_path(session_record)
+    follow_redirect!
+    assert_response :success
+    session_record.reload
+    assert session_record.closed?
+    assert_equal 0, session_record.closing_count_cents
+    assert_equal session_record.opening_float_cents + Pos::SessionTotals.for(session_record).cash_tender_cents,
+                 session_record.closing_expected_cash_cents
+    assert_match format_money(session_record.closing_expected_cash_cents), response.body
+    assert_match format_money(session_record.closing_count_cents), response.body
+    assert_match format_money(session_record.closing_variance_cents), response.body
+    assert_match "Finalize Z", response.body
+    assert_match "Leave period open", response.body
+    assert PosReportingPeriod.open.exists?(register: @register)
+  end
+
+  test "invalid and stale still-open counts stay blind and preserve input" do
+    post pos_register_enter_path, params: enter_params(opening_float: "100.00")
+    session_record = PosSession.open.find_by!(register: @register)
+    post pos_register_close_path
+    follow_redirect!
+
+    post pos_session_close_path(session_record), params: {
+      closing_count: "abc",
+      expected_lock_version: session_record.lock_version
+    }
+    assert_response :unprocessable_content
+    assert_match "Closing Cash count", response.body
+    assert_select "#closing_count[value='abc']"
+    refute_includes response.body, "$100.00"
+    refute_includes response.body, "Expected"
+    refute_includes response.body, "Variance"
+
+    PosSession.where(id: session_record.id).update_all("lock_version = lock_version + 1")
+    post pos_session_close_path(session_record), params: {
+      closing_count: "12.34",
+      expected_lock_version: session_record.lock_version
+    }
+    assert_response :unprocessable_content
+    assert_match "Closing Cash count", response.body
+    assert_select "#closing_count[value='12.34']"
+    refute_includes response.body, "$100.00"
+    assert session_record.reload.open?
+  end
+
+  test "already closed close post redirects without a second audit" do
+    complete_http_sale
+    session_record = PosSession.open.find_by!(register: @register)
+    Pos::CloseSession.call(
+      session: session_record,
+      actor: @actor,
+      expected_lock_version: session_record.lock_version,
+      closing_count_cents: 0
+    )
+    assert_equal 1, AuditEvent.where(action: "pos.session.closed", subject_type: "PosSession", subject_id: session_record.id).count
+
+    post pos_session_close_path(session_record), params: {
+      closing_count: "0.00",
+      expected_lock_version: session_record.lock_version
+    }
+    assert_redirected_to pos_session_closed_path(session_record)
+    assert_equal 1, AuditEvent.where(action: "pos.session.closed", subject_type: "PosSession", subject_id: session_record.id).count
+  end
+
+  test "return to sales resumes an empty working transaction" do
+    post pos_register_enter_path, params: enter_params
+    session_record = PosSession.open.find_by!(register: @register)
+    post pos_register_close_path
+    follow_redirect!
+
+    post pos_session_resume_sales_path(session_record)
+    assert_redirected_to pos_register_workspace_path
+    follow_redirect!
+    assert_match "SALE ENTRY", response.body
+    assert session_record.pos_transactions.working.exists?
+  end
+
+  test "leave period open returns to the enter gate for that register" do
+    complete_http_sale
+    session_record = PosSession.open.find_by!(register: @register)
+    Pos::CloseSession.call(
+      session: session_record,
+      actor: @actor,
+      expected_lock_version: session_record.lock_version,
+      closing_count_cents: 0
+    )
+    get pos_session_closed_path(session_record)
+    assert_select "a[href='#{pos_register_enter_path(register_id: @register.id)}']", text: "Leave period open"
+
+    get pos_register_enter_path(register_id: @register.id)
+    assert_response :success
+    assert_match "Finalize Z", response.body
+    assert_match "Open session", response.body
+    assert PosReportingPeriod.open.exists?(register: @register)
+    assert_equal 0, PosSession.open.where(register: @register).count
+  end
+
+  test "open current-date period with no session offers finalize z and open session" do
+    Pos::OpenReportingPeriod.call(store: @store, register: @register, actor: @actor)
+    get pos_register_enter_path, params: { register_id: @register.id }
+    assert_response :success
+    assert_match "Finalize Z", response.body
+    assert_match "Open session", response.body
+    assert_select "input[name='expected_lock_version']"
+  end
+
+  test "leftover period with no session offers the same actions and a conspicuous date" do
+    period = Pos::OpenReportingPeriod.call(store: @store, register: @register, actor: @actor)
+    leftover_date = period.business_date
+    travel_to Time.current + 1.day do
+      UserSession.where(user: @actor).update_all(last_seen_at: Time.current)
+      get pos_register_enter_path, params: { register_id: @register.id }
+      assert_response :success
+      assert_match "This register is still on business date #{leftover_date.iso8601}.", response.body
+      assert_match "Finalize Z", response.body
+      assert_match "Open session", response.body
+    end
+  end
+
+  test "open session resumes the existing leftover period" do
+    period = Pos::OpenReportingPeriod.call(store: @store, register: @register, actor: @actor)
+    leftover_date = period.business_date
+    travel_to Time.current + 1.day do
+      UserSession.where(user: @actor).update_all(last_seen_at: Time.current)
+      post pos_register_enter_path, params: {
+        register_id: @register.id,
+        opening_float: "25.00"
+      }
+      assert_redirected_to pos_register_workspace_path
+      session_record = PosSession.open.find_by!(register: @register)
+      assert_equal period.id, session_record.reporting_period_id
+      assert_equal leftover_date, session_record.reporting_period.business_date
+      assert_equal 1, PosReportingPeriod.where(register: @register).count
+    end
+  end
+
+  test "unused period can be finalized from the enter gate as an all-zero z" do
+    period = Pos::OpenReportingPeriod.call(store: @store, register: @register, actor: @actor)
+    post pos_reporting_period_finalize_path(period), params: {
+      expected_lock_version: period.lock_version,
+      return_to: "enter",
+      register_id: @register.id
+    }
+    assert_redirected_to pos_reporting_period_z_path(period)
+    follow_redirect!
+    assert_response :success
+    period.reload
+    assert period.finalized?
+    assert_equal 0, period.finalized_session_count
+    assert_equal 0, period.finalized_transaction_count
+    assert_match "Z report", response.body
+    assert_match "Sessions", response.body
+    assert_match format_money(0), response.body
+    assert_match "Store  001", response.body
+    assert_match "Register  01", response.body
+    assert_match format_store_zone(period.closed_at), response.body
+  end
+
+  test "repeated finalize redirects to the existing z without a second audit" do
+    period = Pos::OpenReportingPeriod.call(store: @store, register: @register, actor: @actor)
+    post pos_reporting_period_finalize_path(period), params: {
+      expected_lock_version: period.lock_version,
+      return_to: "enter",
+      register_id: @register.id
+    }
+    assert_equal 1, AuditEvent.where(action: "pos.reporting_period.finalized", subject_type: "PosReportingPeriod", subject_id: period.id).count
+
+    post pos_reporting_period_finalize_path(period), params: {
+      expected_lock_version: period.lock_version,
+      return_to: "enter",
+      register_id: @register.id
+    }
+    assert_redirected_to pos_reporting_period_z_path(period)
+    assert_equal 1, AuditEvent.where(action: "pos.reporting_period.finalized", subject_type: "PosReportingPeriod", subject_id: period.id).count
+  end
+
+  test "stale still-open period finalize stays on enter and reveals no finalized values" do
+    period = Pos::OpenReportingPeriod.call(store: @store, register: @register, actor: @actor)
+    old_version = period.lock_version
+    PosReportingPeriod.where(id: period.id).update_all("lock_version = lock_version + 1")
+
+    post pos_reporting_period_finalize_path(period), params: {
+      expected_lock_version: old_version,
+      return_to: "enter",
+      register_id: @register.id
+    }
+    assert_response :unprocessable_content
+    assert_match "Open session", response.body
+    refute_match(/Z report/i, response.body)
+    assert period.reload.open?
+    assert_nil period.finalized_transaction_count
+  end
+
+  test "finalize while a session is open re-renders enter" do
+    post pos_register_enter_path, params: enter_params
+    period = PosReportingPeriod.open.find_by!(register: @register)
+    post pos_reporting_period_finalize_path(period), params: {
+      expected_lock_version: period.lock_version,
+      return_to: "enter",
+      register_id: @register.id
+    }
+    assert_response :unprocessable_content
+    assert_match "open session", response.body
+    assert period.reload.open?
+  end
+
+  test "second cashier cannot access another cashier close flow but may finalize z" do
+    complete_http_sale
+    session_record = PosSession.open.find_by!(register: @register)
+    Pos::CloseSession.call(
+      session: session_record,
+      actor: @actor,
+      expected_lock_version: session_record.lock_version,
+      closing_count_cents: 0
+    )
+    period = session_record.reporting_period
+    other = pos_transacting_user(store: @store, assigned_by: @actor, username: "other_z")
+    delete session_path
+    sign_in_as("other_z")
+
+    get pos_session_close_path(session_record)
+    assert_response :not_found
+    get pos_session_closed_path(session_record)
+    assert_response :not_found
+    post pos_session_close_path(session_record), params: {
+      closing_count: "0.00",
+      expected_lock_version: session_record.lock_version
+    }
+    assert_response :not_found
+
+    get pos_register_enter_path, params: { register_id: @register.id }
+    assert_match "Finalize Z", response.body
+    post pos_reporting_period_finalize_path(period), params: {
+      expected_lock_version: period.lock_version,
+      return_to: "enter",
+      register_id: @register.id
+    }
+    assert_redirected_to pos_reporting_period_z_path(period)
+    follow_redirect!
+    assert_response :success
+    assert_match other.display_name, response.body
+  end
+
+  test "wrong store cannot access close or z" do
+    complete_http_sale
+    session_record = PosSession.open.find_by!(register: @register)
+    Pos::CloseSession.call(
+      session: session_record,
+      actor: @actor,
+      expected_lock_version: session_record.lock_version,
+      closing_count_cents: 0
+    )
+    period = Pos::FinalizeReportingPeriod.call(
+      period: session_record.reporting_period,
+      actor: @actor,
+      expected_lock_version: session_record.reporting_period.lock_version
+    )
+    east = Store.create!(
+      store_number: 2,
+      code: "east",
+      name: "East Store",
+      timezone: "America/New_York",
+      country_code: "US"
+    )
+    post store_selection_path, params: { store_id: east.id }
+
+    get pos_session_close_path(session_record)
+    assert_response :not_found
+    get pos_session_closed_path(session_record)
+    assert_response :not_found
+    get pos_reporting_period_z_path(period)
+    assert_response :not_found
+  end
+
+  test "finalized z is read-only persisted snapshots" do
+    complete_http_sale
+    session_record = PosSession.open.find_by!(register: @register)
+    Pos::CloseSession.call(
+      session: session_record,
+      actor: @actor,
+      expected_lock_version: session_record.lock_version,
+      closing_count_cents: 0
+    )
+    period = Pos::FinalizeReportingPeriod.call(
+      period: session_record.reporting_period,
+      actor: @actor,
+      expected_lock_version: session_record.reporting_period.lock_version
+    )
+    get pos_reporting_period_z_path(period)
+    assert_response :success
+    assert_match period.finalized_transaction_count.to_s, response.body
+    assert_match format_money(period.finalized_total_cents), response.body
+    assert_match format_money(period.finalized_closing_variance_cents_sum), response.body
+    assert_match "Opening floats total", response.body
+    assert_no_match "Close session", response.body
+  end
+
+  private
+
+  def sign_in_as(username)
+    post session_path, params: { session: { username: username, password: "correct-horse-battery" } }
+  end
+
+  def enter_params(opening_float: "0.00")
+    {
+      register_id: @register.id,
+      opening_float: opening_float,
+      confirmed_business_date: BusinessDate.for_store(@store).iso8601
+    }
+  end
+
+  def complete_http_sale(opening_float: "0.00")
+    post pos_register_enter_path, params: enter_params(opening_float: opening_float)
+    transaction = PosTransaction.working.find_by!(register: @register)
+    post pos_register_merchandise_path, params: { identifier: @variant.sku, lock_version: transaction.lock_version }
+    transaction.reload
+    post pos_register_tender_path, params: { amount_presented: "25.00", lock_version: transaction.lock_version }
+    transaction.reload
+    operation_id = css_select("input[name='completion_operation_id']").first["value"]
+    post pos_transaction_complete_path(transaction), params: {
+      completion_operation_id: operation_id,
+      lock_version: transaction.lock_version,
+      expected_total_cents: transaction.total_cents,
+      amount_presented_cents: 2500
+    }
+    transaction.reload
+  end
+
+  def format_money(cents)
+    sign = cents.negative? ? "-" : ""
+    absolute = cents.abs
+    "#{sign}$#{absolute / 100}.#{format('%02d', absolute % 100)}"
+  end
+
+  def format_store_zone(time)
+    zone = ActiveSupport::TimeZone[@store.timezone] || ActiveSupport::TimeZone["UTC"]
+    time.in_time_zone(zone).strftime("%Y-%m-%d %H:%M")
+  end
+end

--- a/test/integration/pos_close_z_test.rb
+++ b/test/integration/pos_close_z_test.rb
@@ -467,6 +467,45 @@ class PosCloseZTest < ActionDispatch::IntegrationTest
     assert_select "a", text: "Leave period open", count: 0
   end
 
+  test "close initiation without session_id is not found" do
+    post pos_register_enter_path, params: enter_params
+    post pos_register_close_path
+    assert_response :not_found
+    assert PosSession.open.find_by!(register: @register).open?
+    assert PosTransaction.working.exists?(register: @register)
+  end
+
+  test "close initiation for another cashier session is not found" do
+    post pos_register_enter_path, params: enter_params
+    session_record = PosSession.open.find_by!(register: @register)
+    other = pos_transacting_user(store: @store, assigned_by: @actor, username: "other_close_init")
+    delete session_path
+    sign_in_as("other_close_init")
+
+    post pos_register_close_path, params: { session_id: session_record.id, register_id: @register.id }
+    assert_response :not_found
+    assert session_record.reload.open?
+    assert session_record.pos_transactions.working.exists?
+  end
+
+  test "close initiation for another register session is not found" do
+    post pos_register_enter_path, params: enter_params
+    session_a = PosSession.open.find_by!(register: @register)
+    other_register = Register.create!(store: @store, register_number: 2, name: "Back")
+    other_session = pos_open_context(
+      store: @store,
+      actor: @actor,
+      register: other_register,
+      opening_float_cents: 0
+    )[:session]
+
+    post pos_register_close_path, params: { session_id: other_session.id }
+    assert_response :not_found
+    assert session_a.reload.open?
+    assert other_session.reload.open?
+    assert other_session.pos_transactions.working.empty?
+  end
+
   private
 
   def sign_in_as(username)

--- a/test/integration/pos_close_z_test.rb
+++ b/test/integration/pos_close_z_test.rb
@@ -33,6 +33,7 @@ class PosCloseZTest < ActionDispatch::IntegrationTest
     assert_match "Example Book", response.body
     assert_select ".pos-print-only"
     assert_select ".pos-no-print"
+    assert_select "input[name='session_id'][value='#{transaction.pos_session_id}']"
     assert transaction.reload.completed?
     assert_equal 1, PosTransaction.completed.where(id: transaction.id).count
   end
@@ -44,7 +45,7 @@ class PosCloseZTest < ActionDispatch::IntegrationTest
     transaction = PosTransaction.working.find_by!(register: @register)
     session_record = transaction.pos_session
 
-    post pos_register_close_path
+    post pos_register_close_path, params: { session_id: session_record.id }
     assert_redirected_to pos_session_close_path(session_record)
     assert transaction.reload.cancelled?
     follow_redirect!
@@ -65,7 +66,7 @@ class PosCloseZTest < ActionDispatch::IntegrationTest
     get pos_register_workspace_path
     assert_no_match "Close register", response.body
 
-    post pos_register_close_path
+    post pos_register_close_path, params: { session_id: transaction.pos_session_id }
     assert_redirected_to pos_register_workspace_path
     follow_redirect!
     assert_match "Complete or cancel the current sale before closing.", response.body
@@ -75,9 +76,9 @@ class PosCloseZTest < ActionDispatch::IntegrationTest
   test "repeating initiate close after empty cancel still reaches the count screen" do
     post pos_register_enter_path, params: enter_params
     session_record = PosSession.open.find_by!(register: @register)
-    post pos_register_close_path
+    post pos_register_close_path, params: { session_id: session_record.id }
     assert_redirected_to pos_session_close_path(session_record)
-    post pos_register_close_path
+    post pos_register_close_path, params: { session_id: session_record.id }
     assert_redirected_to pos_session_close_path(session_record)
     assert_equal 0, session_record.pos_transactions.working.count
   end
@@ -97,7 +98,7 @@ class PosCloseZTest < ActionDispatch::IntegrationTest
   test "zero dollars closes and reveals persisted snapshots" do
     complete_http_sale(opening_float: "100.00")
     session_record = PosSession.open.find_by!(register: @register)
-    post pos_register_close_path
+    post pos_register_close_path, params: { session_id: session_record.id }
     follow_redirect!
 
     post pos_session_close_path(session_record), params: {
@@ -123,7 +124,7 @@ class PosCloseZTest < ActionDispatch::IntegrationTest
   test "invalid and stale still-open counts stay blind and preserve input" do
     post pos_register_enter_path, params: enter_params(opening_float: "100.00")
     session_record = PosSession.open.find_by!(register: @register)
-    post pos_register_close_path
+    post pos_register_close_path, params: { session_id: session_record.id }
     follow_redirect!
 
     post pos_session_close_path(session_record), params: {
@@ -171,7 +172,7 @@ class PosCloseZTest < ActionDispatch::IntegrationTest
   test "return to sales resumes an empty working transaction" do
     post pos_register_enter_path, params: enter_params
     session_record = PosSession.open.find_by!(register: @register)
-    post pos_register_close_path
+    post pos_register_close_path, params: { session_id: session_record.id }
     follow_redirect!
 
     post pos_session_resume_sales_path(session_record)
@@ -399,6 +400,71 @@ class PosCloseZTest < ActionDispatch::IntegrationTest
     assert_match format_money(period.finalized_closing_variance_cents_sum), response.body
     assert_match "Opening floats total", response.body
     assert_no_match "Close session", response.body
+  end
+
+  test "stale close for session A does not cancel session B" do
+    complete_http_sale
+    session_a = PosSession.open.find_by!(register: @register)
+    Pos::CloseSession.call(
+      session: session_a,
+      actor: @actor,
+      expected_lock_version: session_a.lock_version,
+      closing_count_cents: 0
+    )
+    post pos_register_enter_path, params: { register_id: @register.id, opening_float: "10.00" }
+    session_b = PosSession.open.find_by!(register: @register)
+    refute_equal session_a.id, session_b.id
+    working_b = session_b.pos_transactions.working.first
+    assert working_b.present?
+
+    post pos_register_close_path, params: { session_id: session_a.id }
+    assert_redirected_to pos_session_closed_path(session_a)
+    assert session_b.reload.open?
+    assert working_b.reload.working?
+    assert_equal 0, AuditEvent.where(action: "pos.transaction_cancelled", subject_id: working_b.id).count
+  end
+
+  test "invalid blind count after resume sales returns to the workspace" do
+    post pos_register_enter_path, params: enter_params
+    session_record = PosSession.open.find_by!(register: @register)
+    post pos_register_close_path, params: { session_id: session_record.id }
+    follow_redirect!
+
+    post pos_session_resume_sales_path(session_record)
+    working = session_record.pos_transactions.working.first
+    assert working.present?
+
+    post pos_session_close_path(session_record), params: {
+      closing_count: "abc",
+      expected_lock_version: session_record.lock_version
+    }
+    assert_redirected_to pos_register_workspace_path
+    follow_redirect!
+    assert_match "Complete or cancel the current sale before closing.", response.body
+    refute_match "Closing Cash count", response.body
+    assert working.reload.working?
+  end
+
+  test "closed session shows view z after the period is finalized" do
+    complete_http_sale
+    session_record = PosSession.open.find_by!(register: @register)
+    Pos::CloseSession.call(
+      session: session_record,
+      actor: @actor,
+      expected_lock_version: session_record.lock_version,
+      closing_count_cents: 0
+    )
+    period = Pos::FinalizeReportingPeriod.call(
+      period: session_record.reporting_period,
+      actor: @actor,
+      expected_lock_version: session_record.reporting_period.lock_version
+    )
+
+    get pos_session_closed_path(session_record)
+    assert_response :success
+    assert_select "a[href='#{pos_reporting_period_z_path(period)}']", text: "View Z"
+    assert_select "input[type='submit'][value='Finalize Z']", count: 0
+    assert_select "a", text: "Leave period open", count: 0
   end
 
   private

--- a/test/integration/pos_register_test.rb
+++ b/test/integration/pos_register_test.rb
@@ -28,6 +28,8 @@ class PosRegisterTest < ActionDispatch::IntegrationTest
     assert_equal 0, PosSession.count
     assert_equal 0, PosTransaction.count
     assert_match "Opening float", response.body
+    assert_select "html:not([data-turbo])"
+    assert_select "script[type=module]", text: /import "pos"/
   end
 
   test "post enter then workspace sale tender and complete" do
@@ -95,6 +97,20 @@ class PosRegisterTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_content
     assert_equal 1, PosSession.open.where(register: @register).count
     assert_equal @actor.id, PosSession.open.find_by!(register: @register).cashier_user_id
+  end
+
+  test "user with multiple stores is sent to store selection on enter" do
+    Store.create!(
+      store_number: "2",
+      code: "east",
+      name: "East Store",
+      timezone: "America/New_York",
+      country_code: "US"
+    )
+
+    get pos_register_enter_path
+    assert_redirected_to new_store_selection_path
+    assert_equal 0, PosSession.count
   end
 
   test "user without store access cannot enter the register" do

--- a/test/integration/pos_register_test.rb
+++ b/test/integration/pos_register_test.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PosRegisterTest < ActionDispatch::IntegrationTest
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    @tax = tax_class(code: "physical_book", name: "Physical book")
+    StoreTaxes::Create.call(
+      store: @store,
+      actor: @actor,
+      name: "Illinois State",
+      rate_percent: "5.000",
+      calculation_order: 1,
+      applies_by_tax_class_id: { @tax.id => true }
+    )
+    @variant = pos_sellable_variant(actor: @actor, tax_class: @tax)
+    open_quantity_stock(store: @store, variant: @variant, actor: @actor, quantity: 5)
+    @register = Register.create!(store: @store, register_number: 1, name: "Front")
+    sign_in_as("admin")
+  end
+
+  test "get enter does not create a session or transaction" do
+    get pos_register_enter_path, params: { register_id: @register.id }
+    assert_response :success
+    assert_equal 0, PosSession.count
+    assert_equal 0, PosTransaction.count
+    assert_match "Opening float", response.body
+  end
+
+  test "post enter then workspace sale tender and complete" do
+    post pos_register_enter_path, params: { register_id: @register.id, opening_float: "50.00" }
+    assert_redirected_to pos_register_workspace_path
+    follow_redirect!
+    assert_response :success
+    transaction = PosTransaction.working.find_by!(pos_session: PosSession.open.find_by!(register: @register))
+    assert_match "SALE ENTRY", response.body
+    assert_match "Scan or identifier", response.body
+
+    get pos_register_workspace_path
+    assert_response :success
+    assert_equal 1, PosTransaction.working.where(pos_session: transaction.pos_session).count
+
+    post pos_register_merchandise_path, params: { identifier: @variant.sku, lock_version: transaction.lock_version }
+    assert_response :success
+    transaction.reload
+    assert_equal 1, transaction.pos_transaction_lines.count
+
+    post pos_register_tender_path, params: { amount_presented: "25.00", lock_version: transaction.lock_version }
+    assert_response :success
+    transaction.reload
+    assert_equal 1, transaction.pos_tenders.count
+    assert_match "CHANGE", response.body
+    assert_select "input[name='completion_operation_id']"
+
+    operation_id = css_select("input[name='completion_operation_id']").first["value"]
+    post pos_register_complete_path, params: {
+      completion_operation_id: operation_id,
+      lock_version: transaction.lock_version,
+      expected_total_cents: transaction.total_cents,
+      amount_presented_cents: 2500
+    }
+    assert_redirected_to pos_completed_transaction_path(transaction)
+    follow_redirect!
+    assert_response :success
+    assert_match "Sale complete", response.body
+    assert_match transaction.reload.transaction_reference, response.body
+    assert_match "New sale", response.body
+
+    get pos_register_workspace_path
+    assert_redirected_to pos_register_enter_path(register_id: @register.id)
+
+    post pos_register_continue_path
+    assert_redirected_to pos_register_workspace_path
+    follow_redirect!
+    assert_response :success
+    assert_equal 1, PosTransaction.working.where(pos_session: transaction.pos_session).count
+    refute_equal transaction.id, PosTransaction.working.find_by!(pos_session: transaction.pos_session).id
+  end
+
+  test "occupied register is denied on get and post enter" do
+    Pos::EnterRegister.call(store: @store, register: @register, actor: @actor, opening_float_cents: 0)
+    other = pos_transacting_user(store: @store, assigned_by: @actor, username: "clerk_pos")
+    delete session_path
+    sign_in_as("clerk_pos")
+
+    get pos_register_enter_path, params: { register_id: @register.id }
+    assert_response :success
+    assert_match "is open for", response.body
+    assert_select "input[type='submit'][value='Open register'][disabled]"
+
+    post pos_register_enter_path, params: { register_id: @register.id, opening_float: "0.00" }
+    assert_response :unprocessable_content
+    assert_equal 1, PosSession.open.where(register: @register).count
+    assert_equal @actor.id, PosSession.open.find_by!(register: @register).cashier_user_id
+  end
+
+  test "user without store access cannot enter the register" do
+    User.create!(
+      username: "no_pos",
+      display_name: "No POS",
+      password: "correct-horse-battery",
+      password_confirmation: "correct-horse-battery"
+    )
+    delete session_path
+    post session_path, params: { session: { username: "no_pos", password: "correct-horse-battery" } }
+    get pos_register_enter_path
+    assert_redirected_to root_path
+    assert_equal 0, PosSession.count
+  end
+
+  test "second cashier cannot mutate another cashier workspace" do
+    result = Pos::EnterRegister.call(store: @store, register: @register, actor: @actor, opening_float_cents: 0)
+    Pos::AddMerchandise.call(
+      transaction: result.transaction,
+      actor: @actor,
+      expected_lock_version: result.transaction.lock_version,
+      identifier: @variant.sku
+    )
+    transaction = result.transaction.reload
+    other = pos_transacting_user(store: @store, assigned_by: @actor, username: "other_ws")
+    delete session_path
+    sign_in_as("other_ws")
+
+    post pos_register_merchandise_path, params: {
+      identifier: @variant.sku,
+      lock_version: transaction.lock_version,
+      register_id: @register.id
+    }
+    assert_redirected_to pos_register_enter_path(register_id: @register.id)
+    assert_equal 1, transaction.reload.pos_transaction_lines.count
+  end
+
+  test "abandon tender and cancel clear working tenders" do
+    post pos_register_enter_path, params: { register_id: @register.id, opening_float: "0.00" }
+    transaction = PosTransaction.working.find_by!(register: @register)
+    post pos_register_merchandise_path, params: { identifier: @variant.sku, lock_version: transaction.lock_version }
+    transaction.reload
+    post pos_register_tender_path, params: { amount_presented: "25.00", lock_version: transaction.lock_version }
+    transaction.reload
+    post pos_register_abandon_tender_path, params: { lock_version: transaction.lock_version }
+    transaction.reload
+    assert_equal 0, transaction.pos_tenders.count
+    assert transaction.working?
+
+    post pos_register_tender_path, params: { amount_presented: "25.00", lock_version: transaction.lock_version }
+    transaction.reload
+    post pos_register_cancel_path, params: { lock_version: transaction.lock_version }
+    assert_redirected_to pos_register_workspace_path
+    assert transaction.reload.cancelled?
+    assert_equal 0, transaction.pos_tenders.count
+  end
+
+  test "completed receipt is not found while working" do
+    post pos_register_enter_path, params: { register_id: @register.id, opening_float: "0.00" }
+    transaction = PosTransaction.working.find_by!(register: @register)
+    get pos_completed_transaction_path(transaction)
+    assert_response :not_found
+  end
+
+  private
+
+  def sign_in_as(username)
+    post session_path, params: { session: { username: username, password: "correct-horse-battery" } }
+  end
+end

--- a/test/integration/pos_register_test.rb
+++ b/test/integration/pos_register_test.rb
@@ -71,6 +71,8 @@ class PosRegisterTest < ActionDispatch::IntegrationTest
     assert_match "Sale complete", response.body
     assert_match transaction.reload.transaction_reference, response.body
     assert_match "New sale", response.body
+    assert_match "Print receipt", response.body
+    assert_match "Close register", response.body
 
     get pos_register_workspace_path
     assert_redirected_to pos_register_enter_path(register_id: @register.id)

--- a/test/integration/pos_register_test.rb
+++ b/test/integration/pos_register_test.rb
@@ -34,7 +34,7 @@ class PosRegisterTest < ActionDispatch::IntegrationTest
   end
 
   test "post enter then workspace sale tender and complete" do
-    post pos_register_enter_path, params: { register_id: @register.id, opening_float: "50.00" }
+    post pos_register_enter_path, params: enter_params(opening_float: "50.00")
     assert_redirected_to pos_register_workspace_path
     follow_redirect!
     assert_response :success
@@ -94,7 +94,7 @@ class PosRegisterTest < ActionDispatch::IntegrationTest
     assert_match "is open for", response.body
     assert_select "input[type='submit'][value='Open register'][disabled]"
 
-    post pos_register_enter_path, params: { register_id: @register.id, opening_float: "0.00" }
+    post pos_register_enter_path, params: enter_params
     assert_response :unprocessable_content
     assert_equal 1, PosSession.open.where(register: @register).count
     assert_equal @actor.id, PosSession.open.find_by!(register: @register).cashier_user_id
@@ -151,7 +151,7 @@ class PosRegisterTest < ActionDispatch::IntegrationTest
   end
 
   test "abandon tender and cancel clear working tenders" do
-    post pos_register_enter_path, params: { register_id: @register.id, opening_float: "0.00" }
+    post pos_register_enter_path, params: enter_params
     transaction = PosTransaction.working.find_by!(register: @register)
     post pos_register_merchandise_path, params: { identifier: @variant.sku, lock_version: transaction.lock_version }
     transaction.reload
@@ -171,14 +171,14 @@ class PosRegisterTest < ActionDispatch::IntegrationTest
   end
 
   test "completed receipt is not found while working" do
-    post pos_register_enter_path, params: { register_id: @register.id, opening_float: "0.00" }
+    post pos_register_enter_path, params: enter_params
     transaction = PosTransaction.working.find_by!(register: @register)
     get pos_completed_transaction_path(transaction)
     assert_response :not_found
   end
 
   test "complete retry of an already completed transaction shows that receipt" do
-    post pos_register_enter_path, params: { register_id: @register.id, opening_float: "0.00" }
+    post pos_register_enter_path, params: enter_params
     transaction = PosTransaction.working.find_by!(register: @register)
     post pos_register_merchandise_path, params: { identifier: @variant.sku, lock_version: transaction.lock_version }
     transaction.reload
@@ -204,7 +204,7 @@ class PosRegisterTest < ActionDispatch::IntegrationTest
   end
 
   test "complete does not redirect to enter when the working transaction is gone" do
-    post pos_register_enter_path, params: { register_id: @register.id, opening_float: "0.00" }
+    post pos_register_enter_path, params: enter_params
     transaction = PosTransaction.working.find_by!(register: @register)
     post pos_register_merchandise_path, params: { identifier: @variant.sku, lock_version: transaction.lock_version }
     transaction.reload
@@ -232,7 +232,7 @@ class PosRegisterTest < ActionDispatch::IntegrationTest
   end
 
   test "invalid quantity stays in quantity and invalid cash stays in tender" do
-    post pos_register_enter_path, params: { register_id: @register.id, opening_float: "0.00" }
+    post pos_register_enter_path, params: enter_params
     transaction = PosTransaction.working.find_by!(register: @register)
     post pos_register_merchandise_path, params: { identifier: @variant.sku, lock_version: transaction.lock_version }
     transaction.reload
@@ -262,7 +262,7 @@ class PosRegisterTest < ActionDispatch::IntegrationTest
   end
 
   test "unexpired in_flight completion does not auto submit" do
-    post pos_register_enter_path, params: { register_id: @register.id, opening_float: "0.00" }
+    post pos_register_enter_path, params: enter_params
     transaction = PosTransaction.working.find_by!(register: @register)
     post pos_register_merchandise_path, params: { identifier: @variant.sku, lock_version: transaction.lock_version }
     transaction.reload
@@ -288,6 +288,29 @@ class PosRegisterTest < ActionDispatch::IntegrationTest
     assert_match "Completion is still processing", response.body
     assert_select "[data-register-workspace-auto-complete-value='false']"
     assert_select "input[name='completion_operation_id'][value='#{operation_id}']"
+    assert_select "[data-register-workspace-target='retry']", count: 0
+    assert_select "[data-register-workspace-target='abandonButton']", count: 0
+    assert_select "[data-register-workspace-target='clientRecovery'][hidden]"
+    assert_select "button[data-register-workspace-target='cancelButton'][disabled]"
+  end
+
+  test "opening a new period requires a confirmed business date" do
+    post pos_register_enter_path, params: { register_id: @register.id, opening_float: "0.00" }
+    assert_response :unprocessable_content
+    assert_match(/business date confirmation is required/, response.body)
+    assert_equal 0, PosReportingPeriod.where(register: @register).count
+  end
+
+  test "enter rejects a confirmed date that does not match an already open period" do
+    Pos::OpenReportingPeriod.call(store: @store, register: @register, actor: @actor)
+    post pos_register_enter_path, params: {
+      register_id: @register.id,
+      opening_float: "0.00",
+      confirmed_business_date: (BusinessDate.for_store(@store) - 1.day).iso8601
+    }
+    assert_response :unprocessable_content
+    assert_match(/already open on business date/, response.body)
+    assert_equal 0, PosSession.where(register: @register).count
   end
 
   test "confirmed business date is rejected after the calendar boundary" do
@@ -311,7 +334,7 @@ class PosRegisterTest < ActionDispatch::IntegrationTest
   end
 
   test "completed receipt is scoped to the current store" do
-    post pos_register_enter_path, params: { register_id: @register.id, opening_float: "0.00" }
+    post pos_register_enter_path, params: enter_params
     transaction = PosTransaction.working.find_by!(register: @register)
     post pos_register_merchandise_path, params: { identifier: @variant.sku, lock_version: transaction.lock_version }
     transaction.reload
@@ -340,7 +363,7 @@ class PosRegisterTest < ActionDispatch::IntegrationTest
   end
 
   test "complete retry after inventory failure does not re-tender" do
-    post pos_register_enter_path, params: { register_id: @register.id, opening_float: "0.00" }
+    post pos_register_enter_path, params: enter_params
     transaction = PosTransaction.working.find_by!(register: @register)
     post pos_register_merchandise_path, params: { identifier: @variant.sku, lock_version: transaction.lock_version }
     transaction.reload
@@ -384,5 +407,13 @@ class PosRegisterTest < ActionDispatch::IntegrationTest
 
   def sign_in_as(username)
     post session_path, params: { session: { username: username, password: "correct-horse-battery" } }
+  end
+
+  def enter_params(opening_float: "0.00")
+    {
+      register_id: @register.id,
+      opening_float: opening_float,
+      confirmed_business_date: BusinessDate.for_store(@store).iso8601
+    }
   end
 end

--- a/test/integration/pos_register_test.rb
+++ b/test/integration/pos_register_test.rb
@@ -28,6 +28,7 @@ class PosRegisterTest < ActionDispatch::IntegrationTest
     assert_equal 0, PosSession.count
     assert_equal 0, PosTransaction.count
     assert_match "Opening float", response.body
+    assert_select "input[name='confirmed_business_date']"
     assert_select "html:not([data-turbo])"
     assert_select "script[type=module]", text: /import "pos"/
   end
@@ -58,7 +59,7 @@ class PosRegisterTest < ActionDispatch::IntegrationTest
     assert_select "input[name='completion_operation_id']"
 
     operation_id = css_select("input[name='completion_operation_id']").first["value"]
-    post pos_register_complete_path, params: {
+    post pos_transaction_complete_path(transaction), params: {
       completion_operation_id: operation_id,
       lock_version: transaction.lock_version,
       expected_total_cents: transaction.total_cents,
@@ -174,6 +175,209 @@ class PosRegisterTest < ActionDispatch::IntegrationTest
     transaction = PosTransaction.working.find_by!(register: @register)
     get pos_completed_transaction_path(transaction)
     assert_response :not_found
+  end
+
+  test "complete retry of an already completed transaction shows that receipt" do
+    post pos_register_enter_path, params: { register_id: @register.id, opening_float: "0.00" }
+    transaction = PosTransaction.working.find_by!(register: @register)
+    post pos_register_merchandise_path, params: { identifier: @variant.sku, lock_version: transaction.lock_version }
+    transaction.reload
+    post pos_register_tender_path, params: { amount_presented: "25.00", lock_version: transaction.lock_version }
+    transaction.reload
+    operation_id = css_select("input[name='completion_operation_id']").first["value"]
+    params = {
+      completion_operation_id: operation_id,
+      lock_version: transaction.lock_version,
+      expected_total_cents: transaction.total_cents,
+      amount_presented_cents: 2500
+    }
+    post pos_transaction_complete_path(transaction), params: params
+    assert_redirected_to pos_completed_transaction_path(transaction)
+    assert transaction.reload.completed?
+
+    post pos_transaction_complete_path(transaction), params: params
+    assert_redirected_to pos_completed_transaction_path(transaction)
+    follow_redirect!
+    assert_response :success
+    assert_match transaction.transaction_reference, response.body
+    assert_equal 1, PosTransaction.completed.where(id: transaction.id).count
+  end
+
+  test "complete does not redirect to enter when the working transaction is gone" do
+    post pos_register_enter_path, params: { register_id: @register.id, opening_float: "0.00" }
+    transaction = PosTransaction.working.find_by!(register: @register)
+    post pos_register_merchandise_path, params: { identifier: @variant.sku, lock_version: transaction.lock_version }
+    transaction.reload
+    post pos_register_tender_path, params: { amount_presented: "25.00", lock_version: transaction.lock_version }
+    transaction.reload
+    operation_id = css_select("input[name='completion_operation_id']").first["value"]
+    Pos::CompleteTransaction.call(
+      transaction: transaction,
+      actor: @actor,
+      operation_id: operation_id,
+      expected_lock_version: transaction.lock_version,
+      expected_total_cents: transaction.total_cents,
+      amount_presented_cents: 2500
+    )
+    post pos_transaction_complete_path(transaction), params: {
+      completion_operation_id: operation_id,
+      lock_version: transaction.lock_version,
+      expected_total_cents: transaction.total_cents,
+      amount_presented_cents: 2500
+    }
+    assert_redirected_to pos_completed_transaction_path(transaction)
+    follow_redirect!
+    assert_response :success
+    assert_match transaction.reload.transaction_reference, response.body
+  end
+
+  test "invalid quantity stays in quantity and invalid cash stays in tender" do
+    post pos_register_enter_path, params: { register_id: @register.id, opening_float: "0.00" }
+    transaction = PosTransaction.working.find_by!(register: @register)
+    post pos_register_merchandise_path, params: { identifier: @variant.sku, lock_version: transaction.lock_version }
+    transaction.reload
+    line = transaction.pos_transaction_lines.first
+
+    post pos_register_quantity_path, params: {
+      line_id: line.id,
+      quantity: "0",
+      lock_version: transaction.lock_version
+    }
+    assert_response :success
+    assert_match "QUANTITY", response.body
+    assert_match "quantity must be positive", response.body
+    assert_select "#pos-command-field[value='0']"
+
+    post pos_register_tender_path, params: { amount_presented: "abc", lock_version: transaction.lock_version }
+    assert_response :success
+    assert_match "CASH TENDER", response.body
+    assert_match(/not a valid amount/i, response.body)
+    assert_select "#pos-command-field[value='abc']"
+
+    post pos_register_tender_path, params: { amount_presented: "0.01", lock_version: transaction.reload.lock_version }
+    assert_response :success
+    assert_match "CASH TENDER", response.body
+    assert_match(/amount due/i, response.body)
+    assert transaction.reload.pos_tenders.empty?
+  end
+
+  test "unexpired in_flight completion does not auto submit" do
+    post pos_register_enter_path, params: { register_id: @register.id, opening_float: "0.00" }
+    transaction = PosTransaction.working.find_by!(register: @register)
+    post pos_register_merchandise_path, params: { identifier: @variant.sku, lock_version: transaction.lock_version }
+    transaction.reload
+    post pos_register_tender_path, params: { amount_presented: "25.00", lock_version: transaction.lock_version }
+    transaction.reload
+    operation_id = SecureRandom.uuid_v7
+    payload = Pos::CompleteTransaction.command_payload(
+      transaction: transaction,
+      operation_id: operation_id,
+      expected_lock_version: transaction.lock_version,
+      expected_total_cents: transaction.total_cents,
+      amount_presented_cents: 2500
+    )
+    Pos::OperationLease.begin!(
+      register_id: transaction.register_id,
+      operation_id: operation_id,
+      command_payload: payload,
+      store_id: transaction.store_id,
+      pos_transaction_id: transaction.id
+    )
+    get pos_register_workspace_path
+    assert_response :success
+    assert_match "Completion is still processing", response.body
+    assert_select "[data-register-workspace-auto-complete-value='false']"
+    assert_select "input[name='completion_operation_id'][value='#{operation_id}']"
+  end
+
+  test "confirmed business date is rejected after the calendar boundary" do
+    now = Time.current
+    confirmed = BusinessDate.for_store(@store, at: now)
+    get pos_register_enter_path, params: { register_id: @register.id }
+    assert_response :success
+    assert_select "input[name='confirmed_business_date'][value='#{confirmed.iso8601}']"
+
+    travel_to now + 1.day do
+      UserSession.where(user: @actor).update_all(last_seen_at: Time.current)
+      post pos_register_enter_path, params: {
+        register_id: @register.id,
+        opening_float: "0.00",
+        confirmed_business_date: confirmed.iso8601
+      }
+      assert_response :unprocessable_content
+      assert_select "input[name='confirmed_business_date'][value='#{BusinessDate.for_store(@store).iso8601}']"
+      assert_equal 0, PosReportingPeriod.where(register: @register).count
+    end
+  end
+
+  test "completed receipt is scoped to the current store" do
+    post pos_register_enter_path, params: { register_id: @register.id, opening_float: "0.00" }
+    transaction = PosTransaction.working.find_by!(register: @register)
+    post pos_register_merchandise_path, params: { identifier: @variant.sku, lock_version: transaction.lock_version }
+    transaction.reload
+    post pos_register_tender_path, params: { amount_presented: "25.00", lock_version: transaction.lock_version }
+    transaction.reload
+    operation_id = css_select("input[name='completion_operation_id']").first["value"]
+    post pos_transaction_complete_path(transaction), params: {
+      completion_operation_id: operation_id,
+      lock_version: transaction.lock_version,
+      expected_total_cents: transaction.total_cents,
+      amount_presented_cents: 2500
+    }
+    follow_redirect!
+    assert_match @store.name, response.body
+
+    east = Store.create!(
+      store_number: "2",
+      code: "east",
+      name: "East Store",
+      timezone: "America/New_York",
+      country_code: "US"
+    )
+    post store_selection_path, params: { store_id: east.id }
+    get pos_completed_transaction_path(transaction)
+    assert_response :not_found
+  end
+
+  test "complete retry after inventory failure does not re-tender" do
+    post pos_register_enter_path, params: { register_id: @register.id, opening_float: "0.00" }
+    transaction = PosTransaction.working.find_by!(register: @register)
+    post pos_register_merchandise_path, params: { identifier: @variant.sku, lock_version: transaction.lock_version }
+    transaction.reload
+    post pos_register_tender_path, params: { amount_presented: "25.00", lock_version: transaction.lock_version }
+    transaction.reload
+    operation_id = css_select("input[name='completion_operation_id']").first["value"]
+    complete_params = {
+      completion_operation_id: operation_id,
+      lock_version: transaction.lock_version,
+      expected_total_cents: transaction.total_cents,
+      amount_presented_cents: 2500
+    }
+
+    Inventory::AdjustmentReasons.seed!
+    Inventory::PostAdjustment.call(
+      store: @store,
+      product_variant: @variant,
+      adjustment_reason: AdjustmentReason.find_by!(code: "shrinkage"),
+      quantity_delta: -5,
+      actor: @actor,
+      source_id: SecureRandom.uuid_v7,
+      idempotency_key: SecureRandom.uuid_v7
+    )
+
+    post pos_transaction_complete_path(transaction), params: complete_params
+    assert_response :success
+    assert_match "Retry complete", response.body
+    assert_select "input[name='completion_operation_id'][value='#{operation_id}']"
+    assert transaction.reload.working?
+    assert_equal 1, transaction.pos_tenders.count
+
+    open_quantity_stock(store: @store, variant: @variant, actor: @actor, quantity: 5)
+    post pos_transaction_complete_path(transaction), params: complete_params
+    assert_redirected_to pos_completed_transaction_path(transaction)
+    assert transaction.reload.completed?
+    assert_equal 1, transaction.pos_tenders.count
+    assert_equal 1, OutboxMessage.where(event_type: "pos.transaction_completed").count
   end
 
   private

--- a/test/integration/store_taxes_admin_test.rb
+++ b/test/integration/store_taxes_admin_test.rb
@@ -25,6 +25,20 @@ class StoreTaxesAdminTest < ActionDispatch::IntegrationTest
     assert store_tax.store_tax_rules.find_by!(tax_class: TaxClass.find_by!(code: "physical_book")).applies
   end
 
+  test "admin with multiple stores is sent to store selection instead of aborting" do
+    Store.create!(
+      store_number: "2",
+      code: "east",
+      name: "East Store",
+      timezone: "America/New_York",
+      country_code: "US"
+    )
+    sign_in_as("admin")
+
+    get admin_store_taxes_path
+    assert_redirected_to new_store_selection_path
+  end
+
   test "associate is denied store_taxes.create" do
     associate = User.create!(
       username: "clerk",

--- a/test/models/pos_schema_test.rb
+++ b/test/models/pos_schema_test.rb
@@ -50,6 +50,119 @@ class PosSchemaTest < ActiveSupport::TestCase
     assert_raises(ActiveRecord::RecordNotUnique) { duplicate_period.save! }
   end
 
+  test "database rejects a second working transaction on the same session" do
+    period = open_period
+    session = PosSession.create!(
+      store: @store,
+      register: @register,
+      reporting_period: period,
+      cashier_user: @user,
+      status: "open",
+      opened_at: Time.current
+    )
+    PosTransaction.create!(
+      store: @store,
+      register: @register,
+      pos_session: session,
+      reporting_period: period,
+      cashier_user: @user,
+      status: "working",
+      currency_code: "USD"
+    )
+
+    duplicate = PosTransaction.new(
+      store: @store,
+      register: @register,
+      pos_session: session,
+      reporting_period: period,
+      cashier_user: @user,
+      status: "working",
+      currency_code: "USD"
+    )
+    assert_raises(ActiveRecord::RecordNotUnique) { duplicate.save! }
+  end
+
+  test "completed and cancelled history does not block a new working transaction" do
+    period = open_period
+    session = PosSession.create!(
+      store: @store,
+      register: @register,
+      reporting_period: period,
+      cashier_user: @user,
+      status: "open",
+      opened_at: Time.current
+    )
+    PosTransaction.create!(
+      store: @store,
+      register: @register,
+      pos_session: session,
+      reporting_period: period,
+      cashier_user: @user,
+      status: "cancelled",
+      cancelled_at: Time.current,
+      currency_code: "USD"
+    )
+    working = PosTransaction.create!(
+      store: @store,
+      register: @register,
+      pos_session: session,
+      reporting_period: period,
+      cashier_user: @user,
+      status: "working",
+      currency_code: "USD"
+    )
+    assert working.working?
+  end
+
+  test "different sessions may each have one working transaction" do
+    other_register = Register.create!(store: @store, register_number: 2, name: "Back")
+    first_period = open_period
+    first_session = PosSession.create!(
+      store: @store,
+      register: @register,
+      reporting_period: first_period,
+      cashier_user: @user,
+      status: "open",
+      opened_at: Time.current
+    )
+    second_period = PosReportingPeriod.create!(
+      store: @store,
+      register: other_register,
+      status: "open",
+      opened_at: Time.current,
+      business_date: Date.new(2026, 8, 16)
+    )
+    second_session = PosSession.create!(
+      store: @store,
+      register: other_register,
+      reporting_period: second_period,
+      cashier_user: @user,
+      status: "open",
+      opened_at: Time.current
+    )
+
+    first = PosTransaction.create!(
+      store: @store,
+      register: @register,
+      pos_session: first_session,
+      reporting_period: first_period,
+      cashier_user: @user,
+      status: "working",
+      currency_code: "USD"
+    )
+    second = PosTransaction.create!(
+      store: @store,
+      register: other_register,
+      pos_session: second_session,
+      reporting_period: second_period,
+      cashier_user: @user,
+      status: "working",
+      currency_code: "USD"
+    )
+    assert first.working?
+    assert second.working?
+  end
+
   test "pos.transact is seeded for associate and store manager" do
     assert Permission.exists?(key: "pos.transact")
     assert Role.find_by!(key: "associate").permissions.exists?(key: "pos.transact")

--- a/test/services/pos/cash_accountability_test.rb
+++ b/test/services/pos/cash_accountability_test.rb
@@ -311,6 +311,7 @@ class PosCashAccountabilityTest < ActiveSupport::TestCase
     assert_equal session.closing_count_cents, totals.closing_count_cents
     assert_equal session.closing_variance_cents, totals.closing_variance_cents
     assert_equal(-99, totals.closing_variance_cents)
+    assert_equal session.pos_transactions.completed.sum(:total_cents), totals.total_cents
   end
 
   test "finalized period totals return persisted Z snapshots" do

--- a/test/services/pos/concurrency_test.rb
+++ b/test/services/pos/concurrency_test.rb
@@ -274,4 +274,34 @@ class Pos::ConcurrencyTest < ActiveSupport::TestCase
     )
     { context: context, transaction: transaction.reload }
   end
+
+  test "concurrent resume or start yields one working transaction" do
+    register = Register.create!(store: @store, register_number: 93, name: "Resume")
+    context = pos_open_context(store: @store, actor: @actor, register: register)
+    session_id = context[:session].id
+    actor_id = @actor.id
+
+    results = Array.new(2)
+    errors = Array.new(2)
+    threads = 2.times.map do |i|
+      Thread.new do
+        ActiveRecord::Base.connection_pool.with_connection do
+          results[i] = Pos::ResumeOrStartTransaction.call(
+            session: PosSession.find(session_id),
+            actor: User.find(actor_id)
+          )
+        rescue StandardError => e
+          errors[i] = e
+        end
+      end
+    end
+    threads.each { |thread| assert thread.join(30), "thread did not finish" }
+
+    assert_equal [], errors.compact.map(&:message)
+    ids = results.compact.map(&:id).uniq
+    assert_equal 1, ids.size
+    assert_equal 1, PosTransaction.uncached {
+      PosTransaction.where(pos_session_id: session_id, status: "working").count
+    }
+  end
 end

--- a/test/services/pos/concurrency_test.rb
+++ b/test/services/pos/concurrency_test.rb
@@ -253,28 +253,6 @@ class Pos::ConcurrencyTest < ActiveSupport::TestCase
     assert_equal [ operation_id ], successes.map { |result| result.operation.id }.uniq
   end
 
-  private
-
-  def prepare_sale(register_number:, presented_cents:)
-    register = Register.create!(store: @store, register_number: register_number, name: "Lane #{register_number}")
-    context = pos_open_context(store: @store, actor: @actor, register: register)
-    transaction = Pos::StartTransaction.call(session: context[:session], actor: @actor)
-    Pos::AddMerchandise.call(
-      transaction: transaction,
-      actor: @actor,
-      expected_lock_version: transaction.lock_version,
-      identifier: @variant.sku
-    )
-    transaction.reload
-    Pos::TenderCash.call(
-      transaction: transaction,
-      actor: @actor,
-      expected_lock_version: transaction.lock_version,
-      amount_presented_cents: presented_cents
-    )
-    { context: context, transaction: transaction.reload }
-  end
-
   test "concurrent resume or start yields one working transaction" do
     register = Register.create!(store: @store, register_number: 93, name: "Resume")
     context = pos_open_context(store: @store, actor: @actor, register: register)
@@ -303,5 +281,27 @@ class Pos::ConcurrencyTest < ActiveSupport::TestCase
     assert_equal 1, PosTransaction.uncached {
       PosTransaction.where(pos_session_id: session_id, status: "working").count
     }
+  end
+
+  private
+
+  def prepare_sale(register_number:, presented_cents:)
+    register = Register.create!(store: @store, register_number: register_number, name: "Lane #{register_number}")
+    context = pos_open_context(store: @store, actor: @actor, register: register)
+    transaction = Pos::StartTransaction.call(session: context[:session], actor: @actor)
+    Pos::AddMerchandise.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      identifier: @variant.sku
+    )
+    transaction.reload
+    Pos::TenderCash.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      amount_presented_cents: presented_cents
+    )
+    { context: context, transaction: transaction.reload }
   end
 end

--- a/test/services/pos/enter_register_test.rb
+++ b/test/services/pos/enter_register_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PosEnterRegisterTest < ActiveSupport::TestCase
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    @register = Register.create!(store: @store, register_number: 1, name: "Front")
+  end
+
+  test "opens a period session and working transaction" do
+    result = Pos::EnterRegister.call(
+      store: @store,
+      register: @register,
+      actor: @actor,
+      opening_float_cents: 5000
+    )
+    assert result.session.open?
+    assert_equal 5000, result.session.opening_float_cents
+    assert result.transaction.working?
+    assert_equal @actor.id, result.session.cashier_user_id
+  end
+
+  test "resumes the actor's open session without changing opening float" do
+    first = Pos::EnterRegister.call(
+      store: @store,
+      register: @register,
+      actor: @actor,
+      opening_float_cents: 2500
+    )
+    second = Pos::EnterRegister.call(
+      store: @store,
+      register: @register,
+      actor: @actor,
+      opening_float_cents: 9999
+    )
+    assert_equal first.session.id, second.session.id
+    assert_equal first.transaction.id, second.transaction.id
+    assert_equal 2500, second.session.reload.opening_float_cents
+  end
+
+  test "denies a second cashier on an occupied register" do
+    Pos::EnterRegister.call(
+      store: @store,
+      register: @register,
+      actor: @actor,
+      opening_float_cents: 0
+    )
+    other = pos_transacting_user(store: @store, assigned_by: @actor, username: "other_enter")
+    assert_raises(Pos::Denied) do
+      Pos::EnterRegister.call(
+        store: @store,
+        register: @register,
+        actor: other,
+        opening_float_cents: 0
+      )
+    end
+  end
+
+  test "requires opening float when creating a session" do
+    error = assert_raises(Pos::Error) do
+      Pos::EnterRegister.call(
+        store: @store,
+        register: @register,
+        actor: @actor,
+        opening_float_cents: nil
+      )
+    end
+    assert_match(/opening float is required/, error.message)
+    assert_equal 0, PosSession.where(register: @register).count
+  end
+
+  test "open gate is occupied for a different cashier" do
+    Pos::EnterRegister.call(
+      store: @store,
+      register: @register,
+      actor: @actor,
+      opening_float_cents: 0
+    )
+    other = pos_transacting_user(store: @store, assigned_by: @actor, username: "other_gate")
+    gate = Pos::OpenGate.for(store: @store, register: @register, actor: other)
+    assert gate.occupied?
+    assert_not gate.enterable?
+    assert_equal @actor.id, gate.occupier.id
+  end
+end

--- a/test/services/pos/enter_register_test.rb
+++ b/test/services/pos/enter_register_test.rb
@@ -72,6 +72,37 @@ class PosEnterRegisterTest < ActiveSupport::TestCase
     assert_equal 0, PosSession.where(register: @register).count
   end
 
+  test "rejects a confirmed business date that no longer matches the store calendar" do
+    now = Time.current
+    confirmed = BusinessDate.for_store(@store, at: now)
+
+    travel_to now + 1.day do
+      error = assert_raises(Pos::Error) do
+        Pos::EnterRegister.call(
+          store: @store,
+          register: @register,
+          actor: @actor,
+          opening_float_cents: 0,
+          business_date: confirmed
+        )
+      end
+      assert_match(/business date must match/, error.message)
+      assert_equal 0, PosReportingPeriod.where(register: @register).count
+    end
+  end
+
+  test "opens a period when the confirmed business date matches the store calendar" do
+    confirmed = BusinessDate.for_store(@store)
+    result = Pos::EnterRegister.call(
+      store: @store,
+      register: @register,
+      actor: @actor,
+      opening_float_cents: 0,
+      business_date: confirmed
+    )
+    assert_equal confirmed, result.session.reporting_period.business_date
+  end
+
   test "open gate is occupied for a different cashier" do
     Pos::EnterRegister.call(
       store: @store,

--- a/test/services/pos/enter_register_test.rb
+++ b/test/services/pos/enter_register_test.rb
@@ -103,6 +103,21 @@ class PosEnterRegisterTest < ActiveSupport::TestCase
     assert_equal confirmed, result.session.reporting_period.business_date
   end
 
+  test "rejects a confirmed date that does not match an already open period" do
+    Pos::OpenReportingPeriod.call(store: @store, register: @register, actor: @actor)
+    error = assert_raises(Pos::Error) do
+      Pos::EnterRegister.call(
+        store: @store,
+        register: @register,
+        actor: @actor,
+        opening_float_cents: 0,
+        business_date: BusinessDate.for_store(@store) - 1.day
+      )
+    end
+    assert_match(/already open on business date/, error.message)
+    assert_equal 0, PosSession.where(register: @register).count
+  end
+
   test "open gate is occupied for a different cashier" do
     Pos::EnterRegister.call(
       store: @store,

--- a/test/services/pos/receipt_identity_test.rb
+++ b/test/services/pos/receipt_identity_test.rb
@@ -10,4 +10,12 @@ class Pos::ReceiptIdentityTest < ActiveSupport::TestCase
       receipt_sequence: 1
     )
   end
+
+  test "formats the printed receipt header from snapshots" do
+    assert_equal "Store: 003   Reg: 02   Trans: 0018427", Pos::ReceiptIdentity.header(
+      store_number: 3,
+      register_number: 2,
+      receipt_sequence: 18427
+    )
+  end
 end

--- a/test/services/pos/workspace_invariants_test.rb
+++ b/test/services/pos/workspace_invariants_test.rb
@@ -1,0 +1,311 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PosWorkspaceInvariantsTest < ActiveSupport::TestCase
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    @tax = tax_class(code: "physical_book", name: "Physical book")
+    StoreTaxes::Create.call(
+      store: @store,
+      actor: @actor,
+      name: "Illinois State",
+      rate_percent: "5.000",
+      calculation_order: 1,
+      applies_by_tax_class_id: { @tax.id => true }
+    )
+    @variant = pos_sellable_variant(actor: @actor, tax_class: @tax)
+    @context = pos_open_context(store: @store, actor: @actor)
+  end
+
+  test "start transaction rejects a second working row" do
+    first = Pos::StartTransaction.call(session: @context[:session], actor: @actor)
+    error = assert_raises(Pos::Error) do
+      Pos::StartTransaction.call(session: @context[:session], actor: @actor)
+    end
+    assert_match(/working transaction already exists/, error.message)
+    assert_equal 1, PosTransaction.working.where(pos_session: @context[:session]).count
+    assert_equal first.id, PosTransaction.working.find_by!(pos_session: @context[:session]).id
+  end
+
+  test "resume or start creates then returns the same working transaction" do
+    created = Pos::ResumeOrStartTransaction.call(session: @context[:session], actor: @actor)
+    resumed = Pos::ResumeOrStartTransaction.call(session: @context[:session], actor: @actor)
+    assert_equal created.id, resumed.id
+    assert_equal 1, PosTransaction.working.where(pos_session: @context[:session]).count
+  end
+
+  test "resume or start is denied to a second cashier" do
+    other = pos_transacting_user(store: @store, assigned_by: @actor, username: "other_resume")
+    assert_raises(Pos::Denied) do
+      Pos::ResumeOrStartTransaction.call(session: @context[:session], actor: other)
+    end
+    assert_equal 0, PosTransaction.where(pos_session: @context[:session]).count
+  end
+
+  test "add merchandise rescans a compatible sku onto the existing line" do
+    transaction = Pos::StartTransaction.call(session: @context[:session], actor: @actor)
+    first = Pos::AddMerchandise.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      identifier: @variant.sku
+    )
+    transaction.reload
+    second = Pos::AddMerchandise.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      identifier: @variant.sku
+    )
+    transaction.reload
+    assert_equal first.id, second.id
+    assert_equal 2, second.quantity
+    assert_equal 1, transaction.pos_transaction_lines.count
+    assert_equal 3998, transaction.subtotal_cents
+    assert_equal 200, transaction.tax_cents
+    assert_equal 4198, transaction.total_cents
+  end
+
+  test "add merchandise keeps an incompatible price context as a separate line" do
+    transaction = Pos::StartTransaction.call(session: @context[:session], actor: @actor)
+    first = Pos::AddMerchandise.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      identifier: @variant.sku
+    )
+    first.update_columns(selling_unit_price_cents: 1500, extended_selling_amount_cents: 1500)
+    transaction.reload
+    second = Pos::AddMerchandise.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      identifier: @variant.sku
+    )
+    transaction.reload
+    assert_not_equal first.id, second.id
+    assert_equal 2, transaction.pos_transaction_lines.count
+    assert_equal 1, second.quantity
+    assert_equal 1999, second.selling_unit_price_cents
+  end
+
+  test "basket mutation clears a working cash tender and refreshes lock_version" do
+    transaction = working_sale_with_tender
+    original_version = transaction.lock_version
+    Pos::AddMerchandise.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      identifier: @variant.sku
+    )
+    transaction.reload
+    assert_equal 0, transaction.pos_tenders.count
+    assert_operator transaction.lock_version, :>, original_version
+    assert transaction.working?
+  end
+
+  test "change quantity and remove working line clear a working cash tender" do
+    transaction = working_sale_with_tender
+    line = transaction.pos_transaction_lines.first
+    Pos::ChangeQuantity.call(
+      transaction: transaction,
+      line: line,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      quantity: 2
+    )
+    transaction.reload
+    assert_equal 0, transaction.pos_tenders.count
+    assert transaction.working?
+
+    Pos::TenderCash.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      amount_presented_cents: transaction.total_cents
+    )
+    transaction.reload
+    Pos::RemoveWorkingLine.call(
+      transaction: transaction,
+      line: line,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version
+    )
+    transaction.reload
+    assert_equal 0, transaction.pos_tenders.count
+    assert_equal 0, transaction.pos_transaction_lines.count
+    assert transaction.working?
+  end
+
+  test "abandon tender removes a cash tender and bumps lock_version" do
+    transaction = working_sale_with_tender
+    original_version = transaction.lock_version
+    Pos::AbandonTender.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version
+    )
+    transaction.reload
+    assert_equal 0, transaction.pos_tenders.count
+    assert_equal original_version + 1, transaction.lock_version
+    assert transaction.working?
+  end
+
+  test "abandon tender is a successful no-op without a lock_version bump when there is no tender" do
+    transaction = Pos::StartTransaction.call(session: @context[:session], actor: @actor)
+    original_version = transaction.lock_version
+    Pos::AbandonTender.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version
+    )
+    transaction.reload
+    assert_equal original_version, transaction.lock_version
+    assert transaction.working?
+  end
+
+  test "abandon tender rejects a second cashier stale version and completed transactions" do
+    transaction = working_sale_with_tender
+    other = pos_transacting_user(store: @store, assigned_by: @actor, username: "other_abandon")
+    assert_raises(Pos::Denied) do
+      Pos::AbandonTender.call(
+        transaction: transaction,
+        actor: other,
+        expected_lock_version: transaction.lock_version
+      )
+    end
+    assert_raises(Pos::StaleObject) do
+      Pos::AbandonTender.call(
+        transaction: transaction,
+        actor: @actor,
+        expected_lock_version: transaction.lock_version - 1
+      )
+    end
+    assert_equal 1, transaction.reload.pos_tenders.count
+
+    complete_current_sale!(transaction)
+    assert_raises(Pos::Error) do
+      Pos::AbandonTender.call(
+        transaction: transaction.reload,
+        actor: @actor,
+        expected_lock_version: transaction.lock_version
+      )
+    end
+  end
+
+  test "cancel discards working tenders keeps lines and does not change expected cash" do
+    transaction = working_sale_with_tender
+    line_id = transaction.pos_transaction_lines.first.id
+    Pos::CancelTransaction.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version
+    )
+    transaction.reload
+    assert transaction.cancelled?
+    assert_equal 0, transaction.pos_tenders.count
+    assert_equal line_id, transaction.pos_transaction_lines.first.id
+    assert_equal 0, Pos::SessionTotals.for(@context[:session]).expected_cash_cents
+  end
+
+  test "cancel of an empty working transaction remains allowed" do
+    transaction = Pos::StartTransaction.call(session: @context[:session], actor: @actor)
+    Pos::CancelTransaction.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version
+    )
+    assert transaction.reload.cancelled?
+  end
+
+  test "find completion operation restores the matching failed attempt and ignores a prior abandoned tender" do
+    transaction = working_sale_with_tender
+    first_id = SecureRandom.uuid_v7
+    assert_raises(Pos::Error) do
+      Pos::CompleteTransaction.call(
+        transaction: transaction,
+        actor: @actor,
+        operation_id: first_id,
+        expected_lock_version: transaction.lock_version,
+        expected_total_cents: transaction.total_cents,
+        amount_presented_cents: 2500
+      )
+    end
+    assert_equal first_id, Pos::FindCompletionOperation.call(transaction: transaction.reload, actor: @actor).id
+
+    Pos::AbandonTender.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version
+    )
+    transaction.reload
+    Pos::TenderCash.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      amount_presented_cents: 2500
+    )
+    transaction.reload
+    assert_nil Pos::FindCompletionOperation.call(transaction: transaction, actor: @actor)
+
+    second_id = SecureRandom.uuid_v7
+    assert_raises(Pos::Error) do
+      Pos::CompleteTransaction.call(
+        transaction: transaction,
+        actor: @actor,
+        operation_id: second_id,
+        expected_lock_version: transaction.lock_version,
+        expected_total_cents: transaction.total_cents,
+        amount_presented_cents: 2500
+      )
+    end
+    found = Pos::FindCompletionOperation.call(transaction: transaction.reload, actor: @actor)
+    assert_equal second_id, found.id
+    assert_equal "failed", found.status
+  end
+
+  test "find completion operation is denied to a second cashier and nil without a cash tender" do
+    transaction = Pos::StartTransaction.call(session: @context[:session], actor: @actor)
+    assert_nil Pos::FindCompletionOperation.call(transaction: transaction, actor: @actor)
+
+    other = pos_transacting_user(store: @store, assigned_by: @actor, username: "other_finder")
+    assert_raises(Pos::Denied) do
+      Pos::FindCompletionOperation.call(transaction: transaction, actor: other)
+    end
+  end
+
+  private
+
+  def working_sale_with_tender
+    transaction = Pos::StartTransaction.call(session: @context[:session], actor: @actor)
+    Pos::AddMerchandise.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      identifier: @variant.sku
+    )
+    transaction.reload
+    Pos::TenderCash.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      amount_presented_cents: 2500
+    )
+    transaction.reload
+  end
+
+  def complete_current_sale!(transaction)
+    open_quantity_stock(store: @store, variant: @variant, actor: @actor, quantity: 5)
+    Pos::CompleteTransaction.call(
+      transaction: transaction,
+      actor: @actor,
+      operation_id: SecureRandom.uuid_v7,
+      expected_lock_version: transaction.lock_version,
+      expected_total_cents: transaction.total_cents,
+      amount_presented_cents: transaction.pos_tenders.first.amount_presented_cents
+    )
+  end
+end

--- a/test/services/pos/workspace_invariants_test.rb
+++ b/test/services/pos/workspace_invariants_test.rb
@@ -267,6 +267,52 @@ class PosWorkspaceInvariantsTest < ActiveSupport::TestCase
     assert_equal "failed", found.status
   end
 
+  test "find completion operation prefers the newest in_flight then the newest failed" do
+    transaction = working_sale_with_tender
+    older_failed = SecureRandom.uuid_v7
+    assert_raises(Pos::Error) do
+      Pos::CompleteTransaction.call(
+        transaction: transaction,
+        actor: @actor,
+        operation_id: older_failed,
+        expected_lock_version: transaction.lock_version,
+        expected_total_cents: transaction.total_cents,
+        amount_presented_cents: 2500
+      )
+    end
+    newer_failed = SecureRandom.uuid_v7
+    assert_raises(Pos::Error) do
+      Pos::CompleteTransaction.call(
+        transaction: transaction.reload,
+        actor: @actor,
+        operation_id: newer_failed,
+        expected_lock_version: transaction.lock_version,
+        expected_total_cents: transaction.total_cents,
+        amount_presented_cents: 2500
+      )
+    end
+    assert_equal newer_failed, Pos::FindCompletionOperation.call(transaction: transaction.reload, actor: @actor).id
+
+    in_flight_id = SecureRandom.uuid_v7
+    payload = Pos::CompleteTransaction.command_payload(
+      transaction: transaction,
+      operation_id: in_flight_id,
+      expected_lock_version: transaction.lock_version,
+      expected_total_cents: transaction.total_cents,
+      amount_presented_cents: transaction.pos_tenders.find_by!(tender_type: "cash").amount_presented_cents
+    )
+    Pos::OperationLease.begin!(
+      register_id: transaction.register_id,
+      operation_id: in_flight_id,
+      command_payload: payload,
+      store_id: transaction.store_id,
+      pos_transaction_id: transaction.id
+    )
+    found = Pos::FindCompletionOperation.call(transaction: transaction.reload, actor: @actor)
+    assert_equal in_flight_id, found.id
+    assert_equal "in_flight", found.status
+  end
+
   test "find completion operation is denied to a second cashier and nil without a cash tender" do
     transaction = Pos::StartTransaction.call(session: @context[:session], actor: @actor)
     assert_nil Pos::FindCompletionOperation.call(transaction: transaction, actor: @actor)

--- a/test/system/pos_close_z_test.rb
+++ b/test/system/pos_close_z_test.rb
@@ -92,6 +92,71 @@ class PosCloseZTest < ApplicationSystemTestCase
     assert_no_button "Close register"
   end
 
+  test "cashier can complete the phase 5 open sell print close and z path" do
+    sign_in_admin
+    visit pos_register_enter_path(register_id: @register.id)
+    assert_text "Business date"
+    fill_in "Opening float", with: "100.00"
+    click_on "Open register"
+    assert_text "SALE ENTRY"
+
+    add_current_sku
+    field = find("#pos-command-field")
+    field.fill_in with: @variant.sku
+    field.send_keys :enter
+    assert_selector "tr.is-selected[data-quantity='2']"
+
+    click_on "Quantity (*)"
+    assert_text "QUANTITY"
+    field = find("#pos-command-field")
+    field.fill_in with: "1"
+    field.send_keys :enter
+    assert_text "SALE ENTRY"
+    assert_selector "tr.is-selected[data-quantity='1']"
+
+    click_on "Tender (+)"
+    assert_text "CASH TENDER"
+    field = find("#pos-command-field")
+    field.fill_in with: "25.00"
+    field.send_keys :enter
+    send_keys :enter
+
+    assert_text "Sale complete", wait: 10
+    assert_text "Change"
+    assert_button "Print receipt"
+    assert_selector ".pos-receipt__print-header", visible: :all, text: /Store: 001\s+Reg: 01\s+Trans:/
+    transaction = PosTransaction.completed.find_by!(register: @register)
+    assert transaction.completed?
+
+    click_on "Close register"
+    assert_text "Closing Cash count"
+    assert_no_text "Expected"
+    assert_no_text "Opening float"
+    assert_no_text "$100.00"
+    session_record = PosSession.open.find_by!(register: @register)
+    expected = session_record.opening_float_cents + Pos::SessionTotals.for(session_record).cash_tender_cents
+    fill_in "Closing Cash count", with: format("%<dollars>d.%<cents>02d", dollars: expected / 100, cents: expected % 100)
+    click_on "Close session"
+
+    assert_text "Session closed"
+    session_record.reload
+    assert session_record.closed?
+    assert_equal expected, session_record.closing_expected_cash_cents
+    assert_equal expected, session_record.closing_count_cents
+    assert_equal 0, session_record.closing_variance_cents
+    assert_text "Expected closing Cash"
+    assert_text "Variance"
+
+    click_on "Finalize Z"
+    assert_text "Z report"
+    period = PosReportingPeriod.finalized.find_by!(register: @register)
+    assert period.finalized?
+    assert_equal session_record.closing_expected_cash_cents, period.finalized_closing_expected_cash_cents_sum
+    assert_equal session_record.closing_count_cents, period.finalized_closing_count_cents_sum
+    assert_equal 0, period.finalized_closing_variance_cents_sum
+    assert_no_button "Finalize Z"
+  end
+
   private
 
   def sign_in_admin

--- a/test/system/pos_close_z_test.rb
+++ b/test/system/pos_close_z_test.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class PosCloseZTest < ApplicationSystemTestCase
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    @tax = tax_class(code: "physical_book", name: "Physical book")
+    StoreTaxes::Create.call(
+      store: @store,
+      actor: @actor,
+      name: "Illinois State",
+      rate_percent: "5.000",
+      calculation_order: 1,
+      applies_by_tax_class_id: { @tax.id => true }
+    )
+    @variant = pos_sellable_variant(actor: @actor, tax_class: @tax)
+    open_quantity_stock(store: @store, variant: @variant, actor: @actor, quantity: 5)
+    @register = Register.create!(store: @store, register_number: 1, name: "Front")
+  end
+
+  test "empty sale entry can close with a blind zero count and finalize z" do
+    open_register(opening_float: "100.00")
+    assert_button "Close register"
+    click_on "Close register"
+    assert_text "Closing Cash count"
+    assert_no_text "Expected"
+    assert_no_text "Opening float"
+    assert_no_text "$100.00"
+    assert_no_text "Variance"
+
+    field = find("#closing_count")
+    field.fill_in with: "0.00"
+    field.send_keys :enter
+
+    assert_text "Session closed"
+    assert_text "Expected closing Cash"
+    assert_text "$100.00"
+    assert_text "Counted Cash"
+    click_on "Finalize Z"
+    assert_text "Z report"
+    assert_text "Store 001"
+    assert_text "Register 01"
+    assert_text "Opening floats total"
+    period = PosReportingPeriod.finalized.find_by!(register: @register)
+    assert period.finalized?
+    assert_equal 0, period.finalized_transaction_count
+  end
+
+  test "completed sale can print and close the register" do
+    open_register(opening_float: "100.00")
+    add_current_sku
+    assert_no_button "Close register"
+    click_on "Tender (+)"
+    field = find("#pos-command-field")
+    field.fill_in with: "25.00"
+    field.send_keys :enter
+    send_keys :enter
+
+    assert_text "Sale complete", wait: 10
+    assert_button "Print receipt"
+    assert_text "New sale"
+    assert_text "Close register"
+    assert_selector ".pos-receipt__print-header", visible: :all, text: /Store: 001\s+Reg: 01\s+Trans:/
+    transaction = PosTransaction.completed.find_by!(register: @register)
+    send_keys :enter
+    assert_text "Sale complete"
+    assert transaction.reload.completed?
+
+    click_on "Close register"
+    assert_text "Closing Cash count"
+    fill_in "Closing Cash count", with: "120.99"
+    click_on "Close session"
+    assert_text "Session closed"
+    assert_text "Leave period open"
+    click_on "Leave period open"
+    assert_button "Finalize Z"
+    assert_button "Open session"
+  end
+
+  test "quantity and tender do not expose close register" do
+    open_register
+    add_current_sku
+    click_on "Quantity (*)"
+    assert_text "QUANTITY"
+    assert_no_button "Close register"
+    find("#pos-command-field").send_keys :escape
+    click_on "Tender (+)"
+    assert_text "CASH TENDER"
+    assert_no_button "Close register"
+  end
+
+  private
+
+  def sign_in_admin
+    visit new_session_path
+    fill_in "session_username", with: "admin"
+    fill_in "session_password", with: "correct-horse-battery"
+    find_field("session_password").send_keys :enter
+    assert_text "Signed in successfully"
+  end
+
+  def open_register(opening_float: "0.00")
+    sign_in_admin
+    visit pos_register_enter_path(register_id: @register.id)
+    fill_in "Opening float", with: opening_float
+    click_on "Open register"
+    assert_text "SALE ENTRY"
+  end
+
+  def add_current_sku
+    field = find("#pos-command-field")
+    field.fill_in with: @variant.sku
+    field.send_keys :enter
+    assert_text "Example Book"
+  end
+end

--- a/test/system/pos_register_workspace_test.rb
+++ b/test/system/pos_register_workspace_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class PosRegisterWorkspaceTest < ApplicationSystemTestCase
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    @tax = tax_class(code: "physical_book", name: "Physical book")
+    StoreTaxes::Create.call(
+      store: @store,
+      actor: @actor,
+      name: "Illinois State",
+      rate_percent: "5.000",
+      calculation_order: 1,
+      applies_by_tax_class_id: { @tax.id => true }
+    )
+    @variant = pos_sellable_variant(actor: @actor, tax_class: @tax)
+    open_quantity_stock(store: @store, variant: @variant, actor: @actor, quantity: 5)
+    @register = Register.create!(store: @store, register_number: 1, name: "Front")
+  end
+
+  test "cashier can sell cash and start a new sale from the receipt" do
+    sign_in_admin
+    visit pos_register_enter_path(register_id: @register.id)
+    fill_in "Opening float", with: "0.00"
+    click_on "Open register"
+
+    assert_text "SALE ENTRY"
+    field = find("#pos-command-field")
+    field.fill_in with: @variant.sku
+    field.send_keys :enter
+    assert_text "Example Book"
+    field = find("#pos-command-field")
+    field.fill_in with: @variant.sku
+    field.send_keys :enter
+    assert_text "2"
+    assert_text "SALE ENTRY"
+
+    click_on "Tender (+)"
+    assert_text "CASH TENDER"
+    field = find("#pos-command-field")
+    field.fill_in with: "50.00"
+    field.send_keys :enter
+
+    assert_text "Sale complete", wait: 10
+    assert_text "New sale"
+    send_keys :enter
+    assert_text "Sale complete"
+    click_on "New sale"
+    assert_text "SALE ENTRY"
+    assert_no_text "Example Book"
+  end
+
+  test "empty basket disables cancel" do
+    sign_in_admin
+    visit pos_register_enter_path(register_id: @register.id)
+    fill_in "Opening float", with: "0.00"
+    click_on "Open register"
+
+    assert_text "SALE ENTRY"
+    assert_button "Cancel (F9)", disabled: true
+  end
+
+  private
+
+  def sign_in_admin
+    visit new_session_path
+    fill_in "session_username", with: "admin"
+    fill_in "session_password", with: "correct-horse-battery"
+    click_button "Sign in"
+    assert_text "Signed in successfully"
+  end
+end

--- a/test/system/pos_register_workspace_test.rb
+++ b/test/system/pos_register_workspace_test.rb
@@ -71,6 +71,7 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
   test "empty basket disables cancel" do
     open_register
     assert_button "Cancel (F9)", disabled: true
+    assert_button "Close register"
   end
 
   test "quantity mode prefills and invalid quantity stays in quantity" do

--- a/test/system/pos_register_workspace_test.rb
+++ b/test/system/pos_register_workspace_test.rb
@@ -22,16 +22,8 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
   end
 
   test "cashier can sell cash and start a new sale from the receipt" do
-    sign_in_admin
-    visit pos_register_enter_path(register_id: @register.id)
-    fill_in "Opening float", with: "0.00"
-    click_on "Open register"
-
-    assert_text "SALE ENTRY"
-    field = find("#pos-command-field")
-    field.fill_in with: @variant.sku
-    field.send_keys :enter
-    assert_text "Example Book"
+    open_register
+    add_current_sku
     field = find("#pos-command-field")
     field.fill_in with: @variant.sku
     field.send_keys :enter
@@ -43,8 +35,10 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     field = find("#pos-command-field")
     field.fill_in with: "50.00"
     field.send_keys :enter
+    send_keys :enter
 
     assert_text "Sale complete", wait: 10
+    assert_equal 1, PosTransaction.completed.where(register: @register).count
     assert_text "New sale"
     send_keys :enter
     assert_text "Sale complete"
@@ -53,37 +47,156 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     assert_no_text "Example Book"
   end
 
-  test "delete edits the identifier and minus removes the selected line" do
-    sign_in_admin
-    visit pos_register_enter_path(register_id: @register.id)
-    fill_in "Opening float", with: "0.00"
-    click_on "Open register"
-
-    assert_text "SALE ENTRY"
+  test "delete and hyphen edit the identifier and f8 removes the selected line" do
+    open_register
     field = find("#pos-command-field")
     field.fill_in with: "ABC"
     field.send_keys :left, :left, :delete
     assert_equal "AC", field.value
 
-    field.fill_in with: @variant.sku
+    sku = @variant.sku.to_s
+    hyphenated = sku.length > 3 ? "#{sku[0..2]}-#{sku[3..]}" : "#{sku}-"
+    field.fill_in with: hyphenated
     field.send_keys :enter
     assert_text "Example Book"
     field = find("#pos-command-field")
-    assert_equal "", field.value
-    field.send_keys :delete
+    field.fill_in with: "978-0-14"
+    assert_equal "978-0-14", field.value
     assert_text "Example Book"
-    field.send_keys "-"
+    field.fill_in with: ""
+    field.send_keys :f8
     assert_no_text "Example Book"
   end
 
   test "empty basket disables cancel" do
-    sign_in_admin
-    visit pos_register_enter_path(register_id: @register.id)
-    fill_in "Opening float", with: "0.00"
-    click_on "Open register"
-
-    assert_text "SALE ENTRY"
+    open_register
     assert_button "Cancel (F9)", disabled: true
+  end
+
+  test "quantity mode prefills and invalid quantity stays in quantity" do
+    open_register
+    add_current_sku
+    click_on "Quantity (*)"
+    assert_text "QUANTITY"
+    field = find("#pos-command-field")
+    assert_equal "1", field.value
+    field.fill_in with: "0"
+    field.send_keys :enter
+    assert_text "QUANTITY"
+    assert_text "quantity must be positive"
+    assert_equal "0", find("#pos-command-field").value
+  end
+
+  test "insufficient cash stays in tender and escape returns to sale entry" do
+    open_register
+    add_current_sku
+    click_on "Tender (+)"
+    assert_text "CASH TENDER"
+    field = find("#pos-command-field")
+    field.fill_in with: "0.01"
+    field.send_keys :enter
+    assert_text "CASH TENDER"
+    assert_text "less than amount due"
+    send_keys :escape
+    assert_text "SALE ENTRY"
+    assert_text "Scan or identifier"
+  end
+
+  test "cancel overlay ignores enter and confirms on f9" do
+    open_register
+    add_current_sku
+    send_keys :f9
+    assert_text "Cancel this sale?"
+    send_keys :enter
+    assert_text "Cancel this sale?"
+    assert_text "Example Book"
+    send_keys :f9
+    assert_text "SALE ENTRY"
+    assert_no_text "Example Book"
+  end
+
+  test "completed receipt enter is a no-op and workspace without a working sale returns to enter" do
+    open_register
+    add_current_sku
+    click_on "Tender (+)"
+    field = find("#pos-command-field")
+    field.fill_in with: "50.00"
+    field.send_keys :enter
+    assert_text "Sale complete", wait: 10
+    send_keys :enter
+    assert_text "Sale complete"
+    visit pos_register_workspace_path
+    assert_text "Open register"
+  end
+
+  test "unknown identifier feedback does not move the command field" do
+    open_register
+    field = find("#pos-command-field")
+    before = command_field_top
+    field.fill_in with: "0000000000000"
+    field.send_keys :enter
+    assert_css "#pos_feedback"
+    assert_equal before, command_field_top
+  end
+
+  test "refresh restores the in_flight operation id and return to sale clears the tender" do
+    open_register
+    add_current_sku
+    transaction = PosTransaction.working.find_by!(register: @register)
+    Pos::TenderCash.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      amount_presented_cents: 2500
+    )
+    transaction.reload
+    operation_id = SecureRandom.uuid_v7
+    payload = Pos::CompleteTransaction.command_payload(
+      transaction: transaction,
+      operation_id: operation_id,
+      expected_lock_version: transaction.lock_version,
+      expected_total_cents: transaction.total_cents,
+      amount_presented_cents: 2500
+    )
+    Pos::OperationLease.begin!(
+      register_id: transaction.register_id,
+      operation_id: operation_id,
+      command_payload: payload,
+      store_id: transaction.store_id,
+      pos_transaction_id: transaction.id
+    )
+
+    visit pos_register_workspace_path
+    assert_text "Completion is still processing"
+    assert_selector "input[name='completion_operation_id'][value='#{operation_id}']", visible: false
+    visit pos_register_workspace_path
+    assert_selector "input[name='completion_operation_id'][value='#{operation_id}']", visible: false
+
+    click_on "Return to sale"
+    assert_text "SALE ENTRY"
+    assert_text "Example Book"
+    assert_no_text "CHANGE"
+    assert_equal 0, transaction.reload.pos_tenders.count
+  end
+
+  test "retry complete after inventory failure does not re-tender" do
+    open_register
+    add_current_sku
+    shrink_current_sku(5)
+    click_on "Tender (+)"
+    field = find("#pos-command-field")
+    field.fill_in with: "50.00"
+    field.send_keys :enter
+    assert_text "Retry complete", wait: 10
+    transaction = PosTransaction.working.find_by!(register: @register)
+    assert_equal 1, transaction.pos_tenders.count
+
+    open_quantity_stock(store: @store, variant: @variant, actor: @actor, quantity: 5)
+    click_on "Retry complete"
+    assert_text "Sale complete", wait: 10
+    completed = PosTransaction.completed.find_by!(register: @register)
+    assert_equal 1, completed.pos_tenders.count
+    assert_equal 1, OutboxMessage.where(event_type: "pos.transaction_completed").count
   end
 
   private
@@ -92,7 +205,39 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     visit new_session_path
     fill_in "session_username", with: "admin"
     fill_in "session_password", with: "correct-horse-battery"
-    click_button "Sign in"
+    find_field("session_password").send_keys :enter
     assert_text "Signed in successfully"
+  end
+
+  def open_register
+    sign_in_admin
+    visit pos_register_enter_path(register_id: @register.id)
+    fill_in "Opening float", with: "0.00"
+    click_on "Open register"
+    assert_text "SALE ENTRY"
+  end
+
+  def add_current_sku
+    field = find("#pos-command-field")
+    field.fill_in with: @variant.sku
+    field.send_keys :enter
+    assert_text "Example Book"
+  end
+
+  def command_field_top
+    page.evaluate_script("document.getElementById('pos-command-field').getBoundingClientRect().top")
+  end
+
+  def shrink_current_sku(quantity)
+    Inventory::AdjustmentReasons.seed!
+    Inventory::PostAdjustment.call(
+      store: @store,
+      product_variant: @variant,
+      adjustment_reason: AdjustmentReason.find_by!(code: "shrinkage"),
+      quantity_delta: -quantity,
+      actor: @actor,
+      source_id: SecureRandom.uuid_v7,
+      idempotency_key: SecureRandom.uuid_v7
+    )
   end
 end

--- a/test/system/pos_register_workspace_test.rb
+++ b/test/system/pos_register_workspace_test.rb
@@ -27,7 +27,7 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     field = find("#pos-command-field")
     field.fill_in with: @variant.sku
     field.send_keys :enter
-    assert_text "2"
+    assert_selector "tr.is-selected[data-quantity='2']"
     assert_text "SALE ENTRY"
 
     click_on "Tender (+)"
@@ -139,44 +139,91 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     assert_equal before, command_field_top
   end
 
-  test "refresh restores the in_flight operation id and return to sale clears the tender" do
+  test "in-flight mutation ignores tender remove and cancel" do
     open_register
     add_current_sku
-    transaction = PosTransaction.working.find_by!(register: @register)
-    Pos::TenderCash.call(
-      transaction: transaction,
-      actor: @actor,
-      expected_lock_version: transaction.lock_version,
-      amount_presented_cents: 2500
-    )
-    transaction.reload
-    operation_id = SecureRandom.uuid_v7
-    payload = Pos::CompleteTransaction.command_payload(
-      transaction: transaction,
-      operation_id: operation_id,
-      expected_lock_version: transaction.lock_version,
-      expected_total_cents: transaction.total_cents,
-      amount_presented_cents: 2500
-    )
-    Pos::OperationLease.begin!(
-      register_id: transaction.register_id,
-      operation_id: operation_id,
-      command_payload: payload,
-      store_id: transaction.store_id,
-      pos_transaction_id: transaction.id
-    )
+    page.execute_script(<<~JS)
+      const el = document.getElementById("pos_workspace")
+      const controller = window.Stimulus.getControllerForElementAndIdentifier(el, "register-workspace")
+      controller.beginFlight()
+      controller.enterTender()
+      controller.removeSelected()
+      controller.openOverlay()
+    JS
+    assert_button "Tender (+)", disabled: true
+    assert_button "Remove (F8)", disabled: true
+    assert_button "Cancel (F9)", disabled: true
+    assert_text "SALE ENTRY"
+    assert_no_text "CASH TENDER"
+    assert_no_text "Cancel this sale?"
+    assert_text "Example Book"
+  end
 
+  test "active in_flight completion has no recovery controls" do
+    open_register
+    add_current_sku
+    seed_in_flight_completion
     visit pos_register_workspace_path
     assert_text "Completion is still processing"
-    assert_selector "input[name='completion_operation_id'][value='#{operation_id}']", visible: false
+    assert_no_button "Retry complete"
+    assert_no_button "Return to sale"
+    assert_button "Cancel (F9)", disabled: true
+    assert_selector "input[name='completion_operation_id']", visible: false
     visit pos_register_workspace_path
-    assert_selector "input[name='completion_operation_id'][value='#{operation_id}']", visible: false
+    assert_text "Completion is still processing"
+    assert_no_button "Retry complete"
+  end
 
+  test "return to sale from a failed completion clears the tender" do
+    open_register
+    add_current_sku
+    shrink_current_sku(5)
+    click_on "Tender (+)"
+    field = find("#pos-command-field")
+    field.fill_in with: "50.00"
+    field.send_keys :enter
+    assert_text "Retry complete", wait: 10
     click_on "Return to sale"
     assert_text "SALE ENTRY"
     assert_text "Example Book"
     assert_no_text "CHANGE"
-    assert_equal 0, transaction.reload.pos_tenders.count
+    assert_equal 0, PosTransaction.working.find_by!(register: @register).pos_tenders.count
+  end
+
+  test "transport failure on merchandise reloads the workspace" do
+    open_register
+    add_current_sku
+    page.execute_script(<<~JS)
+      const el = document.getElementById("pos_workspace")
+      const controller = window.Stimulus.getControllerForElementAndIdentifier(el, "register-workspace")
+      controller.beginFlight()
+      const form = el.querySelector("[data-register-workspace-target='merchandiseForm']")
+      form.dispatchEvent(new CustomEvent("turbo:submit-end", { bubbles: true, detail: { success: false } }))
+    JS
+    assert_text "SALE ENTRY"
+    assert_text "Example Book"
+  end
+
+  test "transport failure on complete keeps the same operation and offers retry" do
+    open_register
+    add_current_sku
+    shrink_current_sku(5)
+    click_on "Tender (+)"
+    field = find("#pos-command-field")
+    field.fill_in with: "50.00"
+    field.send_keys :enter
+    assert_text "Retry complete", wait: 10
+    operation_id = find("input[name='completion_operation_id']", visible: :hidden).value
+    page.execute_script(<<~JS)
+      const el = document.getElementById("pos_workspace")
+      const controller = window.Stimulus.getControllerForElementAndIdentifier(el, "register-workspace")
+      controller.beginFlight()
+      const form = el.querySelector("[data-register-workspace-target='completeForm']")
+      form.dispatchEvent(new CustomEvent("turbo:submit-end", { bubbles: true, detail: { success: false } }))
+    JS
+    assert_text "Connection lost"
+    assert_text "Retry complete"
+    assert_equal operation_id, find("input[name='completion_operation_id']", visible: :hidden).value
   end
 
   test "retry complete after inventory failure does not re-tender" do
@@ -226,6 +273,33 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
 
   def command_field_top
     page.evaluate_script("document.getElementById('pos-command-field').getBoundingClientRect().top")
+  end
+
+  def seed_in_flight_completion
+    transaction = PosTransaction.working.find_by!(register: @register)
+    Pos::TenderCash.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      amount_presented_cents: 2500
+    )
+    transaction.reload
+    operation_id = SecureRandom.uuid_v7
+    payload = Pos::CompleteTransaction.command_payload(
+      transaction: transaction,
+      operation_id: operation_id,
+      expected_lock_version: transaction.lock_version,
+      expected_total_cents: transaction.total_cents,
+      amount_presented_cents: 2500
+    )
+    Pos::OperationLease.begin!(
+      register_id: transaction.register_id,
+      operation_id: operation_id,
+      command_payload: payload,
+      store_id: transaction.store_id,
+      pos_transaction_id: transaction.id
+    )
+    operation_id
   end
 
   def shrink_current_sku(quantity)

--- a/test/system/pos_register_workspace_test.rb
+++ b/test/system/pos_register_workspace_test.rb
@@ -53,6 +53,29 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     assert_no_text "Example Book"
   end
 
+  test "delete edits the identifier and minus removes the selected line" do
+    sign_in_admin
+    visit pos_register_enter_path(register_id: @register.id)
+    fill_in "Opening float", with: "0.00"
+    click_on "Open register"
+
+    assert_text "SALE ENTRY"
+    field = find("#pos-command-field")
+    field.fill_in with: "ABC"
+    field.send_keys :left, :left, :delete
+    assert_equal "AC", field.value
+
+    field.fill_in with: @variant.sku
+    field.send_keys :enter
+    assert_text "Example Book"
+    field = find("#pos-command-field")
+    assert_equal "", field.value
+    field.send_keys :delete
+    assert_text "Example Book"
+    field.send_keys "-"
+    assert_no_text "Example Book"
+  end
+
   test "empty basket disables cancel" do
     sign_in_admin
     visit pos_register_enter_path(register_id: @register.id)


### PR DESCRIPTION
## Summary
- Deliver the remaining Phase 5 cashier path on top of Slice 1's headless cash/Z services (already on `main` via #11).
- **Slice 1** (on `main`): Session cash columns, `OpenSession` / `CloseSession` / `FinalizeReportingPeriod`, `SessionTotals` / `PeriodTotals`, audit, immutability, and concurrency. This PR does not change those services.
- **Slice 2**: cashier Register workspace — open gate with confirmed business date and opening float, one working transaction, scan/rescan/quantity, Cash tender, complete, on-screen receipt, keyboard-first Stimulus (Importmap + Turbo). Completes the named in-flight transaction; posts `confirmed_business_date` when opening a new period; unexpired `in_flight` completion does not auto-submit.
- **Slice 3**: browser `window.print()` only, session-bound Close Register, blind Cash count (no expected/variance/float on the count screen), persisted expected/count/variance on the closed summary, enter-gate Finalize Z / Open session, immutable Z. Close Register requires the Session on the page (`session_id`); missing, other-cashier, or other-register Sessions 404. A closed named Session never falls forward to a newer Session.

## Verification
- [x] `./dev/rails-docker bin/rails test` (352 runs, 1823 assertions, 0 failures)
- [x] `./dev/rails-docker bin/rails test:system` (18 runs, 177 assertions, 0 failures), including the Phase 5 open → sell → print → blind close → Z lifecycle
- [x] `./dev/rails-docker bin/rubocop` on touched Ruby
- [x] Full CI matrix on `0dc3b77` (scan_ruby, scan_js, lint, test, test_system)

## Documentation and migrations
- `register-workspace.md`, `close-z-screens.md`, `close-z-screens-ux.md`, `phase5-plan.md`
- Working-transaction uniqueness migration is already on this branch (`db/migrate/20260817120000_add_one_working_transaction_per_session.rb`)
- No new close/Z domain migrations in this PR; Slice 1 schema is already on `main`