### PR TITLE
Let cashiers take unlinked returns without a receipt

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -554,6 +554,8 @@ input[type="submit"]:hover {
 
 .pos-overlay__panel--control {
   max-width: 32rem;
+  max-height: min(90vh, 44rem);
+  overflow-y: auto;
   display: grid;
   gap: var(--space-3);
 }

--- a/app/controllers/pos/workspaces_controller.rb
+++ b/app/controllers/pos/workspaces_controller.rb
@@ -77,9 +77,9 @@ module Pos
         line = find_line!
         @selected_line = Pos::ExecuteControlledAction.call(
           transaction: @transaction,
-          line: line,
           actor: current_user,
           expected_lock_version: expected_lock_version,
+          line: line,
           action_type: params.require(:action_type),
           operation: params.require(:operation),
           reason_code: params[:reason_code],
@@ -87,6 +87,51 @@ module Pos
           **controlled_action_commercial_attrs,
           approver_username: params[:approver_username],
           approver_password: params[:approver_password]
+        )
+        @transaction.reload
+        @ui_mode = "sale_entry"
+        respond_workspace
+      end
+    end
+
+    def unlinked_return_lookup
+      Pos::Support.authorize!(current_user, current_store)
+      result = Pos::ResolveUnlinkedReturnMerchandise.call(
+        identifier: params.require(:identifier),
+        store: current_store
+      )
+      render json: {
+        description: result.description,
+        tracking: result.tracking,
+        quantity_fixed: result.quantity_fixed,
+        reference_unit_price_cents: result.reference_unit_price_cents,
+        product_variant_id: result.variant.id,
+        inventory_unit_id: result.inventory_unit&.id,
+        tax_class_id: result.tax_class.id
+      }
+    rescue Pos::Denied
+      render json: { error: "You are not authorized to perform that action." }, status: :forbidden
+    rescue Identifiers::NormalizationError, Pos::Error => e
+      render json: { error: e.message }, status: :unprocessable_entity
+    end
+
+    def unlinked_return
+      rescue_workspace(error_mode: "sale_entry") do
+        @selected_line = Pos::ExecuteUnlinkedReturn.call(
+          transaction: @transaction,
+          actor: current_user,
+          expected_lock_version: expected_lock_version,
+          identifier: params.require(:identifier),
+          quantity: params[:quantity].presence || 1,
+          reason_code: params.require(:reason_code),
+          reason_note: params[:reason_note],
+          requested_return_unit_price_cents: parse_optional_cents(params.require(:return_price)),
+          approver_username: params[:approver_username],
+          approver_password: params[:approver_password],
+          expected_product_variant_id: params[:expected_product_variant_id],
+          expected_inventory_unit_id: params[:expected_inventory_unit_id],
+          expected_reference_unit_price_cents: params[:expected_reference_unit_price_cents],
+          expected_tax_class_id: params[:expected_tax_class_id]
         )
         @transaction.reload
         @ui_mode = "sale_entry"
@@ -281,7 +326,8 @@ module Pos
       @control_policies = {
         "price_override" => Pos::ControlledActionPolicy.result(user: current_user, store: current_store, action_type: "price_override").to_s,
         "line_discount" => Pos::ControlledActionPolicy.result(user: current_user, store: current_store, action_type: "line_discount").to_s,
-        "tax_class_override" => Pos::ControlledActionPolicy.result(user: current_user, store: current_store, action_type: "tax_class_override").to_s
+        "tax_class_override" => Pos::ControlledActionPolicy.result(user: current_user, store: current_store, action_type: "tax_class_override").to_s,
+        "unlinked_return" => Pos::ControlledActionPolicy.result(user: current_user, store: current_store, action_type: "unlinked_return").to_s
       }
       @feedback ||= nil
       @command_value ||= nil

--- a/app/helpers/pos_helper.rb
+++ b/app/helpers/pos_helper.rb
@@ -114,6 +114,10 @@ module PosHelper
     format_money_cents(cents)
   end
 
+  def pos_unlinked_return_price_adjusted?(line)
+    line.unlinked_return? && line.selling_unit_price_cents != line.reference_unit_price_cents
+  end
+
   def pos_line_controlled?(line)
     line.price_overridden? || line.manually_discounted? || line.tax_class_overridden?
   end

--- a/app/javascript/controllers/register_workspace_controller.js
+++ b/app/javascript/controllers/register_workspace_controller.js
@@ -8,6 +8,8 @@ export default class extends Controller {
     "chrome",
     "overlay",
     "controlOverlay",
+    "unlinkedOverlay",
+    "unlinkedForm",
     "completeForm",
     "tenderForm",
     "removeTenderForm",
@@ -54,6 +56,34 @@ export default class extends Controller {
     "controlCancel",
     "controlApply",
     "controlRemove",
+    "unlinkedButton",
+    "unlinkedIdentifierField",
+    "unlinkedIdentifierInput",
+    "unlinkedQuantityInput",
+    "unlinkedReasonInput",
+    "unlinkedNoteInput",
+    "unlinkedPriceInput",
+    "unlinkedExpectedVariantInput",
+    "unlinkedExpectedUnitInput",
+    "unlinkedExpectedReferenceInput",
+    "unlinkedExpectedTaxInput",
+    "unlinkedApproverUserInput",
+    "unlinkedApproverPasswordInput",
+    "unlinkedFeedback",
+    "unlinkedPreview",
+    "unlinkedDescription",
+    "unlinkedReferenceLabel",
+    "unlinkedQuantityWrap",
+    "unlinkedQuantityField",
+    "unlinkedReasonField",
+    "unlinkedNoteWrap",
+    "unlinkedNoteField",
+    "unlinkedPriceField",
+    "unlinkedApproverWrap",
+    "unlinkedApproverUsername",
+    "unlinkedApproverPassword",
+    "unlinkedCancel",
+    "unlinkedApply",
     "dontCancel",
     "confirmCancel",
     "retry",
@@ -76,6 +106,8 @@ export default class extends Controller {
     tenderTypes: Array,
     policies: Object,
     reasons: Object,
+    returnReasons: Array,
+    unlinkedLookupUrl: String,
     settlement: String,
     refundRemaining: Number
   }
@@ -86,6 +118,11 @@ export default class extends Controller {
     if (this.hasControlReasonFieldTarget) {
       this.controlReasonFieldTarget.addEventListener("change", () => {
         this.toggleHidden(this.hasControlNoteWrapTarget && this.controlNoteWrapTarget, this.controlReasonFieldTarget.value !== "other")
+      })
+    }
+    if (this.hasUnlinkedReasonFieldTarget) {
+      this.unlinkedReasonFieldTarget.addEventListener("change", () => {
+        this.toggleHidden(this.hasUnlinkedNoteWrapTarget && this.unlinkedNoteWrapTarget, this.unlinkedReasonFieldTarget.value !== "other")
       })
     }
     if (this.autoCompleteValue) {
@@ -104,6 +141,11 @@ export default class extends Controller {
     const functionKey = this.functionKey(event)
     const key = functionKey || event.key
     if (this.claimedFunctionKey(functionKey)) this.claimFunctionKey(event)
+
+    if (this.unlinkedOverlayOpen()) {
+      this.onUnlinkedOverlayKeydown(event, key)
+      return
+    }
 
     if (this.controlOverlayOpen()) {
       this.onControlOverlayKeydown(event, key)
@@ -222,6 +264,41 @@ export default class extends Controller {
     if (this.hasApproverPasswordTarget && target === this.approverPasswordTarget) {
       event.preventDefault()
       if (this.approverPasswordTarget.value.trim() !== "") this.submitControlApply()
+      return
+    }
+    if (this.isActionableControl(target)) return
+    event.preventDefault()
+  }
+
+  onUnlinkedOverlayKeydown(event, key = this.functionKey(event) || event.key) {
+    if (key === "Tab") {
+      this.trapUnlinkedOverlayTab(event)
+      return
+    }
+    if (key === "Escape") {
+      event.preventDefault()
+      this.closeUnlinkedOverlay()
+      return
+    }
+    if (key === "F9") {
+      event.preventDefault()
+      return
+    }
+    if (key !== "Enter") return
+
+    const target = event.target
+    if (this.hasUnlinkedIdentifierFieldTarget && target === this.unlinkedIdentifierFieldTarget) {
+      event.preventDefault()
+      this.resolveUnlinkedIdentifier()
+      return
+    }
+    if (this.hasUnlinkedApproverUsernameTarget && target === this.unlinkedApproverUsernameTarget) {
+      event.preventDefault()
+      return
+    }
+    if (this.hasUnlinkedApproverPasswordTarget && target === this.unlinkedApproverPasswordTarget) {
+      event.preventDefault()
+      if (this.unlinkedApproverPasswordTarget.value.trim() !== "") this.submitUnlinkedReturn()
       return
     }
     if (this.isActionableControl(target)) return
@@ -490,6 +567,179 @@ export default class extends Controller {
     this.restoreFocus()
   }
 
+  openUnlinkedOverlay() {
+    if (this.inFlight) return
+    if (this.modeValue !== "sale_entry") return
+    if (this.policyFor("unlinked_return") === "prohibited") return
+    if (!this.hasUnlinkedOverlayTarget) return
+
+    this.resetUnlinkedOverlay()
+    this.populateUnlinkedReasons()
+    const needsApprover = this.policyFor("unlinked_return") === "approval_required"
+    this.toggleHidden(this.hasUnlinkedApproverWrapTarget && this.unlinkedApproverWrapTarget, !needsApprover)
+    this.unlinkedOverlayTarget.hidden = false
+    if (this.hasChromeTarget) this.chromeTarget.inert = true
+    if (this.hasUnlinkedIdentifierFieldTarget) this.unlinkedIdentifierFieldTarget.focus()
+  }
+
+  closeUnlinkedOverlay() {
+    if (!this.hasUnlinkedOverlayTarget) return
+    this.unlinkedOverlayTarget.hidden = true
+    if (this.hasChromeTarget) this.chromeTarget.inert = false
+    this.restoreFocus()
+  }
+
+  resetUnlinkedOverlay() {
+    this.unlinkedPreviewPayload = null
+    if (this.hasUnlinkedFeedbackTarget) this.unlinkedFeedbackTarget.textContent = ""
+    if (this.hasUnlinkedIdentifierFieldTarget) this.unlinkedIdentifierFieldTarget.value = ""
+    this.toggleHidden(this.hasUnlinkedPreviewTarget && this.unlinkedPreviewTarget, true)
+    if (this.hasUnlinkedApplyTarget) this.unlinkedApplyTarget.hidden = true
+    if (this.hasUnlinkedNoteFieldTarget) this.unlinkedNoteFieldTarget.value = ""
+    this.toggleHidden(this.hasUnlinkedNoteWrapTarget && this.unlinkedNoteWrapTarget, true)
+    if (this.hasUnlinkedApproverUsernameTarget) this.unlinkedApproverUsernameTarget.value = ""
+    if (this.hasUnlinkedApproverPasswordTarget) this.unlinkedApproverPasswordTarget.value = ""
+  }
+
+  populateUnlinkedReasons() {
+    if (!this.hasUnlinkedReasonFieldTarget) return
+    const entries = this.returnReasonsValue || []
+    this.unlinkedReasonFieldTarget.innerHTML = ""
+    entries.forEach((entry) => {
+      const option = document.createElement("option")
+      option.value = entry.code
+      option.textContent = entry.name
+      this.unlinkedReasonFieldTarget.appendChild(option)
+    })
+  }
+
+  async resolveUnlinkedIdentifier() {
+    if (this.inFlight || !this.hasUnlinkedIdentifierFieldTarget) return
+    const identifier = this.unlinkedIdentifierFieldTarget.value.trim()
+    if (identifier === "") return
+    const token = document.querySelector('meta[name="csrf-token"]')?.getAttribute("content")
+    try {
+      const response = await fetch(this.unlinkedLookupUrlValue, {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+          "X-CSRF-Token": token || ""
+        },
+        body: new URLSearchParams({ identifier }).toString()
+      })
+      const payload = await response.json()
+      if (!response.ok) {
+        this.showUnlinkedFeedback(payload.error || "merchandise not found")
+        this.toggleHidden(this.hasUnlinkedPreviewTarget && this.unlinkedPreviewTarget, true)
+        if (this.hasUnlinkedApplyTarget) this.unlinkedApplyTarget.hidden = true
+        return
+      }
+      this.applyUnlinkedPreview(payload)
+    } catch (_error) {
+      this.showUnlinkedFeedback("merchandise not found")
+    }
+  }
+
+  applyUnlinkedPreview(payload) {
+    this.unlinkedPreviewPayload = payload
+    if (this.hasUnlinkedFeedbackTarget) this.unlinkedFeedbackTarget.textContent = ""
+    this.toggleHidden(this.hasUnlinkedPreviewTarget && this.unlinkedPreviewTarget, false)
+    if (this.hasUnlinkedDescriptionTarget) this.unlinkedDescriptionTarget.textContent = payload.description || ""
+    if (this.hasUnlinkedReferenceLabelTarget) {
+      this.unlinkedReferenceLabelTarget.textContent = this.formatCents(payload.reference_unit_price_cents)
+    }
+    if (this.hasUnlinkedPriceFieldTarget) {
+      this.unlinkedPriceFieldTarget.value = this.formatCents(payload.reference_unit_price_cents)
+    }
+    const fixed = Boolean(payload.quantity_fixed)
+    this.toggleHidden(this.hasUnlinkedQuantityWrapTarget && this.unlinkedQuantityWrapTarget, fixed)
+    if (this.hasUnlinkedQuantityFieldTarget) {
+      this.unlinkedQuantityFieldTarget.value = "1"
+      this.unlinkedQuantityFieldTarget.disabled = fixed
+    }
+    if (this.hasUnlinkedApplyTarget) this.unlinkedApplyTarget.hidden = false
+    if (this.hasUnlinkedQuantityFieldTarget && !fixed) {
+      this.unlinkedQuantityFieldTarget.focus()
+    } else if (this.hasUnlinkedReasonFieldTarget) {
+      this.unlinkedReasonFieldTarget.focus()
+    }
+  }
+
+  showUnlinkedFeedback(message) {
+    if (this.hasUnlinkedFeedbackTarget) this.unlinkedFeedbackTarget.textContent = message
+  }
+
+  submitUnlinkedReturn() {
+    if (this.inFlight || !this.hasUnlinkedFormTarget) return
+    if (!this.unlinkedPreviewPayload) return
+    if (this.hasUnlinkedIdentifierInputTarget) {
+      this.unlinkedIdentifierInputTarget.value = this.hasUnlinkedIdentifierFieldTarget
+        ? this.unlinkedIdentifierFieldTarget.value.trim()
+        : ""
+    }
+    if (this.hasUnlinkedQuantityInputTarget) {
+      this.unlinkedQuantityInputTarget.value = this.unlinkedPreviewPayload.quantity_fixed
+        ? "1"
+        : (this.hasUnlinkedQuantityFieldTarget ? this.unlinkedQuantityFieldTarget.value.trim() : "1")
+    }
+    if (this.hasUnlinkedReasonInputTarget) {
+      this.unlinkedReasonInputTarget.value = this.hasUnlinkedReasonFieldTarget ? this.unlinkedReasonFieldTarget.value : ""
+    }
+    if (this.hasUnlinkedNoteInputTarget) {
+      this.unlinkedNoteInputTarget.value = this.hasUnlinkedNoteFieldTarget ? this.unlinkedNoteFieldTarget.value.trim() : ""
+    }
+    if (this.hasUnlinkedPriceInputTarget) {
+      this.unlinkedPriceInputTarget.value = this.hasUnlinkedPriceFieldTarget ? this.unlinkedPriceFieldTarget.value.trim() : ""
+    }
+    if (this.hasUnlinkedExpectedVariantInputTarget) {
+      this.unlinkedExpectedVariantInputTarget.value = this.unlinkedPreviewPayload.product_variant_id || ""
+    }
+    if (this.hasUnlinkedExpectedUnitInputTarget) {
+      this.unlinkedExpectedUnitInputTarget.value = this.unlinkedPreviewPayload.inventory_unit_id || ""
+    }
+    if (this.hasUnlinkedExpectedReferenceInputTarget) {
+      this.unlinkedExpectedReferenceInputTarget.value = this.unlinkedPreviewPayload.reference_unit_price_cents ?? ""
+    }
+    if (this.hasUnlinkedExpectedTaxInputTarget) {
+      this.unlinkedExpectedTaxInputTarget.value = this.unlinkedPreviewPayload.tax_class_id || ""
+    }
+    if (this.hasUnlinkedApproverUserInputTarget) {
+      this.unlinkedApproverUserInputTarget.value = this.hasUnlinkedApproverUsernameTarget
+        ? this.unlinkedApproverUsernameTarget.value.trim()
+        : ""
+    }
+    if (this.hasUnlinkedApproverPasswordInputTarget) {
+      this.unlinkedApproverPasswordInputTarget.value = this.hasUnlinkedApproverPasswordTarget
+        ? this.unlinkedApproverPasswordTarget.value
+        : ""
+    }
+    this.beginFlight()
+    this.unlinkedFormTarget.requestSubmit()
+  }
+
+  trapUnlinkedOverlayTab(event) {
+    const controls = this.unlinkedOverlayControls()
+    if (controls.length === 0) return
+    event.preventDefault()
+    const current = controls.indexOf(document.activeElement)
+    let next = current
+    if (event.shiftKey) {
+      next = current <= 0 ? controls.length - 1 : current - 1
+    } else {
+      next = current === controls.length - 1 || current < 0 ? 0 : current + 1
+    }
+    controls[next].focus()
+  }
+
+  unlinkedOverlayControls() {
+    if (!this.hasUnlinkedOverlayTarget) return []
+    return Array.from(this.unlinkedOverlayTarget.querySelectorAll("input, select, button")).filter((el) => {
+      if (el.disabled || el.hidden) return false
+      return !el.closest("[hidden]")
+    })
+  }
+
   submitControlApply() {
     if (this.inFlight || !this.hasControlFormTarget) return
     this.fillControlForm("apply")
@@ -557,7 +807,7 @@ export default class extends Controller {
   }
 
   overlayOpen() {
-    return this.cancelOverlayOpen() || this.controlOverlayOpen()
+    return this.cancelOverlayOpen() || this.controlOverlayOpen() || this.unlinkedOverlayOpen()
   }
 
   cancelOverlayOpen() {
@@ -566,6 +816,10 @@ export default class extends Controller {
 
   controlOverlayOpen() {
     return this.hasControlOverlayTarget && !this.controlOverlayTarget.hidden
+  }
+
+  unlinkedOverlayOpen() {
+    return this.hasUnlinkedOverlayTarget && !this.unlinkedOverlayTarget.hidden
   }
 
   selectedRow() {
@@ -594,7 +848,7 @@ export default class extends Controller {
   }
 
   disableMutationControls() {
-    ["quantityButton", "overrideButton", "discountButton", "taxClassButton", "tenderButton", "removeButton", "cancelButton", "retry", "abandonButton"].forEach((name) => {
+    ["unlinkedButton", "quantityButton", "overrideButton", "discountButton", "taxClassButton", "tenderButton", "removeButton", "cancelButton", "retry", "abandonButton"].forEach((name) => {
       this.setActionEnabled(name, false)
     })
   }
@@ -605,6 +859,7 @@ export default class extends Controller {
       const hasLines = Boolean(this.element.querySelector(".pos-lines tbody tr"))
       const returnLine = this.selectedReturnLine()
       const quantityOk = hasSelection && !this.selectedUnitLine() && !this.selectedQuantityBlocked()
+      this.setActionEnabled("unlinkedButton", this.policyFor("unlinked_return") !== "prohibited")
       this.setActionEnabled("quantityButton", quantityOk)
       this.setActionEnabled("overrideButton", hasSelection && !returnLine && this.policyFor("price_override") !== "prohibited")
       this.setActionEnabled("discountButton", hasSelection && !returnLine && this.policyFor("line_discount") !== "prohibited")

--- a/app/javascript/controllers/register_workspace_controller.js
+++ b/app/javascript/controllers/register_workspace_controller.js
@@ -605,6 +605,10 @@ export default class extends Controller {
     if (!this.hasUnlinkedReasonFieldTarget) return
     const entries = this.returnReasonsValue || []
     this.unlinkedReasonFieldTarget.innerHTML = ""
+    const blank = document.createElement("option")
+    blank.value = ""
+    blank.textContent = "Select…"
+    this.unlinkedReasonFieldTarget.append(blank)
     entries.forEach((entry) => {
       const option = document.createElement("option")
       option.value = entry.code
@@ -631,14 +635,20 @@ export default class extends Controller {
       const payload = await response.json()
       if (!response.ok) {
         this.showUnlinkedFeedback(payload.error || "merchandise not found")
-        this.toggleHidden(this.hasUnlinkedPreviewTarget && this.unlinkedPreviewTarget, true)
-        if (this.hasUnlinkedApplyTarget) this.unlinkedApplyTarget.hidden = true
+        this.clearUnlinkedPreviewState()
         return
       }
       this.applyUnlinkedPreview(payload)
     } catch (_error) {
       this.showUnlinkedFeedback("merchandise not found")
+      this.clearUnlinkedPreviewState()
     }
+  }
+
+  clearUnlinkedPreviewState() {
+    this.unlinkedPreviewPayload = null
+    this.toggleHidden(this.hasUnlinkedPreviewTarget && this.unlinkedPreviewTarget, true)
+    if (this.hasUnlinkedApplyTarget) this.unlinkedApplyTarget.hidden = true
   }
 
   applyUnlinkedPreview(payload) {

--- a/app/models/pos_controlled_action.rb
+++ b/app/models/pos_controlled_action.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PosControlledAction < ApplicationRecord
-  ACTION_TYPES = %w[price_override line_discount tax_class_override].freeze
+  ACTION_TYPES = %w[price_override line_discount tax_class_override unlinked_return].freeze
   POLICY_RESULTS = %w[direct approval_required].freeze
   POLICY_VERSION = "phase6_permission_tier_v1"
   FINGERPRINT_SCHEMA_VERSION = "v1"

--- a/app/models/pos_transaction_line.rb
+++ b/app/models/pos_transaction_line.rb
@@ -35,6 +35,10 @@ class PosTransactionLine < ApplicationRecord
     return? && original_transaction_line_id.present?
   end
 
+  def unlinked_return?
+    return? && original_transaction_line_id.blank?
+  end
+
   def unit_line?
     inventory_unit_id.present?
   end

--- a/app/services/authorization/permission_catalog.rb
+++ b/app/services/authorization/permission_catalog.rb
@@ -89,7 +89,9 @@ module Authorization
       { key: "pos.line_discount.perform", group_key: "pos", name: "Perform line discount", scope_type: "either" },
       { key: "pos.line_discount.approve", group_key: "pos", name: "Approve line discount", scope_type: "either" },
       { key: "pos.tax_class_override.perform", group_key: "pos", name: "Perform Tax Class override", scope_type: "either" },
-      { key: "pos.tax_class_override.approve", group_key: "pos", name: "Approve Tax Class override", scope_type: "either" }
+      { key: "pos.tax_class_override.approve", group_key: "pos", name: "Approve Tax Class override", scope_type: "either" },
+      { key: "pos.unlinked_return.perform", group_key: "pos", name: "Perform unlinked return", scope_type: "either" },
+      { key: "pos.unlinked_return.approve", group_key: "pos", name: "Approve unlinked return", scope_type: "either" }
     ].freeze
 
     PERMISSIONS = (PHASE1_PERMISSIONS + PHASE2_PERMISSIONS + PHASE3_PERMISSIONS + PHASE4_PERMISSIONS).freeze
@@ -124,6 +126,8 @@ module Authorization
       pos.line_discount.approve
       pos.tax_class_override.perform
       pos.tax_class_override.approve
+      pos.unlinked_return.perform
+      pos.unlinked_return.approve
     ].freeze
 
     ROLES = [
@@ -161,6 +165,7 @@ module Authorization
           pos.price_override.perform
           pos.line_discount.perform
           pos.tax_class_override.perform
+          pos.unlinked_return.perform
         ]
       }
     ].freeze

--- a/app/services/inventory/post_return.rb
+++ b/app/services/inventory/post_return.rb
@@ -197,7 +197,8 @@ module Inventory
           original_transaction_line_id: original_line&.id,
           quantity_delta: quantity_delta,
           value_delta_cents: effects[:value_delta_cents],
-          linked: linked?
+          linked: linked?,
+          valuation_basis: @valuation_basis
         }.compact
       )
       Audit::Recorder.record!(

--- a/app/services/inventory/post_return.rb
+++ b/app/services/inventory/post_return.rb
@@ -23,7 +23,7 @@ module Inventory
 
       validate_request!
       tracking == "individual" ? post_individual! : post_quantity!
-    rescue LedgerPairIntegrity::Error => e
+    rescue LedgerPairIntegrity::Error, ReturnValuation::Error => e
       raise Error, e.message
     end
 
@@ -31,6 +31,10 @@ module Inventory
 
     def tracking
       @tracking ||= @line.product_variant.derived_inventory_tracking
+    end
+
+    def linked?
+      @line.linked_return?
     end
 
     def original_line
@@ -45,8 +49,12 @@ module Inventory
       raise Error, "business_date is required" if @business_date.blank?
       raise Error, "actor is required" if @actor.blank?
       raise Error, "line quantity must be positive" unless @line.quantity.to_i.positive?
-      raise Error, "return line is not linked" unless @line.linked_return?
-      raise Error, "original sale line is required" if original_line.nil?
+      raise Error, "line is not a return" unless @line.return?
+      if linked?
+        raise Error, "original sale line is required" if original_line.nil?
+      elsif original_line.present?
+        raise Error, "unlinked return cannot reference an original sale line"
+      end
       return unless tracking == "individual"
 
       raise Error, "inventory unit is required" if @line.inventory_unit_id.blank?
@@ -57,9 +65,23 @@ module Inventory
       variant = @line.product_variant
       store = @line.pos_transaction.store
       quantity_delta = @line.quantity
-      restored_value = allocated_inventory_value
 
-      balance = Balances.lock_or_create!(store: store, product_variant: variant)
+      if linked?
+        restored_value = allocated_inventory_value
+        @valuation_basis = "linked_original_sale"
+        balance = Balances.lock_or_create!(store: store, product_variant: variant)
+      else
+        balance = Balances.lock_or_create!(store: store, product_variant: variant)
+        valuation = ReturnValuation.call(
+          store: store,
+          variant: variant,
+          quantity: quantity_delta,
+          balance: balance
+        )
+        restored_value = valuation.incoming_value_cents
+        @valuation_basis = valuation.basis
+      end
+
       effects = acquire_quantity(balance, quantity_delta, restored_value)
 
       persist_effects!(
@@ -80,9 +102,22 @@ module Inventory
       raise Error, "unit must be removed" unless unit.removed?
       raise Error, "unit store mismatch" unless unit.store_id == store.id
       raise Error, "unit variant mismatch" unless unit.product_variant_id == variant.id
-      raise Error, "return unit does not match the original sale" unless unit.id == original_line.inventory_unit_id
+      if linked?
+        raise Error, "return unit does not match the original sale" unless unit.id == original_line.inventory_unit_id
+        restored_value = original_sale_value_magnitude
+        @valuation_basis = "linked_original_sale"
+      else
+        valuation = ReturnValuation.call(
+          store: store,
+          variant: variant,
+          quantity: 1,
+          inventory_unit: unit,
+          balance: balance
+        )
+        restored_value = valuation.incoming_value_cents
+        @valuation_basis = valuation.basis
+      end
 
-      restored_value = original_sale_value_magnitude
       quantity_delta = 1
       effects = acquire_specific_identification(balance, restored_value)
 
@@ -159,10 +194,10 @@ module Inventory
           inventory_unit_id: inventory_unit&.id,
           pos_transaction_id: @line.pos_transaction_id,
           pos_transaction_line_id: @line.id,
-          original_transaction_line_id: original_line.id,
+          original_transaction_line_id: original_line&.id,
           quantity_delta: quantity_delta,
           value_delta_cents: effects[:value_delta_cents],
-          linked: true
+          linked: linked?
         }.compact
       )
       Audit::Recorder.record!(
@@ -174,11 +209,11 @@ module Inventory
         subject: @line,
         correlation_id: @correlation_id,
         after_values: {
-          original_transaction_line_id: original_line.id,
+          original_transaction_line_id: original_line&.id,
           quantity: @line.quantity,
           inventory_unit_id: inventory_unit&.id,
           value_restored_cents: effects[:value_delta_cents],
-          valuation_basis: "linked_original_sale"
+          valuation_basis: @valuation_basis
         }.compact
       )
 
@@ -193,11 +228,7 @@ module Inventory
         value_delta_cents: restored_value,
         resulting_on_hand: qty + quantity_delta,
         resulting_value_cents: value + restored_value,
-        metadata: {
-          prior_quantity: qty,
-          prior_value_cents: value,
-          original_transaction_line_id: original_line.id
-        }
+        metadata: quantity_metadata(qty, value)
       }
     end
 
@@ -209,13 +240,18 @@ module Inventory
         value_delta_cents: restored_value,
         resulting_on_hand: qty + 1,
         resulting_value_cents: value + restored_value,
-        metadata: {
-          prior_quantity: qty,
-          prior_value_cents: value,
-          inventory_unit_id: @line.inventory_unit_id,
-          original_transaction_line_id: original_line.id
-        }
+        metadata: quantity_metadata(qty, value).merge(inventory_unit_id: @line.inventory_unit_id)
       }
+    end
+
+    def quantity_metadata(qty, value)
+      metadata = {
+        prior_quantity: qty,
+        prior_value_cents: value
+      }
+      metadata[:original_transaction_line_id] = original_line.id if original_line
+      metadata[:valuation_basis] = @valuation_basis if @valuation_basis
+      metadata
     end
 
     def allocated_inventory_value

--- a/app/services/inventory/return_valuation.rb
+++ b/app/services/inventory/return_valuation.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Inventory
+  class ReturnValuation
+    class Error < StandardError; end
+
+    Result = Struct.new(:incoming_value_cents, :basis, keyword_init: true)
+
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(store:, variant:, quantity:, inventory_unit: nil, balance: nil)
+      @store = store
+      @variant = variant
+      @quantity = quantity.to_i
+      @inventory_unit = inventory_unit
+      @balance = balance
+    end
+
+    def call
+      raise Error, "quantity must be positive" unless @quantity.positive?
+
+      tracking = @variant.derived_inventory_tracking
+      case tracking
+      when "individual"
+        value_for_unit
+      when "quantity"
+        value_for_quantity
+      else
+        raise Error, "variant is not inventory-tracked"
+      end
+    end
+
+    private
+
+    def value_for_unit
+      raise Error, "inventory unit is required" if @inventory_unit.nil?
+
+      Result.new(
+        incoming_value_cents: @inventory_unit.carrying_value_cents,
+        basis: "unit_carrying_value"
+      )
+    end
+
+    def value_for_quantity
+      on_hand = current_on_hand
+      if on_hand.positive?
+        incoming = Costing.round_half_up(
+          BigDecimal(current_value.to_s) * @quantity / on_hand
+        )
+        return Result.new(incoming_value_cents: incoming, basis: "current_moving_average")
+      end
+
+      latest = latest_valuation_entry
+      metadata = latest&.calculation_metadata
+      prior_quantity = metadata.is_a?(Hash) ? metadata["prior_quantity"].to_i : 0
+      prior_value = metadata.is_a?(Hash) ? metadata["prior_value_cents"].to_i : 0
+      unless prior_quantity.positive?
+        raise Error, "no defensible inventory valuation basis"
+      end
+
+      incoming = Costing.round_half_up(
+        BigDecimal(prior_value.to_s) * @quantity / prior_quantity
+      )
+      Result.new(incoming_value_cents: incoming, basis: "latest_prior_moving_average")
+    end
+
+    def current_on_hand
+      resolved_balance&.on_hand_quantity.to_i
+    end
+
+    def current_value
+      resolved_balance&.inventory_value_cents.to_i
+    end
+
+    def resolved_balance
+      return @balance if @balance
+
+      InventoryBalance.find_by(store_id: @store.id, product_variant_id: @variant.id)
+    end
+
+    def latest_valuation_entry
+      InventoryValuationEntry.where(store_id: @store.id, product_variant_id: @variant.id)
+                             .order(occurred_at: :desc, id: :desc)
+                             .first
+    end
+  end
+end

--- a/app/services/pos/complete_transaction.rb
+++ b/app/services/pos/complete_transaction.rb
@@ -191,8 +191,10 @@ module Pos
           Pos::FreezeSaleLine.call(transaction: transaction, line: line)
         elsif line.linked_return?
           Pos::FreezeLinkedReturnLine.call(transaction: transaction, line: line)
+        elsif line.unlinked_return?
+          Pos::FreezeUnlinkedReturnLine.call(transaction: transaction, line: line)
         else
-          raise Pos::Error, "unlinked returns are not supported"
+          raise Pos::Error, "return line is missing linkage or unlinked-return facts"
         end
       end
     end
@@ -361,6 +363,15 @@ module Pos
           "line_variance_cents" => unit_variance * line.quantity
         }
       end
+      if emit_return_price_adjustment?(line)
+        unit_variance = line.selling_unit_price_cents - line.reference_unit_price_cents
+        payload["return_price_adjustment"] = {
+          "reference_unit_price_cents" => line.reference_unit_price_cents,
+          "resulting_unit_price_cents" => line.selling_unit_price_cents,
+          "unit_variance_cents" => unit_variance,
+          "line_variance_cents" => unit_variance * line.quantity
+        }
+      end
       if emit_historical_discount?(line)
         payload["discount"] = {
           "source" => "manual",
@@ -381,12 +392,18 @@ module Pos
 
     def emit_historical_override?(line)
       return line.price_overridden? if line.sale?
+      return false if line.unlinked_return?
 
       line.selling_unit_price_cents != line.reference_unit_price_cents
     end
 
+    def emit_return_price_adjustment?(line)
+      line.unlinked_return? && line.selling_unit_price_cents != line.reference_unit_price_cents
+    end
+
     def emit_historical_discount?(line)
       return line.manually_discounted? if line.sale?
+      return false if line.unlinked_return?
 
       line.manual_discount_cents.to_i.positive? || line.manual_discount_basis_points.present?
     end
@@ -463,7 +480,7 @@ module Pos
             actor: @actor,
             correlation_id: correlation_id
           )
-        elsif line.linked_return?
+        elsif line.return?
           Inventory::PostReturn.call(
             line: line,
             occurred_at: completion_time,
@@ -472,7 +489,7 @@ module Pos
             correlation_id: correlation_id
           )
         else
-          raise Pos::Error, "unlinked returns are not supported"
+          raise Pos::Error, "unknown line direction"
         end
       end
     end

--- a/app/services/pos/completed_transaction_facts.rb
+++ b/app/services/pos/completed_transaction_facts.rb
@@ -56,6 +56,7 @@ module Pos
       verify_tenders!
       verify_controlled_actions!
       verify_line_pricing_keys!
+      verify_unlinked_return_facts!
     end
 
     private
@@ -218,6 +219,60 @@ module Pos
           raise Pos::Error, "completed envelope is missing discount basis_points" unless discount["basis_points"].is_a?(Integer)
           raise Pos::Error, "completed envelope is missing discount_cents" unless discount["discount_cents"].is_a?(Integer)
           raise Pos::Error, "completed envelope is missing net_merchandise_amount_cents" unless discount["net_merchandise_amount_cents"].is_a?(Integer)
+        end
+        verify_return_price_adjustment_shape!(line)
+      end
+    end
+
+    def verify_return_price_adjustment_shape!(line)
+      adjustment = line["return_price_adjustment"]
+      sale = line["direction"] != "return"
+      linked = line["direction"] == "return" && line["original_transaction_line_id"].present?
+      if sale || linked
+        raise Pos::Error, "completed envelope cannot include return_price_adjustment" if line.key?("return_price_adjustment")
+        return
+      end
+      return unless line["direction"] == "return"
+
+      reference = line["reference_unit_price_cents"]
+      selling = line["selling_unit_price_cents"]
+      return unless reference.is_a?(Integer) && selling.is_a?(Integer)
+
+      if selling == reference
+        raise Pos::Error, "completed envelope cannot include return_price_adjustment" if line.key?("return_price_adjustment")
+        return
+      end
+
+      raise Pos::Error, "completed envelope is missing return_price_adjustment" unless adjustment.is_a?(Hash)
+      %w[reference_unit_price_cents resulting_unit_price_cents unit_variance_cents line_variance_cents].each do |key|
+        raise Pos::Error, "completed envelope is missing #{key}" unless adjustment[key].is_a?(Integer)
+      end
+      unit_variance = selling - reference
+      unless adjustment["reference_unit_price_cents"] == reference &&
+             adjustment["resulting_unit_price_cents"] == selling &&
+             adjustment["unit_variance_cents"] == unit_variance &&
+             adjustment["line_variance_cents"] == unit_variance * line["quantity"].to_i
+        raise Pos::Error, "completed envelope return_price_adjustment is invalid"
+      end
+    end
+
+    def verify_unlinked_return_facts!
+      lines = @envelope["lines"]
+      return unless lines.is_a?(Array)
+
+      actions = @envelope["controlled_actions"]
+      actions = [] unless actions.is_a?(Array)
+      unlinked_actions = actions.select { |action| action.is_a?(Hash) && action["action"] == "unlinked_return" }
+
+      lines.each do |line|
+        next unless line.is_a?(Hash)
+
+        line_id = line["line_id"].to_s
+        matching = unlinked_actions.select { |action| action.dig("subject", "line_id").to_s == line_id }
+        if line["direction"] == "return" && line["original_transaction_line_id"].blank?
+          raise Pos::Error, "completed envelope is missing unlinked_return action" unless matching.one?
+        else
+          raise Pos::Error, "completed envelope cannot include unlinked_return action" if matching.any?
         end
       end
     end

--- a/app/services/pos/completed_transaction_facts.rb
+++ b/app/services/pos/completed_transaction_facts.rb
@@ -206,6 +206,11 @@ module Pos
       lines.each do |line|
         next unless line.is_a?(Hash)
 
+        unlinked = line["direction"] == "return" && line["original_transaction_line_id"].blank?
+        if unlinked
+          raise Pos::Error, "completed envelope cannot include override" if line.key?("override")
+          raise Pos::Error, "completed envelope cannot include discount" if line.key?("discount")
+        end
         if line.key?("override")
           override = line["override"]
           raise Pos::Error, "completed envelope override is invalid" unless override.is_a?(Hash)
@@ -262,17 +267,21 @@ module Pos
 
       actions = @envelope["controlled_actions"]
       actions = [] unless actions.is_a?(Array)
-      unlinked_actions = actions.select { |action| action.is_a?(Hash) && action["action"] == "unlinked_return" }
+      actions = actions.select { |action| action.is_a?(Hash) }
 
       lines.each do |line|
         next unless line.is_a?(Hash)
 
         line_id = line["line_id"].to_s
-        matching = unlinked_actions.select { |action| action.dig("subject", "line_id").to_s == line_id }
+        targeting = actions.select { |action| action.dig("subject", "line_id").to_s == line_id }
         if line["direction"] == "return" && line["original_transaction_line_id"].blank?
-          raise Pos::Error, "completed envelope is missing unlinked_return action" unless matching.one?
-        else
-          raise Pos::Error, "completed envelope cannot include unlinked_return action" if matching.any?
+          unlinked_matches = targeting.select { |action| action["action"] == "unlinked_return" }
+          raise Pos::Error, "completed envelope is missing unlinked_return action" unless unlinked_matches.one?
+          unless targeting.one?
+            raise Pos::Error, "completed envelope cannot include other controlled actions on an unlinked return"
+          end
+        elsif targeting.any? { |action| action["action"] == "unlinked_return" }
+          raise Pos::Error, "completed envelope cannot include unlinked_return action"
         end
       end
     end

--- a/app/services/pos/completed_transaction_integrity.rb
+++ b/app/services/pos/completed_transaction_integrity.rb
@@ -50,6 +50,18 @@ module Pos
       action = actions["unlinked_return"]
       raise Pos::Error, "unlinked return is missing the unlinked_return fact" if action.nil?
       raise Pos::Error, "unlinked return must have exactly one controlled action" if actions.size != 1
+      if line.manual_discount_basis_points.present? || line.manual_discount_cents.to_i != 0
+        raise Pos::Error, "unlinked returns cannot have a sale discount"
+      end
+      if line.return_reason_code != action.reason_code ||
+         line.return_reason_name_snapshot != action.reason_name_snapshot ||
+         line.return_reason_note.to_s != action.reason_note.to_s
+        raise Pos::Error, "unlinked return reason does not match the approved fact"
+      end
+      expected_name = Pos::ReturnReasons.name_for!(line.return_reason_code)
+      unless line.return_reason_name_snapshot == expected_name
+        raise Pos::Error, "unlinked return reason does not match the approved fact"
+      end
 
       verify_fingerprint!(line, action)
     end
@@ -64,15 +76,24 @@ module Pos
       expected_material = Idempotency::CanonicalJson.normalize(material)
       raise Pos::Error, "controlled action material values do not match" unless stored == expected_material
 
+      reason_code, reason_note = fingerprint_reason(line, action)
       expected = Pos::ControlledActionFingerprint.call(
         action_type: action.action_type,
         transaction_id: line.pos_transaction_id,
         line_id: line.id,
         material_values: material,
-        reason_code: action.reason_code,
-        reason_note: action.reason_note
+        reason_code: reason_code,
+        reason_note: reason_note
       )
       raise Pos::Error, "controlled action fingerprint does not match" unless expected == action.action_fingerprint
+    end
+
+    def fingerprint_reason(line, action)
+      if action.action_type == "unlinked_return"
+        [ line.return_reason_code, line.return_reason_note ]
+      else
+        [ action.reason_code, action.reason_note ]
+      end
     end
 
     def reconstructed_material(line, action)

--- a/app/services/pos/completed_transaction_integrity.rb
+++ b/app/services/pos/completed_transaction_integrity.rb
@@ -12,12 +12,16 @@ module Pos
 
     def verify!
       @transaction.pos_transaction_lines.each do |line|
-        if line.return?
-          raise Pos::Error, "return lines cannot have controlled actions" if line.pos_controlled_actions.any?
+        actions = line.pos_controlled_actions.index_by(&:action_type)
+        if line.linked_return?
+          raise Pos::Error, "return lines cannot have controlled actions" if actions.any?
+          next
+        end
+        if line.unlinked_return?
+          verify_unlinked!(line, actions)
           next
         end
 
-        actions = line.pos_controlled_actions.index_by(&:action_type)
         verify_pair!(
           present: line.price_overridden?,
           action: actions["price_override"],
@@ -38,6 +42,17 @@ module Pos
     end
 
     private
+
+    def verify_unlinked!(line, actions)
+      if actions.key?("price_override") || actions.key?("line_discount") || actions.key?("tax_class_override")
+        raise Pos::Error, "unlinked returns cannot have sale controlled actions"
+      end
+      action = actions["unlinked_return"]
+      raise Pos::Error, "unlinked return is missing the unlinked_return fact" if action.nil?
+      raise Pos::Error, "unlinked return must have exactly one controlled action" if actions.size != 1
+
+      verify_fingerprint!(line, action)
+    end
 
     def verify_pair!(present:, action:, message:)
       raise Pos::Error, message if present ^ action.present?
@@ -80,6 +95,16 @@ module Pos
           "default_tax_class_id" => line.default_tax_class_id.to_s,
           "requested_tax_class_id" => line.tax_class_id.to_s
         }
+      when "unlinked_return"
+        values = {
+          "product_variant_id" => line.product_variant_id.to_s,
+          "quantity" => line.quantity,
+          "reference_unit_price_cents" => line.reference_unit_price_cents,
+          "requested_return_unit_price_cents" => line.selling_unit_price_cents,
+          "tax_class_id" => line.tax_class_id.to_s
+        }
+        values["inventory_unit_id"] = line.inventory_unit_id.to_s if line.inventory_unit_id.present?
+        values
       end
     end
   end

--- a/app/services/pos/execute_unlinked_return.rb
+++ b/app/services/pos/execute_unlinked_return.rb
@@ -1,0 +1,300 @@
+# frozen_string_literal: true
+
+module Pos
+  class ExecuteUnlinkedReturn
+    STALE_PREVIEW_MESSAGE = "Merchandise changed. Resolve the return again."
+
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(
+      transaction:,
+      actor:,
+      expected_lock_version:,
+      identifier:,
+      quantity:,
+      reason_code:,
+      requested_return_unit_price_cents:,
+      reason_note: nil,
+      approver_username: nil,
+      approver_password: nil,
+      expected_product_variant_id: nil,
+      expected_inventory_unit_id: nil,
+      expected_reference_unit_price_cents: nil,
+      expected_tax_class_id: nil
+    )
+      @transaction = transaction
+      @actor = actor
+      @expected_lock_version = expected_lock_version
+      @identifier = identifier
+      @quantity = quantity.to_i
+      @reason_code = reason_code.to_s
+      @reason_note = reason_note.to_s.strip.presence
+      @requested_return_unit_price_cents = requested_return_unit_price_cents
+      @approver_username = approver_username
+      @approver_password = approver_password
+      @expected_product_variant_id = expected_product_variant_id.to_s.presence
+      @expected_inventory_unit_id = expected_inventory_unit_id.to_s.presence
+      @expected_reference_unit_price_cents = expected_reference_unit_price_cents
+      @expected_tax_class_id = expected_tax_class_id.to_s.presence
+    end
+
+    def call
+      Pos::Support.authorize!(@actor, @transaction.store)
+      Pos::Support.require_active_context!(@transaction.store, @transaction.register)
+      Pos::Support.require_transaction_cashier!(@actor, @transaction)
+      raise Pos::Error, "quantity must be positive" unless @quantity.positive?
+
+      @selling_unit_price_cents = Pos::Support.parse_nonnegative_cents!(
+        @requested_return_unit_price_cents,
+        "return price"
+      )
+      @reason_name = Pos::ReturnReasons.name_for!(@reason_code)
+      if Pos::ReturnReasons.require_note?(@reason_code)
+        raise Pos::Error, "reason note is required" if @reason_note.blank?
+        raise Pos::Error, "reason note is too long" if @reason_note.length > 200
+      else
+        @reason_note = nil
+      end
+
+      PosTransaction.transaction do
+        transaction = Pos::Support.lock_working_transaction!(@transaction, @expected_lock_version)
+        resolved = Pos::ResolveUnlinkedReturnMerchandise.call(
+          identifier: @identifier,
+          store: transaction.store,
+          lock_unit: true
+        )
+        capture_resolved!(resolved)
+        validate_resolved!(resolved)
+        preflight_valuation!(transaction, resolved)
+
+        @line_id = SecureRandom.uuid_v7
+        line_number = next_line_number(transaction)
+        material = material_values(resolved)
+        fingerprint = fingerprint_for(transaction, material)
+        policy = Pos::ControlledActionPolicy.result(
+          user: @actor,
+          store: transaction.store,
+          action_type: "unlinked_return"
+        )
+        raise Pos::Denied, "not authorized to perform this action" if policy == :prohibited
+
+        approver = if policy == :approval_required
+          Pos::AuthenticateApprover.call(
+            username: @approver_username,
+            password: @approver_password,
+            store: transaction.store,
+            action_type: "unlinked_return",
+            performer: @actor
+          )
+        end
+
+        Pos::Support.clear_working_tenders!(transaction)
+        line = build_line!(transaction, resolved, line_number)
+        Pos::Support.apply_provisional_tax!(line)
+        line.save!
+        persist_action!(transaction, line, policy, material, fingerprint, approver)
+        Pos::Support.refresh_totals!(transaction)
+        Pos::Support.touch_working_transaction!(transaction)
+        audit_applied!(transaction, line, policy, material, fingerprint, approver)
+        line
+      end
+    rescue Pos::Denied => e
+      record_denied!(e.message)
+      raise Pos::Error, e.message if e.message.start_with?("approver")
+
+      raise
+    rescue Pos::Tax::UnresolvedApplicability, Inventory::ReturnValuation::Error => e
+      raise Pos::Error, e.message
+    end
+
+    private
+
+    def capture_resolved!(resolved)
+      @resolved_product_variant_id = resolved.variant.id.to_s
+      @resolved_inventory_unit_id = resolved.inventory_unit&.id&.to_s
+      @resolved_reference_unit_price_cents = resolved.reference_unit_price_cents
+    end
+
+    def validate_resolved!(resolved)
+      if resolved.quantity_fixed && @quantity != 1
+        raise Pos::Error, "quantity must be 1 for individually tracked merchandise"
+      end
+      return if @expected_product_variant_id.blank? &&
+                @expected_inventory_unit_id.blank? &&
+                @expected_reference_unit_price_cents.nil? &&
+                @expected_tax_class_id.blank?
+
+      expected_unit = @expected_inventory_unit_id
+      actual_unit = resolved.inventory_unit&.id&.to_s
+      expected_reference = if @expected_reference_unit_price_cents.nil?
+        nil
+      else
+        Integer(@expected_reference_unit_price_cents)
+      end
+      stale = @expected_product_variant_id.present? && @expected_product_variant_id != resolved.variant.id.to_s
+      stale ||= expected_unit.present? && expected_unit != actual_unit.to_s
+      stale ||= !expected_reference.nil? && expected_reference != resolved.reference_unit_price_cents
+      stale ||= @expected_tax_class_id.present? && @expected_tax_class_id != resolved.tax_class.id.to_s
+      raise Pos::Error, STALE_PREVIEW_MESSAGE if stale
+    rescue ArgumentError, TypeError
+      raise Pos::Error, STALE_PREVIEW_MESSAGE
+    end
+
+    def preflight_valuation!(transaction, resolved)
+      return unless %w[quantity individual].include?(resolved.tracking)
+
+      Inventory::ReturnValuation.call(
+        store: transaction.store,
+        variant: resolved.variant,
+        quantity: resolved.quantity_fixed ? 1 : @quantity,
+        inventory_unit: resolved.inventory_unit
+      )
+    end
+
+    def material_values(resolved)
+      values = {
+        "product_variant_id" => resolved.variant.id.to_s,
+        "quantity" => resolved.quantity_fixed ? 1 : @quantity,
+        "reference_unit_price_cents" => resolved.reference_unit_price_cents,
+        "requested_return_unit_price_cents" => @selling_unit_price_cents,
+        "tax_class_id" => resolved.tax_class.id.to_s
+      }
+      values["inventory_unit_id"] = resolved.inventory_unit.id.to_s if resolved.inventory_unit
+      values
+    end
+
+    def fingerprint_for(transaction, material)
+      Pos::ControlledActionFingerprint.call(
+        action_type: "unlinked_return",
+        transaction_id: transaction.id,
+        line_id: @line_id,
+        material_values: material,
+        reason_code: @reason_code,
+        reason_note: @reason_note
+      )
+    end
+
+    def next_line_number(transaction)
+      (transaction.pos_transaction_lines.maximum(:line_number) || 0) + 1
+    end
+
+    def build_line!(transaction, resolved, line_number)
+      quantity = resolved.quantity_fixed ? 1 : @quantity
+      line = transaction.pos_transaction_lines.build(
+        id: @line_id,
+        line_number: line_number,
+        direction: "return",
+        product_variant: resolved.variant,
+        inventory_unit: resolved.inventory_unit,
+        quantity: quantity,
+        reference_unit_price_cents: resolved.reference_unit_price_cents,
+        selling_unit_price_cents: @selling_unit_price_cents,
+        tax_class: resolved.tax_class,
+        tax_class_code_snapshot: resolved.tax_class.code,
+        tax_class_name_snapshot: resolved.tax_class.name,
+        default_tax_class: resolved.tax_class,
+        default_tax_class_code_snapshot: resolved.tax_class.code,
+        default_tax_class_name_snapshot: resolved.tax_class.name,
+        manual_discount_cents: 0,
+        return_reason_code: @reason_code,
+        return_reason_name_snapshot: @reason_name,
+        return_reason_note: @reason_note
+      )
+      line.extended_selling_amount_cents = line.selling_unit_price_cents * line.quantity
+      line.net_merchandise_amount_cents = line.extended_selling_amount_cents
+      line
+    end
+
+    def persist_action!(transaction, line, policy, material, fingerprint, approver)
+      PosControlledAction.create!(
+        pos_transaction: transaction,
+        pos_transaction_line: line,
+        action_type: "unlinked_return",
+        performed_by_user: @actor,
+        performed_by_name_snapshot: @actor.display_name,
+        approved_by_user: approver,
+        approved_by_name_snapshot: approver&.display_name,
+        reason_code: @reason_code,
+        reason_name_snapshot: @reason_name,
+        reason_note: @reason_note,
+        policy_result: policy.to_s,
+        policy_version: PosControlledAction::POLICY_VERSION,
+        fingerprint_schema_version: PosControlledAction::FINGERPRINT_SCHEMA_VERSION,
+        action_fingerprint: fingerprint,
+        material_values: material,
+        executed_at: Time.current
+      )
+    end
+
+    def audit_applied!(transaction, line, policy, material, fingerprint, approver)
+      Audit::Recorder.record!(
+        action: "pos.unlinked_return.applied",
+        outcome: "succeeded",
+        actor_user: @actor,
+        store: transaction.store,
+        register: transaction.register,
+        subject: line,
+        reason_code: @reason_code,
+        reason_text: @reason_note,
+        after_values: {
+          quantity: line.quantity,
+          reference_unit_price_cents: line.reference_unit_price_cents,
+          selling_unit_price_cents: line.selling_unit_price_cents
+        },
+        metadata: {
+          transaction_id: transaction.id,
+          line_id: line.id,
+          policy_result: policy.to_s,
+          policy_version: PosControlledAction::POLICY_VERSION,
+          fingerprint: fingerprint,
+          material_values: material,
+          approved_by_user_id: approver&.id
+        }
+      )
+      return unless approver
+
+      Audit::Recorder.record!(
+        action: "pos.controlled_action.approved",
+        outcome: "succeeded",
+        actor_user: approver,
+        store: transaction.store,
+        register: transaction.register,
+        subject: line,
+        reason_code: @reason_code,
+        metadata: {
+          transaction_id: transaction.id,
+          line_id: line.id,
+          action_type: "unlinked_return",
+          performed_by_user_id: @actor.id,
+          fingerprint: fingerprint
+        }
+      )
+    end
+
+    def record_denied!(message)
+      Audit::Recorder.record!(
+        action: "pos.controlled_action.denied",
+        outcome: "denied",
+        actor_user: @actor,
+        store: @transaction.store,
+        register: @transaction.register,
+        subject: @transaction,
+        reason_text: message,
+        metadata: {
+          action_type: "unlinked_return",
+          prospective_line_id: @line_id,
+          product_variant_id: @resolved_product_variant_id || @expected_product_variant_id,
+          inventory_unit_id: @resolved_inventory_unit_id || @expected_inventory_unit_id,
+          quantity: @quantity,
+          reference_unit_price_cents: @resolved_reference_unit_price_cents || @expected_reference_unit_price_cents,
+          requested_return_unit_price_cents: @selling_unit_price_cents,
+          attempted_approver: @approver_username.presence
+        }.compact
+      )
+    rescue StandardError
+      nil
+    end
+  end
+end

--- a/app/services/pos/freeze_unlinked_return_line.rb
+++ b/app/services/pos/freeze_unlinked_return_line.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+module Pos
+  class FreezeUnlinkedReturnLine
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(transaction:, line:)
+      @transaction = transaction
+      @line = line
+    end
+
+    def call
+      raise Pos::Error, "line is not an unlinked return" unless @line.unlinked_return?
+      raise Pos::Error, "regular price is required" if @line.selling_unit_price_cents.nil?
+
+      variant = @line.product_variant
+      tracking = variant.derived_inventory_tracking
+      unless %w[quantity non_inventory individual].include?(tracking)
+        raise Pos::Error, "merchandise tracking is not supported"
+      end
+
+      unit = freeze_unit_line!(variant, tracking)
+      @line.recalc_extended!
+      result = Pos::Tax::Calculate.call(
+        store: @transaction.store,
+        tax_class: @line.tax_class,
+        taxable_basis_cents: @line.net_merchandise_amount_cents
+      )
+      @line.line_tax_cents = result.tax_cents
+      @line.line_total_cents = @line.net_merchandise_amount_cents + @line.line_tax_cents
+      @line.tax_class_code_snapshot = @line.tax_class.code
+      @line.tax_class_name_snapshot ||= @line.tax_class.name
+      if @line.default_tax_class_id.present?
+        default_class = @line.default_tax_class || TaxClass.find(@line.default_tax_class_id)
+        @line.default_tax_class_code_snapshot ||= default_class.code
+        @line.default_tax_class_name_snapshot ||= default_class.name
+      end
+      @line.merchandise_snapshot = merchandise_snapshot_for(variant, unit)
+      @line.save!
+      @line.pos_line_tax_components.delete_all
+      result.determinations.each do |determination|
+        @line.pos_line_tax_components.create!(
+          store_tax_id: determination.store_tax_id,
+          store_tax_code_snapshot: determination.store_tax_code,
+          store_tax_name_snapshot: determination.store_tax_name,
+          rate_percent: determination.rate_percent,
+          applies: determination.applies,
+          taxable_basis_cents: determination.taxable_basis_cents,
+          tax_cents: determination.tax_cents,
+          calculation_order: determination.calculation_order
+        )
+      end
+      @line
+    rescue Pos::Tax::UnresolvedApplicability => e
+      raise Pos::Error, e.message
+    end
+
+    private
+
+    def freeze_unit_line!(variant, tracking)
+      if tracking == "individual"
+        raise Pos::Error, "inventory unit is required" if @line.inventory_unit_id.blank?
+        raise Pos::Error, "quantity must be 1 for individually tracked merchandise" unless @line.quantity == 1
+
+        unit = InventoryUnit.find(@line.inventory_unit_id)
+        raise Pos::Error, "unit must be removed" unless unit.removed?
+        raise Pos::Error, "unit is not at this store" unless unit.store_id == @transaction.store_id
+        raise Pos::Error, "unit does not match the merchandise" unless unit.product_variant_id == variant.id
+        unit
+      else
+        raise Pos::Error, "inventory unit must be blank" if @line.inventory_unit_id.present?
+
+        nil
+      end
+    rescue ActiveRecord::RecordNotFound
+      raise Pos::Error, "unit must be removed"
+    end
+
+    def merchandise_snapshot_for(variant, unit)
+      snapshot = {
+        "sku" => variant.sku,
+        "description" => variant.product.name,
+        "tax_class_code" => @line.tax_class.code
+      }
+      return snapshot if unit.nil?
+
+      condition_code = variant.merchandise_condition&.code
+      raise Pos::Error, "condition is required for individually tracked merchandise" if condition_code.blank?
+
+      snapshot.merge(
+        "unit_identifier" => unit.unit_identifier,
+        "condition_code" => condition_code
+      )
+    end
+  end
+end

--- a/app/services/pos/freeze_unlinked_return_line.rb
+++ b/app/services/pos/freeze_unlinked_return_line.rb
@@ -14,6 +14,9 @@ module Pos
     def call
       raise Pos::Error, "line is not an unlinked return" unless @line.unlinked_return?
       raise Pos::Error, "regular price is required" if @line.selling_unit_price_cents.nil?
+      if @line.manual_discount_basis_points.present? || @line.manual_discount_cents.to_i != 0
+        raise Pos::Error, "unlinked returns cannot have a sale discount"
+      end
 
       variant = @line.product_variant
       tracking = variant.derived_inventory_tracking

--- a/app/services/pos/remove_working_line.rb
+++ b/app/services/pos/remove_working_line.rb
@@ -24,6 +24,7 @@ module Pos
         Pos::Support.clear_working_tenders!(transaction)
         transaction.pos_transaction_lines.find(@line.id).tap do |line|
           record_linked_return_removed!(transaction, line) if line.linked_return?
+          record_unlinked_return_removed!(transaction, line) if line.unlinked_return?
           line.destroy!
         end
         Pos::Support.refresh_totals!(transaction)
@@ -33,6 +34,31 @@ module Pos
     end
 
     private
+
+    def record_unlinked_return_removed!(transaction, line)
+      action = line.pos_controlled_actions.find_by(action_type: "unlinked_return")
+      Audit::Recorder.record!(
+        action: "pos.unlinked_return.removed",
+        outcome: "succeeded",
+        actor_user: @actor,
+        actor_label: @actor.display_name,
+        store: transaction.store,
+        register: transaction.register,
+        subject: line,
+        reason_code: line.return_reason_code,
+        reason_text: line.return_reason_note,
+        before_values: {
+          quantity: line.quantity,
+          reference_unit_price_cents: line.reference_unit_price_cents,
+          selling_unit_price_cents: line.selling_unit_price_cents,
+          product_variant_id: line.product_variant_id,
+          inventory_unit_id: line.inventory_unit_id,
+          action_fingerprint: action&.action_fingerprint,
+          performed_by_user_id: action&.performed_by_user_id,
+          approved_by_user_id: action&.approved_by_user_id
+        }.compact
+      )
+    end
 
     def record_linked_return_removed!(transaction, line)
       Audit::Recorder.record!(

--- a/app/services/pos/resolve_unlinked_return_merchandise.rb
+++ b/app/services/pos/resolve_unlinked_return_merchandise.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+module Pos
+  class ResolveUnlinkedReturnMerchandise
+    Result = Struct.new(
+      :variant,
+      :inventory_unit,
+      :tracking,
+      :quantity_fixed,
+      :reference_unit_price_cents,
+      :tax_class,
+      :description,
+      keyword_init: true
+    )
+
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(identifier:, store:, lock_unit: false, advisory_working_unit_check: true)
+      @identifier = identifier
+      @store = store
+      @lock_unit = lock_unit
+      @advisory_working_unit_check = advisory_working_unit_check
+    end
+
+    def call
+      row = registry_row!
+      case row.identifier_kind
+      when "variant_sku", "variant_industry"
+        resolve_variant!(row.product_variant)
+      when "product_primary"
+        resolve_product_primary!(row.product)
+      when "inventory_unit"
+        resolve_unit!(row.inventory_unit)
+      else
+        raise Pos::Error, "merchandise not found"
+      end
+    rescue Identifiers::NormalizationError => e
+      raise Pos::Error, e.message
+    end
+
+    private
+
+    def registry_row!
+      normalized = Identifiers::Normalizer.normalize(@identifier, allow_shelfsense_222: true)
+      row = Identifiers::Registry.find_any(normalized)
+      raise Pos::Error, "merchandise not found" if row.nil? || row.retired_at.present?
+
+      row
+    end
+
+    def resolve_variant!(variant)
+      raise Pos::Error, "merchandise not found" if variant.nil?
+
+      tracking = tracking_for!(variant)
+      raise Pos::Error, "scan the unit identifier" if tracking == "individual"
+
+      Result.new(**variant_result(variant, tracking: tracking))
+    end
+
+    def resolve_product_primary!(product)
+      raise Pos::Error, "merchandise not found" if product.nil?
+
+      candidates = product.product_variants.select { |variant| return_identity_eligible?(variant) }
+      if candidates.empty?
+        raise Pos::Error, "scan/enter variant or unit identifier"
+      end
+
+      individual, others = candidates.partition { |variant| tracking_for(variant) == "individual" }
+      if others.empty?
+        raise Pos::Error, "scan the unit identifier"
+      end
+      if others.many? || individual.any?
+        raise Pos::Error, "scan/enter variant or unit identifier"
+      end
+
+      resolve_variant!(others.first)
+    end
+
+    def resolve_unit!(unit)
+      raise Pos::Error, "merchandise not found" if unit.nil?
+
+      unit = lock_unit!(unit) if @lock_unit
+      variant = unit.product_variant
+      raise Pos::Error, "merchandise not found" if variant.nil?
+      raise Pos::Error, "scan the unit identifier" unless tracking_for!(variant) == "individual"
+      raise Pos::Error, "unit is not at this store" unless unit.store_id == @store.id
+      raise Pos::Error, "unit must be removed" unless unit.removed?
+      raise Pos::Error, "unit is already on a working return" if working_return_unit?(unit)
+
+      price = unit.effective_regular_price_cents
+      raise Pos::Error, "regular price is required" if price.nil?
+
+      tax_class = require_tax_class!(variant)
+      Result.new(
+        variant: variant,
+        inventory_unit: unit,
+        tracking: "individual",
+        quantity_fixed: true,
+        reference_unit_price_cents: price,
+        tax_class: tax_class,
+        description: variant.product.name
+      )
+    end
+
+    def lock_unit!(unit)
+      InventoryUnit.lock.find(unit.id)
+    rescue ActiveRecord::RecordNotFound
+      raise Pos::Error, "merchandise not found"
+    end
+
+    def working_return_unit?(unit)
+      return false unless @advisory_working_unit_check || @lock_unit
+
+      PosTransactionLine.joins(:pos_transaction)
+                        .where(inventory_unit_id: unit.id, pos_transactions: { status: "working" })
+                        .exists?
+    end
+
+    def variant_result(variant, tracking:)
+      price = variant.regular_price_cents
+      raise Pos::Error, "regular price is required" if price.nil?
+
+      {
+        variant: variant,
+        inventory_unit: nil,
+        tracking: tracking,
+        quantity_fixed: false,
+        reference_unit_price_cents: price,
+        tax_class: require_tax_class!(variant),
+        description: variant.product.name
+      }
+    end
+
+    def return_identity_eligible?(variant)
+      tracking = tracking_for(variant)
+      return false unless %w[quantity non_inventory individual].include?(tracking)
+      return false if variant.tax_class.nil?
+      return true if tracking == "individual"
+
+      variant.regular_price_cents.present?
+    end
+
+    def tracking_for(variant)
+      variant.derived_inventory_tracking
+    end
+
+    def tracking_for!(variant)
+      tracking = tracking_for(variant)
+      unless %w[quantity non_inventory individual].include?(tracking)
+        raise Pos::Error, "merchandise tracking is not supported"
+      end
+
+      tracking
+    end
+
+    def require_tax_class!(variant)
+      tax_class = variant.tax_class
+      raise Pos::Error, "Tax Class is required" if tax_class.nil?
+
+      tax_class
+    end
+  end
+end

--- a/app/views/pos/completed_transactions/show.html.erb
+++ b/app/views/pos/completed_transactions/show.html.erb
@@ -36,6 +36,14 @@
         </li>
         <% if line.linked_return? && line.original_transaction_line&.pos_transaction %>
           <li class="muted">Return from <%= line.original_transaction_line.pos_transaction.transaction_reference %></li>
+        <% elsif line.unlinked_return? %>
+          <li class="muted">Unlinked return</li>
+          <% if pos_unlinked_return_price_adjusted?(line) %>
+            <li class="muted">
+              Reference <%= format_money_cents(line.reference_unit_price_cents) %>
+              · Return <%= format_money_cents(line.selling_unit_price_cents) %>
+            </li>
+          <% end %>
         <% end %>
         <% if line.manual_discount_cents.to_i.positive? %>
           <li><%= line.return? ? "Discount reversal" : "Discount" %>  <%= format_signed_money_cents(pos_line_discount_cents(line)) %></li>

--- a/app/views/pos/receipts/_print.html.erb
+++ b/app/views/pos/receipts/_print.html.erb
@@ -31,6 +31,22 @@
             <td>Return from <%= line.original_transaction_line.pos_transaction.transaction_reference %></td>
             <td></td>
           </tr>
+        <% elsif line.unlinked_return? %>
+          <tr>
+            <td></td>
+            <td>Unlinked return</td>
+            <td></td>
+          </tr>
+          <% if pos_unlinked_return_price_adjusted?(line) %>
+            <tr>
+              <td></td>
+              <td>
+                Reference <%= format_money_cents(line.reference_unit_price_cents) %>
+                · Return <%= format_money_cents(line.selling_unit_price_cents) %>
+              </td>
+              <td></td>
+            </tr>
+          <% end %>
         <% end %>
         <% if line.manual_discount_cents.to_i.positive? %>
           <tr>

--- a/app/views/pos/transactions/_line.html.erb
+++ b/app/views/pos/transactions/_line.html.erb
@@ -30,12 +30,18 @@
     <% if line.tax_class_name_snapshot.present? %>
       <div><dt>Applied Tax Class</dt><dd><%= line.tax_class_name_snapshot %></dd></div>
     <% end %>
-    <% if line.return? %>
+      <% if line.return? %>
       <div><dt>Return reason</dt><dd><%= line.return_reason_name_snapshot %></dd></div>
       <% if line.return_reason_note.present? %>
         <div><dt>Note</dt><dd><%= line.return_reason_note %></dd></div>
       <% end %>
-      <% if line.original_transaction_line&.pos_transaction %>
+      <% if line.unlinked_return? %>
+        <div><dt>Linkage</dt><dd>Unlinked return</dd></div>
+        <% if pos_unlinked_return_price_adjusted?(line) %>
+          <div><dt>Reference</dt><dd><%= format_money_cents(line.reference_unit_price_cents) %></dd></div>
+          <div><dt>Return price</dt><dd><%= format_money_cents(line.selling_unit_price_cents) %></dd></div>
+        <% end %>
+      <% elsif line.original_transaction_line&.pos_transaction %>
         <div>
           <dt>Original receipt</dt>
           <dd><%= link_to line.original_transaction_line.pos_transaction.transaction_reference, pos_transaction_path(line.original_transaction_line.pos_transaction) %></dd>
@@ -69,7 +75,7 @@
       </ul>
     <% end %>
   <% end %>
-  <% if line.sale? %>
+  <% if line.sale? || line.unlinked_return? %>
     <% line.pos_controlled_actions.each do |action| %>
       <section class="pos-history__control" aria-label="<%= action.action_type.tr('_', ' ') %>">
         <h3><%= action.action_type.tr("_", " ") %></h3>

--- a/app/views/pos/workspaces/_surface.html.erb
+++ b/app/views/pos/workspaces/_surface.html.erb
@@ -67,6 +67,8 @@
      data-register-workspace-refund-remaining-value="<%= remaining_refund_cents %>"
      data-register-workspace-policies-value="<%= h((@control_policies || {}).to_json) %>"
      data-register-workspace-reasons-value="<%= h(Pos::ControlledActionReasons::CATALOGS.to_json) %>"
+     data-register-workspace-return-reasons-value="<%= h(Pos::ReturnReasons::ENTRIES.to_json) %>"
+     data-register-workspace-unlinked-lookup-url-value="<%= pos_register_unlinked_return_lookup_path %>"
      data-action="turbo:submit-end->register-workspace#onSubmitEnd">
   <div data-register-workspace-target="chrome">
     <header class="pos-header">
@@ -125,6 +127,19 @@
                         <%= original ? " · " : "" %><%= line.return_reason_name_snapshot %>
                       <% end %>
                     </div>
+                  <% elsif line.unlinked_return? %>
+                    <div class="muted">
+                      Unlinked return
+                      <% if line.return_reason_name_snapshot.present? %>
+                        · <%= line.return_reason_name_snapshot %>
+                      <% end %>
+                    </div>
+                    <% if pos_unlinked_return_price_adjusted?(line) %>
+                      <div class="muted">
+                        Reference <%= format_money_cents(line.reference_unit_price_cents) %>
+                        · Return <%= format_money_cents(line.selling_unit_price_cents) %>
+                      </div>
+                    <% end %>
                   <% end %>
                 </td>
                 <td class="numeric"><%= format_money_cents(line.selling_unit_price_cents) %></td>
@@ -207,6 +222,7 @@
               form: { data: { turbo: true } },
               data: { register_workspace_target: "abandonButton" } %>
       <% else %>
+        <button type="button" class="btn btn--secondary" data-action="register-workspace#openUnlinkedOverlay" data-register-workspace-target="unlinkedButton" disabled>Return without receipt</button>
         <button type="button" class="btn btn--secondary" data-action="register-workspace#enterQuantity" data-register-workspace-target="quantityButton" disabled>Quantity (*)</button>
         <button type="button" class="btn btn--secondary" data-action="register-workspace#openPriceOverride" data-register-workspace-target="overrideButton" disabled>Price override (F5)</button>
         <button type="button" class="btn btn--secondary" data-action="register-workspace#openLineDiscount" data-register-workspace-target="discountButton" disabled>Discount (F6)</button>
@@ -287,6 +303,21 @@
       <%= hidden_field_tag :approver_password, "", data: { register_workspace_target: "controlApproverPasswordInput" } %>
     <% end %>
 
+    <%= form_with url: pos_register_unlinked_return_path, method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "unlinkedForm", turbo: true } } do %>
+      <%= hidden_field_tag :lock_version, @transaction.lock_version %>
+      <%= hidden_field_tag :identifier, "", data: { register_workspace_target: "unlinkedIdentifierInput" } %>
+      <%= hidden_field_tag :quantity, "", data: { register_workspace_target: "unlinkedQuantityInput" } %>
+      <%= hidden_field_tag :reason_code, "", data: { register_workspace_target: "unlinkedReasonInput" } %>
+      <%= hidden_field_tag :reason_note, "", data: { register_workspace_target: "unlinkedNoteInput" } %>
+      <%= hidden_field_tag :return_price, "", data: { register_workspace_target: "unlinkedPriceInput" } %>
+      <%= hidden_field_tag :expected_product_variant_id, "", data: { register_workspace_target: "unlinkedExpectedVariantInput" } %>
+      <%= hidden_field_tag :expected_inventory_unit_id, "", data: { register_workspace_target: "unlinkedExpectedUnitInput" } %>
+      <%= hidden_field_tag :expected_reference_unit_price_cents, "", data: { register_workspace_target: "unlinkedExpectedReferenceInput" } %>
+      <%= hidden_field_tag :expected_tax_class_id, "", data: { register_workspace_target: "unlinkedExpectedTaxInput" } %>
+      <%= hidden_field_tag :approver_username, "", data: { register_workspace_target: "unlinkedApproverUserInput" } %>
+      <%= hidden_field_tag :approver_password, "", data: { register_workspace_target: "unlinkedApproverPasswordInput" } %>
+    <% end %>
+
     <%= form_with url: pos_register_cancel_path, method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "cancelForm", turbo: true } } do %>
       <%= hidden_field_tag :lock_version, @transaction.lock_version %>
     <% end %>
@@ -356,6 +387,55 @@
         <button type="button" class="btn btn--secondary" data-action="register-workspace#closeControlOverlay" data-register-workspace-target="controlCancel">Don't apply (Esc)</button>
         <button type="button" class="btn" data-action="register-workspace#submitControlApply" data-register-workspace-target="controlApply">Apply</button>
         <button type="button" class="btn btn--secondary" data-action="register-workspace#submitControlRemove" data-register-workspace-target="controlRemove" hidden>Remove</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="pos-overlay"
+       id="pos_unlinked_overlay"
+       hidden
+       data-register-workspace-target="unlinkedOverlay"
+       role="dialog"
+       aria-modal="true"
+       aria-labelledby="pos-unlinked-title">
+    <div class="pos-overlay__panel pos-overlay__panel--control">
+      <h2 id="pos-unlinked-title">Return without receipt</h2>
+      <p data-register-workspace-target="unlinkedFeedback" role="status"></p>
+
+      <label for="pos-unlinked-identifier">Scan or identifier</label>
+      <input id="pos-unlinked-identifier" class="pos-command__field" data-register-workspace-target="unlinkedIdentifierField" autocomplete="off">
+
+      <div id="pos_unlinked_preview" data-register-workspace-target="unlinkedPreview" hidden>
+        <p data-register-workspace-target="unlinkedDescription"></p>
+        <p>Current price <span data-register-workspace-target="unlinkedReferenceLabel"></span></p>
+
+        <div data-register-workspace-target="unlinkedQuantityWrap">
+          <label for="pos-unlinked-quantity">Quantity</label>
+          <input id="pos-unlinked-quantity" class="pos-command__field" data-register-workspace-target="unlinkedQuantityField" inputmode="numeric" autocomplete="off" value="1">
+        </div>
+
+        <label for="pos-unlinked-reason">Return reason</label>
+        <select id="pos-unlinked-reason" class="pos-command__field" data-register-workspace-target="unlinkedReasonField"></select>
+
+        <div data-register-workspace-target="unlinkedNoteWrap" hidden>
+          <label for="pos-unlinked-note">Note</label>
+          <input id="pos-unlinked-note" class="pos-command__field" data-register-workspace-target="unlinkedNoteField" maxlength="200" autocomplete="off">
+        </div>
+
+        <label for="pos-unlinked-price">Return unit price</label>
+        <input id="pos-unlinked-price" class="pos-command__field" data-register-workspace-target="unlinkedPriceField" inputmode="decimal" autocomplete="off">
+
+        <div data-register-workspace-target="unlinkedApproverWrap" hidden>
+          <label for="pos-unlinked-approver-username">Approver username</label>
+          <input id="pos-unlinked-approver-username" class="pos-command__field" data-register-workspace-target="unlinkedApproverUsername" autocomplete="off">
+          <label for="pos-unlinked-approver-password">Approver password</label>
+          <input id="pos-unlinked-approver-password" class="pos-command__field" type="password" data-register-workspace-target="unlinkedApproverPassword" autocomplete="off">
+        </div>
+      </div>
+
+      <div class="pos-overlay__actions">
+        <button type="button" class="btn btn--secondary" data-action="register-workspace#closeUnlinkedOverlay" data-register-workspace-target="unlinkedCancel">Don't return (Esc)</button>
+        <button type="button" class="btn" data-action="register-workspace#submitUnlinkedReturn" data-register-workspace-target="unlinkedApply" hidden>Add return</button>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,6 +89,8 @@ Rails.application.routes.draw do
     post "register/quantity", to: "workspaces#quantity"
     post "register/remove", to: "workspaces#remove"
     post "register/controlled_action", to: "workspaces#controlled_action"
+    post "register/unlinked_return_lookup", to: "workspaces#unlinked_return_lookup"
+    post "register/unlinked_return", to: "workspaces#unlinked_return"
     post "register/abandon_tender", to: "workspaces#abandon_tender"
     post "register/cancel", to: "workspaces#cancel"
     post "register/tender", to: "workspaces#tender"

--- a/db/migrate/20260819130000_add_unlinked_return_controlled_action_type.rb
+++ b/db/migrate/20260819130000_add_unlinked_return_controlled_action_type.rb
@@ -9,9 +9,7 @@ class AddUnlinkedReturnControlledActionType < ActiveRecord::Migration[8.1]
   end
 
   def down
-    remove_check_constraint :pos_controlled_actions, name: "pos_controlled_actions_type_valid"
-    add_check_constraint :pos_controlled_actions,
-                         "action_type IN ('price_override', 'line_discount', 'tax_class_override')",
-                         name: "pos_controlled_actions_type_valid"
+    raise ActiveRecord::IrreversibleMigration,
+          "cannot restore the prior action_type CHECK while unlinked_return rows may exist"
   end
 end

--- a/db/migrate/20260819130000_add_unlinked_return_controlled_action_type.rb
+++ b/db/migrate/20260819130000_add_unlinked_return_controlled_action_type.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddUnlinkedReturnControlledActionType < ActiveRecord::Migration[8.1]
+  def up
+    remove_check_constraint :pos_controlled_actions, name: "pos_controlled_actions_type_valid"
+    add_check_constraint :pos_controlled_actions,
+                         "action_type IN ('price_override', 'line_discount', 'tax_class_override', 'unlinked_return')",
+                         name: "pos_controlled_actions_type_valid"
+  end
+
+  def down
+    remove_check_constraint :pos_controlled_actions, name: "pos_controlled_actions_type_valid"
+    add_check_constraint :pos_controlled_actions,
+                         "action_type IN ('price_override', 'line_discount', 'tax_class_override')",
+                         name: "pos_controlled_actions_type_valid"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_18_200000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_19_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -386,7 +386,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_18_200000) do
     t.index ["pos_transaction_id"], name: "index_pos_controlled_actions_on_pos_transaction_id"
     t.index ["pos_transaction_line_id", "action_type"], name: "index_pos_controlled_actions_effective_line", unique: true, where: "(pos_transaction_line_id IS NOT NULL)"
     t.index ["pos_transaction_line_id"], name: "index_pos_controlled_actions_on_pos_transaction_line_id"
-    t.check_constraint "action_type::text = ANY (ARRAY['price_override'::character varying, 'line_discount'::character varying, 'tax_class_override'::character varying]::text[])", name: "pos_controlled_actions_type_valid"
+    t.check_constraint "action_type::text = ANY (ARRAY['price_override'::character varying, 'line_discount'::character varying, 'tax_class_override'::character varying, 'unlinked_return'::character varying]::text[])", name: "pos_controlled_actions_type_valid"
     t.check_constraint "approved_by_user_id IS NULL OR approved_by_user_id <> performed_by_user_id", name: "pos_controlled_actions_approver_not_performer"
     t.check_constraint "policy_result::text = 'approval_required'::text AND approved_by_user_id IS NOT NULL AND approved_by_name_snapshot IS NOT NULL OR policy_result::text = 'direct'::text AND approved_by_user_id IS NULL AND approved_by_name_snapshot IS NULL", name: "pos_controlled_actions_approver_matches_policy"
     t.check_constraint "policy_result::text = ANY (ARRAY['direct'::character varying, 'approval_required'::character varying]::text[])", name: "pos_controlled_actions_policy_valid"

--- a/docs/planning/phase3-inventory-foundation/inventory-posting-contract.md
+++ b/docs/planning/phase3-inventory-foundation/inventory-posting-contract.md
@@ -105,7 +105,7 @@ entry_type  = return
 valuation   = acquisition (stock in)
 ```
 
-`Pos::CompleteTransaction` skips `Inventory::PostReturn` for `non_inventory` lines. Customer refund price never writes inventory value. Outbox/audit `inventory.return_posted`.
+`Pos::CompleteTransaction` skips `Inventory::PostReturn` for `non_inventory` lines. Customer refund price never writes inventory value. Outbox/audit `inventory.return_posted` include `linked` and `valuation_basis`.
 
 ## `Inventory::PostAdjustment` required inputs
 

--- a/docs/planning/phase3-inventory-foundation/inventory-posting-contract.md
+++ b/docs/planning/phase3-inventory-foundation/inventory-posting-contract.md
@@ -1,6 +1,6 @@
 # Inventory posting service contract
 
-Status: Implemented with Phase 3 adjustments, Phase 4 quantity-tracked POS sales, Phase 6 Slice 6.1 individual unit sales, and Phase 6 Slice 6.5A linked-return restore. Unlinked `Inventory::PostReturn` valuation is 6.5C ([returns.md](../phase4-6-point-of-sale/phase6-pos-mvp/returns.md) §15).
+Status: Implemented with Phase 3 adjustments, Phase 4 quantity-tracked POS sales, Phase 6 Slice 6.1 individual unit sales, Phase 6 Slice 6.5A linked-return restore, and Phase 6 Slice 6.5C unlinked `Inventory::PostReturn` valuation ([returns.md](../phase4-6-point-of-sale/phase6-pos-mvp/returns.md) §15).
 
 Later purchasing, POS, transfer, reservation, and disposition workflows must post physical and valuation effects only through the named inventory posting services. Controllers, callbacks, imports, and future workflows must not update `inventory_balances` directly.
 
@@ -65,7 +65,7 @@ InventoryUnit      # FOR UPDATE
 
 ## `Inventory::PostReturn`
 
-Named 6.5 boundary, parallel to `PostSale`. Joins the **caller's** transaction. Do not call `PostAdjustment`. Authority: [returns.md](../phase4-6-point-of-sale/phase6-pos-mvp/returns.md) §12 / §15. Linked restore is implemented (6.5A). The current service requires `linked_return?`; unlinked quantity and Used valuation in this section wait for 6.5C.
+Named 6.5 boundary, parallel to `PostSale`. Joins the **caller's** transaction. Do not call `PostAdjustment`. Authority: [returns.md](../phase4-6-point-of-sale/phase6-pos-mvp/returns.md) §12 / §15. Linked restore is implemented (6.5A). Unlinked quantity and Used valuation in this section are implemented (6.5C): lock the balance first, then `Inventory::ReturnValuation`.
 
 Required inputs (received from completion; not re-derived):
 

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md
@@ -467,6 +467,6 @@ System tests (when the workspace is implemented) must cover at least: scan → f
 
 This Slice 2 contract does not define split tender, discounts, returns, suspend/recall, drawers, Terminal, new permissions, close/Z outbox, polished visual design, mobile POS, or customer display.
 
-Later slices that reuse this workspace: 6.2 mixed tender, 6.4 controlled actions, 6.5B linked returns and refunds ([returns.md](../phase6-pos-mvp/returns.md)). 6.5C unlinked return is next.
+Later slices that reuse this workspace: 6.2 mixed tender, 6.4 controlled actions, 6.5B linked returns and refunds ([returns.md](../phase6-pos-mvp/returns.md)), 6.5C unlinked return (Return without receipt overlay; no F-key). 6.5D mixed/unlinked closeout hardening is next.
 
 Receipt print, blind close, and Z screens are Slice 3: [close-z-screens.md](close-z-screens.md).

--- a/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/README.md
+++ b/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/README.md
@@ -1,6 +1,6 @@
 # Phase 6 — Operational POS MVP
 
-**Status:** Slice 6.0 contract locked. Slice 6.1 merchandise breadth is implemented. Slice 6.2 tender breadth is implemented ([tender-breadth.md](tender-breadth.md)). Slice 6.3 transaction history is implemented ([transaction-history.md](transaction-history.md)). Slice 6.4 controlled actions are implemented ([controlled-actions.md](controlled-actions.md)). Slice 6.5A directional Core and 6.5B linked-return operator workflow are implemented ([returns.md](returns.md)). Next: 6.5C unlinked return.
+**Status:** Slice 6.0 contract locked. Slice 6.1 merchandise breadth is implemented. Slice 6.2 tender breadth is implemented ([tender-breadth.md](tender-breadth.md)). Slice 6.3 transaction history is implemented ([transaction-history.md](transaction-history.md)). Slice 6.4 controlled actions are implemented ([controlled-actions.md](controlled-actions.md)). Slice 6.5A directional Core, 6.5B linked-return operator workflow, and 6.5C unlinked return are implemented ([returns.md](returns.md)). Next: 6.5D mixed/unlinked closeout hardening.
 
 | Document | Purpose |
 |---|---|
@@ -10,7 +10,7 @@
 | [tender-breadth.md](tender-breadth.md) | Slice 6.2: Cash/Card/Check/Other settlement (implemented) |
 | [transaction-history.md](transaction-history.md) | Slice 6.3: completed lookup, detail, reprint (implemented) |
 | [controlled-actions.md](controlled-actions.md) | Slice 6.4: price override, line discount, Tax Class override (implemented) |
-| [returns.md](returns.md) | Slice 6.5: linked/unlinked returns, refunds, mixed sale+return (6.5A/B implemented; 6.5C next) |
+| [returns.md](returns.md) | Slice 6.5: linked/unlinked returns, refunds, mixed sale+return (6.5A/B/C implemented; 6.5D next) |
 
 Parent multi-phase sequencing: [../spec.md](../spec.md). Phase 4 completion kernel: [../phase4-point-of-sale/](../phase4-point-of-sale/). Phase 5 cash register: [../phase5-cash-register/](../phase5-cash-register/).
 

--- a/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/controlled-actions.md
+++ b/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/controlled-actions.md
@@ -77,7 +77,7 @@ pos.tax_class_override.perform
 pos.tax_class_override.approve
 ```
 
-`scope_type: either`. Do **not** seed `unlinked_return` / `return_price_adjustment` / `post_void` in 6.4 (identifiers remain reserved in [mvp-contract.md](mvp-contract.md) §11). 6.5 seeds only `unlinked_return`; `return_price_adjustment` stays reserved. 6.4 completion integrity stays **sale-direction**; those three actions are prohibited on return lines ([returns.md](returns.md) §16 / §19).
+`scope_type: either`. Do **not** seed `unlinked_return` / `return_price_adjustment` / `post_void` in 6.4 (identifiers remain reserved in [mvp-contract.md](mvp-contract.md) §11). 6.5C seeds only `unlinked_return`; `return_price_adjustment` stays reserved. 6.4 completion integrity stays **sale-direction**; those three actions are prohibited on return lines ([returns.md](returns.md) §16 / §19).
 
 | Role | Perform | Approve |
 |---|---|---|

--- a/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/phase6-plan.md
+++ b/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/phase6-plan.md
@@ -1,6 +1,6 @@
 # Phase 6 — Operational POS MVP
 
-**Status:** Slice 6.0 contract locked ([mvp-contract.md](mvp-contract.md)). Slice 6.1 merchandise breadth implemented ([merchandise-breadth.md](merchandise-breadth.md)). Slice 6.2 tender breadth implemented ([tender-breadth.md](tender-breadth.md)). Slice 6.3 transaction history implemented ([transaction-history.md](transaction-history.md)). Slice 6.4 controlled actions implemented ([controlled-actions.md](controlled-actions.md)). Slice 6.5A directional Core implemented; slice 6.5B linked-return operator workflow implemented ([returns.md](returns.md)).
+**Status:** Slice 6.0 contract locked ([mvp-contract.md](mvp-contract.md)). Slice 6.1 merchandise breadth implemented ([merchandise-breadth.md](merchandise-breadth.md)). Slice 6.2 tender breadth implemented ([tender-breadth.md](tender-breadth.md)). Slice 6.3 transaction history implemented ([transaction-history.md](transaction-history.md)). Slice 6.4 controlled actions implemented ([controlled-actions.md](controlled-actions.md)). Slice 6.5A directional Core implemented; slice 6.5B linked-return operator workflow implemented; slice 6.5C unlinked return implemented ([returns.md](returns.md)).
 
 **Authority**
 
@@ -11,7 +11,7 @@
 | [Tender breadth](tender-breadth.md) | Slice 6.2: Cash/Card/Check/Other settlement |
 | [Transaction history](transaction-history.md) | Slice 6.3: completed lookup, detail, reprint |
 | [Controlled actions](controlled-actions.md) | Slice 6.4: price override, line discount, Tax Class override |
-| [Returns](returns.md) | Slice 6.5: linked/unlinked returns, refunds, mixed sale+return (6.5A/B implemented; 6.5C next) |
+| [Returns](returns.md) | Slice 6.5: linked/unlinked returns, refunds, mixed sale+return (6.5A/B/C implemented; 6.5D next) |
 | [Phase 4 plan](../phase4-point-of-sale/phase4-plan.md) | Completion, receipt allocation, inventory posting |
 | [CompletedPosOperation v1](../phase4-point-of-sale/completed-pos-operation-v1.md) | Commercial base; v2 is additive |
 | [POS tax contract](../phase4-point-of-sale/pos-tax-contract.md) | Tax Class / Store Tax; linked-return reversal ([§10](../phase4-point-of-sale/pos-tax-contract.md)) |
@@ -112,7 +112,7 @@ Write the detailed implementation contract for slices 6.6–6.7 immediately befo
 | **6.2** | Tender breadth | Card, Check, admin-created Other, mixed tender | **Implemented.** All-Cash sale remains Phase 5-equivalent; Session/Z shows Card/Check/Other |
 | **6.3** | Transaction history | Lookup, detail, receipt reprint | **Implemented.** Sale workspace does not depend on history |
 | **6.4** | Controlled pricing/actions | Approval framework, price override, line discount, Tax Class override | **Implemented.** Ordinary path stays `direct` unless policy requires a second actor |
-| **6.5** | Returns | Linked, unlinked, price adjustment, mixed sale/return | **6.5A/B implemented** ([returns.md](returns.md)). 6.5C unlinked is next. Sale-only baskets still complete the same way; Session/Z is direction-aware |
+| **6.5** | Returns | Linked, unlinked, price adjustment, mixed sale/return | **6.5A/B/C implemented** ([returns.md](returns.md)). 6.5D mixed/closeout hardening is next. Sale-only baskets still complete the same way; Session/Z is direction-aware |
 | **6.6** | Post-void | Controlled whole-transaction correction | Entry is from history; sale path untouched |
 | **6.7** | MVP closeout | Receipts, Z/tender reporting polish, audit/history UX, regression | Additive snapshots; already-finalized periods stay immutable |
 
@@ -183,7 +183,7 @@ Perform/approve permission keys arrive in this slice. Z finalize stays on `pos.t
 
 ### 6.5 — Returns and exchanges
 
-**6.5A/B implemented. 6.5C next.** Authority: [returns.md](returns.md).
+**6.5A/B/C implemented. 6.5D next.** Authority: [returns.md](returns.md).
 
 No Exchange entity. Returns are new facts; refunds are settlement. Directional Core keeps sale-side `subtotal_cents` / `discount_cents` / `tax_cents` and adds `return_*` plus persisted `signed_net_cents`. `total_cents = abs(signed_net_cents)`.
 
@@ -195,7 +195,7 @@ MVP linked-return eligibility is limited to authoritative original-line linkage,
 - **Refunds:** tender settlement, not return valuation. External Card refund is cashier-confirmed outside ShelfSense. Expected Cash becomes `float + Cash payments − Cash refunds` and **may be negative** (not a physical drawer cap).
 - **Session/Z:** this slice must make commercial and Cash calculations direction-aware in the same change that first completes a return. `SUM(transaction.total_cents)` must not treat refund magnitude as sales. 6.7 may reorganize snapshot columns; it does not fix a knowingly wrong Z.
 
-Working/cancelled returns do not consume eligibility. Concurrency must prevent two Registers from both returning the final eligible quantity. Delivery: 6.5A Core and 6.5B operator workflow are implemented; 6.5C unlinked is next; 6.5D remains as specified in [returns.md](returns.md) §32.
+Working/cancelled returns do not consume eligibility. Concurrency must prevent two Registers from both returning the final eligible quantity. Delivery: 6.5A Core, 6.5B operator workflow, and 6.5C unlinked return are implemented; 6.5D remains as specified in [returns.md](returns.md) §32.
 
 ### 6.6 — Post-void
 
@@ -285,7 +285,7 @@ Fractional quantities
 3. Lock 6.2 tender contract → implement settlement redesign (Cash equivalence gate; Session/Z tender totals)
 4. Lock 6.3 history contract → lookup / detail / reprint
 5. Lock 6.4 controlled-action contract → framework, then override / discount / Tax Class
-6. 6.5A linked Core and 6.5B operator workflow implemented ([returns.md](returns.md)) → 6.5C unlinked return, then 6.5D mixed/unlinked closeout hardening
+6. 6.5A linked Core, 6.5B operator workflow, and 6.5C unlinked return implemented ([returns.md](returns.md)) → 6.5D mixed/unlinked closeout hardening
 7. Lock 6.6 post-void contract → compensating whole-transaction fact
 8. Lock 6.7 closeout contract → receipt/Z/audit/keyboard regression (polish, not first truthful reporting)
 ```

--- a/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/returns.md
+++ b/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/returns.md
@@ -385,7 +385,7 @@ Do not share one “recalculate tax” helper for historical reversal and curren
 
 Named boundary `Inventory::PostReturn`, parallel to `Inventory::PostSale`. Joins the caller’s transaction. Do not call `PostAdjustment`. Lock order: `InventoryBalance` then `InventoryUnit`. Skip `non_inventory`. Duplicate protection remains `(source_type, source_id, effect_sequence)` with `source_type = PosTransactionLine` and `source_id =` **return** line id.
 
-Ledger `entry_type = return`. Valuation increase uses `acquisition` (stock in). Outbox/audit `inventory.return_posted`.
+Ledger `entry_type = return`. Valuation increase uses `acquisition` (stock in). Outbox/audit `inventory.return_posted` include `linked` and `valuation_basis`.
 
 **Every linked return restores inventory using the valuation actually relieved by the original completed sale.** Do not use today’s moving average. Do not treat live `InventoryUnit.carrying_value_cents` as historical authority.
 

--- a/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/returns.md
+++ b/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/returns.md
@@ -1,6 +1,6 @@
 # Phase 6 Slice 6.5 — Returns, refunds, and exchanges
 
-**Status:** Contract locked. 6.5A implemented. 6.5B implemented. Next: 6.5C unlinked return.
+**Status:** Contract locked. 6.5A implemented. 6.5B implemented. 6.5C implemented. Next: 6.5D mixed/unlinked closeout hardening.
 
 **Authority:** Linked return, unlinked return, mixed sale+return, refund tenders, and direction-aware Session/Z on the existing POS transaction. Dual authority with Core remains [mvp-contract.md](mvp-contract.md) / [ADR-020](../../../adr/ADR-020-pos-operation-envelope-and-core-facts.md). Tax remains [pos-tax-contract.md](../phase4-point-of-sale/pos-tax-contract.md) §10. Inventory posting remains [inventory-posting-contract.md](../../phase3-inventory-foundation/inventory-posting-contract.md). Settlement extends [tender-breadth.md](tender-breadth.md). Controlled-action policy remains [controlled-actions.md](controlled-actions.md). History initiation extends [transaction-history.md](transaction-history.md).
 
@@ -858,9 +858,15 @@ Implementation notes:
 
 ### 6.5C — Unlinked return
 
-**Next.** `unlinked_return` permissions; `ExecuteUnlinkedReturn`; prospective line UUID; current-rule price/tax; cashier-entered return unit price; known removed Used unit; unlinked quantity valuation; single approval overlay; history/audit/envelope. No separate RPA permission framework.
+**Implemented.** Merge gate: cashier-usable return-only unlinked workflow — Return without receipt, identify known merchandise, quantity/reason/return price, manager approval when required, Cash refund complete.
 
-Do not redo 6.5B workspace settlement, even-exchange hold-open, directional receipts, or Return items. 6.5C adds the unlinked command and its permission keys. `Inventory::PostReturn` currently requires a linked return line; this slice must extend it with the unlinked valuation rules in §15. `pos.unlinked_return.perform` / `.approve` are not seeded yet. `FreezeUnlinkedReturnLine` is specified in §24 and is not yet callable.
+Implementation notes:
+
+- Seeded `pos.unlinked_return.perform` / `.approve` only. No `return_price_adjustment` permission. `action_type` CHECK includes `unlinked_return`.
+- `Pos::ExecuteUnlinkedReturn` creates the line (preallocated UUIDv7) plus one `unlinked_return` fact. Return-owned identifier resolution does not inherit `Identifiers::Lookup`'s `sellable?` filter. Denied approval audits the working transaction; there is no pending line.
+- Overlay lookup is JSON resolve-only. Identifier Enter never submits approval. F8 remove audits `pos.unlinked_return.removed` before `dependent: :destroy`.
+- `FreezeUnlinkedReturnLine` keeps approved reference/selling/Tax Class, applies current Store Tax, and writes `merchandise_snapshot`. `Inventory::ReturnValuation` runs after the balance lock. Envelope `return_price_adjustment` is arithmetic and is not a sale override/discount.
+- Mixed sale+unlinked remains structurally allowed. 6.5D owns the comprehensive mixed/closeout matrix.
 
 ### 6.5D — Mixed transaction and closeout hardening
 

--- a/test/helpers/pos_helper_test.rb
+++ b/test/helpers/pos_helper_test.rb
@@ -78,4 +78,17 @@ class PosHelperTest < ActionView::TestCase
     assert pos_line_controlled?(line)
     assert_equal "Override · Discount · Tax Class", pos_line_control_flags(line)
   end
+
+  test "unlinked return price distinction is not a sale override" do
+    line = PosTransactionLine.new(
+      direction: "return",
+      original_transaction_line_id: nil,
+      reference_unit_price_cents: 1999,
+      selling_unit_price_cents: 1800
+    )
+
+    assert pos_unlinked_return_price_adjusted?(line)
+    refute pos_line_controlled?(line)
+    assert_equal "", pos_line_control_flags(line)
+  end
 end

--- a/test/integration/pos_unlinked_return_workspace_test.rb
+++ b/test/integration/pos_unlinked_return_workspace_test.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PosUnlinkedReturnWorkspaceTest < ActionDispatch::IntegrationTest
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    @tax = tax_class(code: "physical_book", name: "Physical book")
+    StoreTaxes::Create.call(
+      store: @store,
+      actor: @actor,
+      name: "Illinois State",
+      rate_percent: "5.000",
+      calculation_order: 1,
+      applies_by_tax_class_id: { @tax.id => true }
+    )
+    @variant = pos_sellable_variant(actor: @actor, tax_class: @tax)
+    open_quantity_stock(store: @store, variant: @variant, actor: @actor, quantity: 20)
+    @register = Register.create!(store: @store, register_number: 1, name: "Front")
+    @associate = pos_transacting_user(store: @store, assigned_by: @actor, username: "clerk_ui65c")
+    @manager = pos_store_manager(store: @store, assigned_by: @actor, username: "mgr_ui65c")
+    sign_in_as("admin")
+  end
+
+  test "lookup resolves merchandise without creating a line" do
+    post pos_register_enter_path, params: enter_params
+    transaction = PosTransaction.working.find_by!(register: @register)
+
+    post pos_register_unlinked_return_lookup_path, params: { identifier: @variant.sku }
+    assert_response :success
+    payload = JSON.parse(response.body)
+    assert_equal "Example Book", payload.fetch("description")
+    assert_equal "quantity", payload.fetch("tracking")
+    assert_equal false, payload.fetch("quantity_fixed")
+    assert_equal 1999, payload.fetch("reference_unit_price_cents")
+    assert_equal @variant.id.to_s, payload.fetch("product_variant_id").to_s
+    assert_nil payload.fetch("inventory_unit_id")
+    assert_equal @tax.id.to_s, payload.fetch("tax_class_id").to_s
+    assert_equal 0, transaction.reload.pos_transaction_lines.count
+  end
+
+  test "overlay post creates the return line and unlinked_return fact" do
+    post pos_register_enter_path, params: enter_params
+    transaction = PosTransaction.working.find_by!(register: @register)
+
+    post pos_register_unlinked_return_path, params: {
+      lock_version: transaction.lock_version,
+      identifier: @variant.sku,
+      quantity: 1,
+      reason_code: "changed_mind",
+      return_price: "18.00",
+      expected_product_variant_id: @variant.id,
+      expected_reference_unit_price_cents: 1999,
+      expected_tax_class_id: @tax.id
+    }
+    assert_response :success
+    transaction.reload
+    line = transaction.pos_transaction_lines.first
+    assert line.unlinked_return?
+    assert_equal 1800, line.selling_unit_price_cents
+    assert_equal 1, line.pos_controlled_actions.where(action_type: "unlinked_return").count
+    assert_match "Unlinked return", response.body
+    assert_match "Reference $19.99", response.body
+    assert_match "Return $18.00", response.body
+    refute_includes css_select(".pos-lines").text, "Override"
+    assert_select "tr[data-direction='return'][data-linked-return='false']"
+  end
+
+  test "associate overlay post stays on the workspace until a manager approves" do
+    delete session_path
+    sign_in_as("clerk_ui65c")
+    post pos_register_enter_path, params: enter_params
+    transaction = PosTransaction.working.find_by!(register: @register)
+
+    post pos_register_unlinked_return_path, params: {
+      lock_version: transaction.lock_version,
+      identifier: @variant.sku,
+      quantity: 1,
+      reason_code: "defective",
+      return_price: "19.99"
+    }
+    assert_response :success
+    assert_match "approver credentials are required", response.body
+    assert_equal 0, transaction.reload.pos_transaction_lines.count
+
+    post pos_register_unlinked_return_path, params: {
+      lock_version: transaction.lock_version,
+      identifier: @variant.sku,
+      quantity: 1,
+      reason_code: "defective",
+      return_price: "19.99",
+      approver_username: "mgr_ui65c",
+      approver_password: "correct-horse-battery"
+    }
+    assert_response :success
+    line = transaction.reload.pos_transaction_lines.first
+    assert line.unlinked_return?
+    assert_equal @manager.id, line.pos_controlled_actions.first.approved_by_user_id
+  end
+
+  test "F8 audits unlinked facts before destroying the line" do
+    post pos_register_enter_path, params: enter_params
+    transaction = PosTransaction.working.find_by!(register: @register)
+    post pos_register_unlinked_return_path, params: {
+      lock_version: transaction.lock_version,
+      identifier: @variant.sku,
+      quantity: 1,
+      reason_code: "changed_mind",
+      return_price: "19.99"
+    }
+    line = transaction.reload.pos_transaction_lines.first
+    fingerprint = line.pos_controlled_actions.find_by!(action_type: "unlinked_return").action_fingerprint
+
+    post pos_register_remove_path, params: {
+      line_id: line.id,
+      lock_version: transaction.lock_version
+    }
+    assert_response :success
+    assert_equal 0, transaction.reload.pos_transaction_lines.count
+    assert_equal 0, PosControlledAction.where(pos_transaction_line_id: line.id).count
+
+    event = AuditEvent.find_by!(action: "pos.unlinked_return.removed")
+    assert_equal line.id, event.subject_id
+    assert_equal fingerprint, event.before_values["action_fingerprint"]
+    assert_equal 1999, event.before_values["selling_unit_price_cents"]
+    assert_equal 1, event.before_values["quantity"]
+  end
+
+  private
+
+  def sign_in_as(username)
+    post session_path, params: { session: { username: username, password: "correct-horse-battery" } }
+  end
+
+  def enter_params
+    {
+      register_id: @register.id,
+      opening_float: "0.00",
+      confirmed_business_date: BusinessDate.for_store(@store).iso8601
+    }
+  end
+end

--- a/test/models/pos_schema_test.rb
+++ b/test/models/pos_schema_test.rb
@@ -172,7 +172,7 @@ class PosSchemaTest < ActiveSupport::TestCase
   test "controlled-action permissions are seeded by role" do
     associate = Role.find_by!(key: "associate")
     manager = Role.find_by!(key: "store_manager")
-    %w[price_override line_discount tax_class_override].each do |action|
+    %w[price_override line_discount tax_class_override unlinked_return].each do |action|
       assert Permission.exists?(key: "pos.#{action}.perform")
       assert Permission.exists?(key: "pos.#{action}.approve")
       assert associate.permissions.exists?(key: "pos.#{action}.perform")
@@ -180,7 +180,7 @@ class PosSchemaTest < ActiveSupport::TestCase
       assert manager.permissions.exists?(key: "pos.#{action}.perform")
       assert manager.permissions.exists?(key: "pos.#{action}.approve")
     end
-    assert_not Permission.exists?(key: "pos.unlinked_return.perform")
+    assert_not Permission.exists?(key: "pos.return_price_adjustment.perform")
     assert_not Permission.exists?(key: "pos.post_void.perform")
   end
 

--- a/test/services/inventory/post_return_test.rb
+++ b/test/services/inventory/post_return_test.rb
@@ -95,6 +95,7 @@ class InventoryPostReturnTest < ActiveSupport::TestCase
     assert_equal "current_moving_average", event.after_values["valuation_basis"]
     outbox = OutboxMessage.find_by!(event_type: "inventory.return_posted", aggregate_id: line.id)
     assert_equal false, outbox.payload["linked"]
+    assert_equal "current_moving_average", outbox.payload["valuation_basis"]
   end
 
   test "unlinked used restore posts the unit carrying value" do
@@ -123,6 +124,9 @@ class InventoryPostReturnTest < ActiveSupport::TestCase
 
     assert_equal 500, result.fetch(:valuation).value_delta_cents
     assert_equal "unit_carrying_value", result.fetch(:valuation).calculation_metadata["valuation_basis"]
+    outbox = OutboxMessage.where(event_type: "inventory.return_posted", aggregate_id: line.id).order(:created_at).last
+    assert_equal false, outbox.payload["linked"]
+    assert_equal "unit_carrying_value", outbox.payload["valuation_basis"]
     assert unit.reload.on_hand?
     assert_equal 500, unit.carrying_value_cents
     assert_equal used_variant.id, line.product_variant_id

--- a/test/services/inventory/post_return_test.rb
+++ b/test/services/inventory/post_return_test.rb
@@ -61,6 +61,75 @@ class InventoryPostReturnTest < ActiveSupport::TestCase
     assert_empty Inventory::LedgerPairIntegrity.drifts(store_id: @store.id, product_variant_id: @variant.id)
   end
 
+  test "unlinked quantity restore uses the locked current moving average not the refund price" do
+    transaction = Pos::StartTransaction.call(session: @context[:session], actor: @actor)
+    line = Pos::ExecuteUnlinkedReturn.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      identifier: @variant.sku,
+      quantity: 2,
+      reason_code: "changed_mind",
+      requested_return_unit_price_cents: 1999
+    )
+    balance_before = InventoryBalance.find_by!(store: @store, product_variant: @variant)
+    result = nil
+    PosTransaction.transaction do
+      result = Inventory::PostReturn.call(
+        line: line,
+        occurred_at: Time.utc(2026, 8, 19, 17, 0, 0),
+        business_date: Date.new(2026, 8, 19),
+        actor: @actor
+      )
+    end
+
+    valuation = result.fetch(:valuation)
+    balance = InventoryBalance.find_by!(store: @store, product_variant: @variant)
+    assert_equal 2, result.fetch(:ledger).quantity_delta
+    assert_equal 200, valuation.value_delta_cents
+    assert_equal "current_moving_average", valuation.calculation_metadata["valuation_basis"]
+    assert_equal balance_before.on_hand_quantity + 2, balance.on_hand_quantity
+    assert_equal balance_before.inventory_value_cents + 200, balance.inventory_value_cents
+    assert_not_equal line.extended_selling_amount_cents, valuation.value_delta_cents
+    event = AuditEvent.find_by!(action: "inventory.return_posted", subject_id: line.id)
+    assert_equal "current_moving_average", event.after_values["valuation_basis"]
+    outbox = OutboxMessage.find_by!(event_type: "inventory.return_posted", aggregate_id: line.id)
+    assert_equal false, outbox.payload["linked"]
+  end
+
+  test "unlinked used restore posts the unit carrying value" do
+    used_variant, unit = pos_on_hand_unit(store: @store, actor: @actor, tax_class: @tax, unit_cost_cents: 500)
+    sale = complete_unit_sale(unit)
+    assert unit.reload.removed?
+    transaction = Pos::StartTransaction.call(session: @context[:session], actor: @actor)
+    line = Pos::ExecuteUnlinkedReturn.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      identifier: unit.unit_identifier,
+      quantity: 1,
+      reason_code: "changed_mind",
+      requested_return_unit_price_cents: 1200
+    )
+    result = nil
+    PosTransaction.transaction do
+      result = Inventory::PostReturn.call(
+        line: line,
+        occurred_at: Time.utc(2026, 8, 19, 17, 5, 0),
+        business_date: Date.new(2026, 8, 19),
+        actor: @actor
+      )
+    end
+
+    assert_equal 500, result.fetch(:valuation).value_delta_cents
+    assert_equal "unit_carrying_value", result.fetch(:valuation).calculation_metadata["valuation_basis"]
+    assert unit.reload.on_hand?
+    assert_equal 500, unit.carrying_value_cents
+    assert_equal used_variant.id, line.product_variant_id
+    assert_nil line.original_transaction_line_id
+    assert_not_equal sale.pos_transaction_lines.first.id, line.id
+  end
+
   private
 
   def complete_sale
@@ -98,5 +167,30 @@ class InventoryPostReturnTest < ActiveSupport::TestCase
       quantity: 1,
       reason_code: "defective"
     )
+  end
+
+  def complete_unit_sale(unit)
+    transaction = Pos::StartTransaction.call(session: @context[:session], actor: @actor)
+    Pos::AddMerchandise.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      identifier: unit.unit_identifier
+    )
+    transaction.reload
+    Pos::TenderCash.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      amount_presented_cents: transaction.total_cents
+    )
+    Pos::CompleteTransaction.call(
+      transaction: transaction.reload,
+      actor: @actor,
+      operation_id: SecureRandom.uuid_v7,
+      expected_lock_version: transaction.lock_version,
+      expected_total_cents: transaction.total_cents,
+      expected_signed_net_cents: transaction.signed_net_cents
+    ).transaction
   end
 end

--- a/test/services/inventory/return_valuation_test.rb
+++ b/test/services/inventory/return_valuation_test.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class InventoryReturnValuationTest < ActiveSupport::TestCase
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    @tax = tax_class(code: "return_val_tax")
+    @variant = pos_sellable_variant(actor: @actor, tax_class: @tax)
+  end
+
+  test "quantity on-hand uses current moving average without capping at current value" do
+    open_quantity_stock(store: @store, variant: @variant, actor: @actor, quantity: 2, unit_cost_cents: 50)
+    balance = InventoryBalance.find_by!(store: @store, product_variant: @variant)
+
+    result = Inventory::ReturnValuation.call(
+      store: @store,
+      variant: @variant,
+      quantity: 3,
+      balance: balance
+    )
+
+    assert_equal 150, result.incoming_value_cents
+    assert_equal "current_moving_average", result.basis
+  end
+
+  test "quantity on-hand zero uses only the latest prior moving average" do
+    open_quantity_stock(store: @store, variant: @variant, actor: @actor, quantity: 5, unit_cost_cents: 100)
+    sell_all_quantity!(5)
+    latest = InventoryValuationEntry.where(store: @store, product_variant: @variant)
+                                    .order(occurred_at: :desc, id: :desc)
+                                    .first
+    assert_equal 0, InventoryBalance.find_by!(store: @store, product_variant: @variant).on_hand_quantity
+    assert_equal 5, latest.calculation_metadata["prior_quantity"]
+    assert_equal 500, latest.calculation_metadata["prior_value_cents"]
+
+    result = Inventory::ReturnValuation.call(store: @store, variant: @variant, quantity: 2)
+    assert_equal 200, result.incoming_value_cents
+    assert_equal "latest_prior_moving_average", result.basis
+  end
+
+  test "quantity without a prior basis is rejected" do
+    error = assert_raises(Inventory::ReturnValuation::Error) do
+      Inventory::ReturnValuation.call(store: @store, variant: @variant, quantity: 1)
+    end
+    assert_match(/no defensible inventory valuation basis/, error.message)
+  end
+
+  test "used unit restores carrying value independent of a later price" do
+    _used_variant, unit = pos_on_hand_unit(store: @store, actor: @actor, tax_class: @tax, unit_cost_cents: 500)
+    unit.update_columns(lifecycle_state: "removed", removed_at: Time.current)
+
+    result = Inventory::ReturnValuation.call(
+      store: @store,
+      variant: unit.product_variant,
+      quantity: 1,
+      inventory_unit: unit
+    )
+    assert_equal 500, result.incoming_value_cents
+    assert_equal "unit_carrying_value", result.basis
+  end
+
+  private
+
+  def sell_all_quantity!(quantity)
+    StoreTaxes::Create.call(
+      store: @store,
+      actor: @actor,
+      name: "State",
+      rate_percent: "0.000",
+      calculation_order: 1,
+      applies_by_tax_class_id: { @tax.id => false }
+    )
+    context = pos_open_context(store: @store, actor: @actor)
+    Pos::TenderTypes.seed!
+    transaction = Pos::StartTransaction.call(session: context[:session], actor: @actor)
+    Pos::AddMerchandise.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      identifier: @variant.sku,
+      quantity: quantity
+    )
+    transaction.reload
+    Pos::TenderCash.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      amount_presented_cents: [ transaction.total_cents, 1 ].max
+    )
+    Pos::CompleteTransaction.call(
+      transaction: transaction.reload,
+      actor: @actor,
+      operation_id: SecureRandom.uuid_v7,
+      expected_lock_version: transaction.lock_version,
+      expected_total_cents: transaction.total_cents,
+      expected_signed_net_cents: transaction.signed_net_cents
+    )
+  end
+end

--- a/test/services/pos/concurrency_test.rb
+++ b/test/services/pos/concurrency_test.rb
@@ -479,6 +479,76 @@ class Pos::ConcurrencyTest < ActiveSupport::TestCase
     assert_equal 0, remaining
   end
 
+  test "two registers cannot concurrently claim the same removed used unit" do
+    Pos::TenderTypes.seed!
+    _used_variant, unit = pos_on_hand_unit(store: @store, actor: @actor, tax_class: @tax)
+    sale = prepare_unit_sale(register_number: 21, unit: unit, presented_cents: 2500)
+    Pos::CompleteTransaction.call(
+      transaction: sale[:transaction],
+      actor: @actor,
+      operation_id: SecureRandom.uuid_v7,
+      expected_lock_version: sale[:transaction].lock_version,
+      expected_total_cents: sale[:transaction].total_cents,
+      expected_signed_net_cents: sale[:transaction].signed_net_cents
+    )
+    assert unit.reload.removed?
+
+    first = prepare_empty_sale(register_number: 22)
+    second = prepare_empty_sale(register_number: 23)
+    jobs = [
+      { transaction_id: first[:transaction].id, lock_version: first[:transaction].lock_version },
+      { transaction_id: second[:transaction].id, lock_version: second[:transaction].lock_version }
+    ]
+    unit_id = unit.id
+    identifier = unit.unit_identifier
+    actor_id = @actor.id
+    ready = Queue.new
+    go = Queue.new
+    results = Array.new(2)
+    errors = Array.new(2)
+    threads = jobs.each_with_index.map do |job, i|
+      Thread.new do
+        ActiveRecord::Base.connection_pool.with_connection do
+          ready << true
+          go.pop
+          results[i] = Pos::ExecuteUnlinkedReturn.call(
+            transaction: PosTransaction.find(job[:transaction_id]),
+            actor: User.find(actor_id),
+            expected_lock_version: job[:lock_version],
+            identifier: identifier,
+            quantity: 1,
+            reason_code: "changed_mind",
+            requested_return_unit_price_cents: 1200
+          )
+        rescue StandardError => e
+          errors[i] = e
+        end
+      end
+    end
+    2.times { ready.pop }
+    2.times { go << true }
+    threads.each { |thread| assert thread.join(30), "thread did not finish" }
+
+    successes = results.compact
+    failures = errors.compact
+    assert_equal 1, successes.size, failures.map(&:message).inspect
+    assert_equal 1, failures.size, successes.inspect
+    assert_match(/already on a working return|stale lock/i, failures.first.message)
+
+    working_lines = PosTransactionLine.uncached {
+      PosTransactionLine.joins(:pos_transaction).where(
+        inventory_unit_id: unit_id,
+        pos_transactions: { status: "working" }
+      ).to_a
+    }
+    assert_equal 1, working_lines.size
+    assert_equal successes.first.id, working_lines.first.id
+    assert_equal 1, PosControlledAction.uncached {
+      PosControlledAction.where(action_type: "unlinked_return", pos_transaction_line_id: working_lines.first.id).count
+    }
+    assert InventoryUnit.uncached { InventoryUnit.find(unit_id).removed? }
+  end
+
   private
 
   def prepare_sale(register_number:, presented_cents:)

--- a/test/services/pos/execute_unlinked_return_test.rb
+++ b/test/services/pos/execute_unlinked_return_test.rb
@@ -1,0 +1,302 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PosExecuteUnlinkedReturnTest < ActiveSupport::TestCase
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @admin = @bootstrap[:administrator]
+    @tax = tax_class(code: "physical_book", name: "Physical book")
+    StoreTaxes::Create.call(
+      store: @store,
+      actor: @admin,
+      name: "Illinois State",
+      rate_percent: "5.000",
+      calculation_order: 1,
+      applies_by_tax_class_id: { @tax.id => true }
+    )
+    @variant = pos_sellable_variant(actor: @admin, tax_class: @tax)
+    open_quantity_stock(store: @store, variant: @variant, actor: @admin, quantity: 20, unit_cost_cents: 100)
+    @associate = pos_transacting_user(store: @store, assigned_by: @admin, username: "clerk65c")
+    @manager = pos_store_manager(store: @store, assigned_by: @admin, username: "mgr65c")
+    Pos::TenderTypes.seed!
+  end
+
+  test "associate unlinked return requires a manager and binds fingerprint material" do
+    transaction = start_transaction(@associate)
+    line = add_unlinked!(
+      transaction,
+      @associate,
+      quantity: 2,
+      requested_return_unit_price_cents: 1800,
+      reason_code: "defective",
+      approver_username: "mgr65c",
+      approver_password: "correct-horse-battery"
+    )
+
+    action = line.pos_controlled_actions.find_by!(action_type: "unlinked_return")
+    assert line.unlinked_return?
+    assert_nil line.original_transaction_line_id
+    assert_equal 2, line.quantity
+    assert_equal 1999, line.reference_unit_price_cents
+    assert_equal 1800, line.selling_unit_price_cents
+    assert_equal 0, line.manual_discount_cents
+    assert_equal "defective", line.return_reason_code
+    assert_equal "approval_required", action.policy_result
+    assert_equal @associate.id, action.performed_by_user_id
+    assert_equal @manager.id, action.approved_by_user_id
+    assert_equal(
+      {
+        "product_variant_id" => @variant.id.to_s,
+        "quantity" => 2,
+        "reference_unit_price_cents" => 1999,
+        "requested_return_unit_price_cents" => 1800,
+        "tax_class_id" => @tax.id.to_s
+      },
+      action.material_values
+    )
+    assert_equal fingerprint_for(transaction, line, action), action.action_fingerprint
+    assert AuditEvent.exists?(action: "pos.unlinked_return.applied", subject_id: line.id)
+    assert AuditEvent.exists?(action: "pos.controlled_action.approved", actor_user_id: @manager.id, subject_id: line.id)
+  end
+
+  test "manager cashier applies an unlinked return as direct" do
+    transaction = start_transaction(@manager)
+    line = add_unlinked!(transaction, @manager)
+
+    action = line.pos_controlled_actions.find_by!(action_type: "unlinked_return")
+    assert_equal "direct", action.policy_result
+    assert_nil action.approved_by_user_id
+    refute AuditEvent.exists?(action: "pos.controlled_action.approved", subject_id: line.id)
+  end
+
+  test "zero dollar unlinked return still advances lock_version" do
+    transaction = start_transaction(@manager)
+    before = transaction.lock_version
+    line = add_unlinked!(transaction, @manager, requested_return_unit_price_cents: 0)
+
+    assert_equal 0, line.selling_unit_price_cents
+    assert_operator transaction.reload.lock_version, :>, before
+  end
+
+  test "return price may be above the current reference" do
+    transaction = start_transaction(@manager)
+    line = add_unlinked!(transaction, @manager, requested_return_unit_price_cents: 2500)
+
+    assert_equal 1999, line.reference_unit_price_cents
+    assert_equal 2500, line.selling_unit_price_cents
+  end
+
+  test "successful addition clears working tenders" do
+    transaction = start_transaction(@manager)
+    Pos::AddMerchandise.call(
+      transaction: transaction,
+      actor: @manager,
+      expected_lock_version: transaction.lock_version,
+      identifier: @variant.sku
+    )
+    transaction.reload
+    Pos::TenderCash.call(
+      transaction: transaction,
+      actor: @manager,
+      expected_lock_version: transaction.lock_version,
+      amount_presented_cents: transaction.total_cents
+    )
+    assert_equal 1, transaction.reload.pos_tenders.count
+
+    add_unlinked!(transaction.reload, @manager)
+    assert_equal 0, transaction.reload.pos_tenders.count
+  end
+
+  test "unknown used identifier is rejected" do
+    transaction = start_transaction(@manager)
+    error = assert_raises(Pos::Error) do
+      add_unlinked!(transaction, @manager, identifier: Identifiers::Ean13.complete("220", "999999001"))
+    end
+    assert_match(/merchandise not found/, error.message)
+    assert_equal 0, transaction.reload.pos_transaction_lines.count
+  end
+
+  test "on-hand used unit is rejected" do
+    _used_variant, unit = pos_on_hand_unit(store: @store, actor: @admin, tax_class: @tax)
+    transaction = start_transaction(@manager)
+    error = assert_raises(Pos::Error) do
+      add_unlinked!(transaction, @manager, identifier: unit.unit_identifier)
+    end
+    assert_match(/unit must be removed/, error.message)
+  end
+
+  test "missing regular price is rejected" do
+    @variant.update_columns(regular_price_cents: nil)
+    transaction = start_transaction(@manager)
+    error = assert_raises(Pos::Error) do
+      add_unlinked!(transaction, @manager)
+    end
+    assert_match(/regular price is required/, error.message)
+  end
+
+  test "missing return price is rejected" do
+    transaction = start_transaction(@manager)
+    error = assert_raises(Pos::Error) do
+      add_unlinked!(transaction, @manager, requested_return_unit_price_cents: nil)
+    end
+    assert_match(/return price must be a non-negative integer/, error.message)
+  end
+
+  test "discontinued merchandise with a price is returnable without inheriting sellable" do
+    @variant.update!(status: "discontinued")
+    @variant.product.update!(status: "discontinued")
+    refute @variant.reload.sellable?
+
+    transaction = start_transaction(@manager)
+    line = add_unlinked!(transaction, @manager)
+    assert_equal @variant.id, line.product_variant_id
+  end
+
+  test "product-primary identifier with multiple variants is rejected" do
+    ProductVariants::Create.call(
+      product: @variant.product,
+      attributes: {
+        variant_type: "standard",
+        status: "active",
+        merchandise_class_id: @variant.merchandise_class_id,
+        department_id: @variant.department_id,
+        tax_class_id: @variant.tax_class_id,
+        regular_price_cents: 1500
+      },
+      actor: @admin
+    )
+    transaction = start_transaction(@manager)
+    error = assert_raises(Pos::Error) do
+      add_unlinked!(transaction, @manager, identifier: @variant.product.primary_identifier)
+    end
+    assert_match(/scan\/enter variant or unit identifier/, error.message)
+  end
+
+  test "unlinked returns do not merge on rescan" do
+    transaction = start_transaction(@manager)
+    first = add_unlinked!(transaction, @manager)
+    second = add_unlinked!(transaction.reload, @manager)
+
+    assert_equal 2, transaction.reload.pos_transaction_lines.count
+    assert_not_equal first.id, second.id
+    assert_equal 1, first.quantity
+    assert_equal 1, second.quantity
+  end
+
+  test "denied approver produces no line and audits the working transaction" do
+    transaction = start_transaction(@associate)
+    error = assert_raises(Pos::Error) do
+      add_unlinked!(
+        transaction,
+        @associate,
+        approver_username: "mgr65c",
+        approver_password: "wrong-password"
+      )
+    end
+    assert_match(/approver credentials are invalid/, error.message)
+    assert_equal 0, transaction.reload.pos_transaction_lines.count
+    assert_equal 0, PosControlledAction.where(pos_transaction_id: transaction.id).count
+
+    event = AuditEvent.find_by!(action: "pos.controlled_action.denied")
+    assert_equal "denied", event.outcome
+    assert_equal transaction.id, event.subject_id
+    assert_equal "PosTransaction", event.subject_type
+  end
+
+  test "stale preview expectations reject without creating a line" do
+    transaction = start_transaction(@manager)
+    error = assert_raises(Pos::Error) do
+      add_unlinked!(transaction, @manager, expected_reference_unit_price_cents: 1)
+    end
+    assert_equal Pos::ExecuteUnlinkedReturn::STALE_PREVIEW_MESSAGE, error.message
+    assert_equal 0, transaction.reload.pos_transaction_lines.count
+  end
+
+  test "two registers cannot claim the same removed used unit" do
+    used_variant, unit = pos_on_hand_unit(store: @store, actor: @admin, tax_class: @tax)
+    first_context = pos_open_context(store: @store, actor: @manager)
+    complete_unit_sale!(unit, actor: @manager, session: first_context[:session])
+    assert unit.reload.removed?
+
+    second_manager = pos_store_manager(store: @store, assigned_by: @admin, username: "mgr65c_b")
+    second_context = pos_open_context(store: @store, actor: second_manager)
+    first_txn = Pos::StartTransaction.call(session: first_context[:session], actor: @manager)
+    second_txn = Pos::StartTransaction.call(session: second_context[:session], actor: second_manager)
+
+    add_unlinked!(first_txn, @manager, identifier: unit.unit_identifier)
+    error = assert_raises(Pos::Error) do
+      add_unlinked!(second_txn, second_manager, identifier: unit.unit_identifier)
+    end
+    assert_match(/already on a working return/, error.message)
+    assert_equal 1, PosTransactionLine.joins(:pos_transaction).where(
+      inventory_unit_id: unit.id,
+      pos_transactions: { status: "working" }
+    ).count
+    assert_equal used_variant.id, first_txn.reload.pos_transaction_lines.first.product_variant_id
+  end
+
+  private
+
+  def start_transaction(actor)
+    context = pos_open_context(store: @store, actor: actor)
+    Pos::StartTransaction.call(session: context[:session], actor: actor)
+  end
+
+  def add_unlinked!(transaction, actor, **attrs)
+    identifier = attrs.delete(:identifier) || @variant.sku
+    Pos::ExecuteUnlinkedReturn.call(
+      transaction: transaction,
+      actor: actor,
+      expected_lock_version: transaction.lock_version,
+      identifier: identifier,
+      quantity: attrs.fetch(:quantity, 1),
+      reason_code: attrs.fetch(:reason_code, "changed_mind"),
+      reason_note: attrs[:reason_note],
+      requested_return_unit_price_cents: attrs.fetch(:requested_return_unit_price_cents, 1999),
+      approver_username: attrs[:approver_username],
+      approver_password: attrs[:approver_password],
+      expected_product_variant_id: attrs[:expected_product_variant_id],
+      expected_inventory_unit_id: attrs[:expected_inventory_unit_id],
+      expected_reference_unit_price_cents: attrs[:expected_reference_unit_price_cents],
+      expected_tax_class_id: attrs[:expected_tax_class_id]
+    )
+  end
+
+  def fingerprint_for(transaction, line, action)
+    Pos::ControlledActionFingerprint.call(
+      action_type: "unlinked_return",
+      transaction_id: transaction.id,
+      line_id: line.id,
+      material_values: action.material_values,
+      reason_code: action.reason_code,
+      reason_note: action.reason_note
+    )
+  end
+
+  def complete_unit_sale!(unit, actor:, session:)
+    transaction = Pos::StartTransaction.call(session: session, actor: actor)
+    Pos::AddMerchandise.call(
+      transaction: transaction,
+      actor: actor,
+      expected_lock_version: transaction.lock_version,
+      identifier: unit.unit_identifier
+    )
+    transaction.reload
+    Pos::TenderCash.call(
+      transaction: transaction,
+      actor: actor,
+      expected_lock_version: transaction.lock_version,
+      amount_presented_cents: transaction.total_cents
+    )
+    Pos::CompleteTransaction.call(
+      transaction: transaction.reload,
+      actor: actor,
+      operation_id: SecureRandom.uuid_v7,
+      expected_lock_version: transaction.lock_version,
+      expected_total_cents: transaction.total_cents,
+      expected_signed_net_cents: transaction.signed_net_cents
+    )
+  end
+end

--- a/test/services/pos/execute_unlinked_return_test.rb
+++ b/test/services/pos/execute_unlinked_return_test.rb
@@ -214,29 +214,6 @@ class PosExecuteUnlinkedReturnTest < ActiveSupport::TestCase
     assert_equal 0, transaction.reload.pos_transaction_lines.count
   end
 
-  test "two registers cannot claim the same removed used unit" do
-    used_variant, unit = pos_on_hand_unit(store: @store, actor: @admin, tax_class: @tax)
-    first_context = pos_open_context(store: @store, actor: @manager)
-    complete_unit_sale!(unit, actor: @manager, session: first_context[:session])
-    assert unit.reload.removed?
-
-    second_manager = pos_store_manager(store: @store, assigned_by: @admin, username: "mgr65c_b")
-    second_context = pos_open_context(store: @store, actor: second_manager)
-    first_txn = Pos::StartTransaction.call(session: first_context[:session], actor: @manager)
-    second_txn = Pos::StartTransaction.call(session: second_context[:session], actor: second_manager)
-
-    add_unlinked!(first_txn, @manager, identifier: unit.unit_identifier)
-    error = assert_raises(Pos::Error) do
-      add_unlinked!(second_txn, second_manager, identifier: unit.unit_identifier)
-    end
-    assert_match(/already on a working return/, error.message)
-    assert_equal 1, PosTransactionLine.joins(:pos_transaction).where(
-      inventory_unit_id: unit.id,
-      pos_transactions: { status: "working" }
-    ).count
-    assert_equal used_variant.id, first_txn.reload.pos_transaction_lines.first.product_variant_id
-  end
-
   private
 
   def start_transaction(actor)
@@ -272,31 +249,6 @@ class PosExecuteUnlinkedReturnTest < ActiveSupport::TestCase
       material_values: action.material_values,
       reason_code: action.reason_code,
       reason_note: action.reason_note
-    )
-  end
-
-  def complete_unit_sale!(unit, actor:, session:)
-    transaction = Pos::StartTransaction.call(session: session, actor: actor)
-    Pos::AddMerchandise.call(
-      transaction: transaction,
-      actor: actor,
-      expected_lock_version: transaction.lock_version,
-      identifier: unit.unit_identifier
-    )
-    transaction.reload
-    Pos::TenderCash.call(
-      transaction: transaction,
-      actor: actor,
-      expected_lock_version: transaction.lock_version,
-      amount_presented_cents: transaction.total_cents
-    )
-    Pos::CompleteTransaction.call(
-      transaction: transaction.reload,
-      actor: actor,
-      operation_id: SecureRandom.uuid_v7,
-      expected_lock_version: transaction.lock_version,
-      expected_total_cents: transaction.total_cents,
-      expected_signed_net_cents: transaction.signed_net_cents
     )
   end
 end

--- a/test/services/pos/unlinked_return_completion_test.rb
+++ b/test/services/pos/unlinked_return_completion_test.rb
@@ -122,6 +122,73 @@ class PosUnlinkedReturnCompletionTest < ActiveSupport::TestCase
     assert_match(/unlinked_return fact/, error.message)
   end
 
+  test "completion refuses an unlinked line whose return reason drifted from the approved fact" do
+    transaction = start_transaction
+    line = add_unlinked!(transaction, requested_return_unit_price_cents: 1999)
+    line.update_columns(
+      return_reason_code: "defective",
+      return_reason_name_snapshot: "Defective"
+    )
+    transaction.reload
+    Pos::AddRefundTender.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      tender_type: @cash,
+      amount_cents: -transaction.signed_net_cents
+    )
+    error = assert_raises(Pos::Error) { complete_current!(transaction.reload) }
+    assert_match(/return reason/, error.message)
+  end
+
+  test "freeze refuses a manual discount on an unlinked return" do
+    transaction = start_transaction
+    line = add_unlinked!(transaction)
+    line.update_columns(manual_discount_basis_points: 1000)
+    error = assert_raises(Pos::Error) do
+      Pos::FreezeUnlinkedReturnLine.call(transaction: transaction.reload, line: line.reload)
+    end
+    assert_match(/sale discount/, error.message)
+
+    error = assert_raises(Pos::Error) { Pos::CompletedTransactionIntegrity.verify!(transaction.reload) }
+    assert_match(/sale discount/, error.message)
+  end
+
+  test "envelope forbids override discount and extra actions on an unlinked return" do
+    transaction = start_transaction
+    add_unlinked!(transaction, requested_return_unit_price_cents: 1800)
+    envelope = refund_and_complete!(transaction.reload).operation.envelope.deep_dup
+    Pos::CompletedTransactionFacts.new(envelope).verify!
+
+    with_discount = envelope.deep_dup
+    with_discount["lines"].first["discount"] = {
+      "source" => "manual",
+      "method" => "percentage",
+      "basis_points" => 1000,
+      "discount_cents" => 180,
+      "net_merchandise_amount_cents" => 1620
+    }
+    error = assert_raises(Pos::Error) { Pos::CompletedTransactionFacts.new(with_discount).verify! }
+    assert_match(/cannot include discount/, error.message)
+
+    with_override = envelope.deep_dup
+    with_override["lines"].first["override"] = {
+      "reference_unit_price_cents" => 1999,
+      "selling_unit_price_cents" => 1800,
+      "unit_variance_cents" => -199,
+      "line_variance_cents" => -199
+    }
+    error = assert_raises(Pos::Error) { Pos::CompletedTransactionFacts.new(with_override).verify! }
+    assert_match(/cannot include override/, error.message)
+
+    extra_action = envelope.deep_dup
+    extra_action["controlled_actions"] << extra_action["controlled_actions"].first.merge(
+      "action" => "price_override"
+    )
+    error = assert_raises(Pos::Error) { Pos::CompletedTransactionFacts.new(extra_action).verify! }
+    assert_match(/other controlled actions/, error.message)
+  end
+
   test "malformed return_price_adjustment arithmetic is rejected" do
     transaction = start_transaction
     add_unlinked!(transaction, requested_return_unit_price_cents: 1800)

--- a/test/services/pos/unlinked_return_completion_test.rb
+++ b/test/services/pos/unlinked_return_completion_test.rb
@@ -1,0 +1,301 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PosUnlinkedReturnCompletionTest < ActiveSupport::TestCase
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    @tax = tax_class(code: "physical_book", name: "Physical book")
+    @store_tax = StoreTaxes::Create.call(
+      store: @store,
+      actor: @actor,
+      name: "Illinois State",
+      rate_percent: "5.000",
+      calculation_order: 1,
+      applies_by_tax_class_id: { @tax.id => true }
+    )
+    @variant = pos_sellable_variant(actor: @actor, tax_class: @tax)
+    open_quantity_stock(store: @store, variant: @variant, actor: @actor, quantity: 20, unit_cost_cents: 100)
+    @context = pos_open_context(store: @store, actor: @actor)
+    Pos::TenderTypes.seed!
+    @cash = TenderType.find_by!(code: "cash")
+  end
+
+  test "freeze writes merchandise snapshot and keeps approved prices after a live variant change" do
+    transaction = start_transaction
+    line = add_unlinked!(transaction, requested_return_unit_price_cents: 1800)
+    approved_reference = line.reference_unit_price_cents
+    approved_selling = line.selling_unit_price_cents
+    @variant.update_columns(regular_price_cents: 1)
+
+    result = refund_and_complete!(transaction.reload)
+    line.reload
+    snapshot = line.merchandise_snapshot
+
+    assert result.transaction.completed?
+    assert_equal approved_reference, line.reference_unit_price_cents
+    assert_equal approved_selling, line.selling_unit_price_cents
+    assert_equal @variant.sku, snapshot["sku"]
+    assert_equal @variant.product.name, snapshot["description"]
+    assert_equal @tax.code, snapshot["tax_class_code"]
+    refute snapshot.key?("unit_identifier")
+    envelope = result.operation.envelope
+    Pos::CompletedTransactionFacts.new(envelope).verify!
+    adjustment = envelope.dig("lines", 0, "return_price_adjustment")
+    assert_equal 1999, adjustment["reference_unit_price_cents"]
+    assert_equal 1800, adjustment["resulting_unit_price_cents"]
+    assert_equal(-199, adjustment["unit_variance_cents"])
+    assert_equal(-199, adjustment["line_variance_cents"])
+    refute envelope.dig("lines", 0).key?("override")
+    refute envelope.dig("lines", 0).key?("discount")
+    assert_equal 1, envelope.fetch("controlled_actions").count
+    assert_equal "unlinked_return", envelope.dig("controlled_actions", 0, "action")
+  end
+
+  test "changing store tax after approval affects unlinked completion tax" do
+    transaction = start_transaction
+    line = add_unlinked!(transaction, requested_return_unit_price_cents: 2000)
+    assert_equal 100, line.line_tax_cents
+
+    StoreTaxes::Update.call(
+      store_tax: @store_tax,
+      actor: @actor,
+      expected_lock_version: @store_tax.lock_version,
+      rate_percent: "10.000"
+    )
+    Pos::FreezeUnlinkedReturnLine.call(transaction: transaction.reload, line: line.reload)
+    assert_equal 200, line.reload.line_tax_cents
+  end
+
+  test "linked freeze never calls current tax calculate" do
+    original = complete_quantity_sale!(quantity: 1)
+    original_tax = original.pos_transaction_lines.first.line_tax_cents
+    StoreTaxes::Update.call(
+      store_tax: @store_tax.reload,
+      actor: @actor,
+      expected_lock_version: @store_tax.lock_version,
+      rate_percent: "10.000"
+    )
+    transaction = start_transaction
+    return_line = Pos::AddLinkedReturnLine.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      original_line: original.pos_transaction_lines.first,
+      quantity: 1,
+      reason_code: "changed_mind"
+    )
+    Pos::FreezeLinkedReturnLine.call(transaction: transaction.reload, line: return_line.reload)
+    assert_equal original_tax, return_line.reload.line_tax_cents
+  end
+
+  test "used freeze snapshot includes unit identity and condition" do
+    used_variant, unit = pos_on_hand_unit(store: @store, actor: @actor, tax_class: @tax)
+    complete_unit_sale!(unit)
+    transaction = start_transaction
+    line = add_unlinked!(transaction, identifier: unit.unit_identifier, requested_return_unit_price_cents: 1200)
+    refund_and_complete!(transaction.reload)
+
+    snapshot = line.reload.merchandise_snapshot
+    assert_equal used_variant.sku, snapshot["sku"]
+    assert_equal unit.unit_identifier, snapshot["unit_identifier"]
+    assert_equal used_variant.merchandise_condition.code, snapshot["condition_code"]
+    assert unit.reload.on_hand?
+    assert_equal 500, unit.carrying_value_cents
+  end
+
+  test "integrity refuses an unlinked line without the unlinked_return fact" do
+    transaction = start_transaction
+    line = add_unlinked!(transaction)
+    line.pos_controlled_actions.delete_all
+    transaction.reload
+    Pos::AddRefundTender.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      tender_type: @cash,
+      amount_cents: -transaction.signed_net_cents
+    )
+    error = assert_raises(Pos::Error) { complete_current!(transaction.reload) }
+    assert_match(/unlinked_return fact/, error.message)
+  end
+
+  test "malformed return_price_adjustment arithmetic is rejected" do
+    transaction = start_transaction
+    add_unlinked!(transaction, requested_return_unit_price_cents: 1800)
+    envelope = refund_and_complete!(transaction.reload).operation.envelope.deep_dup
+    Pos::CompletedTransactionFacts.new(envelope).verify!
+
+    envelope["lines"].first["return_price_adjustment"]["line_variance_cents"] = 0
+    error = assert_raises(Pos::Error) { Pos::CompletedTransactionFacts.new(envelope).verify! }
+    assert_match(/return_price_adjustment is invalid/, error.message)
+  end
+
+  test "return_price_adjustment is omitted when unlinked selling equals reference" do
+    transaction = start_transaction
+    add_unlinked!(transaction, requested_return_unit_price_cents: 1999)
+    envelope = refund_and_complete!(transaction.reload).operation.envelope
+    Pos::CompletedTransactionFacts.new(envelope).verify!
+    refute envelope.fetch("lines").first.key?("return_price_adjustment")
+  end
+
+  test "return_price_adjustment is forbidden on sale and linked return envelopes" do
+    sale = complete_quantity_sale!(quantity: 1)
+    sale_envelope = PosOperation.find_by!(pos_transaction_id: sale.id).envelope.deep_dup
+    sale_envelope["lines"].first["return_price_adjustment"] = { "reference_unit_price_cents" => 1 }
+    error = assert_raises(Pos::Error) { Pos::CompletedTransactionFacts.new(sale_envelope).verify! }
+    assert_match(/cannot include return_price_adjustment/, error.message)
+
+    transaction = start_transaction
+    Pos::AddLinkedReturnLine.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      original_line: sale.pos_transaction_lines.first,
+      quantity: 1,
+      reason_code: "changed_mind"
+    )
+    linked_envelope = refund_and_complete!(transaction.reload).operation.envelope.deep_dup
+    linked_envelope["lines"].first["return_price_adjustment"] = {
+      "reference_unit_price_cents" => 1999,
+      "resulting_unit_price_cents" => 1800,
+      "unit_variance_cents" => -199,
+      "line_variance_cents" => -199
+    }
+    error = assert_raises(Pos::Error) { Pos::CompletedTransactionFacts.new(linked_envelope).verify! }
+    assert_match(/cannot include return_price_adjustment/, error.message)
+  end
+
+  test "sale 30 plus unlinked 20 nets plus 10" do
+    thirty, twenty = mixed_priced_variants
+    result = complete_mixed!(sale_variant: thirty, unlinked_variant: twenty)
+    assert_equal 1000, result.transaction.signed_net_cents
+  end
+
+  test "sale 20 plus unlinked 30 nets minus 10" do
+    thirty, twenty = mixed_priced_variants
+    result = complete_mixed!(sale_variant: twenty, unlinked_variant: thirty)
+    assert_equal(-1000, result.transaction.signed_net_cents)
+  end
+
+  test "sale 20 plus unlinked 20 nets zero" do
+    _thirty, twenty = mixed_priced_variants
+    result = complete_mixed!(sale_variant: twenty, unlinked_variant: twenty)
+    assert_equal 0, result.transaction.signed_net_cents
+    assert_equal 0, result.transaction.pos_tenders.count
+  end
+
+  private
+
+  def start_transaction
+    Pos::StartTransaction.call(session: open_session, actor: @actor)
+  end
+
+  def open_session
+    session = @context[:session]
+    return session if session.reload.open?
+
+    @context = pos_open_context(store: @store, actor: @actor, register: @context[:register])
+    @context[:session]
+  end
+
+  def add_unlinked!(transaction, identifier: @variant.sku, quantity: 1, requested_return_unit_price_cents: 1999)
+    Pos::ExecuteUnlinkedReturn.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      identifier: identifier,
+      quantity: quantity,
+      reason_code: "changed_mind",
+      requested_return_unit_price_cents: requested_return_unit_price_cents
+    )
+  end
+
+  def refund_and_complete!(transaction)
+    transaction.reload
+    if transaction.signed_net_cents.negative?
+      Pos::AddRefundTender.call(
+        transaction: transaction,
+        actor: @actor,
+        expected_lock_version: transaction.lock_version,
+        tender_type: @cash,
+        amount_cents: -transaction.signed_net_cents
+      )
+      transaction.reload
+    elsif transaction.signed_net_cents.positive?
+      Pos::TenderCash.call(
+        transaction: transaction,
+        actor: @actor,
+        expected_lock_version: transaction.lock_version,
+        amount_presented_cents: transaction.total_cents
+      )
+      transaction.reload
+    end
+    complete_current!(transaction)
+  end
+
+  def complete_current!(transaction)
+    Pos::CompleteTransaction.call(
+      transaction: transaction,
+      actor: @actor,
+      operation_id: SecureRandom.uuid_v7,
+      expected_lock_version: transaction.lock_version,
+      expected_total_cents: transaction.total_cents,
+      expected_signed_net_cents: transaction.signed_net_cents
+    )
+  end
+
+  def complete_quantity_sale!(quantity:)
+    transaction = start_transaction
+    Pos::AddMerchandise.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      identifier: @variant.sku,
+      quantity: quantity
+    )
+    refund_and_complete!(transaction.reload).transaction
+  end
+
+  def complete_unit_sale!(unit)
+    transaction = start_transaction
+    Pos::AddMerchandise.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      identifier: unit.unit_identifier
+    )
+    refund_and_complete!(transaction.reload).transaction
+  end
+
+  def mixed_priced_variants
+    untaxed = tax_class(code: "untaxed_mixed")
+    StoreTaxes::EnsureRules.for_tax_class(untaxed)
+    StoreTaxRule.find_by!(store_tax: @store_tax, tax_class: untaxed).update!(applies: false)
+    thirty = pos_sellable_variant(actor: @actor, tax_class: untaxed, name: "Thirty Book")
+    twenty = pos_sellable_variant(actor: @actor, tax_class: untaxed, name: "Twenty Book")
+    thirty.update_columns(regular_price_cents: 3000)
+    twenty.update_columns(regular_price_cents: 2000)
+    open_quantity_stock(store: @store, variant: thirty, actor: @actor, quantity: 5, unit_cost_cents: 100)
+    open_quantity_stock(store: @store, variant: twenty, actor: @actor, quantity: 5, unit_cost_cents: 100)
+    [ thirty, twenty ]
+  end
+
+  def complete_mixed!(sale_variant:, unlinked_variant:)
+    transaction = start_transaction
+    Pos::AddMerchandise.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      identifier: sale_variant.sku
+    )
+    add_unlinked!(
+      transaction.reload,
+      identifier: unlinked_variant.sku,
+      requested_return_unit_price_cents: unlinked_variant.regular_price_cents
+    )
+    refund_and_complete!(transaction.reload)
+  end
+end

--- a/test/system/pos_unlinked_return_test.rb
+++ b/test/system/pos_unlinked_return_test.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class PosUnlinkedReturnTest < ApplicationSystemTestCase
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    @tax = tax_class(code: "physical_book", name: "Physical book")
+    StoreTaxes::Create.call(
+      store: @store,
+      actor: @actor,
+      name: "Illinois State",
+      rate_percent: "5.000",
+      calculation_order: 1,
+      applies_by_tax_class_id: { @tax.id => true }
+    )
+    @variant = pos_sellable_variant(actor: @actor, tax_class: @tax)
+    open_quantity_stock(store: @store, variant: @variant, actor: @actor, quantity: 5)
+    @register = Register.create!(store: @store, register_number: 1, name: "Front")
+    @associate = pos_transacting_user(store: @store, assigned_by: @actor, username: "clerk_sys65c")
+    pos_store_manager(store: @store, assigned_by: @actor, username: "mgr_sys65c")
+  end
+
+  test "associate return without receipt needs manager credentials then cash refunds" do
+    open_register_as("clerk_sys65c")
+    assert_button "Return without receipt", disabled: false
+    click_on "Return without receipt"
+    assert_text "Return without receipt"
+
+    identifier = find("#pos-unlinked-identifier")
+    identifier.fill_in with: @variant.sku
+    identifier.send_keys :enter
+    assert_text "Example Book", wait: 5
+    assert_text "Current price"
+    assert_equal 0, PosTransaction.working.find_by!(register: @register).pos_transaction_lines.count
+
+    fill_in "Return unit price", with: "18.00"
+    find("#pos-unlinked-approver-username", visible: true).fill_in with: "mgr_sys65c"
+    password = find("#pos-unlinked-approver-password", visible: :all)
+    scroll_to password
+    password.fill_in with: "correct-horse-battery"
+    click_on "Add return"
+
+    assert_text "RETURN", wait: 10
+    assert_text "Unlinked return"
+    assert_text "Refund due"
+    refute_text "Override"
+
+    click_on "Refund (+)"
+    assert_text "REFUND"
+    field = find("#pos-command-field")
+    field.send_keys :enter
+    send_keys :enter
+    assert_text "Transaction complete", wait: 10
+    assert_text "Cash refund"
+    assert_text "Unlinked return"
+    assert_text "Reference"
+  end
+
+  test "cashier returns a known removed used unit without a receipt" do
+    used_variant, unit = pos_on_hand_unit(store: @store, actor: @actor, tax_class: @tax)
+    open_register_as("admin")
+    field = find("#pos-command-field")
+    field.fill_in with: unit.unit_identifier
+    field.send_keys :enter
+    assert_text used_variant.product.name
+    click_on "Tender (+)"
+    field = find("#pos-command-field")
+    field.fill_in with: "20.00"
+    field.send_keys :enter
+    send_keys :enter
+    assert_text "Transaction complete", wait: 10
+    assert unit.reload.removed?
+
+    click_on "New transaction"
+    assert_text "SALE ENTRY"
+    click_on "Return without receipt"
+    identifier = find("#pos-unlinked-identifier")
+    identifier.fill_in with: unit.unit_identifier
+    identifier.send_keys :enter
+    assert_text used_variant.product.name, wait: 5
+    assert_no_selector "#pos-unlinked-quantity", visible: true
+    click_on "Add return"
+    assert_text "Unlinked return", wait: 10
+
+    click_on "Refund (+)"
+    field = find("#pos-command-field")
+    field.send_keys :enter
+    send_keys :enter
+    assert_text "Transaction complete", wait: 10
+    assert unit.reload.on_hand?
+  end
+
+  private
+
+  def open_register_as(username)
+    visit new_session_path
+    fill_in "session_username", with: username
+    fill_in "session_password", with: "correct-horse-battery"
+    find_field("session_password").send_keys :enter
+    assert_text "Signed in successfully"
+    visit pos_register_enter_path(register_id: @register.id)
+    fill_in "Opening float", with: "0.00"
+    click_on "Open register"
+    assert_text "SALE ENTRY"
+  end
+end

--- a/test/system/pos_unlinked_return_test.rb
+++ b/test/system/pos_unlinked_return_test.rb
@@ -37,6 +37,7 @@ class PosUnlinkedReturnTest < ApplicationSystemTestCase
     assert_equal 0, PosTransaction.working.find_by!(register: @register).pos_transaction_lines.count
 
     fill_in "Return unit price", with: "18.00"
+    select "Defective", from: "Return reason"
     find("#pos-unlinked-approver-username", visible: true).fill_in with: "mgr_sys65c"
     password = find("#pos-unlinked-approver-password", visible: :all)
     scroll_to password
@@ -82,6 +83,7 @@ class PosUnlinkedReturnTest < ApplicationSystemTestCase
     identifier.send_keys :enter
     assert_text used_variant.product.name, wait: 5
     assert_no_selector "#pos-unlinked-quantity", visible: true
+    select "Changed mind", from: "Return reason"
     click_on "Add return"
     assert_text "Unlinked return", wait: 10
 


### PR DESCRIPTION
## Summary
- Implements 6.5C: cashiers can take a return without a receipt as one `unlinked_return` controlled action (identifier, quantity/reason, cashier-entered return price, manager approval when required, Cash refund).
- Return-owned merchandise resolution does not inherit sale `sellable?` lookup. Used units must be known and `removed` at the current Store; freeze keeps the approved price/Tax Class and applies current Store Tax; inventory restore is independent of the refund amount (`valuation_basis` on `inventory.return_posted`).
- Completion binds the Core line reason to the approved fact, forbids sale discounts/overrides on unlinked lines, and races two Registers for the same Used unit so only one working owner wins.

## Verification
- `./dev/rails-docker bin/ci` (local: Rails 535, system 27, RuboCop, Brakeman, bundler-audit)
- `./dev/rails-docker bin/rails test test/services/pos/unlinked_return_completion_test.rb test/services/pos/execute_unlinked_return_test.rb test/services/pos/concurrency_test.rb test/services/inventory/post_return_test.rb test/system/pos_unlinked_return_test.rb`

## Documentation and migrations
- [returns.md](docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/returns.md), [inventory-posting-contract.md](docs/planning/phase3-inventory-foundation/inventory-posting-contract.md), Phase 6 README/plan/workspace/controlled-actions status
- `db/migrate/20260819130000_add_unlinked_return_controlled_action_type.rb` expands the `pos_controlled_actions` type CHECK. `down` is irreversible once `unlinked_return` rows may exist. Rollout also needs `shelfsense:seed_permissions` for `pos.unlinked_return.perform` / `.approve`.

6.5D still owns comprehensive mixed/unlinked closeout hardening.

Made with [Cursor](https://cursor.com)