### PR TITLE
Prove mixed sale and return baskets through closeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ShelfSense is an inventory, purchasing, customer-service, and point-of-sale system for independent bookstores. It is designed for one organization operating one or more stores, with a central organization server and store Registers. A future standalone Terminal (ADR-021) may continue ordinary checkout during temporary connectivity loss.
 
-Phases 0–5 are implemented. Phase 6 is the operational POS MVP: slices 6.0–6.4 and 6.5A/B (linked-return Core and cashier workflow) are implemented. Next is 6.5C unlinked return.
+Phases 0–5 are implemented. Phase 6 is the operational POS MVP: slices 6.0–6.5 are implemented (through mixed returns and closeout hardening). Next is 6.6 post-void.
 
 ## Goals
 
@@ -208,7 +208,7 @@ Authoritative plan: [phase5-plan.md](docs/planning/phase4-6-point-of-sale/phase5
 
 ### Phase 6: Operational POS MVP
 
-Status: slices 6.0–6.4 and 6.5A/B implemented (CompletedPosOperation v2, Used/non-inventory sales, mixed tenders, history/reprint, controlled pricing, linked returns and refunds). Next: 6.5C unlinked return.
+Status: slices 6.0–6.5 implemented (CompletedPosOperation v2, Used/non-inventory sales, mixed tenders, history/reprint, controlled pricing, linked and unlinked returns, mixed baskets, refunds, direction-aware Session/Z). Next: 6.6 post-void.
 
 Phase 6 extends the Phase 5 Cash register with Used/non-inventory sales, mixed tenders, history/reprint, controlled pricing, returns, post-void, and closeout reporting. Each slice merges independently to `main`.
 

--- a/app/services/inventory/post_return.rb
+++ b/app/services/inventory/post_return.rb
@@ -138,7 +138,7 @@ module Inventory
     end
 
     def lock_inventory_unit!
-      InventoryUnit.lock.find(@line.inventory_unit_id)
+      InventoryUnit.uncached { InventoryUnit.lock.find(@line.inventory_unit_id) }
     rescue ActiveRecord::RecordNotFound
       raise Error, "unit must be removed"
     end

--- a/app/services/inventory/post_sale.rb
+++ b/app/services/inventory/post_sale.rb
@@ -93,7 +93,7 @@ module Inventory
     end
 
     def lock_inventory_unit!
-      InventoryUnit.lock.find(@line.inventory_unit_id)
+      InventoryUnit.uncached { InventoryUnit.lock.find(@line.inventory_unit_id) }
     rescue ActiveRecord::RecordNotFound
       raise Error, "unit must be on hand"
     end

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,13 +28,13 @@ This directory contains the project’s technical authority, development guidanc
 | [Phase 5 cash register schema](planning/phase4-6-point-of-sale/phase5-cash-register/phase5-schema.md) | Implemented session close snapshots and reporting-period Z aggregates |
 | [Phase 5 register workspace](planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md) | Slice 2 open gate, modes, HTTP/retry, focus, completion receipt vs print |
 | [Phase 5 register workspace UX](planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace-ux.md) | Slice 2 low-fidelity wireframes (focus, keys, Turbo regions) |
-| [Phase 6 POS MVP plan](planning/phase4-6-point-of-sale/phase6-pos-mvp/phase6-plan.md) | Phase 6 slice map, deferrals, merge-to-main, and acceptance (6.0–6.4 and 6.5A/B implemented; 6.5C next) |
+| [Phase 6 POS MVP plan](planning/phase4-6-point-of-sale/phase6-pos-mvp/phase6-plan.md) | Phase 6 slice map, deferrals, merge-to-main, and acceptance (6.0–6.5 implemented; 6.6 next) |
 | [Phase 6 MVP contract](planning/phase4-6-point-of-sale/phase6-pos-mvp/mvp-contract.md) | Slice 6.0 CompletedPosOperation v2 and cross-cutting locks |
 | [Phase 6 merchandise breadth](planning/phase4-6-point-of-sale/phase6-pos-mvp/merchandise-breadth.md) | Slice 6.1 Used/individual and non-inventory sales (implemented) |
 | [Phase 6 tender breadth](planning/phase4-6-point-of-sale/phase6-pos-mvp/tender-breadth.md) | Slice 6.2 Cash/Card/Check/Other settlement (implemented) |
 | [Phase 6 transaction history](planning/phase4-6-point-of-sale/phase6-pos-mvp/transaction-history.md) | Slice 6.3 completed lookup, detail, reprint (implemented) |
 | [Phase 6 controlled actions](planning/phase4-6-point-of-sale/phase6-pos-mvp/controlled-actions.md) | Slice 6.4 price override, line discount, Tax Class override (implemented) |
-| [Phase 6 returns](planning/phase4-6-point-of-sale/phase6-pos-mvp/returns.md) | Slice 6.5 linked/unlinked returns, refunds, mixed sale+return (6.5A/B implemented; 6.5C next) |
+| [Phase 6 returns](planning/phase4-6-point-of-sale/phase6-pos-mvp/returns.md) | Slice 6.5 linked/unlinked returns, refunds, mixed sale+return (6.5A–D implemented) |
 | [POS Phases 4–6 plan](planning/phase4-6-point-of-sale/spec.md) | Multi-phase POS sequencing (foundation → cash register → MVP); §6 deferred to the Phase 6 packet |
 | [UX conventions](ux-conventions.md) | Shared admin page anatomy, partials, currency boundaries, palette, and Hotwire deferral |
 | [Development guide](development.md) | Docker-only local setup, PostgreSQL configuration, application commands, and troubleshooting |

--- a/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md
+++ b/docs/planning/phase4-6-point-of-sale/phase5-cash-register/register-workspace.md
@@ -467,6 +467,6 @@ System tests (when the workspace is implemented) must cover at least: scan → f
 
 This Slice 2 contract does not define split tender, discounts, returns, suspend/recall, drawers, Terminal, new permissions, close/Z outbox, polished visual design, mobile POS, or customer display.
 
-Later slices that reuse this workspace: 6.2 mixed tender, 6.4 controlled actions, 6.5B linked returns and refunds ([returns.md](../phase6-pos-mvp/returns.md)), 6.5C unlinked return (Return without receipt overlay; no F-key). 6.5D mixed/unlinked closeout hardening is next.
+Later slices that reuse this workspace: 6.2 mixed tender, 6.4 controlled actions, 6.5B linked returns and refunds ([returns.md](../phase6-pos-mvp/returns.md)), 6.5C unlinked return (Return without receipt overlay; no F-key), 6.5D mixed sale+unlinked closeout. Next: 6.6 post-void.
 
 Receipt print, blind close, and Z screens are Slice 3: [close-z-screens.md](close-z-screens.md).

--- a/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/README.md
+++ b/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/README.md
@@ -1,6 +1,6 @@
 # Phase 6 — Operational POS MVP
 
-**Status:** Slice 6.0 contract locked. Slice 6.1 merchandise breadth is implemented. Slice 6.2 tender breadth is implemented ([tender-breadth.md](tender-breadth.md)). Slice 6.3 transaction history is implemented ([transaction-history.md](transaction-history.md)). Slice 6.4 controlled actions are implemented ([controlled-actions.md](controlled-actions.md)). Slice 6.5A directional Core, 6.5B linked-return operator workflow, and 6.5C unlinked return are implemented ([returns.md](returns.md)). Next: 6.5D mixed/unlinked closeout hardening.
+**Status:** Slice 6.0 contract locked. Slice 6.1 merchandise breadth is implemented. Slice 6.2 tender breadth is implemented ([tender-breadth.md](tender-breadth.md)). Slice 6.3 transaction history is implemented ([transaction-history.md](transaction-history.md)). Slice 6.4 controlled actions are implemented ([controlled-actions.md](controlled-actions.md)). Slice 6.5 returns are implemented (6.5A–D; [returns.md](returns.md)). Next: 6.6 post-void.
 
 | Document | Purpose |
 |---|---|
@@ -10,7 +10,7 @@
 | [tender-breadth.md](tender-breadth.md) | Slice 6.2: Cash/Card/Check/Other settlement (implemented) |
 | [transaction-history.md](transaction-history.md) | Slice 6.3: completed lookup, detail, reprint (implemented) |
 | [controlled-actions.md](controlled-actions.md) | Slice 6.4: price override, line discount, Tax Class override (implemented) |
-| [returns.md](returns.md) | Slice 6.5: linked/unlinked returns, refunds, mixed sale+return (6.5A/B/C implemented; 6.5D next) |
+| [returns.md](returns.md) | Slice 6.5: linked/unlinked returns, refunds, mixed sale+return (6.5A–D implemented) |
 
 Parent multi-phase sequencing: [../spec.md](../spec.md). Phase 4 completion kernel: [../phase4-point-of-sale/](../phase4-point-of-sale/). Phase 5 cash register: [../phase5-cash-register/](../phase5-cash-register/).
 

--- a/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/phase6-plan.md
+++ b/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/phase6-plan.md
@@ -1,6 +1,6 @@
 # Phase 6 — Operational POS MVP
 
-**Status:** Slice 6.0 contract locked ([mvp-contract.md](mvp-contract.md)). Slice 6.1 merchandise breadth implemented ([merchandise-breadth.md](merchandise-breadth.md)). Slice 6.2 tender breadth implemented ([tender-breadth.md](tender-breadth.md)). Slice 6.3 transaction history implemented ([transaction-history.md](transaction-history.md)). Slice 6.4 controlled actions implemented ([controlled-actions.md](controlled-actions.md)). Slice 6.5A directional Core implemented; slice 6.5B linked-return operator workflow implemented; slice 6.5C unlinked return implemented ([returns.md](returns.md)).
+**Status:** Slice 6.0 contract locked ([mvp-contract.md](mvp-contract.md)). Slice 6.1 merchandise breadth implemented ([merchandise-breadth.md](merchandise-breadth.md)). Slice 6.2 tender breadth implemented ([tender-breadth.md](tender-breadth.md)). Slice 6.3 transaction history implemented ([transaction-history.md](transaction-history.md)). Slice 6.4 controlled actions implemented ([controlled-actions.md](controlled-actions.md)). Slice 6.5 returns implemented (6.5A–D; [returns.md](returns.md)). Next: 6.6 post-void.
 
 **Authority**
 
@@ -11,7 +11,7 @@
 | [Tender breadth](tender-breadth.md) | Slice 6.2: Cash/Card/Check/Other settlement |
 | [Transaction history](transaction-history.md) | Slice 6.3: completed lookup, detail, reprint |
 | [Controlled actions](controlled-actions.md) | Slice 6.4: price override, line discount, Tax Class override |
-| [Returns](returns.md) | Slice 6.5: linked/unlinked returns, refunds, mixed sale+return (6.5A/B/C implemented; 6.5D next) |
+| [Returns](returns.md) | Slice 6.5: linked/unlinked returns, refunds, mixed sale+return (6.5A–D implemented) |
 | [Phase 4 plan](../phase4-point-of-sale/phase4-plan.md) | Completion, receipt allocation, inventory posting |
 | [CompletedPosOperation v1](../phase4-point-of-sale/completed-pos-operation-v1.md) | Commercial base; v2 is additive |
 | [POS tax contract](../phase4-point-of-sale/pos-tax-contract.md) | Tax Class / Store Tax; linked-return reversal ([§10](../phase4-point-of-sale/pos-tax-contract.md)) |
@@ -112,7 +112,7 @@ Write the detailed implementation contract for slices 6.6–6.7 immediately befo
 | **6.2** | Tender breadth | Card, Check, admin-created Other, mixed tender | **Implemented.** All-Cash sale remains Phase 5-equivalent; Session/Z shows Card/Check/Other |
 | **6.3** | Transaction history | Lookup, detail, receipt reprint | **Implemented.** Sale workspace does not depend on history |
 | **6.4** | Controlled pricing/actions | Approval framework, price override, line discount, Tax Class override | **Implemented.** Ordinary path stays `direct` unless policy requires a second actor |
-| **6.5** | Returns | Linked, unlinked, price adjustment, mixed sale/return | **6.5A/B/C implemented** ([returns.md](returns.md)). 6.5D mixed/closeout hardening is next. Sale-only baskets still complete the same way; Session/Z is direction-aware |
+| **6.5** | Returns | Linked, unlinked, price adjustment, mixed sale/return | **Implemented** ([returns.md](returns.md)). Sale-only baskets still complete the same way; Session/Z is direction-aware |
 | **6.6** | Post-void | Controlled whole-transaction correction | Entry is from history; sale path untouched |
 | **6.7** | MVP closeout | Receipts, Z/tender reporting polish, audit/history UX, regression | Additive snapshots; already-finalized periods stay immutable |
 
@@ -183,7 +183,7 @@ Perform/approve permission keys arrive in this slice. Z finalize stays on `pos.t
 
 ### 6.5 — Returns and exchanges
 
-**6.5A/B/C implemented. 6.5D next.** Authority: [returns.md](returns.md).
+**6.5A–D implemented. Phase 6.5 complete.** Authority: [returns.md](returns.md). Next: 6.6 post-void.
 
 No Exchange entity. Returns are new facts; refunds are settlement. Directional Core keeps sale-side `subtotal_cents` / `discount_cents` / `tax_cents` and adds `return_*` plus persisted `signed_net_cents`. `total_cents = abs(signed_net_cents)`.
 
@@ -195,7 +195,7 @@ MVP linked-return eligibility is limited to authoritative original-line linkage,
 - **Refunds:** tender settlement, not return valuation. External Card refund is cashier-confirmed outside ShelfSense. Expected Cash becomes `float + Cash payments − Cash refunds` and **may be negative** (not a physical drawer cap).
 - **Session/Z:** this slice must make commercial and Cash calculations direction-aware in the same change that first completes a return. `SUM(transaction.total_cents)` must not treat refund magnitude as sales. 6.7 may reorganize snapshot columns; it does not fix a knowingly wrong Z.
 
-Working/cancelled returns do not consume eligibility. Concurrency must prevent two Registers from both returning the final eligible quantity. Delivery: 6.5A Core, 6.5B operator workflow, and 6.5C unlinked return are implemented; 6.5D remains as specified in [returns.md](returns.md) §32.
+Working/cancelled returns do not consume eligibility. Concurrency must prevent two Registers from both returning the final eligible quantity. Delivery: 6.5A Core, 6.5B operator workflow, 6.5C unlinked return, and 6.5D mixed/closeout hardening are implemented as specified in [returns.md](returns.md) §32.
 
 ### 6.6 — Post-void
 
@@ -285,7 +285,7 @@ Fractional quantities
 3. Lock 6.2 tender contract → implement settlement redesign (Cash equivalence gate; Session/Z tender totals)
 4. Lock 6.3 history contract → lookup / detail / reprint
 5. Lock 6.4 controlled-action contract → framework, then override / discount / Tax Class
-6. 6.5A linked Core, 6.5B operator workflow, and 6.5C unlinked return implemented ([returns.md](returns.md)) → 6.5D mixed/unlinked closeout hardening
+6. 6.5A–D implemented ([returns.md](returns.md)); Phase 6.5 complete
 7. Lock 6.6 post-void contract → compensating whole-transaction fact
 8. Lock 6.7 closeout contract → receipt/Z/audit/keyboard regression (polish, not first truthful reporting)
 ```

--- a/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/returns.md
+++ b/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/returns.md
@@ -1,6 +1,6 @@
 # Phase 6 Slice 6.5 — Returns, refunds, and exchanges
 
-**Status:** Contract locked. 6.5A implemented. 6.5B implemented. 6.5C implemented. Next: 6.5D mixed/unlinked closeout hardening.
+**Status:** Contract locked. 6.5A–D implemented. Phase 6.5 complete. Next: 6.6 post-void.
 
 **Authority:** Linked return, unlinked return, mixed sale+return, refund tenders, and direction-aware Session/Z on the existing POS transaction. Dual authority with Core remains [mvp-contract.md](mvp-contract.md) / [ADR-020](../../../adr/ADR-020-pos-operation-envelope-and-core-facts.md). Tax remains [pos-tax-contract.md](../phase4-point-of-sale/pos-tax-contract.md) §10. Inventory posting remains [inventory-posting-contract.md](../../phase3-inventory-foundation/inventory-posting-contract.md). Settlement extends [tender-breadth.md](tender-breadth.md). Controlled-action policy remains [controlled-actions.md](controlled-actions.md). History initiation extends [transaction-history.md](transaction-history.md).
 
@@ -866,11 +866,22 @@ Implementation notes:
 - `Pos::ExecuteUnlinkedReturn` creates the line (preallocated UUIDv7) plus one `unlinked_return` fact. Return-owned identifier resolution does not inherit `Identifiers::Lookup`'s `sellable?` filter. Denied approval audits the working transaction; there is no pending line.
 - Overlay lookup is JSON resolve-only. Identifier Enter never submits approval. F8 remove audits `pos.unlinked_return.removed` before `dependent: :destroy`.
 - `FreezeUnlinkedReturnLine` keeps approved reference/selling/Tax Class, applies current Store Tax, and writes `merchandise_snapshot`. `Inventory::ReturnValuation` runs after the balance lock. Envelope `return_price_adjustment` is arithmetic and is not a sale override/discount.
-- Mixed sale+unlinked remains structurally allowed. 6.5D owns the comprehensive mixed/closeout matrix.
+- Mixed sale+unlinked remains structurally allowed. 6.5D owns the comprehensive mixed/closeout matrix and is implemented.
 
 ### 6.5D — Mixed transaction and closeout hardening
 
-Comprehensive mixed/unlinked/closeout hardening: sale + unlinked; net positive/negative/zero with unlinked; mixed refund tender; Session close; Z finalize; receipt/reprint; concurrency; completion retry/idempotency; full Phase 5–6.4 regression. Sale + linked return is already cashier-operable in 6.5B. No new domain model.
+**Implemented.** Merge gate: cashier-usable mixed sale + unlinked +/−/0, sale + linked + unlinked, split Cash+Card payment and refund; receipt/reprint/history, inventory, expected Cash, Session close, two-session Z, and completion retry stay truthful.
+
+Implementation notes:
+
+- Mixed baskets are ordinary `direction = return` lines with different historical authority. Linked + unlinked on the same transaction is allowed.
+- Unlinked reference-vs-return-price variance stays out of `discount_cents` / `return_discount_cents`.
+- Any material basket mutation clears working tenders so a sign change cannot keep the wrong settlement direction.
+- Concurrent linked vs unlinked restore of the same removed Used unit yields one `on_hand` unit. Completing a mixed transaction versus closing the Session never omits a completed fact from closed Session Cash.
+- Used-unit posting reloads the unit with `SELECT … FOR UPDATE` outside the transaction query cache so two restorers cannot both treat the row as still removed.
+- Pre-6.5 finalized additive Z columns remain NULL and display as not captured; they are not backfilled.
+
+Sale + linked-only +/−/0 and even exchange remain 6.5B regressions. Return-only unlinked remains a 6.5C regression.
 
 ---
 

--- a/test/integration/pos_mixed_return_workspace_test.rb
+++ b/test/integration/pos_mixed_return_workspace_test.rb
@@ -1,0 +1,328 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PosMixedReturnWorkspaceTest < ActionDispatch::IntegrationTest
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    @tax = tax_class(code: "physical_book", name: "Physical book")
+    StoreTaxes::Create.call(
+      store: @store,
+      actor: @actor,
+      name: "Illinois State",
+      rate_percent: "5.000",
+      calculation_order: 1,
+      applies_by_tax_class_id: { @tax.id => true }
+    )
+    @variant = pos_sellable_variant(actor: @actor, tax_class: @tax)
+    open_quantity_stock(store: @store, variant: @variant, actor: @actor, quantity: 20)
+    @thirty, @twenty = priced_variants(3000, 2000)
+    @register = Register.create!(store: @store, register_number: 1, name: "Front")
+    @cash = TenderType.find_by!(code: "cash")
+    @card = TenderType.find_by!(code: "card")
+    sign_in_as("admin")
+  end
+
+  test "workspace completes sale plus unlinked as payment refund and even exchange" do
+    post pos_register_enter_path, params: enter_params
+    follow_redirect!
+    working = PosTransaction.working.find_by!(register: @register)
+
+    post pos_register_merchandise_path, params: { identifier: @thirty.sku, lock_version: working.lock_version }
+    post_unlinked!(working.reload, @twenty, "20.00")
+    working.reload
+    assert working.signed_net_cents.positive?
+    assert_match "Amount due", response.body
+    post pos_register_tender_path, params: {
+      tender_amount: dollars(working.signed_net_cents),
+      lock_version: working.lock_version
+    }
+    complete_working!(working.reload)
+    follow_redirect!
+    assert_match "Transaction complete", response.body
+    assert_match "RETURN", response.body
+    assert_match "Unlinked return", response.body
+    assert_match "Net", response.body
+
+    post pos_register_continue_path
+    follow_redirect!
+    working = PosTransaction.working.find_by!(register: @register)
+    post pos_register_merchandise_path, params: { identifier: @twenty.sku, lock_version: working.lock_version }
+    post_unlinked!(working.reload, @thirty, "30.00")
+    working.reload
+    assert working.signed_net_cents.negative?
+    assert_match "Refund due", response.body
+    post pos_register_tender_path, params: {
+      tender_amount: dollars(-working.signed_net_cents),
+      lock_version: working.lock_version
+    }
+    complete_working!(working.reload)
+    follow_redirect!
+    assert_match "Cash refund", response.body
+    assert_match format_signed(working.reload.signed_net_cents), response.body
+    refute_match "Cash presented", response.body
+
+    post pos_register_continue_path
+    follow_redirect!
+    working = PosTransaction.working.find_by!(register: @register)
+    post pos_register_merchandise_path, params: { identifier: @twenty.sku, lock_version: working.lock_version }
+    post_unlinked!(working.reload, @twenty, "20.00")
+    working.reload
+    assert working.even_exchange?
+    assert_equal 0, working.pos_tenders.count
+    assert_match "Even exchange", response.body
+    complete_working!(working)
+    follow_redirect!
+    assert_match "Transaction complete", response.body
+    assert_equal 0, working.reload.pos_tenders.count
+  end
+
+  test "negative net split refund and positive net split payment complete from the workspace" do
+    post pos_register_enter_path, params: enter_params
+    follow_redirect!
+    working = PosTransaction.working.find_by!(register: @register)
+    post pos_register_merchandise_path, params: { identifier: @twenty.sku, lock_version: working.lock_version }
+    post_unlinked!(working.reload, @thirty, "30.00")
+    working.reload
+    due = -working.signed_net_cents
+    post pos_register_tender_path, params: {
+      tender_amount: "4.00",
+      tender_type_id: @card.id,
+      external_reference: "REF-MIX",
+      lock_version: working.lock_version
+    }
+    post pos_register_tender_path, params: {
+      tender_amount: dollars(due - 400),
+      tender_type_id: @cash.id,
+      lock_version: working.reload.lock_version
+    }
+    complete_working!(working.reload)
+    follow_redirect!
+    assert_match "External Card refund", response.body
+    assert_match "Cash refund", response.body
+    completed = working.reload
+    assert_equal %w[card cash], completed.pos_tenders.ordered.map(&:behavioral_category)
+    assert(completed.pos_tenders.all? { |tender| tender.direction == "refund" })
+
+    post pos_register_continue_path
+    follow_redirect!
+    working = PosTransaction.working.find_by!(register: @register)
+    post pos_register_merchandise_path, params: { identifier: @thirty.sku, lock_version: working.lock_version }
+    post_unlinked!(working.reload, @twenty, "20.00")
+    working.reload
+    post pos_register_tender_path, params: {
+      tender_amount: "4.00",
+      tender_type_id: @card.id,
+      external_reference: "AUTH-MIX",
+      lock_version: working.lock_version
+    }
+    post pos_register_tender_path, params: {
+      tender_amount: dollars(working.reload.signed_net_cents - 400),
+      tender_type_id: @cash.id,
+      lock_version: working.reload.lock_version
+    }
+    complete_working!(working.reload)
+    follow_redirect!
+    completed = working.reload
+    assert(completed.pos_tenders.all? { |tender| tender.direction == "payment" })
+    assert_equal completed.signed_net_cents, completed.pos_tenders.sum(:amount_cents)
+  end
+
+  test "mixed receipt reprint and history keep snapshots after live catalog changes" do
+    post pos_register_enter_path, params: enter_params
+    follow_redirect!
+    working = PosTransaction.working.find_by!(register: @register)
+    add_http_sale!(working, @twenty)
+    settle_http!(working.reload)
+    complete_working!(working.reload)
+    original = working.reload
+    post pos_register_continue_path
+    follow_redirect!
+    working = PosTransaction.working.find_by!(register: @register)
+    sale_line = add_http_sale!(working, @thirty)
+    Pos::ExecuteControlledAction.call(
+      transaction: working.reload,
+      line: sale_line.reload,
+      actor: @actor,
+      expected_lock_version: working.lock_version,
+      action_type: "line_discount",
+      operation: "apply",
+      reason_code: "customer_service",
+      discount_basis_points: 1000
+    )
+    post_unlinked!(working.reload, @twenty, "15.00")
+    post pos_transaction_return_items_path(original), params: selected_item(original.pos_transaction_lines.first)
+    follow_redirect!
+    working.reload
+    settle_http!(working)
+    complete_working!(working.reload)
+    follow_redirect!
+    completed = working.reload
+    assert_match "RETURN", response.body
+    assert_match "Unlinked return", response.body
+    assert_match "Return from #{original.transaction_reference}", response.body
+    assert_match "Net", response.body
+    snapshot_title = completed.pos_transaction_lines.find(&:sale?).merchandise_snapshot.fetch("description")
+
+    @thirty.product.update!(name: "Renamed Mixed Title")
+    @thirty.update_columns(regular_price_cents: 1)
+    TenderType.find_by!(code: "cash").update!(name: "Drawer Cash")
+    @tax.update!(name: "Renamed Tax Class")
+
+    get pos_transactions_path
+    assert_response :success
+    assert_match format_signed(completed.signed_net_cents), response.body
+
+    get pos_transaction_path(completed)
+    assert_response :success
+    assert_match snapshot_title, response.body
+    refute_match "Renamed Mixed Title", response.body
+    assert_match "Unlinked return", response.body
+    assert_match "Return from #{original.transaction_reference}", response.body
+    assert_select ".pos-receipt__reprint", text: "REPRINT"
+    assert_equal 0, Pos::Returnability.remaining_quantity(original.pos_transaction_lines.first)
+  end
+
+  test "other store cannot take linked original used unit history or refund" do
+    used_variant, unit = pos_on_hand_unit(store: @store, actor: @actor, tax_class: @tax)
+    post pos_register_enter_path, params: enter_params
+    follow_redirect!
+    working = PosTransaction.working.find_by!(register: @register)
+    add_http_sale!(working, unit)
+    settle_http!(working.reload)
+    complete_working!(working.reload)
+    sale = working.reload
+
+    east = Store.create!(store_number: "2", code: "east", name: "East Store", timezone: "America/New_York", country_code: "US")
+    pos_transacting_user(store: east, assigned_by: @actor, username: "east_clerk")
+    east_register = Register.create!(store: east, register_number: 1, name: "East Front")
+    delete session_path
+    sign_in_as("east_clerk")
+
+    get pos_transaction_path(sale)
+    assert_response :not_found
+
+    post pos_transaction_return_items_path(sale), params: selected_item(sale.pos_transaction_lines.first)
+    assert_response :not_found
+
+    post pos_register_enter_path, params: {
+      register_id: east_register.id,
+      opening_float: "0.00",
+      confirmed_business_date: BusinessDate.for_store(east).iso8601
+    }
+    follow_redirect!
+    east_working = PosTransaction.working.find_by!(register: east_register)
+    post pos_register_unlinked_return_path, params: {
+      lock_version: east_working.lock_version,
+      identifier: unit.unit_identifier,
+      quantity: 1,
+      reason_code: "changed_mind",
+      return_price: "12.00"
+    }
+    assert_response :success
+    assert_match(/not at this store|merchandise not found/i, response.body)
+    assert_equal 0, east_working.reload.pos_transaction_lines.count
+    assert used_variant.present?
+  end
+
+  private
+
+  def sign_in_as(username)
+    post session_path, params: { session: { username: username, password: "correct-horse-battery" } }
+  end
+
+  def enter_params
+    {
+      register_id: @register.id,
+      opening_float: "0.00",
+      confirmed_business_date: BusinessDate.for_store(@store).iso8601
+    }
+  end
+
+  def priced_variants(*prices)
+    untaxed = tax_class(code: "untaxed_mixed_ui_#{SecureRandom.hex(3)}")
+    StoreTaxes::EnsureRules.for_tax_class(untaxed)
+    StoreTaxRule.find_by!(store_tax: StoreTax.find_by!(store: @store), tax_class: untaxed).update!(applies: false)
+    prices.map.with_index do |cents, index|
+      variant = pos_sellable_variant(actor: @actor, tax_class: untaxed, name: "Priced #{cents} #{index}")
+      variant.update_columns(regular_price_cents: cents)
+      open_quantity_stock(store: @store, variant: variant, actor: @actor, quantity: 20, unit_cost_cents: 100)
+      variant
+    end
+  end
+
+  def post_unlinked!(transaction, variant, return_price)
+    post pos_register_unlinked_return_path, params: {
+      lock_version: transaction.lock_version,
+      identifier: variant.sku,
+      quantity: 1,
+      reason_code: "changed_mind",
+      return_price: return_price,
+      expected_product_variant_id: variant.id,
+      expected_reference_unit_price_cents: variant.regular_price_cents,
+      expected_tax_class_id: variant.tax_class_id
+    }
+    assert_response :success
+  end
+
+  def add_http_sale!(transaction, source)
+    identifier = source.respond_to?(:sku) ? source.sku : source.unit_identifier
+    post pos_register_merchandise_path, params: { identifier: identifier, lock_version: transaction.lock_version }
+    assert_response :success
+    transaction.reload.pos_transaction_lines.last
+  end
+
+  def settle_http!(transaction)
+    if transaction.signed_net_cents.positive?
+      post pos_register_tender_path, params: {
+        tender_amount: dollars(transaction.signed_net_cents),
+        lock_version: transaction.lock_version
+      }
+    elsif transaction.signed_net_cents.negative?
+      post pos_register_tender_path, params: {
+        tender_amount: dollars(-transaction.signed_net_cents),
+        lock_version: transaction.lock_version
+      }
+    end
+    assert_response :success
+  end
+
+  def complete_working!(transaction)
+    operation_id = css_select("input[name='completion_operation_id']").first["value"]
+    post pos_transaction_complete_path(transaction), params: {
+      completion_operation_id: operation_id,
+      lock_version: transaction.lock_version,
+      expected_total_cents: transaction.total_cents,
+      expected_signed_net_cents: transaction.signed_net_cents
+    }
+    assert_redirected_to pos_completed_transaction_path(transaction)
+  end
+
+  def selected_item(line, quantity: 1, reason_code: "changed_mind")
+    {
+      items: {
+        line.id => {
+          selected: "1",
+          original_line_id: line.id,
+          quantity: quantity,
+          reason_code: reason_code,
+          reason_note: ""
+        }
+      }
+    }
+  end
+
+  def dollars(cents)
+    "#{cents / 100}.#{format("%02d", cents % 100)}"
+  end
+
+  def format_signed(cents)
+    return "$0.00" if cents.to_i.zero?
+
+    prefix = cents.positive? ? "+" : "-"
+    absolute = cents.abs
+    "#{prefix}$#{absolute / 100}.#{format("%02d", absolute % 100)}"
+  end
+end

--- a/test/services/pos/concurrency_test.rb
+++ b/test/services/pos/concurrency_test.rb
@@ -810,12 +810,17 @@ class Pos::ConcurrencyTest < ActiveSupport::TestCase
     2.times { go << true }
     threads.each { |thread| assert thread.join(30), "thread did not finish" }
 
-    assert complete_result || complete_error
-    assert close_result || close_error
+    failures = [ complete_error, close_error ].compact
+    assert complete_result, failures.map(&:message).inspect
+    refute complete_error && close_error, failures.map(&:message).inspect
+
     session = PosSession.uncached { PosSession.find(session_id) }
     txn = PosTransaction.uncached { PosTransaction.find(transaction_id) }
+    assert txn.completed?, complete_error&.message
     refute session.closed? && txn.working?
-    if txn.completed? && session.closed?
+
+    if session.closed?
+      assert close_result
       assert_equal session.id, txn.pos_session_id
       expected = session.opening_float_cents +
                  PosTender.joins(:pos_transaction).where(
@@ -829,6 +834,8 @@ class Pos::ConcurrencyTest < ActiveSupport::TestCase
                    direction: "refund"
                  ).sum(:amount_cents)
       assert_equal expected, session.closing_expected_cash_cents
+    else
+      assert close_error
     end
   end
 

--- a/test/services/pos/concurrency_test.rb
+++ b/test/services/pos/concurrency_test.rb
@@ -549,6 +549,289 @@ class Pos::ConcurrencyTest < ActiveSupport::TestCase
     assert InventoryUnit.uncached { InventoryUnit.find(unit_id).removed? }
   end
 
+  test "sale versus unlinked restore of the same used unit leaves one valid unit state" do
+    Pos::TenderTypes.seed!
+    _used_variant, unit = pos_on_hand_unit(store: @store, actor: @actor, tax_class: @tax, name: "Sale vs unlinked")
+    sale = prepare_unit_sale(register_number: 41, unit: unit, presented_cents: 2500)
+    Pos::CompleteTransaction.call(
+      transaction: sale[:transaction],
+      actor: @actor,
+      operation_id: SecureRandom.uuid_v7,
+      expected_lock_version: sale[:transaction].lock_version,
+      expected_total_cents: sale[:transaction].total_cents,
+      expected_signed_net_cents: sale[:transaction].signed_net_cents
+    )
+    assert unit.reload.removed?
+
+    unlinked = prepare_unlinked_return(register_number: 42, unit: unit)
+    sale_job = prepare_empty_sale(register_number: 43)
+    actor_id = @actor.id
+    unit_id = unit.id
+    identifier = unit.unit_identifier
+    unlinked_id = unlinked[:transaction].id
+    unlinked_lock = unlinked[:transaction].lock_version
+    unlinked_total = unlinked[:transaction].total_cents
+    unlinked_net = unlinked[:transaction].signed_net_cents
+    sale_id = sale_job[:transaction].id
+    sale_lock = sale_job[:transaction].lock_version
+    ready = Queue.new
+    go = Queue.new
+    unlinked_result = nil
+    sale_result = nil
+    unlinked_error = nil
+    sale_error = nil
+
+    threads = [
+      Thread.new do
+        ActiveRecord::Base.connection_pool.with_connection do
+          ready << true
+          go.pop
+          unlinked_result = Pos::CompleteTransaction.call(
+            transaction: PosTransaction.find(unlinked_id),
+            actor: User.find(actor_id),
+            operation_id: SecureRandom.uuid_v7,
+            expected_lock_version: unlinked_lock,
+            expected_total_cents: unlinked_total,
+            expected_signed_net_cents: unlinked_net
+          )
+        rescue StandardError => e
+          unlinked_error = e
+        end
+      end,
+      Thread.new do
+        ActiveRecord::Base.connection_pool.with_connection do
+          ready << true
+          go.pop
+          transaction = PosTransaction.find(sale_id)
+          Pos::AddMerchandise.call(
+            transaction: transaction,
+            actor: User.find(actor_id),
+            expected_lock_version: sale_lock,
+            identifier: identifier
+          )
+          transaction.reload
+          Pos::TenderCash.call(
+            transaction: transaction,
+            actor: User.find(actor_id),
+            expected_lock_version: transaction.lock_version,
+            amount_presented_cents: transaction.total_cents
+          )
+          sale_result = Pos::CompleteTransaction.call(
+            transaction: transaction.reload,
+            actor: User.find(actor_id),
+            operation_id: SecureRandom.uuid_v7,
+            expected_lock_version: transaction.lock_version,
+            expected_total_cents: transaction.total_cents,
+            expected_signed_net_cents: transaction.signed_net_cents
+          )
+        rescue StandardError => e
+          sale_error = e
+        end
+      end
+    ]
+    2.times { ready.pop }
+    2.times { go << true }
+    threads.each { |thread| assert thread.join(30), "thread did not finish" }
+
+    assert unlinked_result || unlinked_error
+    assert sale_result || sale_error
+    unit = InventoryUnit.uncached { InventoryUnit.find(unit_id) }
+    restores = InventoryLedgerEntry.uncached {
+      InventoryLedgerEntry.where(
+        inventory_unit_id: unit_id,
+        source_type: "PosTransactionLine",
+        entry_type: "return"
+      ).count
+    }
+    assert_equal 1, restores
+    assert unit.on_hand? || unit.removed?
+    if unit.removed?
+      assert sale_result
+      assert unlinked_result
+    else
+      assert unlinked_result
+      assert_nil sale_result
+    end
+    assert_empty Inventory::LedgerPairIntegrity.drifts(store_id: @store.id)
+  end
+
+  test "linked versus unlinked restore of the same used unit yields one on-hand unit" do
+    Pos::TenderTypes.seed!
+    _used_variant, unit = pos_on_hand_unit(store: @store, actor: @actor, tax_class: @tax, name: "Linked vs unlinked")
+    sale = prepare_unit_sale(register_number: 31, unit: unit, presented_cents: 2500)
+    original = Pos::CompleteTransaction.call(
+      transaction: sale[:transaction],
+      actor: @actor,
+      operation_id: SecureRandom.uuid_v7,
+      expected_lock_version: sale[:transaction].lock_version,
+      expected_total_cents: sale[:transaction].total_cents,
+      expected_signed_net_cents: sale[:transaction].signed_net_cents
+    ).transaction
+    original_line = original.pos_transaction_lines.first
+    assert unit.reload.removed?
+
+    unlinked = prepare_unlinked_return(register_number: 32, unit: unit)
+    linked = prepare_linked_return(register_number: 33, original_line: original_line)
+    jobs = [ unlinked, linked ]
+    actor_id = @actor.id
+    unit_id = unit.id
+    ready = Queue.new
+    go = Queue.new
+    results = Array.new(2)
+    errors = Array.new(2)
+    threads = jobs.each_with_index.map do |job, i|
+      Thread.new do
+        ActiveRecord::Base.connection_pool.with_connection do
+          ready << true
+          go.pop
+          transaction = PosTransaction.find(job[:transaction].id)
+          results[i] = Pos::CompleteTransaction.call(
+            transaction: transaction,
+            actor: User.find(actor_id),
+            operation_id: SecureRandom.uuid_v7,
+            expected_lock_version: transaction.lock_version,
+            expected_total_cents: transaction.total_cents,
+            expected_signed_net_cents: transaction.signed_net_cents
+          )
+        rescue StandardError => e
+          errors[i] = e
+        end
+      end
+    end
+    2.times { ready.pop }
+    2.times { go << true }
+    threads.each { |thread| assert thread.join(30), "thread did not finish" }
+
+    successes = results.compact
+    failures = errors.compact
+    assert_equal 1, successes.size, failures.map(&:message).inspect
+    assert_equal 1, failures.size, successes.inspect
+    assert InventoryUnit.uncached { InventoryUnit.find(unit_id).on_hand? }
+    restores = InventoryLedgerEntry.uncached {
+      InventoryLedgerEntry.where(
+        inventory_unit_id: unit_id,
+        source_type: "PosTransactionLine",
+        entry_type: "return"
+      ).count
+    }
+    assert_equal 1, restores
+    loser_id = jobs.map { |job| job[:transaction].id } - [ successes.first.transaction.id ]
+    loser = PosTransaction.uncached { PosTransaction.find(loser_id.first) }
+    assert loser.working?
+    assert_nil loser.receipt_sequence
+  end
+
+  test "complete mixed transaction versus close session never omits a completed fact" do
+    Pos::TenderTypes.seed!
+    open_quantity_stock(store: @store, variant: @variant, actor: @actor, quantity: 5)
+    register = Register.create!(store: @store, register_number: 51, name: "Mixed close race")
+    context = pos_open_context(store: @store, actor: @actor, register: register)
+    transaction = Pos::StartTransaction.call(session: context[:session], actor: @actor)
+    Pos::AddMerchandise.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      identifier: @variant.sku
+    )
+    Pos::ExecuteUnlinkedReturn.call(
+      transaction: transaction.reload,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      identifier: @variant.sku,
+      quantity: 1,
+      reason_code: "changed_mind",
+      requested_return_unit_price_cents: 500
+    )
+    transaction.reload
+    if transaction.signed_net_cents.positive?
+      Pos::TenderCash.call(
+        transaction: transaction,
+        actor: @actor,
+        expected_lock_version: transaction.lock_version,
+        amount_presented_cents: transaction.total_cents
+      )
+    elsif transaction.signed_net_cents.negative?
+      Pos::AddRefundTender.call(
+        transaction: transaction,
+        actor: @actor,
+        expected_lock_version: transaction.lock_version,
+        tender_type: TenderType.find_by!(code: "cash"),
+        amount_cents: -transaction.signed_net_cents
+      )
+    end
+    transaction.reload
+    session_id = context[:session].id
+    session_lock = context[:session].lock_version
+    transaction_id = transaction.id
+    txn_lock = transaction.lock_version
+    total = transaction.total_cents
+    signed_net = transaction.signed_net_cents
+    actor_id = @actor.id
+    ready = Queue.new
+    go = Queue.new
+    complete_result = nil
+    close_result = nil
+    complete_error = nil
+    close_error = nil
+
+    threads = [
+      Thread.new do
+        ActiveRecord::Base.connection_pool.with_connection do
+          ready << true
+          go.pop
+          complete_result = Pos::CompleteTransaction.call(
+            transaction: PosTransaction.find(transaction_id),
+            actor: User.find(actor_id),
+            operation_id: SecureRandom.uuid_v7,
+            expected_lock_version: txn_lock,
+            expected_total_cents: total,
+            expected_signed_net_cents: signed_net
+          )
+        rescue StandardError => e
+          complete_error = e
+        end
+      end,
+      Thread.new do
+        ActiveRecord::Base.connection_pool.with_connection do
+          ready << true
+          go.pop
+          close_result = Pos::CloseSession.call(
+            session: PosSession.find(session_id),
+            actor: User.find(actor_id),
+            expected_lock_version: session_lock,
+            closing_count_cents: 0
+          )
+        rescue StandardError => e
+          close_error = e
+        end
+      end
+    ]
+    2.times { ready.pop }
+    2.times { go << true }
+    threads.each { |thread| assert thread.join(30), "thread did not finish" }
+
+    assert complete_result || complete_error
+    assert close_result || close_error
+    session = PosSession.uncached { PosSession.find(session_id) }
+    txn = PosTransaction.uncached { PosTransaction.find(transaction_id) }
+    refute session.closed? && txn.working?
+    if txn.completed? && session.closed?
+      assert_equal session.id, txn.pos_session_id
+      expected = session.opening_float_cents +
+                 PosTender.joins(:pos_transaction).where(
+                   pos_transactions: { pos_session_id: session.id, status: "completed" },
+                   behavioral_category: "cash",
+                   direction: "payment"
+                 ).sum(:amount_cents) -
+                 PosTender.joins(:pos_transaction).where(
+                   pos_transactions: { pos_session_id: session.id, status: "completed" },
+                   behavioral_category: "cash",
+                   direction: "refund"
+                 ).sum(:amount_cents)
+      assert_equal expected, session.closing_expected_cash_cents
+    end
+  end
+
   private
 
   def prepare_sale(register_number:, presented_cents:)
@@ -594,6 +877,29 @@ class Pos::ConcurrencyTest < ActiveSupport::TestCase
     Pos::AddRefundTender.call(
       transaction: transaction,
       actor: actor,
+      expected_lock_version: transaction.lock_version,
+      tender_type: TenderType.find_by!(code: "cash"),
+      amount_cents: -transaction.signed_net_cents
+    )
+    { context: job[:context], transaction: transaction.reload }
+  end
+
+  def prepare_unlinked_return(register_number:, unit:)
+    job = prepare_empty_sale(register_number: register_number)
+    transaction = job[:transaction]
+    Pos::ExecuteUnlinkedReturn.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      identifier: unit.unit_identifier,
+      quantity: 1,
+      reason_code: "changed_mind",
+      requested_return_unit_price_cents: 1200
+    )
+    transaction.reload
+    Pos::AddRefundTender.call(
+      transaction: transaction,
+      actor: @actor,
       expected_lock_version: transaction.lock_version,
       tender_type: TenderType.find_by!(code: "cash"),
       amount_cents: -transaction.signed_net_cents

--- a/test/services/pos/returns_mixed_test.rb
+++ b/test/services/pos/returns_mixed_test.rb
@@ -1,0 +1,895 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PosReturnsMixedTest < ActiveSupport::TestCase
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    @tax = tax_class(code: "physical_book", name: "Physical book")
+    @food = tax_class(code: "prepared_food", name: "Prepared food")
+    StoreTaxes::Create.call(
+      store: @store,
+      actor: @actor,
+      name: "Illinois State",
+      rate_percent: "5.000",
+      calculation_order: 1,
+      applies_by_tax_class_id: { @tax.id => true, @food.id => true }
+    )
+    @variant = pos_sellable_variant(actor: @actor, tax_class: @tax)
+    open_quantity_stock(store: @store, variant: @variant, actor: @actor, quantity: 40, unit_cost_cents: 100)
+    @thirty, @twenty = priced_variants(3000, 2000)
+    @context = pos_open_context(store: @store, actor: @actor, opening_float_cents: 0)
+    Pos::TenderTypes.seed!
+    @cash = TenderType.find_by!(code: "cash")
+    @card = TenderType.find_by!(code: "card")
+    @check = TenderType.find_by!(code: "check")
+    @check.update!(allows_refund: true)
+    @other = TenderType.create!(
+      code: "campus_charge_65d",
+      name: "Campus Charge",
+      behavioral_category: "other",
+      external_reference_policy: "required",
+      allows_refund: true,
+      active: true
+    )
+  end
+
+  test "sale plus unlinked settles positive negative and zero nets" do
+    positive = complete_sale_and_unlinked!(sale: @thirty, unlinked: @twenty)
+    assert_directional_arithmetic!(positive.transaction)
+    assert_equal 1000, positive.transaction.signed_net_cents
+    assert_equal :payment, Pos::Support.settlement_direction(positive.transaction)
+    assert(positive.transaction.pos_tenders.all? { |tender| tender.direction == "payment" })
+    refute positive.transaction.even_exchange?
+    Pos::CompletedTransactionFacts.new(positive.operation.envelope).verify!
+
+    negative = complete_sale_and_unlinked!(sale: @twenty, unlinked: @thirty)
+    assert_directional_arithmetic!(negative.transaction)
+    assert_equal(-1000, negative.transaction.signed_net_cents)
+    assert(negative.transaction.pos_tenders.all? { |tender| tender.direction == "refund" })
+    Pos::CompletedTransactionFacts.new(negative.operation.envelope).verify!
+
+    even = complete_sale_and_unlinked!(sale: @twenty, unlinked: @twenty)
+    assert_directional_arithmetic!(even.transaction)
+    assert_equal 0, even.transaction.signed_net_cents
+    assert_equal 0, even.transaction.pos_tenders.count
+    assert even.transaction.even_exchange?
+    assert_empty even.operation.envelope.fetch("tenders")
+    Pos::CompletedTransactionFacts.new(even.operation.envelope).verify!
+  end
+
+  test "sale plus linked settles positive negative and zero nets" do
+    original_small = complete_priced_sale!(@twenty)
+    original_large = complete_priced_sale!(@thirty)
+    original_even = complete_priced_sale!(@twenty)
+
+    positive = complete_sale_and_linked!(sale: @thirty, original_line: original_small.pos_transaction_lines.first)
+    assert_directional_arithmetic!(positive.transaction)
+    assert positive.transaction.signed_net_cents.positive?
+    refute positive.transaction.even_exchange?
+
+    negative = complete_sale_and_linked!(sale: @twenty, original_line: original_large.pos_transaction_lines.first)
+    assert_directional_arithmetic!(negative.transaction)
+    assert negative.transaction.signed_net_cents.negative?
+
+    even = complete_sale_and_linked!(sale: @twenty, original_line: original_even.pos_transaction_lines.first)
+    assert_equal 0, even.transaction.signed_net_cents
+    assert even.transaction.even_exchange?
+    assert_equal 0, even.transaction.pos_tenders.count
+  end
+
+  test "sale linked and unlinked complete on one basket" do
+    original = complete_priced_sale!(@twenty)
+    transaction = start_transaction
+    add_sale!(transaction, @thirty)
+    add_linked!(transaction, original.pos_transaction_lines.first)
+    add_unlinked!(transaction, @twenty, requested_cents: 2000)
+    result = settle_and_complete!(transaction.reload)
+    txn = result.transaction
+    assert_equal 3, txn.pos_transaction_lines.count
+    assert txn.pos_transaction_lines.any?(&:sale?)
+    assert txn.pos_transaction_lines.any?(&:linked_return?)
+    assert txn.pos_transaction_lines.any?(&:unlinked_return?)
+    assert_directional_arithmetic!(txn)
+    Pos::CompletedTransactionFacts.new(result.operation.envelope).verify!
+  end
+
+  test "linked plus unlinked without a sale completes as a refund" do
+    original = complete_priced_sale!(@twenty)
+    transaction = start_transaction
+    add_linked!(transaction, original.pos_transaction_lines.first)
+    add_unlinked!(transaction, @thirty, requested_cents: 3000)
+    result = settle_and_complete!(transaction.reload)
+    assert result.transaction.pos_transaction_lines.none?(&:sale?)
+    assert result.transaction.signed_net_cents.negative?
+    assert_directional_arithmetic!(result.transaction)
+  end
+
+  test "unlinked price variance never leaks into discount totals" do
+    transaction = start_transaction
+    add_sale!(transaction, @thirty)
+    add_unlinked!(transaction, @twenty, requested_cents: 1500)
+    result = settle_and_complete!(transaction.reload)
+    txn = result.transaction
+    unlinked = txn.pos_transaction_lines.find(&:unlinked_return?)
+    assert_equal 0, txn.discount_cents
+    assert_equal 0, txn.return_discount_cents
+    assert_equal 0, unlinked.manual_discount_cents
+    assert_nil unlinked.manual_discount_basis_points
+    envelope = result.operation.envelope
+    unlinked_fact = envelope.fetch("lines").find { |line| line["original_transaction_line_id"].blank? && line["direction"] == "return" }
+    assert unlinked_fact.key?("return_price_adjustment")
+    refute unlinked_fact.key?("discount")
+    refute envelope.fetch("transaction").fetch("discount_cents").positive? if envelope.fetch("transaction").key?("discount_cents")
+  end
+
+  test "positive net rejects refunds and accepts each payment identity" do
+    transaction = start_transaction
+    add_sale!(transaction, @thirty)
+    add_unlinked!(transaction, @twenty, requested_cents: 2000)
+    transaction.reload
+    error = assert_raises(Pos::Error) do
+      Pos::AddRefundTender.call(
+        transaction: transaction,
+        actor: @actor,
+        expected_lock_version: transaction.lock_version,
+        tender_type: @cash,
+        amount_cents: transaction.signed_net_cents
+      )
+    end
+    assert_match(/does not require a refund/, error.message)
+    cancel_working!(transaction)
+
+    {
+      cash: ->(txn) { cash_payment!(txn, txn.signed_net_cents) },
+      card: ->(txn) { add_payment!(txn, @card, txn.signed_net_cents, "AUTH-POS") },
+      check: ->(txn) { add_payment!(txn, @check, txn.signed_net_cents, "CK-1") },
+      other: ->(txn) { add_payment!(txn, @other, txn.signed_net_cents, "PO-1") }
+    }.each_value do |settle|
+      txn = start_transaction
+      add_sale!(txn, @thirty)
+      add_unlinked!(txn, @twenty, requested_cents: 2000)
+      settle.call(txn.reload)
+      completed = complete_current!(txn.reload)
+      assert(completed.transaction.pos_tenders.all? { |tender| tender.direction == "payment" })
+    end
+
+    split = start_transaction
+    add_sale!(split, @thirty)
+    add_unlinked!(split, @twenty, requested_cents: 2000)
+    split.reload
+    add_payment!(split, @card, 400, "AUTH-SPLIT")
+    cash_payment!(split.reload, split.signed_net_cents - 400)
+    completed = complete_current!(split.reload)
+    assert_equal 2, completed.transaction.pos_tenders.count
+    assert_equal completed.transaction.signed_net_cents, completed.transaction.pos_tenders.sum(:amount_cents)
+  end
+
+  test "negative net rejects payments and accepts split refunds" do
+    transaction = start_transaction
+    add_sale!(transaction, @twenty)
+    add_unlinked!(transaction, @thirty, requested_cents: 3000)
+    transaction.reload
+    error = assert_raises(Pos::Error) do
+      Pos::TenderCash.call(
+        transaction: transaction,
+        actor: @actor,
+        expected_lock_version: transaction.lock_version,
+        amount_presented_cents: transaction.total_cents
+      )
+    end
+    assert_match(/does not require payment/, error.message)
+    cancel_working!(transaction)
+
+    [
+      [ @cash, nil ],
+      [ @card, "REF-CARD" ],
+      [ @check, "REF-CK" ],
+      [ @other, "PO-R" ]
+    ].each do |type, reference|
+      txn = start_transaction
+      add_sale!(txn, @twenty)
+      add_unlinked!(txn, @thirty, requested_cents: 3000)
+      add_refund!(txn.reload, type, -txn.signed_net_cents, reference)
+      completed = complete_current!(txn.reload)
+      assert(completed.transaction.pos_tenders.all? { |tender| tender.direction == "refund" })
+    end
+
+    split = start_transaction
+    add_sale!(split, @twenty)
+    add_unlinked!(split, @thirty, requested_cents: 3000)
+    due = -split.reload.signed_net_cents
+    card_refund_before = Pos::SessionTotals.for(@context[:session].reload).card_refund_cents
+    add_refund!(split, @card, 400, "REF-HALF")
+    add_refund!(split.reload, @cash, due - 400)
+    completed = complete_current!(split.reload)
+    assert_equal 2, completed.transaction.pos_tenders.count
+    assert_equal due, completed.transaction.pos_tenders.sum(:amount_cents)
+    totals = Pos::SessionTotals.for(@context[:session].reload)
+    assert_equal card_refund_before + 400, totals.card_refund_cents
+    assert totals.cash_refund_cents.positive?
+    assert_equal(
+      @context[:session].opening_float_cents + totals.cash_payment_cents - totals.cash_refund_cents,
+      totals.expected_cash_cents
+    )
+  end
+
+  test "zero net mixed basket rejects tenders" do
+    transaction = start_transaction
+    add_sale!(transaction, @twenty)
+    add_unlinked!(transaction, @twenty, requested_cents: 2000)
+    transaction.reload
+    error = assert_raises(Pos::Error) do
+      Pos::TenderCash.call(
+        transaction: transaction,
+        actor: @actor,
+        expected_lock_version: transaction.lock_version,
+        amount_presented_cents: 2000
+      )
+    end
+    assert_match(/does not require payment/, error.message)
+    error = assert_raises(Pos::Error) do
+      Pos::AddRefundTender.call(
+        transaction: transaction.reload,
+        actor: @actor,
+        expected_lock_version: transaction.lock_version,
+        tender_type: @cash,
+        amount_cents: 2000
+      )
+    end
+    assert_match(/does not require a refund/, error.message)
+    completed = complete_current!(transaction.reload)
+    assert_equal 0, completed.transaction.pos_tenders.count
+  end
+
+  test "basket mutations clear working tenders when signed net changes sign" do
+    transaction = start_transaction
+    add_sale!(transaction, @thirty)
+    cash_payment!(transaction.reload, transaction.signed_net_cents)
+    assert_equal 1, transaction.reload.pos_tenders.count
+    add_unlinked!(transaction.reload, @thirty, requested_cents: 4000)
+    transaction.reload
+    assert_equal 0, transaction.pos_tenders.count
+    assert_equal :refund, Pos::Support.settlement_direction(transaction)
+    cancel_working!(transaction)
+
+    transaction = start_transaction
+    add_unlinked!(transaction, @thirty, requested_cents: 3000)
+    add_refund!(transaction.reload, @cash, -transaction.signed_net_cents)
+    assert_equal 1, transaction.reload.pos_tenders.count
+    add_sale!(transaction.reload, @thirty)
+    add_sale!(transaction.reload, @twenty)
+    transaction.reload
+    assert_equal 0, transaction.pos_tenders.count
+    assert_equal :payment, Pos::Support.settlement_direction(transaction)
+    cancel_working!(transaction)
+
+    transaction = start_transaction
+    add_sale!(transaction, @twenty)
+    cash_payment!(transaction.reload, transaction.signed_net_cents)
+    add_unlinked!(transaction.reload, @twenty, requested_cents: 2000)
+    transaction.reload
+    assert_equal 0, transaction.pos_tenders.count
+    assert_equal :none, Pos::Support.settlement_direction(transaction)
+    assert transaction.even_exchange?
+  end
+
+  test "mixed basket keeps sale linked and unlinked mutation rules" do
+    original = complete_quantity_sale!(quantity: 2)
+    transaction = start_transaction
+    sale_line = add_sale!(transaction, @variant)
+    linked = add_linked!(transaction.reload, original.pos_transaction_lines.first)
+    unlinked = add_unlinked!(transaction.reload, @twenty, requested_cents: 2000)
+
+    Pos::ChangeQuantity.call(
+      transaction: transaction.reload,
+      line: sale_line.reload,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      quantity: 2
+    )
+    assert_equal 2, sale_line.reload.quantity
+
+    Pos::ExecuteControlledAction.call(
+      transaction: transaction.reload,
+      line: sale_line.reload,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      action_type: "price_override",
+      operation: "apply",
+      reason_code: "shelf_price_mismatch",
+      selling_unit_price_cents: 1800
+    )
+    Pos::ExecuteControlledAction.call(
+      transaction: transaction.reload,
+      line: sale_line.reload,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      action_type: "price_override",
+      operation: "remove"
+    )
+    Pos::ExecuteControlledAction.call(
+      transaction: transaction.reload,
+      line: sale_line.reload,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      action_type: "line_discount",
+      operation: "apply",
+      reason_code: "customer_service",
+      discount_basis_points: 1000
+    )
+    Pos::ExecuteControlledAction.call(
+      transaction: transaction.reload,
+      line: sale_line.reload,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      action_type: "tax_class_override",
+      operation: "apply",
+      reason_code: "classification_correction",
+      tax_class_id: @food.id
+    )
+
+    Pos::ChangeQuantity.call(
+      transaction: transaction.reload,
+      line: linked.reload,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      quantity: 1
+    )
+    assert_equal 1, linked.reload.quantity
+
+    error = assert_raises(Pos::Error) do
+      Pos::ExecuteControlledAction.call(
+        transaction: transaction.reload,
+        line: linked.reload,
+        actor: @actor,
+        expected_lock_version: transaction.lock_version,
+        action_type: "price_override",
+        operation: "apply",
+        reason_code: "shelf_price_mismatch",
+        selling_unit_price_cents: 1
+      )
+    end
+    assert_match(/sale-direction only/, error.message)
+
+    error = assert_raises(Pos::Error) do
+      Pos::ChangeQuantity.call(
+        transaction: transaction.reload,
+        line: unlinked.reload,
+        actor: @actor,
+        expected_lock_version: transaction.lock_version,
+        quantity: 2
+      )
+    end
+    assert_match(/unlinked returns cannot change quantity/, error.message)
+
+    assert linked.reload.linked_return?
+    assert unlinked.reload.unlinked_return?
+    assert_nil unlinked.original_transaction_line_id
+  end
+
+  test "mixed inventory posts sale return used and skips non-inventory" do
+    non_inventory = pos_sellable_variant(
+      actor: @actor,
+      tax_class: @tax,
+      inventory_mode: "non_inventory",
+      name: "Gift Wrap"
+    )
+    sale_used_variant, sale_unit = pos_on_hand_unit(store: @store, actor: @actor, tax_class: @tax, name: "Used Sale")
+    linked_used_variant, linked_unit = pos_on_hand_unit(store: @store, actor: @actor, tax_class: @tax, name: "Used Linked")
+    unlinked_used_variant, unlinked_unit = pos_on_hand_unit(store: @store, actor: @actor, tax_class: @tax, name: "Used Unlinked")
+    linked_used_sale = complete_unit_sale!(linked_unit)
+    complete_unit_sale!(unlinked_unit)
+    original_qty = complete_quantity_sale!(quantity: 1)
+    qty_before = InventoryBalance.find_by!(store: @store, product_variant: @variant).on_hand_quantity
+
+    transaction = start_transaction
+    sale_line = add_sale!(transaction, @variant, quantity: 2)
+    add_sale!(transaction.reload, non_inventory)
+    add_sale!(transaction.reload, sale_unit)
+    add_linked!(transaction.reload, original_qty.pos_transaction_lines.first)
+    add_linked!(transaction.reload, linked_used_sale.pos_transaction_lines.first)
+    add_unlinked!(transaction.reload, @twenty, quantity: 3, requested_cents: 2000)
+    add_unlinked!(transaction.reload, unlinked_unit, requested_cents: 1200)
+    result = settle_and_complete!(transaction.reload)
+    txn = result.transaction
+
+    sale_ledger = InventoryLedgerEntry.find_by!(source_type: "PosTransactionLine", source_id: sale_line.id)
+    assert_equal(-2, sale_ledger.quantity_delta)
+    assert_equal qty_before - 2 + 1, InventoryBalance.find_by!(store: @store, product_variant: @variant).on_hand_quantity
+
+    linked_qty_line = txn.pos_transaction_lines.find { |line| line.linked_return? && line.inventory_unit_id.nil? }
+    linked_qty_valuation = InventoryValuationEntry.find_by!(source_type: "PosTransactionLine", source_id: linked_qty_line.id)
+    original_depletion = InventoryValuationEntry.find_by!(
+      source_type: "PosTransactionLine",
+      source_id: original_qty.pos_transaction_lines.first.id,
+      entry_type: "depletion"
+    )
+    assert_equal(-original_depletion.value_delta_cents, linked_qty_valuation.value_delta_cents)
+
+    unlinked_qty = txn.pos_transaction_lines.find { |line| line.unlinked_return? && line.inventory_unit_id.nil? }
+    unlinked_outbox = OutboxMessage.find_by!(event_type: "inventory.return_posted", aggregate_id: unlinked_qty.id)
+    assert_equal false, unlinked_outbox.payload["linked"]
+    assert unlinked_outbox.payload["valuation_basis"].present?
+
+    assert sale_unit.reload.removed?
+    assert linked_unit.reload.on_hand?
+    assert unlinked_unit.reload.on_hand?
+    assert_equal 500, unlinked_unit.carrying_value_cents
+
+    non_inventory_line = txn.pos_transaction_lines.find { |line| line.product_variant_id == non_inventory.id }
+    assert_equal 0, InventoryLedgerEntry.where(source_type: "PosTransactionLine", source_id: non_inventory_line.id).count
+    assert_equal 0, OutboxMessage.where(event_type: "inventory.sale_posted", aggregate_id: non_inventory_line.id).count
+
+    txn.pos_transaction_lines.each do |line|
+      next if line.product_variant.derived_inventory_tracking == "non_inventory"
+
+      ledger = InventoryLedgerEntry.find_by(source_type: "PosTransactionLine", source_id: line.id)
+      next if ledger.nil?
+
+      assert_equal line.id, ledger.source_id
+    end
+    assert_empty Inventory::LedgerPairIntegrity.drifts(store_id: @store.id)
+    assert_equal sale_used_variant.id, sale_unit.product_variant_id
+    assert_equal linked_used_variant.id, linked_unit.product_variant_id
+    assert_equal unlinked_used_variant.id, unlinked_unit.product_variant_id
+  end
+
+  test "replay of mixed cash and card refund does not duplicate facts" do
+    transaction = start_transaction
+    add_sale!(transaction, @twenty)
+    add_unlinked!(transaction, @thirty, requested_cents: 3000)
+    due = -transaction.reload.signed_net_cents
+    add_refund!(transaction, @card, 400, "REF-R")
+    add_refund!(transaction.reload, @cash, due - 400)
+    transaction.reload
+    operation_id = SecureRandom.uuid_v7
+    args = {
+      transaction: transaction,
+      actor: @actor,
+      operation_id: operation_id,
+      expected_lock_version: transaction.lock_version,
+      expected_total_cents: transaction.total_cents,
+      expected_signed_net_cents: transaction.signed_net_cents
+    }
+    first = Pos::CompleteTransaction.call(**args)
+    second = Pos::CompleteTransaction.call(**args)
+    assert second.replayed
+    assert_equal first.transaction.id, second.transaction.id
+    assert_equal first.operation.envelope_hash, second.operation.envelope_hash
+    assert_equal 1, PosTransaction.completed.where(id: first.transaction.id).count
+    assert_equal 2, first.transaction.pos_tenders.count
+    assert_equal 1, OutboxMessage.where(event_type: "pos.transaction_completed", aggregate_id: first.transaction.id).count
+    assert_equal 1, InventoryLedgerEntry.where(source_type: "PosTransactionLine", source_id: first.transaction.pos_transaction_lines.find(&:sale?).id).count
+    assert_equal 1, InventoryLedgerEntry.where(source_type: "PosTransactionLine", source_id: first.transaction.pos_transaction_lines.find(&:unlinked_return?).id).count
+  end
+
+  test "changed signed net on the same operation id is a payload mismatch" do
+    transaction = start_transaction
+    add_sale!(transaction, @twenty)
+    add_unlinked!(transaction, @thirty, requested_cents: 3000)
+    add_refund!(transaction.reload, @cash, -transaction.signed_net_cents)
+    transaction.reload
+    operation_id = SecureRandom.uuid_v7
+    Pos::CompleteTransaction.call(
+      transaction: transaction,
+      actor: @actor,
+      operation_id: operation_id,
+      expected_lock_version: transaction.lock_version,
+      expected_total_cents: transaction.total_cents,
+      expected_signed_net_cents: transaction.signed_net_cents
+    )
+    assert_raises(Pos::PayloadMismatch) do
+      Pos::CompleteTransaction.call(
+        transaction: transaction.reload,
+        actor: @actor,
+        operation_id: operation_id,
+        expected_lock_version: transaction.lock_version,
+        expected_total_cents: transaction.total_cents,
+        expected_signed_net_cents: transaction.signed_net_cents - 1
+      )
+    end
+  end
+
+  test "FindCompletionOperation recovers a failed mixed refund lease" do
+    transaction = start_transaction
+    add_sale!(transaction, @twenty)
+    add_unlinked!(transaction, @thirty, requested_cents: 3000)
+    add_refund!(transaction.reload, @cash, -transaction.signed_net_cents)
+    transaction.reload
+    payload = Pos::CompleteTransaction.command_payload(
+      transaction: transaction,
+      operation_id: SecureRandom.uuid_v7,
+      expected_lock_version: transaction.lock_version,
+      expected_total_cents: transaction.total_cents,
+      expected_signed_net_cents: transaction.signed_net_cents
+    )
+    operation_id = payload.fetch("operation_id")
+    Pos::OperationLease.begin!(
+      register_id: transaction.register_id,
+      operation_id: operation_id,
+      command_payload: payload,
+      store_id: transaction.store_id,
+      pos_transaction_id: transaction.id
+    )
+    PosOperation.find(operation_id).update!(status: "failed", lease_expires_at: nil)
+    found = Pos::FindCompletionOperation.call(transaction: transaction.reload, actor: @actor)
+    assert_equal operation_id, found.id
+  end
+
+  test "even exchange replay keeps zero tenders" do
+    transaction = start_transaction
+    add_sale!(transaction, @twenty)
+    add_unlinked!(transaction, @twenty, requested_cents: 2000)
+    transaction.reload
+    operation_id = SecureRandom.uuid_v7
+    args = {
+      transaction: transaction,
+      actor: @actor,
+      operation_id: operation_id,
+      expected_lock_version: transaction.lock_version,
+      expected_total_cents: 0,
+      expected_signed_net_cents: 0
+    }
+    first = Pos::CompleteTransaction.call(**args)
+    second = Pos::CompleteTransaction.call(**args)
+    assert second.replayed
+    assert_equal 0, first.transaction.pos_tenders.count
+  end
+
+  test "completion failure after a corrupted unlinked fact rolls back" do
+    transaction = start_transaction
+    add_sale!(transaction, @twenty)
+    line = add_unlinked!(transaction.reload, @thirty, requested_cents: 3000)
+    add_refund!(transaction.reload, @cash, -transaction.signed_net_cents)
+    line.pos_controlled_actions.delete_all
+    error = assert_raises(Pos::Error) { complete_current!(transaction.reload) }
+    assert_match(/unlinked_return fact/, error.message)
+    assert transaction.reload.working?
+    assert_nil transaction.receipt_sequence
+    assert_equal 0, OutboxMessage.where(event_type: "pos.transaction_completed").count
+    assert_equal 0, InventoryLedgerEntry.where(source_type: "PosTransactionLine", source_id: line.id).count
+    assert_equal 1, transaction.pos_tenders.count
+  end
+
+  test "sale controls plus unlinked fact complete and reject the wrong attachments" do
+    original = complete_quantity_sale!(quantity: 1)
+    transaction = start_transaction
+    sale_line = add_sale!(transaction, @variant)
+    Pos::ExecuteControlledAction.call(
+      transaction: transaction.reload,
+      line: sale_line.reload,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      action_type: "price_override",
+      operation: "apply",
+      reason_code: "shelf_price_mismatch",
+      selling_unit_price_cents: 1800
+    )
+    Pos::ExecuteControlledAction.call(
+      transaction: transaction.reload,
+      line: sale_line.reload,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      action_type: "price_override",
+      operation: "remove"
+    )
+    Pos::ExecuteControlledAction.call(
+      transaction: transaction.reload,
+      line: sale_line.reload,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      action_type: "line_discount",
+      operation: "apply",
+      reason_code: "customer_service",
+      discount_basis_points: 1000
+    )
+    Pos::ExecuteControlledAction.call(
+      transaction: transaction.reload,
+      line: sale_line.reload,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      action_type: "tax_class_override",
+      operation: "apply",
+      reason_code: "classification_correction",
+      tax_class_id: @food.id
+    )
+    unlinked = add_unlinked!(transaction.reload, @twenty, requested_cents: 1800)
+    linked = add_linked!(transaction.reload, original.pos_transaction_lines.first)
+    result = settle_and_complete!(transaction.reload)
+    envelope = result.operation.envelope
+    Pos::CompletedTransactionFacts.new(envelope).verify!
+    actions = envelope.fetch("controlled_actions").map { |action| action["action"] }
+    assert_includes actions, "line_discount"
+    assert_includes actions, "tax_class_override"
+    assert_includes actions, "unlinked_return"
+    refute_includes actions, "price_override"
+    assert_equal 0, linked.reload.pos_controlled_actions.count
+    assert_equal 1, unlinked.reload.pos_controlled_actions.where(action_type: "unlinked_return").count
+  end
+
+  test "session close and two-session z capture mixed sales returns and tenders" do
+    complete_sale_and_unlinked!(sale: @thirty, unlinked: @twenty)
+    original = complete_priced_sale!(@twenty)
+    linked_txn = start_transaction
+    add_linked!(linked_txn, original.pos_transaction_lines.first)
+    settle_and_complete!(linked_txn.reload)
+    even = complete_sale_and_unlinked!(sale: @twenty, unlinked: @twenty)
+    assert even.transaction.even_exchange?
+
+    totals = Pos::SessionTotals.for(@context[:session].reload)
+    expected = @context[:session].opening_float_cents + totals.cash_payment_cents - totals.cash_refund_cents
+    assert_equal expected, totals.expected_cash_cents
+    session = Pos::CloseSession.call(
+      session: @context[:session],
+      actor: @actor,
+      expected_lock_version: @context[:session].reload.lock_version,
+      closing_count_cents: 0
+    )
+    assert_equal expected, session.closing_expected_cash_cents
+    assert_equal 0 - expected, session.closing_variance_cents
+
+    period = @context[:period]
+    second_session = Pos::OpenSession.call(
+      store: @store,
+      register: @context[:register],
+      actor: @actor,
+      reporting_period: period,
+      opening_float_cents: 0
+    )
+    @context = @context.merge(session: second_session)
+    unlinked_only = start_transaction
+    add_unlinked!(unlinked_only, @thirty, requested_cents: 3000)
+    add_refund!(unlinked_only.reload, @card, -unlinked_only.signed_net_cents, "Z-CARD")
+    complete_current!(unlinked_only.reload)
+    Pos::CloseSession.call(
+      session: second_session,
+      actor: @actor,
+      expected_lock_version: second_session.reload.lock_version,
+      closing_count_cents: 0
+    )
+
+    period = Pos::FinalizeReportingPeriod.call(
+      period: period.reload,
+      actor: @actor,
+      expected_lock_version: period.lock_version
+    )
+    z = Pos::PeriodTotals.for(period)
+    sale_direction_total = z.subtotal_cents - z.discount_cents + z.tax_cents
+    assert_equal sale_direction_total, period.finalized_total_cents
+    assert period.finalized_return_total_cents.positive?
+    assert_equal z.net_cents, period.finalized_net_cents
+    assert period.finalized_card_refund_cents.positive?
+    assert_equal 2, period.finalized_session_count
+
+    snapshot_subtotal = period.finalized_subtotal_cents
+    snapshot_total = period.finalized_total_cents
+    @thirty.update_columns(regular_price_cents: 1)
+    @thirty.product.update!(name: "Renamed after Z")
+    z_after = Pos::PeriodTotals.for(period.reload)
+    assert_equal snapshot_subtotal, z_after.subtotal_cents
+    assert_equal snapshot_total, z_after.total_cents
+    assert_equal period.finalized_subtotal_cents, z_after.subtotal_cents
+  end
+
+  test "pre-6.5 finalized additive columns stay null" do
+    unused = Pos::OpenReportingPeriod.call(
+      store: @store,
+      register: Register.create!(store: @store, register_number: 77, name: "Legacy"),
+      actor: @actor
+    )
+    Pos::FinalizeReportingPeriod.call(period: unused, actor: @actor, expected_lock_version: unused.lock_version)
+    PosReportingPeriod.where(id: unused.id).update_all(
+      finalized_return_total_cents: nil,
+      finalized_net_cents: nil,
+      finalized_cash_refund_cents: nil
+    )
+    unused.reload
+    assert_nil unused.finalized_return_total_cents
+    assert_nil unused.finalized_net_cents
+    assert_nil unused.finalized_cash_refund_cents
+  end
+
+  test "unlinked remaining quantity does not consume linked returnability" do
+    original = complete_quantity_sale!(quantity: 2)
+    original_line = original.pos_transaction_lines.first
+    transaction = start_transaction
+    add_unlinked!(transaction, @variant, quantity: 2, requested_cents: @variant.regular_price_cents)
+    settle_and_complete!(transaction.reload)
+    assert_equal 2, Pos::Returnability.remaining_quantity(original_line)
+  end
+
+  test "mixed completion audits and posts inventory outbox once per tracked line" do
+    transaction = start_transaction
+    sale_line = add_sale!(transaction, @thirty)
+    unlinked = add_unlinked!(transaction.reload, @twenty, requested_cents: 1800)
+    settle_and_complete!(transaction.reload)
+    assert AuditEvent.exists?(action: "pos.unlinked_return.applied", subject_id: unlinked.id)
+    assert AuditEvent.exists?(action: "pos.transaction_completed", subject_id: sale_line.pos_transaction_id)
+    assert_equal 1, OutboxMessage.where(event_type: "inventory.sale_posted", aggregate_id: sale_line.id).count
+    assert_equal 1, OutboxMessage.where(event_type: "inventory.return_posted", aggregate_id: unlinked.id).count
+    event = AuditEvent.find_by!(action: "pos.unlinked_return.applied", subject_id: unlinked.id)
+    dumped = [ event.after_values, event.before_values, event.metadata ].compact.to_json
+    refute_match(/password|correct-horse/i, dumped)
+  end
+
+  private
+
+  def cancel_working!(transaction)
+    Pos::CancelTransaction.call(
+      transaction: transaction.reload,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version
+    )
+  end
+
+  def start_transaction
+    Pos::StartTransaction.call(session: open_session, actor: @actor)
+  end
+
+  def open_session
+    session = @context[:session]
+    return session if session.reload.open?
+
+    @context = pos_open_context(
+      store: @store,
+      actor: @actor,
+      register: @context[:register],
+      opening_float_cents: 0
+    )
+    @context[:session]
+  end
+
+  def priced_variants(*prices)
+    untaxed = tax_class(code: "untaxed_mixed_#{SecureRandom.hex(3)}")
+    StoreTaxes::EnsureRules.for_tax_class(untaxed)
+    StoreTaxRule.find_by!(store_tax: StoreTax.find_by!(store: @store), tax_class: untaxed).update!(applies: false)
+    prices.map.with_index do |cents, index|
+      variant = pos_sellable_variant(actor: @actor, tax_class: untaxed, name: "Priced #{cents} #{index}")
+      variant.update_columns(regular_price_cents: cents)
+      open_quantity_stock(store: @store, variant: variant, actor: @actor, quantity: 20, unit_cost_cents: 100)
+      variant
+    end
+  end
+
+  def add_sale!(transaction, source, quantity: 1)
+    identifier = source.respond_to?(:sku) ? source.sku : source.unit_identifier
+    Pos::AddMerchandise.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      identifier: identifier,
+      quantity: quantity
+    )
+  end
+
+  def add_unlinked!(transaction, source, requested_cents:, quantity: 1)
+    identifier = source.respond_to?(:sku) ? source.sku : source.unit_identifier
+    Pos::ExecuteUnlinkedReturn.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      identifier: identifier,
+      quantity: quantity,
+      reason_code: "changed_mind",
+      requested_return_unit_price_cents: requested_cents
+    )
+  end
+
+  def add_linked!(transaction, original_line, quantity: original_line.quantity)
+    Pos::AddLinkedReturnLine.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      original_line: original_line,
+      quantity: quantity,
+      reason_code: "changed_mind"
+    )
+  end
+
+  def cash_payment!(transaction, amount_cents)
+    Pos::TenderCash.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      amount_presented_cents: amount_cents
+    )
+  end
+
+  def add_payment!(transaction, tender_type, amount_cents, reference)
+    Pos::AddTender.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      tender_type: tender_type,
+      amount_cents: amount_cents,
+      external_reference: reference
+    )
+  end
+
+  def add_refund!(transaction, tender_type, amount_cents, reference = nil)
+    Pos::AddRefundTender.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      tender_type: tender_type,
+      amount_cents: amount_cents,
+      external_reference: reference
+    )
+  end
+
+  def settle_and_complete!(transaction)
+    transaction.reload
+    case Pos::Support.settlement_direction(transaction)
+    when :payment
+      cash_payment!(transaction, transaction.signed_net_cents)
+    when :refund
+      add_refund!(transaction, @cash, -transaction.signed_net_cents)
+    end
+    complete_current!(transaction.reload)
+  end
+
+  def complete_current!(transaction)
+    Pos::CompleteTransaction.call(
+      transaction: transaction,
+      actor: @actor,
+      operation_id: SecureRandom.uuid_v7,
+      expected_lock_version: transaction.lock_version,
+      expected_total_cents: transaction.total_cents,
+      expected_signed_net_cents: transaction.signed_net_cents
+    )
+  end
+
+  def complete_sale_and_unlinked!(sale:, unlinked:)
+    transaction = start_transaction
+    add_sale!(transaction, sale)
+    add_unlinked!(transaction.reload, unlinked, requested_cents: unlinked.regular_price_cents)
+    settle_and_complete!(transaction.reload)
+  end
+
+  def complete_sale_and_linked!(sale:, original_line:)
+    transaction = start_transaction
+    add_sale!(transaction, sale)
+    add_linked!(transaction.reload, original_line)
+    settle_and_complete!(transaction.reload)
+  end
+
+  def complete_priced_sale!(variant)
+    transaction = start_transaction
+    add_sale!(transaction, variant)
+    settle_and_complete!(transaction.reload).transaction
+  end
+
+  def complete_quantity_sale!(quantity:)
+    transaction = start_transaction
+    add_sale!(transaction, @variant, quantity: quantity)
+    settle_and_complete!(transaction.reload).transaction
+  end
+
+  def complete_unit_sale!(unit)
+    transaction = start_transaction
+    add_sale!(transaction, unit)
+    settle_and_complete!(transaction.reload).transaction
+  end
+
+  def assert_directional_arithmetic!(txn)
+    sale_lines = txn.pos_transaction_lines.select(&:sale?)
+    return_lines = txn.pos_transaction_lines.select(&:return?)
+    assert_equal sale_lines.sum(&:extended_selling_amount_cents), txn.subtotal_cents
+    assert_equal sale_lines.sum(&:manual_discount_cents), txn.discount_cents
+    assert_equal sale_lines.sum(&:line_tax_cents), txn.tax_cents
+    assert_equal return_lines.sum(&:extended_selling_amount_cents), txn.return_subtotal_cents
+    assert_equal return_lines.sum(&:manual_discount_cents), txn.return_discount_cents
+    assert_equal return_lines.sum(&:line_tax_cents), txn.return_tax_cents
+    assert_equal txn.return_subtotal_cents - txn.return_discount_cents + txn.return_tax_cents, txn.return_total_cents
+    sale_total = txn.subtotal_cents - txn.discount_cents + txn.tax_cents
+    assert_equal sale_total - txn.return_total_cents, txn.signed_net_cents
+    assert_equal txn.signed_net_cents.abs, txn.total_cents
+    unlinked = return_lines.select(&:unlinked_return?)
+    if unlinked.any? { |line| line.selling_unit_price_cents != line.reference_unit_price_cents }
+      assert_equal 0, unlinked.sum(&:manual_discount_cents)
+    end
+  end
+end

--- a/test/system/pos_mixed_return_test.rb
+++ b/test/system/pos_mixed_return_test.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class PosMixedReturnTest < ApplicationSystemTestCase
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    @tax = tax_class(code: "physical_book", name: "Physical book")
+    StoreTaxes::Create.call(
+      store: @store,
+      actor: @actor,
+      name: "Illinois State",
+      rate_percent: "5.000",
+      calculation_order: 1,
+      applies_by_tax_class_id: { @tax.id => true }
+    )
+    @thirty, @twenty = priced_variants(3000, 2000)
+    @register = Register.create!(store: @store, register_number: 1, name: "Front")
+  end
+
+  test "sale then unlinked return tenders cash for the positive net" do
+    open_register
+    add_sku(@thirty.sku)
+    add_unlinked_return(@twenty.sku, price: "20.00")
+    assert_text "Amount due"
+    click_on "Tender (+)"
+    field = find("#pos-command-field")
+    field.fill_in with: "10.00"
+    field.send_keys :enter
+    send_keys :enter
+    assert_text "Transaction complete", wait: 10
+    completed = PosTransaction.completed.find_by!(register: @register)
+    assert completed.signed_net_cents.positive?
+    assert_text "Unlinked return"
+    assert_text "Net"
+    click_on "Transactions"
+    assert_text format_signed(completed.signed_net_cents)
+    click_on completed.transaction_reference
+    assert_text "Unlinked return"
+    assert_selector ".pos-receipt__reprint", visible: :all, text: "REPRINT"
+  end
+
+  test "negative net split refunds cash and card" do
+    open_register
+    add_sku(@twenty.sku)
+    add_unlinked_return(@thirty.sku, price: "30.00")
+    assert_text "Refund due"
+    click_on "Refund (+)"
+    assert_text "REFUND"
+    send_keys :f2
+    assert_selector "[data-register-workspace-target='fieldLabel']", text: /External Card/
+    field = find("#pos-command-field")
+    field.fill_in with: "4.00"
+    field.send_keys :enter
+    field = find("#pos-command-field")
+    field.send_keys :f2
+    assert_selector "[data-register-workspace-target='fieldLabel']", text: /Refund amount/
+    field = find("#pos-command-field")
+    field.send_keys :enter
+    send_keys :enter
+    assert_text "Transaction complete", wait: 10
+    assert_text "Cash refund"
+    assert_text "External Card refund"
+    completed = PosTransaction.completed.find_by!(register: @register)
+    assert completed.signed_net_cents.negative?
+    assert_equal %w[card cash], completed.pos_tenders.ordered.map(&:behavioral_category)
+  end
+
+  test "even exchange completes with plus and no tender rows" do
+    open_register
+    add_sku(@twenty.sku)
+    add_unlinked_return(@twenty.sku, price: "20.00")
+    assert_text "Even exchange"
+    assert_text "SALE ENTRY"
+    assert_no_text "Transaction complete"
+    assert_button "Complete (+)"
+    click_on "Complete (+)"
+    assert_text "Transaction complete", wait: 10
+    completed = PosTransaction.completed.find_by!(register: @register)
+    assert_equal 0, completed.signed_net_cents
+    assert_equal 0, completed.pos_tenders.count
+  end
+
+  test "overlay lookup enter escape and return-line keys stay on sale entry" do
+    open_register
+    click_on "Return without receipt"
+    assert_text "Return without receipt"
+    identifier = find("#pos-unlinked-identifier")
+    identifier.fill_in with: @twenty.sku
+    identifier.send_keys :enter
+    assert_text "Priced 2000", wait: 5
+    assert_equal 0, PosTransaction.working.find_by!(register: @register).pos_transaction_lines.count
+    send_keys :escape
+    assert_no_selector "#pos_unlinked_overlay", visible: true
+    assert_equal "pos-command-field", page.evaluate_script("document.activeElement && document.activeElement.id")
+
+    add_sku(@thirty.sku)
+    add_unlinked_return(@twenty.sku, price: "20.00")
+    assert_selector "tr.is-selected[data-direction='return']"
+    send_keys :f5
+    assert_no_selector "#pos_control_overlay", visible: true
+    send_keys :f6
+    assert_no_selector "#pos_control_overlay", visible: true
+    send_keys :f7
+    assert_no_selector "#pos_control_overlay", visible: true
+    send_keys :f8
+    assert_no_selector "tr[data-direction='return']"
+    assert_selector "tr[data-direction='sale']"
+
+    send_keys :f9
+    assert_selector "#pos_overlay", visible: true
+    send_keys :escape
+    assert_no_selector "#pos_overlay", visible: true
+    assert_text "SALE ENTRY"
+    send_keys :f9
+    send_keys :f9
+    assert_text "SALE ENTRY"
+    assert_no_text "Priced 3000"
+  end
+
+  private
+
+  def open_register
+    visit new_session_path
+    fill_in "session_username", with: "admin"
+    fill_in "session_password", with: "correct-horse-battery"
+    find_field("session_password").send_keys :enter
+    assert_text "Signed in successfully"
+    visit pos_register_enter_path(register_id: @register.id)
+    fill_in "Opening float", with: "0.00"
+    click_on "Open register"
+    assert_text "SALE ENTRY"
+  end
+
+  def priced_variants(*prices)
+    untaxed = tax_class(code: "untaxed_mixed_sys_#{SecureRandom.hex(3)}")
+    StoreTaxes::EnsureRules.for_tax_class(untaxed)
+    StoreTaxRule.find_by!(store_tax: StoreTax.find_by!(store: @store), tax_class: untaxed).update!(applies: false)
+    prices.map.with_index do |cents, index|
+      variant = pos_sellable_variant(actor: @actor, tax_class: untaxed, name: "Priced #{cents} #{index}")
+      variant.update_columns(regular_price_cents: cents)
+      open_quantity_stock(store: @store, variant: variant, actor: @actor, quantity: 20, unit_cost_cents: 100)
+      variant
+    end
+  end
+
+  def add_sku(sku)
+    field = find("#pos-command-field")
+    field.fill_in with: sku
+    field.send_keys :enter
+    assert_selector "tr[data-direction='sale']"
+  end
+
+  def add_unlinked_return(sku, price:)
+    click_on "Return without receipt"
+    identifier = find("#pos-unlinked-identifier")
+    identifier.fill_in with: sku
+    identifier.send_keys :enter
+    assert_text "Priced", wait: 5
+    fill_in "Return unit price", with: price
+    select "Changed mind", from: "Return reason"
+    click_on "Add return"
+    assert_text "Unlinked return", wait: 10
+  end
+
+  def format_signed(cents)
+    return "$0.00" if cents.to_i.zero?
+
+    prefix = cents.positive? ? "+" : "-"
+    absolute = cents.abs
+    "#{prefix}$#{absolute / 100}.#{format("%02d", absolute % 100)}"
+  end
+end


### PR DESCRIPTION
## Summary
- Close Phase 6.5 by proving mixed sale + linked/unlinked returns compose through signed-net settlement, inventory, receipt/history, Session close, and two-session Z.
- Lock Used-unit posting with a cache-bypassing `SELECT … FOR UPDATE` so concurrent linked and unlinked restores cannot both restore the same removed unit.
- Mark 6.5A–D implemented; next slice is 6.6 post-void.

## Test plan
- [x] `./dev/rails-docker bin/ci` (563 Rails tests, 31 system tests, RuboCop, Brakeman, bundler-audit, importmap audit, seed replant)
- [x] Cashier path: sale $30 + unlinked $20 → Cash payment $10 → receipt/history
- [x] Cashier path: sale $20 + unlinked $30 → split Cash+Card refund
- [x] Cashier path: sale $20 + unlinked $20 → Even exchange `+` with no tenders
- [x] Confirm other-Store history/linked original/Used unit remain rejected


Made with [Cursor](https://cursor.com)