### PR TITLE
Add Store-scoped completed transaction history

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -626,6 +626,77 @@ input[type="submit"]:hover {
   margin-top: var(--space-5);
 }
 
+.pos-header__link {
+  margin-left: auto;
+}
+
+.pos-history {
+  width: min(100% - 2rem, 56rem);
+  margin: var(--space-6) auto;
+}
+
+.pos-history__nav {
+  display: flex;
+  gap: var(--space-4);
+  margin-top: var(--space-3);
+}
+
+.pos-history__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin: var(--space-4) 0;
+}
+
+.pos-history__table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.pos-history__table th,
+.pos-history__table td {
+  text-align: left;
+  padding: var(--space-2);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.pos-history__table .numeric {
+  text-align: right;
+}
+
+.pos-history__header,
+.pos-history__line-facts {
+  display: grid;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+}
+
+.pos-history__header div,
+.pos-history__line-facts div {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.pos-history__line {
+  margin-bottom: var(--space-4);
+}
+
+.pos-history__line-main {
+  display: grid;
+  grid-template-columns: 2rem 4rem 3rem 1fr auto;
+  gap: var(--space-2);
+}
+
+.pos-history__tender {
+  margin-bottom: var(--space-3);
+}
+
+.pos-receipt__reprint {
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
 .pos-close__field {
   width: 100%;
   font-size: 1.25rem;
@@ -655,6 +726,11 @@ input[type="submit"]:hover {
 
   .pos-receipt__print-header {
     font-weight: 700;
+  }
+
+  .pos-receipt__reprint {
+    font-weight: 700;
+    letter-spacing: 0.08em;
   }
 
   .pos-receipt__print-lines {

--- a/app/controllers/pos/base_controller.rb
+++ b/app/controllers/pos/base_controller.rb
@@ -7,7 +7,7 @@ module Pos
     before_action :require_store_context
     before_action :require_pos_transact!
 
-    helper_method :pos_actor_open_session, :pos_resume_register_path
+    helper_method :pos_resume_register_path
 
     private
 
@@ -39,17 +39,29 @@ module Pos
       active_registers.find_by(id: register_id)
     end
 
-    def pos_actor_open_session
-      PosSession.open.find_by(store: current_store, cashier_user: current_user)
-    end
-
     def pos_resume_register_path
-      open_session = pos_actor_open_session
-      if open_session
-        pos_register_workspace_path(register_id: open_session.register_id)
+      resume_session = bound_cashier_open_session || sole_cashier_open_session
+      if resume_session
+        pos_register_workspace_path(register_id: resume_session.register_id)
       else
         pos_register_enter_path
       end
+    end
+
+    def cashier_open_sessions
+      PosSession.open.where(store: current_store, cashier_user: current_user)
+    end
+
+    def bound_cashier_open_session
+      register_id = session[:pos_register_id]
+      return if register_id.blank?
+
+      cashier_open_sessions.find_by(register_id: register_id)
+    end
+
+    def sole_cashier_open_session
+      sessions = cashier_open_sessions.limit(2).to_a
+      sessions.first if sessions.size == 1
     end
   end
 end

--- a/app/controllers/pos/base_controller.rb
+++ b/app/controllers/pos/base_controller.rb
@@ -7,6 +7,8 @@ module Pos
     before_action :require_store_context
     before_action :require_pos_transact!
 
+    helper_method :pos_actor_open_session, :pos_resume_register_path
+
     private
 
     def require_pos_transact!
@@ -35,6 +37,19 @@ module Pos
     def find_register
       register_id = params[:register_id].presence || session[:pos_register_id]
       active_registers.find_by(id: register_id)
+    end
+
+    def pos_actor_open_session
+      PosSession.open.find_by(store: current_store, cashier_user: current_user)
+    end
+
+    def pos_resume_register_path
+      open_session = pos_actor_open_session
+      if open_session
+        pos_register_workspace_path(register_id: open_session.register_id)
+      else
+        pos_register_enter_path
+      end
     end
   end
 end

--- a/app/controllers/pos/transactions_controller.rb
+++ b/app/controllers/pos/transactions_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Pos
+  class TransactionsController < BaseController
+    def index
+      @search = Pos::CompletedTransactionSearch.call(
+        store: current_store,
+        transaction_reference: params[:transaction_reference],
+        register_id: params[:register_id],
+        receipt_sequence: params[:receipt_sequence],
+        business_date: params[:business_date],
+        page: params[:page]
+      )
+      @registers = current_store.registers.order(:register_number)
+    end
+
+    def show
+      @transaction = PosTransaction.completed.find_by!(id: params[:id], store_id: current_store.id)
+      @tenders = @transaction.pos_tenders.ordered.to_a
+      @lines = @transaction.pos_transaction_lines.includes(:pos_line_tax_components).to_a
+    end
+  end
+end

--- a/app/helpers/pos_helper.rb
+++ b/app/helpers/pos_helper.rb
@@ -25,6 +25,27 @@ module PosHelper
     )
   end
 
+  def pos_cashier_name(transaction)
+    transaction.cashier_name_snapshot.presence || "Not captured"
+  end
+
+  def pos_tender_summary(transaction)
+    transaction.pos_tenders.sort_by(&:tender_number).map(&:tender_name).join(" + ")
+  end
+
+  def pos_history_query_params(search)
+    {
+      transaction_reference: search.transaction_reference,
+      register_id: search.register_id,
+      receipt_sequence: search.receipt_sequence,
+      business_date: search.business_date
+    }.compact_blank
+  end
+
+  def pos_applicable_tax_components(line)
+    line.pos_line_tax_components.select(&:applies).sort_by(&:calculation_order)
+  end
+
   def pos_print_line_description(line)
     snapshot = line.merchandise_snapshot
     return "Description unavailable" unless snapshot.is_a?(Hash)
@@ -45,6 +66,10 @@ module PosHelper
 
   def pos_padded_register_number(register)
     Pos::ReceiptIdentity.pad(register.register_number, 2)
+  end
+
+  def pos_padded_register_snapshot(number)
+    Pos::ReceiptIdentity.pad(number, 2)
   end
 
   def pos_optional_money_cents(cents)

--- a/app/helpers/pos_helper.rb
+++ b/app/helpers/pos_helper.rb
@@ -29,6 +29,14 @@ module PosHelper
     transaction.cashier_name_snapshot.presence || "Not captured"
   end
 
+  def pos_history_line_description(line)
+    snapshot = line.merchandise_snapshot
+    return "Description not captured" unless snapshot.is_a?(Hash)
+    return "Description not captured" if snapshot["description"].blank?
+
+    pos_snapshot_line_description(snapshot)
+  end
+
   def pos_tender_summary(transaction)
     transaction.pos_tenders.sort_by(&:tender_number).map(&:tender_name).join(" + ")
   end

--- a/app/services/pos/complete_transaction.rb
+++ b/app/services/pos/complete_transaction.rb
@@ -265,7 +265,8 @@ module Pos
           "register_id" => transaction.register_id.to_s,
           "pos_session_id" => transaction.pos_session_id.to_s,
           "reporting_period_id" => transaction.reporting_period_id.to_s,
-          "performed_by_user_id" => transaction.cashier_user_id.to_s
+          "performed_by_user_id" => transaction.cashier_user_id.to_s,
+          "performed_by_name" => @actor.display_name
         },
         "receipt" => {
           "sequence" => receipt.fetch(:sequence),
@@ -352,7 +353,8 @@ module Pos
         receipt_sequence: facts.receipt_sequence,
         store_number_snapshot: facts.store_number,
         register_number_snapshot: facts.register_number,
-        transaction_reference: facts.transaction_reference
+        transaction_reference: facts.transaction_reference,
+        cashier_name_snapshot: @actor.display_name
       )
     end
 

--- a/app/services/pos/completed_transaction_facts.rb
+++ b/app/services/pos/completed_transaction_facts.rb
@@ -50,12 +50,20 @@ module Pos
 
       signed_net = @envelope.fetch("transaction")["signed_net_cents"]
       raise Pos::Error, "completed envelope is missing signed_net_cents" unless signed_net.is_a?(Integer)
+      verify_origin_name!
       verify_tenders!
     end
 
     private
 
     V2_TENDER_KEYS = %w[behavioral_category tender_name tender_number].freeze
+
+    def verify_origin_name!
+      origin = @envelope["origin"]
+      return unless origin.is_a?(Hash)
+      return unless origin.key?("performed_by_name")
+      raise Pos::Error, "completed envelope is missing performed_by_name" if origin["performed_by_name"].blank?
+    end
 
     def verify_tenders!
       tenders = @envelope["tenders"]

--- a/app/services/pos/completed_transaction_search.rb
+++ b/app/services/pos/completed_transaction_search.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+module Pos
+  class CompletedTransactionSearch
+    PER_PAGE = 50
+
+    Result = Struct.new(
+      :records, :page, :per_page, :total_count, :total_pages,
+      :transaction_reference, :register_id, :receipt_sequence, :business_date, :filtered,
+      keyword_init: true
+    )
+
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(store:, transaction_reference: nil, register_id: nil, receipt_sequence: nil, business_date: nil, page: 1)
+      @store = store
+      @transaction_reference = transaction_reference
+      @register_id = register_id
+      @receipt_sequence = receipt_sequence
+      @business_date = business_date
+      @page = page
+    end
+
+    def call
+      relation = PosTransaction.completed.where(store_id: @store.id)
+      relation = apply_filters(relation)
+
+      total_count = relation.except(:order, :select).count
+      total_pages = [ (total_count.to_f / PER_PAGE).ceil, 1 ].max
+      page = parse_page(total_pages)
+      offset = (page - 1) * PER_PAGE
+
+      records = relation.includes(:pos_tenders)
+                        .order(completed_at: :desc, id: :desc)
+                        .offset(offset)
+                        .limit(PER_PAGE)
+
+      Result.new(
+        records: records,
+        page: page,
+        per_page: PER_PAGE,
+        total_count: total_count,
+        total_pages: total_pages,
+        transaction_reference: normalized_reference,
+        register_id: @register_id.to_s.presence,
+        receipt_sequence: @receipt_sequence.to_s.strip.presence,
+        business_date: @business_date.to_s.strip.presence,
+        filtered: filtered?
+      )
+    end
+
+    private
+
+    def apply_filters(relation)
+      if normalized_reference.present?
+        return relation.where(transaction_reference: normalized_reference)
+      end
+
+      sequence = parsed_receipt_sequence
+      date = parsed_business_date
+      return relation.none if sequence == :invalid || date == :invalid
+
+      if @register_id.to_s.present?
+        register = @store.registers.find_by(id: @register_id)
+        return relation.none unless register
+
+        relation = relation.where(register_id: register.id)
+      end
+      relation = relation.where(receipt_sequence: sequence) if sequence.present?
+      relation = relation.where(business_date: date) if date.present?
+      relation
+    end
+
+    def normalized_reference
+      @transaction_reference.to_s.strip.upcase.presence
+    end
+
+    def parsed_receipt_sequence
+      return @parsed_receipt_sequence if defined?(@parsed_receipt_sequence)
+
+      raw = @receipt_sequence.to_s.strip
+      @parsed_receipt_sequence =
+        if raw.blank?
+          nil
+        elsif raw.match?(/\A\d+\z/)
+          value = Integer(raw, 10)
+          value.positive? ? value : :invalid
+        else
+          :invalid
+        end
+    end
+
+    def parsed_business_date
+      return @parsed_business_date if defined?(@parsed_business_date)
+
+      raw = @business_date.to_s.strip
+      @parsed_business_date =
+        if raw.blank?
+          nil
+        else
+          Date.iso8601(raw)
+        end
+    rescue Date::Error, ArgumentError
+      @parsed_business_date = :invalid
+    end
+
+    def filtered?
+      normalized_reference.present? ||
+        @register_id.to_s.present? ||
+        @receipt_sequence.to_s.strip.present? ||
+        @business_date.to_s.strip.present?
+    end
+
+    def parse_page(total_pages)
+      value = Integer(@page)
+      return 1 if value < 1
+
+      [ value, total_pages ].min
+    rescue ArgumentError, TypeError
+      1
+    end
+  end
+end

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -8,6 +8,7 @@
       <p>Current store: <%= current_store.admin_label %>.</p>
       <% if effective_permissions.include?("pos.transact") %>
         <p><%= link_to "Open register", pos_register_enter_path %></p>
+        <p><%= link_to "Transactions", pos_transactions_path %></p>
       <% end %>
     <% elsif accessible_stores.exists? %>
       <p><%= link_to "Select a store", new_store_selection_path %></p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -88,6 +88,7 @@
             <% end %>
             <% if effective_permissions.include?("pos.transact") && current_store.present? %>
               <%= link_to "Register", pos_register_enter_path %>
+              <%= link_to "Transactions", pos_transactions_path %>
             <% end %>
             <% if accessible_stores.many? %>
               <%= link_to "Switch store", new_store_selection_path %>

--- a/app/views/pos/completed_transactions/show.html.erb
+++ b/app/views/pos/completed_transactions/show.html.erb
@@ -35,47 +35,11 @@
     </ul>
   </div>
 
-  <section class="pos-receipt__print pos-print-only" aria-hidden="true">
-    <p class="pos-receipt__print-header"><%= pos_receipt_print_header(@transaction) %></p>
-    <p><%= @transaction.transaction_reference %></p>
-    <p>Business date  <%= @transaction.business_date.iso8601 %></p>
-    <p>Completed  <%= format_store_timestamp(@transaction.completed_at, @transaction.store) %></p>
-
-    <table class="pos-receipt__print-lines">
-      <thead>
-        <tr>
-          <th>Qty</th>
-          <th>Description</th>
-          <th>Amount</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @transaction.pos_transaction_lines.each do |line| %>
-          <tr>
-            <td><%= line.quantity %></td>
-            <td><%= pos_print_line_description(line) %></td>
-            <td><%= format_money_cents(line.extended_selling_amount_cents) %></td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-
-    <dl class="pos-receipt__print-totals">
-      <div><dt>Subtotal</dt><dd><%= format_money_cents(@transaction.subtotal_cents) %></dd></div>
-      <div><dt>Tax</dt><dd><%= format_money_cents(@transaction.tax_cents) %></dd></div>
-      <div><dt>Total</dt><dd><%= format_money_cents(@transaction.total_cents) %></dd></div>
-      <% @tenders.each do |tender| %>
-        <div><dt><%= tender.tender_name %></dt><dd><%= format_money_cents(tender.amount_cents) %></dd></div>
-        <% if tender.cash? %>
-          <div><dt>Cash presented</dt><dd><%= format_money_cents(tender.amount_presented_cents) %></dd></div>
-          <div><dt>Change</dt><dd><%= format_money_cents(tender.change_cents) %></dd></div>
-        <% end %>
-      <% end %>
-    </dl>
-  </section>
+  <%= render "pos/receipts/print", transaction: @transaction, tenders: @tenders, reprint: false %>
 
   <div class="pos-receipt__actions pos-no-print">
     <button type="button" class="btn" data-action="pos-receipt#print">Print receipt</button>
+    <%= link_to "Transactions", pos_transactions_path, class: "btn btn--secondary" %>
     <%= button_to "New sale", pos_register_continue_path, method: :post, class: "btn pos-receipt__new" %>
     <%= button_to "Close register", pos_register_close_path, method: :post,
           params: { session_id: @session_record.id }, class: "btn btn--secondary" %>

--- a/app/views/pos/receipts/_print.html.erb
+++ b/app/views/pos/receipts/_print.html.erb
@@ -1,0 +1,42 @@
+<section class="pos-receipt__print pos-print-only" aria-hidden="true">
+  <% if local_assigns.fetch(:reprint, false) %>
+    <p class="pos-receipt__reprint">REPRINT</p>
+  <% end %>
+  <p class="pos-receipt__print-header"><%= pos_receipt_print_header(transaction) %></p>
+  <p><%= transaction.transaction_reference %></p>
+  <p>Business date  <%= transaction.business_date.iso8601 %></p>
+  <p>Completed  <%= format_store_timestamp(transaction.completed_at, transaction.store) %></p>
+  <p>Cashier  <%= pos_cashier_name(transaction) %></p>
+
+  <table class="pos-receipt__print-lines">
+    <thead>
+      <tr>
+        <th>Qty</th>
+        <th>Description</th>
+        <th>Amount</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% transaction.pos_transaction_lines.each do |line| %>
+        <tr>
+          <td><%= line.quantity %></td>
+          <td><%= pos_print_line_description(line) %></td>
+          <td><%= format_money_cents(line.extended_selling_amount_cents) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <dl class="pos-receipt__print-totals">
+    <div><dt>Subtotal</dt><dd><%= format_money_cents(transaction.subtotal_cents) %></dd></div>
+    <div><dt>Tax</dt><dd><%= format_money_cents(transaction.tax_cents) %></dd></div>
+    <div><dt>Total</dt><dd><%= format_money_cents(transaction.total_cents) %></dd></div>
+    <% tenders.each do |tender| %>
+      <div><dt><%= tender.tender_name %></dt><dd><%= format_money_cents(tender.amount_cents) %></dd></div>
+      <% if tender.cash? %>
+        <div><dt>Cash presented</dt><dd><%= format_money_cents(tender.amount_presented_cents) %></dd></div>
+        <div><dt>Change</dt><dd><%= format_money_cents(tender.change_cents) %></dd></div>
+      <% end %>
+    <% end %>
+  </dl>
+</section>

--- a/app/views/pos/transactions/_chrome.html.erb
+++ b/app/views/pos/transactions/_chrome.html.erb
@@ -1,0 +1,10 @@
+<header class="pos-header pos-no-print">
+  <div class="pos-header__row">
+    <span>Store  <%= current_store.admin_label %></span>
+    <span><%= current_user.display_name %></span>
+  </div>
+  <nav class="pos-history__nav" aria-label="History">
+    <%= link_to "Transactions", pos_transactions_path %>
+    <%= link_to "Register", pos_resume_register_path %>
+  </nav>
+</header>

--- a/app/views/pos/transactions/_line.html.erb
+++ b/app/views/pos/transactions/_line.html.erb
@@ -3,7 +3,7 @@
     <span><%= line.line_number %></span>
     <span><%= line.direction %></span>
     <span><%= line.quantity %></span>
-    <span><%= pos_line_description(line) %></span>
+    <span><%= pos_history_line_description(line) %></span>
     <span class="numeric"><%= format_money_cents(line.line_total_cents) %></span>
   </div>
   <dl class="pos-history__line-facts">

--- a/app/views/pos/transactions/_line.html.erb
+++ b/app/views/pos/transactions/_line.html.erb
@@ -1,0 +1,30 @@
+<article class="pos-history__line">
+  <div class="pos-history__line-main">
+    <span><%= line.line_number %></span>
+    <span><%= line.direction %></span>
+    <span><%= line.quantity %></span>
+    <span><%= pos_line_description(line) %></span>
+    <span class="numeric"><%= format_money_cents(line.line_total_cents) %></span>
+  </div>
+  <dl class="pos-history__line-facts">
+    <div><dt>SKU</dt><dd><%= line.merchandise_snapshot.is_a?(Hash) ? line.merchandise_snapshot["sku"] : "" %></dd></div>
+    <div><dt>Reference</dt><dd><%= format_money_cents(line.reference_unit_price_cents) %></dd></div>
+    <div><dt>Selling</dt><dd><%= format_money_cents(line.selling_unit_price_cents) %></dd></div>
+    <div><dt>Extended</dt><dd><%= format_money_cents(line.extended_selling_amount_cents) %></dd></div>
+    <div><dt>Tax</dt><dd><%= format_money_cents(line.line_tax_cents) %></dd></div>
+  </dl>
+  <% components = pos_applicable_tax_components(line) %>
+  <% if components.any? %>
+    <details class="pos-history__tax">
+      <summary>Tax detail</summary>
+      <% components.each do |component| %>
+        <div>
+          <%= component.store_tax_name_snapshot %>
+          Rate <%= number_with_precision(component.rate_percent, precision: 3) %>%
+          Taxable <%= format_money_cents(component.taxable_basis_cents) %>
+          Tax <%= format_money_cents(component.tax_cents) %>
+        </div>
+      <% end %>
+    </details>
+  <% end %>
+</article>

--- a/app/views/pos/transactions/index.html.erb
+++ b/app/views/pos/transactions/index.html.erb
@@ -1,0 +1,75 @@
+<% content_for :title, "Transactions" %>
+
+<main class="pos-history">
+  <%= render "pos/transactions/chrome" %>
+
+  <h1>Transactions</h1>
+
+  <%= form_with url: pos_transactions_path, method: :get, local: true, class: "pos-history__filters" do %>
+    <div class="form-field">
+      <%= label_tag :transaction_reference, "Receipt reference" %>
+      <%= text_field_tag :transaction_reference, @search.transaction_reference, autocomplete: "off" %>
+    </div>
+    <div class="form-field">
+      <%= label_tag :register_id, "Register" %>
+      <%= select_tag :register_id,
+            options_for_select([["Any register", ""]] + @registers.map { |register| [register.admin_label, register.id] }, @search.register_id) %>
+    </div>
+    <div class="form-field">
+      <%= label_tag :receipt_sequence, "Transaction #" %>
+      <%= text_field_tag :receipt_sequence, @search.receipt_sequence, inputmode: "numeric", autocomplete: "off" %>
+    </div>
+    <div class="form-field">
+      <%= label_tag :business_date, "Business date" %>
+      <%= date_field_tag :business_date, @search.business_date %>
+    </div>
+    <div class="form-field">
+      <%= submit_tag "Find", class: "btn" %>
+    </div>
+  <% end %>
+
+  <% if @search.records.empty? && !@search.filtered %>
+    <p class="muted">No completed transactions yet.</p>
+  <% elsif @search.records.empty? %>
+    <p class="muted">No matching transactions.</p>
+  <% else %>
+    <table class="pos-history__table">
+      <thead>
+        <tr>
+          <th>Receipt</th>
+          <th>Business date</th>
+          <th>Completed</th>
+          <th>Register</th>
+          <th>Cashier</th>
+          <th class="numeric">Total</th>
+          <th>Tender</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @search.records.each do |transaction| %>
+          <tr>
+            <td><%= link_to transaction.transaction_reference, pos_transaction_path(transaction) %></td>
+            <td><%= transaction.business_date.iso8601 %></td>
+            <td><%= format_store_timestamp(transaction.completed_at, current_store) %></td>
+            <td><%= pos_padded_register_snapshot(transaction.register_number_snapshot) %></td>
+            <td><%= pos_cashier_name(transaction) %></td>
+            <td class="numeric"><%= format_money_cents(transaction.total_cents) %></td>
+            <td><%= pos_tender_summary(transaction) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+    <div class="pagination">
+      <span class="muted">
+        Page <%= @search.page %> of <%= @search.total_pages %> · <%= @search.total_count %> total
+      </span>
+      <% if @search.page > 1 %>
+        <%= link_to "Previous", pos_transactions_path(pos_history_query_params(@search).merge(page: @search.page - 1)), class: "btn btn--ghost" %>
+      <% end %>
+      <% if @search.page < @search.total_pages %>
+        <%= link_to "Next", pos_transactions_path(pos_history_query_params(@search).merge(page: @search.page + 1)), class: "btn btn--ghost" %>
+      <% end %>
+    </div>
+  <% end %>
+</main>

--- a/app/views/pos/transactions/show.html.erb
+++ b/app/views/pos/transactions/show.html.erb
@@ -1,0 +1,48 @@
+<% content_for :title, "Transaction #{@transaction.transaction_reference}" %>
+
+<main class="pos-history pos-receipt" data-controller="pos-receipt" data-action="keydown@document->pos-receipt#onKeydown">
+  <%= render "pos/transactions/chrome" %>
+
+  <div class="pos-history__detail pos-no-print">
+    <h1>Receipt  <%= @transaction.transaction_reference %></h1>
+    <dl class="pos-history__header">
+      <div><dt>Business date</dt><dd><%= @transaction.business_date.iso8601 %></dd></div>
+      <div><dt>Completed</dt><dd><%= format_store_timestamp(@transaction.completed_at, @transaction.store) %></dd></div>
+      <div><dt>Register</dt><dd><%= pos_padded_register_snapshot(@transaction.register_number_snapshot) %></dd></div>
+      <div><dt>Cashier</dt><dd><%= pos_cashier_name(@transaction) %></dd></div>
+      <div><dt>Total</dt><dd><%= format_money_cents(@transaction.total_cents) %></dd></div>
+    </dl>
+
+    <section aria-label="Lines">
+      <% @lines.each do |line| %>
+        <%= render "pos/transactions/line", line: line %>
+      <% end %>
+    </section>
+
+    <section aria-label="Tenders">
+      <h2>Tenders</h2>
+      <% @tenders.each do |tender| %>
+        <div class="pos-history__tender">
+          <div>
+            <%= tender.tender_number %>
+            <%= tender.tender_name %>
+            <%= format_money_cents(tender.amount_cents) %>
+          </div>
+          <% if tender.cash? %>
+            <div>Presented  <%= format_money_cents(tender.amount_presented_cents) %></div>
+            <div>Change  <%= format_money_cents(tender.change_cents) %></div>
+          <% elsif tender.external_reference.present? %>
+            <div>Reference  <%= tender.external_reference %></div>
+          <% end %>
+        </div>
+      <% end %>
+    </section>
+  </div>
+
+  <%= render "pos/receipts/print", transaction: @transaction, tenders: @tenders, reprint: true %>
+
+  <div class="pos-receipt__actions pos-no-print">
+    <button type="button" class="btn" data-action="pos-receipt#print">Reprint receipt</button>
+    <%= link_to "Back to transactions", pos_transactions_path, class: "btn btn--secondary" %>
+  </div>
+</main>

--- a/app/views/pos/workspaces/_surface.html.erb
+++ b/app/views/pos/workspaces/_surface.html.erb
@@ -52,6 +52,7 @@
         <span>Store  <%= current_store.admin_label %></span>
         <span>Register  <%= @register.register_number %></span>
         <span><%= current_user.display_name %></span>
+        <%= link_to "Transactions", pos_transactions_path, class: "pos-header__link" %>
       </div>
       <div class="pos-header__date <%= "pos-date-emphasis" if leftover %>">
         Business date  <%= @session_record.reporting_period.business_date.iso8601 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,6 +81,7 @@ Rails.application.routes.draw do
   end
 
   namespace :pos do
+    resources :transactions, only: %i[index show]
     get "register/enter", to: "enters#show", as: :register_enter
     post "register/enter", to: "enters#create"
     get "register", to: "workspaces#show", as: :register_workspace

--- a/db/migrate/20260818130000_add_completed_transaction_history.rb
+++ b/db/migrate/20260818130000_add_completed_transaction_history.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class AddCompletedTransactionHistory < ActiveRecord::Migration[8.1]
+  def up
+    add_column :pos_transactions, :cashier_name_snapshot, :string
+
+    execute <<~SQL
+      UPDATE pos_transactions AS t
+      SET cashier_name_snapshot = a.actor_label
+      FROM (
+        SELECT DISTINCT ON (subject_id)
+          subject_id, actor_label
+        FROM audit_events
+        WHERE action = 'pos.transaction_completed'
+          AND outcome = 'succeeded'
+          AND subject_type = 'PosTransaction'
+        ORDER BY subject_id, occurred_at ASC, id ASC
+      ) AS a
+      WHERE t.id = a.subject_id
+        AND t.status = 'completed'
+        AND t.cashier_name_snapshot IS NULL
+    SQL
+
+    add_index :pos_transactions, %i[store_id completed_at id],
+              order: { completed_at: :desc, id: :desc },
+              where: "status = 'completed'",
+              name: "index_pos_transactions_completed_recent"
+    add_index :pos_transactions, %i[store_id business_date completed_at id],
+              order: { completed_at: :desc, id: :desc },
+              where: "status = 'completed'",
+              name: "index_pos_transactions_completed_business_date"
+  end
+
+  def down
+    remove_index :pos_transactions, name: "index_pos_transactions_completed_business_date"
+    remove_index :pos_transactions, name: "index_pos_transactions_completed_recent"
+    remove_column :pos_transactions, :cashier_name_snapshot
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_18_021000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_18_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -536,6 +536,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_18_021000) do
   create_table "pos_transactions", id: :uuid, default: nil, force: :cascade do |t|
     t.date "business_date"
     t.timestamptz "cancelled_at"
+    t.string "cashier_name_snapshot"
     t.uuid "cashier_user_id", null: false
     t.timestamptz "completed_at"
     t.timestamptz "created_at", null: false
@@ -560,6 +561,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_18_021000) do
     t.index ["pos_session_id"], name: "index_pos_transactions_one_working_per_session", unique: true, where: "((status)::text = 'working'::text)"
     t.index ["register_id"], name: "index_pos_transactions_on_register_id"
     t.index ["reporting_period_id"], name: "index_pos_transactions_on_reporting_period_id"
+    t.index ["store_id", "business_date", "completed_at", "id"], name: "index_pos_transactions_completed_business_date", order: { completed_at: :desc, id: :desc }, where: "((status)::text = 'completed'::text)"
+    t.index ["store_id", "completed_at", "id"], name: "index_pos_transactions_completed_recent", order: { completed_at: :desc, id: :desc }, where: "((status)::text = 'completed'::text)"
     t.index ["store_id", "register_id", "receipt_sequence"], name: "index_pos_transactions_receipt_identity", unique: true, where: "(receipt_sequence IS NOT NULL)"
     t.index ["store_id"], name: "index_pos_transactions_on_store_id"
     t.index ["transaction_reference"], name: "index_pos_transactions_on_transaction_reference", unique: true, where: "(transaction_reference IS NOT NULL)"

--- a/docs/planning/phase4-6-point-of-sale/phase4-point-of-sale/phase4-schema.md
+++ b/docs/planning/phase4-6-point-of-sale/phase4-point-of-sale/phase4-schema.md
@@ -142,6 +142,7 @@ One row for working and completed (or cancelled) commercial state.
 | `pos_session_id` | uuid | FK, null: false |
 | `reporting_period_id` | uuid | FK, null: false (denormalized for query convenience; must match session) |
 | `cashier_user_id` | uuid | FK, null: false |
+| `cashier_name_snapshot` | string | nullable; 6.3 display name at completion. Null on legacy rows → history shows “Not captured”. Not part of `pos_transactions_status_null_rules`. |
 | `status` | string | `working`, `completed`, `cancelled` (exact enum locked in migration) |
 | `currency_code` | string(3) | null: false |
 | `occurred_at` | timestamptz | null while working; set at completion (not provisional) |

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md
@@ -51,7 +51,7 @@ completed-receipt New sale shortcut (not Enter)
 |---|---|
 | Client | Rails-native online POS. No Terminal table (ADR-021). No scanner API; scanners are keyboard input ending in Enter |
 | UI stack | Importmap + Turbo + Stimulus. Gems are installed for the Register workspace. The POS layout loads `pos.js`; the admin layout loads `application.js` without Turbo and sets `data-turbo="false"` |
-| Layout | Dedicated POS layout. Do not reuse admin chrome for the selling surface (it would steal scan focus) |
+| Layout | Dedicated POS layout. Do not reuse admin chrome for the selling surface (it would steal scan focus). Header includes **Transactions** ([transaction-history.md](../phase6-pos-mvp/transaction-history.md)); following it does not cancel or complete the working basket |
 | Permission | `pos.transact` at the current store. Session cashier for session/transaction commands (`require_session_cashier!` / `require_transaction_cashier!`) |
 | Controllers | Orchestrate Phase 4/5 services only. No receipt allocation, inventory posting, tax calculation, or commercial total mutation in controllers or Stimulus |
 | Browser tests | Meaningful client-side POS behavior **requires** system/browser tests. Request tests cannot prove focus, scanner Enter, Escape, or duplicate-submit prevention |

--- a/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/README.md
+++ b/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/README.md
@@ -1,6 +1,6 @@
 # Phase 6 — Operational POS MVP
 
-**Status:** Slice 6.0 contract locked. Slice 6.1 merchandise breadth is implemented. Slice 6.2 tender breadth is implemented ([tender-breadth.md](tender-breadth.md)).
+**Status:** Slice 6.0 contract locked. Slice 6.1 merchandise breadth is implemented. Slice 6.2 tender breadth is implemented ([tender-breadth.md](tender-breadth.md)). Slice 6.3 transaction history is implemented ([transaction-history.md](transaction-history.md)).
 
 | Document | Purpose |
 |---|---|
@@ -8,6 +8,7 @@
 | [mvp-contract.md](mvp-contract.md) | Slice 6.0: CompletedPosOperation v2 shape and cross-cutting locks |
 | [merchandise-breadth.md](merchandise-breadth.md) | Slice 6.1: Used/individual and non-inventory sales (implemented) |
 | [tender-breadth.md](tender-breadth.md) | Slice 6.2: Cash/Card/Check/Other settlement (implemented) |
+| [transaction-history.md](transaction-history.md) | Slice 6.3: completed lookup, detail, reprint (implemented) |
 
 Parent multi-phase sequencing: [../spec.md](../spec.md). Phase 4 completion kernel: [../phase4-point-of-sale/](../phase4-point-of-sale/). Phase 5 cash register: [../phase5-cash-register/](../phase5-cash-register/).
 

--- a/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/mvp-contract.md
+++ b/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/mvp-contract.md
@@ -4,7 +4,7 @@
 
 **Authority:** Cross-cutting completed-operation shape for the Phase 6 MVP. Dual authority with normalized Core remains [ADR-020](../../../adr/ADR-020-pos-operation-envelope-and-core-facts.md) / [operation-and-core-facts.md](../phase4-point-of-sale/operation-and-core-facts.md). Commercial base is [CompletedPosOperation v1](../phase4-point-of-sale/completed-pos-operation-v1.md).
 
-Companions: [phase6-plan.md](phase6-plan.md), [merchandise-breadth.md](merchandise-breadth.md), [tender-breadth.md](tender-breadth.md). Tax: [pos-tax-contract.md](../phase4-point-of-sale/pos-tax-contract.md). Cash/Z: [phase5-plan.md](../phase5-cash-register/phase5-plan.md).
+Companions: [phase6-plan.md](phase6-plan.md), [merchandise-breadth.md](merchandise-breadth.md), [tender-breadth.md](tender-breadth.md), [transaction-history.md](transaction-history.md). Tax: [pos-tax-contract.md](../phase4-point-of-sale/pos-tax-contract.md). Cash/Z: [phase5-plan.md](../phase5-cash-register/phase5-plan.md).
 
 This slice does **not** implement capabilities. It locks meaning so 6.1–6.7 do not each invent a new completion shape. Do not add unused Core columns here ([AGENTS.md](../../../../AGENTS.md) §10). Columns appear in the owning slice.
 
@@ -88,7 +88,9 @@ CompletedPosOperation
 │                                     #  commercial fact_type; relationship lives on
 │                                     #  the correction block, not a second envelope type)
 │
-├── origin                            # v1
+├── origin                            # v1 + additive 6.3 name
+│   ├── (v1 origin ids)
+│   └── performed_by_name             # omit when absent; 6.3
 ├── receipt                           # v1; still assigned only at completion
 │
 ├── transaction

--- a/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/phase6-plan.md
+++ b/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/phase6-plan.md
@@ -1,6 +1,6 @@
 # Phase 6 — Operational POS MVP
 
-**Status:** Slice 6.0 contract locked ([mvp-contract.md](mvp-contract.md)). Slice 6.1 merchandise breadth implemented ([merchandise-breadth.md](merchandise-breadth.md)). Slice 6.2 tender-breadth contract locked ([tender-breadth.md](tender-breadth.md)).
+**Status:** Slice 6.0 contract locked ([mvp-contract.md](mvp-contract.md)). Slice 6.1 merchandise breadth implemented ([merchandise-breadth.md](merchandise-breadth.md)). Slice 6.2 tender breadth implemented ([tender-breadth.md](tender-breadth.md)). Slice 6.3 transaction history implemented ([transaction-history.md](transaction-history.md)).
 
 **Authority**
 
@@ -9,6 +9,7 @@
 | [MVP contract](mvp-contract.md) | Slice 6.0: CompletedPosOperation v2 and cross-cutting locks |
 | [Merchandise breadth](merchandise-breadth.md) | Slice 6.1: Used/individual and non-inventory sales |
 | [Tender breadth](tender-breadth.md) | Slice 6.2: Cash/Card/Check/Other settlement |
+| [Transaction history](transaction-history.md) | Slice 6.3: completed lookup, detail, reprint |
 | [Phase 4 plan](../phase4-point-of-sale/phase4-plan.md) | Completion, receipt allocation, inventory posting |
 | [CompletedPosOperation v1](../phase4-point-of-sale/completed-pos-operation-v1.md) | Commercial base; v2 is additive |
 | [POS tax contract](../phase4-point-of-sale/pos-tax-contract.md) | Tax Class / Store Tax; linked-return reversal ([§10](../phase4-point-of-sale/pos-tax-contract.md)) |
@@ -107,7 +108,7 @@ Write the detailed implementation contract for slices 6.2–6.7 immediately befo
 | **6.0** | MVP contract | Lock Phase 6 invariants and completed-operation shape | Docs only; no behavior change |
 | **6.1** | Merchandise breadth | Used/individual + non-inventory sales | **Implemented.** Quantity-tracked Cash Standard path unchanged |
 | **6.2** | Tender breadth | Card, Check, admin-created Other, mixed tender | **Implemented.** All-Cash sale remains Phase 5-equivalent; Session/Z shows Card/Check/Other |
-| **6.3** | Transaction history | Lookup, detail, receipt reprint | Sale workspace does not depend on history |
+| **6.3** | Transaction history | Lookup, detail, receipt reprint | **Implemented.** Sale workspace does not depend on history |
 | **6.4** | Controlled pricing/actions | Approval framework, price override, line discount, Tax Class override | Ordinary path stays `direct` unless policy requires a second actor |
 | **6.5** | Returns | Linked, unlinked, price adjustment, mixed sale/return | Sale-only baskets still complete the same way; Session/Z is direction-aware |
 | **6.6** | Post-void | Controlled whole-transaction correction | Entry is from history; sale path untouched |
@@ -153,14 +154,18 @@ One settlement redesign, not three unrelated tender implementations.
 
 **6.2E merge gate:** ordinary all-Cash behavior remains exactly equivalent to Phase 5.
 
-### 6.3 — Completed transaction history
+### 6.3 — Completed transaction history (implemented)
+
+Authority: [transaction-history.md](transaction-history.md).
 
 Make completed commercial history retrievable before returns need it.
 
-- Search: exact receipt reference, Store/Register/transaction number, recent, date, Register. Not a reporting query builder.
-- Detail: immutable completed facts (lines, tenders, totals, snapshots).
-- Reprint: same completed snapshots as the original receipt. No new receipt number, no `printed_at` mutation, no live Product/price/tax.
-- UI may reserve positions for Return items / Post-void; those actions appear in 6.5 / 6.6.
+- Search: exact receipt reference (sufficient lookup), Register + `receipt_sequence`, exact `business_date`, recent. Not a reporting query builder.
+- Authorized by `pos.transact` at the current Store, not original-cashier ownership. No open Session required.
+- Detail: immutable completed facts (lines, tenders, totals, snapshots), including `cashier_name_snapshot`.
+- Reprint: same completed snapshots as the original receipt, visibly marked **REPRINT**. No new receipt number, no commercial mutation, no live Product/price/tax.
+- Immediate completion and historical lookup are separate screens that share print rendering.
+- UI may later attach Return items / Post-void on detail; 6.3 does not render those actions.
 
 ### 6.4 — Controlled actions and pricing
 

--- a/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/transaction-history.md
+++ b/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/transaction-history.md
@@ -18,6 +18,7 @@ exact receipt reference is a sufficient lookup
 search date means business_date
 cashier_name_snapshot on new completions; null displays "Not captured"
 history never rebinds session[:pos_register_id]
+history Register resume is deterministic (bound Session, else exactly one, else enter)
 immediate completion and historical lookup are separate screens
 reprint is marked REPRINT, keeps original identity, creates no commercial state
 history renders Core snapshots; it does not parse the envelope
@@ -182,7 +183,7 @@ Header from receipt snapshots (`store_number_snapshot`, `register_number_snapsho
 
 Lines from Core + `merchandise_snapshot`: line number, `direction` (always `sale` in 6.3), quantity, description, SKU, Used `condition_code` / `unit_identifier` when present, reference unit price, selling unit price, extended, line tax, line total.
 
-Do **not** join live Product / InventoryUnit / MerchandiseCondition for historical description.
+Do **not** join live Product / InventoryUnit / MerchandiseCondition for historical description. Absent or blank snapshot description displays `Description not captured`; never substitute today’s Product name.
 
 Default tax: line tax + transaction tax. Collapsed details: stored `PosLineTaxComponent` rows where `applies` is true (name, rate, taxable basis, tax). Omit non-applicable determinations.
 
@@ -205,7 +206,7 @@ No reprint table. No reprint audit in 6.3 (`window.print` stays client-side).
 - Application nav (next to Register): `pos.transact` + current store — lookup without opening a Session.
 - Register workspace header: Transactions. Does not cancel or complete a working basket.
 - Immediate completion actions may include Transactions (POS layout has no application nav).
-- History pages: Store, signed-in user, Transactions, Register (workspace if *this* cashier has an open Session at the current Store, else enter). No New sale / Close register / scan field.
+- History pages: Store, signed-in user, Transactions, Register. Register resumes the bound Register when `session[:pos_register_id]` has an open Session owned by this cashier; otherwise the cashier’s sole open Session at this Store; otherwise enter. No New sale / Close register / scan field. Multiple open Sessions never pick an arbitrary Register.
 
 History stays under `/pos` with the POS importmap. No 6.3 keyboard shortcut (6.7). Do not add Hotwire to admin chrome.
 
@@ -252,11 +253,13 @@ Envelope remains durable provenance. Required history behavior uses normalized C
 7. Historical detail shows line, unit, tax, tender, cashier, timing, receipt, and total facts from completed snapshots.
 8. History remains materially unchanged after live Product / Tender / User changes; Used unit identity survives unit removal.
 9. Null `cashier_name_snapshot` displays `Not captured`, not the live user name.
-10. Historical print uses the original receipt identity and a visible **REPRINT** marker; customer print omits external tender references.
-11. Reprint creates no commercial / inventory / tender / receipt-sequence effects.
-12. Historical show does not set `session[:pos_register_id]`.
-13. 6.5 can later attach Return items to historical line IDs without redesigning this surface.
-14. Phase 5/6.1/6.2 checkout and close/Z remain green.
+10. Absent or blank `merchandise_snapshot` description displays `Description not captured`, never the live Product name.
+11. Historical print uses the original receipt identity and a visible **REPRINT** marker; customer print omits external tender references.
+12. Reprint creates no commercial / inventory / tender / receipt-sequence effects.
+13. Historical show does not set `session[:pos_register_id]`.
+14. History Register resumes the bound open Session when present; the cashier’s sole open Session otherwise; enter when several Sessions are open and none is bound.
+15. 6.5 can later attach Return items to historical line IDs without redesigning this surface.
+16. Phase 5/6.1/6.2 checkout and close/Z remain green.
 
 ---
 

--- a/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/transaction-history.md
+++ b/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/transaction-history.md
@@ -1,0 +1,267 @@
+# Phase 6 Slice 6.3 — Completed transaction history
+
+**Status:** Implemented.
+
+**Authority:** Store-scoped completed-transaction lookup, immutable detail, and customer-receipt reprint for the Phase 5/6 register. Dual authority with Core remains [mvp-contract.md](mvp-contract.md) / [ADR-020](../../../adr/ADR-020-pos-operation-envelope-and-core-facts.md). Receipt identity remains [receipt-identity.md](../phase4-point-of-sale/receipt-identity.md).
+
+Companions: [phase6-plan.md](phase6-plan.md), [register-workspace.md](../phase5-cash-register/register-workspace.md), [phase4-schema.md](../phase4-point-of-sale/phase4-schema.md).
+
+Draft [receipts.md](../../../drafts/specifications/pos/receipts.md) is vocabulary. This document is implementation authority for the MVP subset.
+
+### Actually locked
+
+```text
+pos.transact + current Store authorizes history (not original cashier)
+no open Session required
+search is Store-scoped completed rows only
+exact receipt reference is a sufficient lookup
+search date means business_date
+cashier_name_snapshot on new completions; null displays "Not captured"
+history never rebinds session[:pos_register_id]
+immediate completion and historical lookup are separate screens
+reprint is marked REPRINT, keeps original identity, creates no commercial state
+history renders Core snapshots; it does not parse the envelope
+Phase 5/6.1/6.2 checkout and close/Z remain unchanged
+```
+
+---
+
+## 1. Objective
+
+A user with `pos.transact` at the current Store can:
+
+```text
+find a completed transaction
+        ↓
+inspect exactly what happened
+        ↓
+reprint its customer receipt as REPRINT
+```
+
+even after live Product description, price, tax configuration, tender name, InventoryUnit state, or user display name change.
+
+---
+
+## 2. Authorization
+
+```text
+pos.transact + current Store
+  → search / view / reprint that Store’s completed transactions
+```
+
+No new permission. Do **not** require an open Session, the same Register, or the original cashier.
+
+Another Store’s transaction — including a globally unique `transaction_reference` or a direct UUID — is inaccessible (`404` on show; empty index).
+
+`GET /pos/transactions/:id/completed` (immediate post-completion) **keeps** `require_transaction_cashier!` and may bind `session[:pos_register_id]` to the completing Register.
+
+History is a separate path:
+
+```text
+GET /pos/transactions
+GET /pos/transactions/:id
+```
+
+Historical `show` must **not** set `session[:pos_register_id]`. Viewing another cashier’s sale on Register 2 must not retarget this cashier’s workspace.
+
+Working and cancelled rows are not history. Direct UUID to a non-completed row → `404`.
+
+---
+
+## 3. Immediate completion vs history
+
+| Path | Controller | Meaning |
+|---|---|---|
+| `GET /pos/transactions/:id/completed` | `CompletedTransactionsController` | “I just completed this sale” (New sale / Close register) |
+| `GET /pos/transactions` / `:id` | `TransactionsController` | Historical lookup |
+
+They share the customer-receipt **print** partial. They do not share controller behavior or chrome.
+
+---
+
+## 4. Search
+
+GET form. No fuzzy `q`. Fields:
+
+```text
+Receipt reference     [S001-R01-T0000123]
+Register              [all Registers for the Store, including inactive]
+Transaction #         [receipt_sequence]
+Business date         [YYYY-MM-DD]
+```
+
+Query object: `Pos::CompletedTransactionSearch`, starting at `PosTransaction.completed.where(store_id:)`.
+
+### 4.1 Precedence
+
+If `transaction_reference` is present after trim + uppercase → **only** that exact match, still scoped to the current Store. Ignore Register, sequence, and date (leftover filters must not hide a pasted reference).
+
+Otherwise AND supplied `register_id`, `receipt_sequence`, and `business_date` (blank ignored).
+
+No auto-redirect to detail. Zero or one row is a normal index result.
+
+### 4.2 Receipt reference
+
+Exact `transaction_reference` after trim and uppercase. No contains/prefix. Uniqueness is global; history still filters `store_id`.
+
+### 4.3 Register + Transaction #
+
+Form label **Transaction #**. Param and column: `receipt_sequence` (integer; `0000123` → `123`).
+
+`register_id` must belong to the current Store. A foreign id is an invalid filter (empty result), not a `404`.
+
+Dropdown lists **all** Registers for the Store (not `active` only), labeled with current number + name. List/detail still render `register_number_snapshot`.
+
+Without Register, sequence matches across the Store’s Registers and may return multiple rows.
+
+### 4.4 Date
+
+Exact `business_date`. Display `completed_at` separately in Store-local time. Do not derive the filter from `completed_at`.
+
+### 4.5 Recent
+
+No filters: most recent 50 completed transactions for the current Store.
+
+```text
+completed_at DESC
+id DESC
+```
+
+Pagination matches [Products::AdminIndexQuery](../../../../app/services/products/admin_index_query.rb): 50 per page, invalid page clamped. Invalid date/sequence fail safely (empty result, no 500).
+
+Preload `pos_tenders` for the index tender column.
+
+---
+
+## 5. Indexes
+
+Partial indexes:
+
+```text
+(store_id, completed_at DESC, id DESC) WHERE status = 'completed'
+(store_id, business_date, completed_at DESC, id DESC) WHERE status = 'completed'
+```
+
+Existing unique `transaction_reference` and `(store_id, register_id, receipt_sequence)` stay. Do not index every filter combination.
+
+---
+
+## 6. Cashier snapshot
+
+Column `pos_transactions.cashier_name_snapshot` (nullable string). Do **not** add it to `pos_transactions_status_null_rules`. Legacy completed rows may remain null.
+
+New completions set it from the completing actor’s `display_name` in the same update that marks `completed`, and emit envelope `origin.performed_by_name` with the same string.
+
+`verify!` accepts v2 envelopes **without** `performed_by_name`. If the key is present, it must be non-blank. Do not bump `schema_version`. Do not rewrite stored envelopes.
+
+History list/detail display the snapshot. Null → `Not captured`. Never fall back to live `User#display_name`.
+
+Backfill (same migration, best-effort): `pos.transaction_completed` succeeded audit `actor_label` for `subject_type = PosTransaction`.
+
+---
+
+## 7. Index columns
+
+```text
+Receipt        transaction_reference
+Business date  completed fact
+Completed      completed_at, Store-local
+Register       register_number_snapshot
+Cashier        cashier_name_snapshot
+Total          total_cents
+Tender         tender_name by tender_number, joined with " + "
+```
+
+Row/reference opens detail. No live Product / TenderType / User joins except compatibility that does not rewrite displayed facts.
+
+---
+
+## 8. Historical detail
+
+Header from receipt snapshots (`store_number_snapshot`, `register_number_snapshot`, `receipt_sequence`, `transaction_reference`), cashier snapshot, `business_date`, Store-local `completed_at`.
+
+Lines from Core + `merchandise_snapshot`: line number, `direction` (always `sale` in 6.3), quantity, description, SKU, Used `condition_code` / `unit_identifier` when present, reference unit price, selling unit price, extended, line tax, line total.
+
+Do **not** join live Product / InventoryUnit / MerchandiseCondition for historical description.
+
+Default tax: line tax + transaction tax. Collapsed details: stored `PosLineTaxComponent` rows where `applies` is true (name, rate, taxable basis, tax). Omit non-applicable determinations.
+
+Tenders in `tender_number` order. Operator detail **may** show `external_reference`. Customer print omits it.
+
+Fact-driven sections only. Do not render empty override / discount / return / post-void blocks or disabled fake actions. Line IDs remain the 6.5 hook.
+
+---
+
+## 9. Reprint
+
+Immediate completion Print is the original copy (`reprint: false`). History Print is `REPRINT` (`reprint: true`). Same print partial; same receipt identity; no new commercial records, inventory, outbox, or receipt sequence.
+
+No reprint table. No reprint audit in 6.3 (`window.print` stays client-side).
+
+---
+
+## 10. Navigation
+
+- Application nav (next to Register): `pos.transact` + current store — lookup without opening a Session.
+- Register workspace header: Transactions. Does not cancel or complete a working basket.
+- Immediate completion actions may include Transactions (POS layout has no application nav).
+- History pages: Store, signed-in user, Transactions, Register (workspace if *this* cashier has an open Session at the current Store, else enter). No New sale / Close register / scan field.
+
+History stays under `/pos` with the POS importmap. No 6.3 keyboard shortcut (6.7). Do not add Hotwire to admin chrome.
+
+---
+
+## 11. Out of 6.3
+
+```text
+linked return execution
+return eligibility / returned-to-date
+post-void
+cancelled-transaction history
+working-transaction history
+product/SKU / InventoryUnit / cashier / tender / amount-range search
+arbitrary date ranges
+export / reporting
+receipt print-attempt persistence / reprint audit
+electronic receipt delivery
+cross-Store history
+live User display-name fallback for cashier
+auto-redirect from search to detail
+rebinding session[:pos_register_id] from historical detail
+envelope-driven UI
+```
+
+---
+
+## 12. Authorization, audit, envelope
+
+Register/history: `pos.transact` at the current Store. Completion audit is unchanged. History reads are not audited in 6.3.
+
+Envelope remains durable provenance. Required history behavior uses normalized Core. New completions emit `performed_by_name`; old v2 envelopes without it still `verify!`.
+
+---
+
+## 13. Acceptance
+
+1. A Store cashier can view recent completed Store transactions without opening a Register Session.
+2. Exact full receipt reference finds the row (leftover other filters ignored).
+3. Register + Transaction # finds the row; sequence without Register may return multiple Store rows.
+4. Business date and Register filters AND together when no reference is supplied.
+5. History never exposes another Store.
+6. A cashier may view another cashier’s completed transaction at the same authorized Store.
+7. Historical detail shows line, unit, tax, tender, cashier, timing, receipt, and total facts from completed snapshots.
+8. History remains materially unchanged after live Product / Tender / User changes; Used unit identity survives unit removal.
+9. Null `cashier_name_snapshot` displays `Not captured`, not the live user name.
+10. Historical print uses the original receipt identity and a visible **REPRINT** marker; customer print omits external tender references.
+11. Reprint creates no commercial / inventory / tender / receipt-sequence effects.
+12. Historical show does not set `session[:pos_register_id]`.
+13. 6.5 can later attach Return items to historical line IDs without redesigning this surface.
+14. Phase 5/6.1/6.2 checkout and close/Z remain green.
+
+---
+
+## 14. Rollout
+
+`db:migrate` only. No new permission; `shelfsense:seed_permissions` is not required for 6.3.
+
+Rollback of the history indexes and `cashier_name_snapshot` is supported. Do not delete completed facts to roll back. Legacy `cashier_name_snapshot` may remain null.

--- a/test/helpers/pos_helper_test.rb
+++ b/test/helpers/pos_helper_test.rb
@@ -33,4 +33,35 @@ class PosHelperTest < ActionView::TestCase
     assert_equal "Snapshot Used Book  like_new  2200000000001", pos_print_line_description(line)
     refute_includes pos_print_line_description(line), "Live Product Name"
   end
+
+  test "history line description uses the completed snapshot only" do
+    line = PosTransactionLine.new(merchandise_snapshot: { "description" => "Snapshot Book", "sku" => "OLD" })
+    assert_equal "Snapshot Book  OLD", pos_history_line_description(line)
+  end
+
+  test "history line description does not fall back to live product metadata" do
+    product = Product.new(name: "Live Product Name")
+    variant = ProductVariant.new(sku: "LIVE-SKU", product: product)
+    line = PosTransactionLine.new(merchandise_snapshot: {}, product_variant: variant)
+
+    assert_equal "Description not captured", pos_history_line_description(line)
+    refute_includes pos_history_line_description(line), "Live Product Name"
+  end
+
+  test "history line description shows unit identity from the snapshot only" do
+    product = Product.new(name: "Live Product Name")
+    variant = ProductVariant.new(sku: "LIVE-SKU", product: product)
+    line = PosTransactionLine.new(
+      product_variant: variant,
+      merchandise_snapshot: {
+        "description" => "Snapshot Used Book",
+        "sku" => "OLD-SKU",
+        "unit_identifier" => "2200000000001",
+        "condition_code" => "like_new"
+      }
+    )
+
+    assert_equal "Snapshot Used Book  like_new  2200000000001", pos_history_line_description(line)
+    refute_includes pos_history_line_description(line), "Live Product Name"
+  end
 end

--- a/test/integration/pos_transaction_history_test.rb
+++ b/test/integration/pos_transaction_history_test.rb
@@ -173,6 +173,42 @@ class PosTransactionHistoryTest < ActionDispatch::IntegrationTest
     assert_select "option[value='#{other_register.id}']"
   end
 
+  test "history does not substitute live product names when the merchandise snapshot is missing" do
+    transaction = complete_cash_sale!
+    line = transaction.pos_transaction_lines.first
+    PosTransactionLine.where(id: line.id).update_all(merchandise_snapshot: {})
+    @variant.product.update!(name: "Live Catalog Name After History")
+
+    get pos_transaction_path(transaction)
+    assert_response :success
+    assert_match "Description not captured", response.body
+    refute_match "Live Catalog Name After History", response.body
+    refute_match "Example Book", response.body
+    assert_select ".pos-receipt__print", text: /Description unavailable/
+  end
+
+  test "history register link resumes the bound session when the cashier has several open" do
+    other_register = Register.create!(store: @store, register_number: 2, name: "Back")
+    pos_open_context(store: @store, actor: @actor, register: other_register)
+    assert_equal 2, PosSession.open.where(store: @store, cashier_user: @actor).count
+
+    get pos_transactions_path
+    assert_response :success
+    assert_select "a[href='#{pos_register_enter_path}']", text: "Register"
+
+    post pos_register_enter_path, params: {
+      register_id: other_register.id,
+      opening_float: "0.00",
+      confirmed_business_date: @context[:period].business_date.iso8601
+    }
+    assert_equal other_register.id.to_s, session[:pos_register_id].to_s
+
+    get pos_transactions_path
+    assert_response :success
+    assert_select "a[href='#{pos_register_workspace_path(register_id: other_register.id)}']", text: "Register"
+    assert_select "a[href='#{pos_register_workspace_path(register_id: @register.id)}']", text: "Register", count: 0
+  end
+
   private
 
   def sign_in_as(username)

--- a/test/integration/pos_transaction_history_test.rb
+++ b/test/integration/pos_transaction_history_test.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PosTransactionHistoryTest < ActionDispatch::IntegrationTest
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    @tax = tax_class(code: "physical_book", name: "Physical book")
+    StoreTaxes::Create.call(
+      store: @store,
+      actor: @actor,
+      name: "Illinois State",
+      rate_percent: "5.000",
+      calculation_order: 1,
+      applies_by_tax_class_id: { @tax.id => true }
+    )
+    @variant = pos_sellable_variant(actor: @actor, tax_class: @tax)
+    open_quantity_stock(store: @store, variant: @variant, actor: @actor, quantity: 8)
+    @register = Register.create!(store: @store, register_number: 1, name: "Front")
+    @context = pos_open_context(store: @store, actor: @actor, register: @register)
+    sign_in_as("admin")
+  end
+
+  test "cashier can search and view history without an open session" do
+    transaction = complete_cash_sale!
+    clerk = pos_transacting_user(store: @store, assigned_by: @actor, username: "clerk_hist")
+    delete session_path
+    sign_in_as("clerk_hist")
+
+    get pos_transactions_path
+    assert_response :success
+    assert_select "a", text: transaction.transaction_reference
+    refute PosSession.open.exists?(cashier_user: clerk)
+
+    get pos_transaction_path(transaction)
+    assert_response :success
+    assert_match transaction.transaction_reference, response.body
+    assert_match "Example Book", response.body
+    assert_match "REPRINT", response.body
+    assert_select ".pos-receipt__reprint", text: "REPRINT"
+    assert_nil session[:pos_register_id]
+  end
+
+  test "another cashier at the same store can view and leftover filters do not hide an exact reference" do
+    transaction = complete_cash_sale!
+    pos_transacting_user(store: @store, assigned_by: @actor, username: "clerk_b")
+    delete session_path
+    sign_in_as("clerk_b")
+
+    get pos_transactions_path, params: {
+      transaction_reference: transaction.transaction_reference.downcase,
+      business_date: "2020-01-01",
+      receipt_sequence: "999"
+    }
+    assert_response :success
+    assert_select "a", text: transaction.transaction_reference
+
+    get pos_transaction_path(transaction)
+    assert_response :success
+    assert_match pos_cashier_name_for(transaction), response.body
+  end
+
+  test "other store and missing pos.transact cannot view history" do
+    transaction = complete_cash_sale!
+    east = Store.create!(store_number: "2", code: "east", name: "East Store", timezone: "America/New_York", country_code: "US")
+    pos_transacting_user(store: east, assigned_by: @actor, username: "east_clerk")
+    delete session_path
+    sign_in_as("east_clerk")
+
+    get pos_transactions_path
+    assert_response :success
+    assert_select "a", text: transaction.transaction_reference, count: 0
+
+    get pos_transaction_path(transaction)
+    assert_response :not_found
+
+    User.create!(
+      username: "no_pos",
+      display_name: "No POS",
+      password: "correct-horse-battery",
+      password_confirmation: "correct-horse-battery"
+    )
+    delete session_path
+    sign_in_as("no_pos")
+    get pos_transactions_path
+    assert_redirected_to root_path
+  end
+
+  test "historical show does not rebind the cashier register session" do
+    other_register = Register.create!(store: @store, register_number: 2, name: "Back")
+    other_context = pos_open_context(store: @store, actor: @actor, register: other_register)
+    transaction = complete_cash_sale!(session: other_context[:session], actor: @actor)
+    post pos_register_enter_path, params: {
+      register_id: @register.id,
+      opening_float: "0.00",
+      confirmed_business_date: @context[:period].business_date.iso8601
+    }
+    assert_equal @register.id.to_s, session[:pos_register_id].to_s
+
+    get pos_transaction_path(transaction)
+    assert_response :success
+    assert_equal @register.id.to_s, session[:pos_register_id].to_s
+  end
+
+  test "history keeps snapshots after live catalog and user changes and reprint has no commercial effect" do
+    used_variant, unit = pos_on_hand_unit(store: @store, actor: @actor, tax_class: @tax, name: "Used Book")
+    transaction = Pos::StartTransaction.call(session: @context[:session], actor: @actor)
+    Pos::AddMerchandise.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      identifier: unit.unit_identifier
+    )
+    transaction.reload
+    Pos::AddTender.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      tender_type: TenderType.find_by!(code: "card"),
+      amount_cents: transaction.total_cents,
+      external_reference: "AUTH-77"
+    )
+    transaction.reload
+    Pos::CompleteTransaction.call(
+      transaction: transaction,
+      actor: @actor,
+      operation_id: SecureRandom.uuid_v7,
+      expected_lock_version: transaction.lock_version,
+      expected_total_cents: transaction.total_cents
+    )
+    transaction.reload
+    original_description = transaction.pos_transaction_lines.first.merchandise_snapshot.fetch("description")
+    unit_identifier = unit.unit_identifier
+
+    used_variant.product.update!(name: "Renamed Used Book")
+    TenderType.find_by!(code: "card").update!(name: "Bank Card")
+    @actor.reload.update!(display_name: "Renamed Admin")
+    PosTransaction.where(id: transaction.id).update_all(cashier_name_snapshot: nil)
+    transaction.reload
+
+    counts = commercial_counts
+    get pos_transaction_path(transaction)
+    assert_response :success
+    assert_match original_description, response.body
+    assert_match unit_identifier, response.body
+    assert_match "External Card", response.body
+    assert_match "AUTH-77", response.body
+    assert_match "Not captured", response.body
+    refute_match "Renamed Used Book", response.body
+    refute_match "Bank Card", response.body
+    assert_select ".pos-history__header dd", text: "Not captured"
+    assert_select ".pos-receipt__print", text: /AUTH-77/, count: 0
+    assert_select ".pos-receipt__reprint", text: "REPRINT"
+    assert_equal counts, commercial_counts
+    assert_equal transaction.receipt_sequence, transaction.reload.receipt_sequence
+  end
+
+  test "inactive register remains listed for history filters" do
+    other_register = Register.create!(store: @store, register_number: 2, name: "Back")
+    other_context = pos_open_context(store: @store, actor: @actor, register: other_register)
+    sale = insert_completed_transaction!(
+      session: other_context[:session],
+      receipt_sequence: 3,
+      completed_at: Time.utc(2026, 8, 18, 15, 0, 0)
+    )
+    other_register.update_column(:active, false)
+
+    get pos_transactions_path, params: { register_id: other_register.id }
+    assert_response :success
+    assert_select "a", text: sale.transaction_reference
+    assert_select "option[value='#{other_register.id}']"
+  end
+
+  private
+
+  def sign_in_as(username)
+    post session_path, params: { session: { username: username, password: "correct-horse-battery" } }
+  end
+
+  def complete_cash_sale!(session: @context[:session], actor: @actor, variant: @variant)
+    transaction = Pos::StartTransaction.call(session: session, actor: actor)
+    Pos::AddMerchandise.call(
+      transaction: transaction,
+      actor: actor,
+      expected_lock_version: transaction.lock_version,
+      identifier: variant.sku
+    )
+    transaction.reload
+    Pos::TenderCash.call(
+      transaction: transaction,
+      actor: actor,
+      expected_lock_version: transaction.lock_version,
+      amount_presented_cents: transaction.total_cents
+    )
+    transaction.reload
+    Pos::CompleteTransaction.call(
+      transaction: transaction,
+      actor: actor,
+      operation_id: SecureRandom.uuid_v7,
+      expected_lock_version: transaction.lock_version,
+      expected_total_cents: transaction.total_cents
+    )
+    transaction.reload
+  end
+
+  def pos_cashier_name_for(transaction)
+    transaction.cashier_name_snapshot.presence || "Not captured"
+  end
+
+  def commercial_counts
+    {
+      transactions: PosTransaction.count,
+      tenders: PosTender.count,
+      ledger: InventoryLedgerEntry.count,
+      outbox: OutboxMessage.count
+    }
+  end
+end

--- a/test/services/pos/complete_transaction_test.rb
+++ b/test/services/pos/complete_transaction_test.rb
@@ -70,6 +70,8 @@ class PosCompleteTransactionTest < ActiveSupport::TestCase
     assert_equal 1, operation.envelope.dig("receipt", "register_number")
     assert_equal transaction.transaction_reference, operation.envelope.dig("receipt", "reference")
     assert_equal @actor.id.to_s, operation.envelope.dig("origin", "performed_by_user_id")
+    assert_equal @actor.display_name, operation.envelope.dig("origin", "performed_by_name")
+    assert_equal @actor.display_name, transaction.cashier_name_snapshot
     assert_equal @actor.id, transaction.cashier_user_id
     assert_equal @actor.id, transaction.pos_session.cashier_user_id
 

--- a/test/services/pos/completed_transaction_search_test.rb
+++ b/test/services/pos/completed_transaction_search_test.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PosCompletedTransactionSearchTest < ActiveSupport::TestCase
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    @context = pos_open_context(store: @store, actor: @actor)
+    @session = @context[:session]
+    @base_time = Time.utc(2026, 8, 18, 12, 0, 0)
+  end
+
+  test "no filters returns only current-store completed transactions newest first" do
+    other_store = Store.create!(store_number: "2", code: "east", name: "East", timezone: "America/New_York", country_code: "US")
+    other_context = pos_open_context(store: other_store, actor: @actor)
+    older = insert_completed_transaction!(session: @session, receipt_sequence: 1, completed_at: @base_time, cashier_name: "Ada")
+    newer = insert_completed_transaction!(session: @session, receipt_sequence: 2, completed_at: @base_time + 60, cashier_name: "Ada")
+    insert_completed_transaction!(session: other_context[:session], receipt_sequence: 1, completed_at: @base_time + 120, cashier_name: "Ada")
+    PosTransaction.create!(
+      store: @store,
+      register: @context[:register],
+      pos_session: @session,
+      reporting_period: @context[:period],
+      cashier_user: @actor,
+      status: "working",
+      currency_code: "USD"
+    )
+    PosTransaction.create!(
+      store: @store,
+      register: @context[:register],
+      pos_session: @session,
+      reporting_period: @context[:period],
+      cashier_user: @actor,
+      status: "cancelled",
+      cancelled_at: Time.current,
+      currency_code: "USD"
+    )
+
+    result = Pos::CompletedTransactionSearch.call(store: @store)
+    assert_equal [ newer.id, older.id ], result.records.map(&:id)
+    assert_equal 2, result.total_count
+    refute result.filtered
+  end
+
+  test "page size is 50 and invalid page is clamped" do
+    51.times do |index|
+      insert_completed_transaction!(
+        session: @session,
+        receipt_sequence: index + 1,
+        completed_at: @base_time + index
+      )
+    end
+
+    first = Pos::CompletedTransactionSearch.call(store: @store, page: 1)
+    assert_equal 50, first.records.size
+    assert_equal 51, first.total_count
+    assert_equal 2, first.total_pages
+
+    second = Pos::CompletedTransactionSearch.call(store: @store, page: 2)
+    assert_equal 1, second.records.size
+
+    clamped = Pos::CompletedTransactionSearch.call(store: @store, page: "nope")
+    assert_equal 1, clamped.page
+    overflow = Pos::CompletedTransactionSearch.call(store: @store, page: 99)
+    assert_equal 2, overflow.page
+  end
+
+  test "exact transaction_reference ignores leftover register sequence and date" do
+    match = insert_completed_transaction!(
+      session: @session,
+      receipt_sequence: 10,
+      completed_at: @base_time,
+      business_date: Date.new(2026, 8, 18)
+    )
+    insert_completed_transaction!(
+      session: @session,
+      receipt_sequence: 11,
+      completed_at: @base_time + 10,
+      business_date: Date.new(2026, 8, 19)
+    )
+
+    result = Pos::CompletedTransactionSearch.call(
+      store: @store,
+      transaction_reference: "  #{match.transaction_reference.downcase}  ",
+      register_id: SecureRandom.uuid_v7,
+      receipt_sequence: "11",
+      business_date: "2026-08-19"
+    )
+    assert_equal [ match.id ], result.records.map(&:id)
+    assert result.filtered
+  end
+
+  test "register and receipt_sequence and business_date AND together" do
+    second = pos_open_context(store: @store, actor: @actor, register: Register.create!(store: @store, register_number: 2, name: "Back"))
+    wanted = insert_completed_transaction!(
+      session: second[:session],
+      receipt_sequence: 7,
+      completed_at: @base_time,
+      business_date: Date.new(2026, 8, 18)
+    )
+    insert_completed_transaction!(
+      session: second[:session],
+      receipt_sequence: 8,
+      completed_at: @base_time + 10,
+      business_date: Date.new(2026, 8, 18)
+    )
+    insert_completed_transaction!(
+      session: @session,
+      receipt_sequence: 7,
+      completed_at: @base_time + 20,
+      business_date: Date.new(2026, 8, 18)
+    )
+
+    result = Pos::CompletedTransactionSearch.call(
+      store: @store,
+      register_id: second[:register].id,
+      receipt_sequence: "0000007",
+      business_date: "2026-08-18"
+    )
+    assert_equal [ wanted.id ], result.records.map(&:id)
+  end
+
+  test "receipt_sequence without register matches across the store" do
+    second = pos_open_context(store: @store, actor: @actor, register: Register.create!(store: @store, register_number: 2, name: "Back"))
+    first = insert_completed_transaction!(session: @session, receipt_sequence: 4, completed_at: @base_time)
+    other = insert_completed_transaction!(session: second[:session], receipt_sequence: 4, completed_at: @base_time + 30)
+
+    result = Pos::CompletedTransactionSearch.call(store: @store, receipt_sequence: "4")
+    assert_equal [ other.id, first.id ], result.records.map(&:id)
+  end
+
+  test "inactive register remains a valid filter and foreign register is empty" do
+    second = pos_open_context(store: @store, actor: @actor, register: Register.create!(store: @store, register_number: 2, name: "Back"))
+    sale = insert_completed_transaction!(session: second[:session], receipt_sequence: 1, completed_at: @base_time)
+    second[:register].update_column(:active, false)
+
+    found = Pos::CompletedTransactionSearch.call(store: @store, register_id: second[:register].id)
+    assert_equal [ sale.id ], found.records.map(&:id)
+
+    east = Store.create!(store_number: "9", code: "west", name: "West", timezone: "America/New_York", country_code: "US")
+    foreign = Register.create!(store: east, register_number: 1, name: "Foreign")
+    empty = Pos::CompletedTransactionSearch.call(store: @store, register_id: foreign.id)
+    assert_equal 0, empty.total_count
+  end
+
+  test "invalid date and sequence fail safely" do
+    insert_completed_transaction!(session: @session, receipt_sequence: 1, completed_at: @base_time)
+    assert_equal 0, Pos::CompletedTransactionSearch.call(store: @store, business_date: "18/08/2026").total_count
+    assert_equal 0, Pos::CompletedTransactionSearch.call(store: @store, receipt_sequence: "abc").total_count
+    assert_equal 0, Pos::CompletedTransactionSearch.call(store: @store, receipt_sequence: "0").total_count
+  end
+end

--- a/test/services/pos/golden_fixtures_test.rb
+++ b/test/services/pos/golden_fixtures_test.rb
@@ -99,6 +99,16 @@ class PosGoldenFixturesTest < ActiveSupport::TestCase
     Pos::CompletedTransactionFacts.new(payload).verify!
   end
 
+  test "v2 verify accepts origin without performed_by_name and rejects a blank name" do
+    payload = JSON.parse(File.read(FIXTURES.join("completed_pos_operation_v2/cash_sale.json")))
+    refute payload.fetch("origin").key?("performed_by_name")
+    Pos::CompletedTransactionFacts.new(payload).verify!
+
+    payload["origin"]["performed_by_name"] = ""
+    error = assert_raises(Pos::Error) { Pos::CompletedTransactionFacts.new(payload).verify! }
+    assert_match(/performed_by_name/, error.message)
+  end
+
   test "tax golden cases compute half-up independently and include non-applicable rows" do
     catalog = JSON.parse(File.read(FIXTURES.join("tax_cases.json")))
     catalog.fetch("cases").each do |tax_case|

--- a/test/support/pos_fixtures.rb
+++ b/test/support/pos_fixtures.rb
@@ -107,4 +107,42 @@ module PosFixtures
     )
     user
   end
+
+  def insert_completed_transaction!(
+    session:,
+    receipt_sequence:,
+    completed_at:,
+    business_date: nil,
+    cashier_name: "Jane Smith",
+    cashier_user: nil,
+    total_cents: 2099
+  )
+    store = session.store
+    register = session.register
+    business_date ||= session.reporting_period.business_date
+    PosTransaction.create!(
+      store: store,
+      register: register,
+      pos_session: session,
+      reporting_period: session.reporting_period,
+      cashier_user: cashier_user || session.cashier_user,
+      cashier_name_snapshot: cashier_name,
+      status: "completed",
+      currency_code: "USD",
+      occurred_at: completed_at,
+      completed_at: completed_at,
+      business_date: business_date,
+      receipt_sequence: receipt_sequence,
+      store_number_snapshot: store.store_number,
+      register_number_snapshot: register.register_number,
+      transaction_reference: Pos::ReceiptIdentity.reference(
+        store_number: store.store_number,
+        register_number: register.register_number,
+        receipt_sequence: receipt_sequence
+      ),
+      subtotal_cents: total_cents,
+      tax_cents: 0,
+      total_cents: total_cents
+    )
+  end
 end

--- a/test/system/pos_register_workspace_test.rb
+++ b/test/system/pos_register_workspace_test.rb
@@ -336,6 +336,36 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     assert_equal 1, PosTransaction.completed.where(register: @register).count
   end
 
+  test "cashier can open completed history and reprint without changing the sale" do
+    open_register
+    add_current_sku
+    click_on "Tender (+)"
+    field = find("#pos-command-field")
+    field.fill_in with: "50.00"
+    field.send_keys :enter
+    send_keys :enter
+    assert_text "Sale complete", wait: 10
+    completed = PosTransaction.completed.find_by!(register: @register)
+    counts = {
+      transactions: PosTransaction.count,
+      tenders: PosTender.count,
+      ledger: InventoryLedgerEntry.count,
+      outbox: OutboxMessage.count,
+      receipt: completed.receipt_sequence
+    }
+
+    click_on "Transactions"
+    assert_text completed.transaction_reference
+    click_on completed.transaction_reference
+    assert_selector ".pos-receipt__reprint", text: "REPRINT", visible: :all
+    assert_text "Example Book"
+    assert_equal counts[:transactions], PosTransaction.count
+    assert_equal counts[:tenders], PosTender.count
+    assert_equal counts[:ledger], InventoryLedgerEntry.count
+    assert_equal counts[:outbox], OutboxMessage.count
+    assert_equal counts[:receipt], completed.reload.receipt_sequence
+  end
+
   private
 
   def sign_in_admin


### PR DESCRIPTION
## Summary
- Slice 6.3: cashiers with `pos.transact` at the current Store can search completed sales, inspect frozen snapshots, and reprint the customer receipt as **REPRINT**. History does not require an open Session, the original cashier, or the same Register.
- Exact receipt reference is a sufficient lookup (leftover Register / sequence / date are ignored). Otherwise filters AND `register_id`, `receipt_sequence`, and `business_date`. Historical `show` never rebinds `session[:pos_register_id]`.
- New completions snapshot `cashier_name_snapshot` and envelope `origin.performed_by_name`. Null snapshots display “Not captured”; history never falls back to a live user name. `verify!` still accepts 6.1/6.2 envelopes without the name key.
- Immediate completion print stays the original copy; history Print is REPRINT with the same identity and no commercial, inventory, tender, or receipt-sequence writes. No new permission.

## Verification
- `./dev/rails-docker bin/rails test`
- `./dev/rails-docker bin/rails test:system`
- `./dev/rails-docker bin/rubocop`
- `./dev/rails-docker bin/brakeman --no-pager`

## Documentation and migrations
- Contract: `docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/transaction-history.md`
- Companions: `phase6-plan.md`, `mvp-contract.md`, `phase4-schema.md`, `register-workspace.md`
- Rollout is `db:migrate` only (`20260818130000_add_completed_transaction_history`). `shelfsense:seed_permissions` is not required.
- Rollback of the history indexes and `cashier_name_snapshot` is supported. Do not delete completed facts to roll back. Legacy `cashier_name_snapshot` may remain null.


Made with [Cursor](https://cursor.com)