### PR TITLE
Phase 6.1: merchandise classification and identifiers

### DIFF
--- a/app/controllers/admin/departments_controller.rb
+++ b/app/controllers/admin/departments_controller.rb
@@ -12,7 +12,9 @@ module Admin
       @departments = Department.admin_ordered
     end
 
-    def show; end
+    def show
+      @merchandise_classes = @department.merchandise_classes.admin_ordered
+    end
 
     def new
       @department = Department.new(display_order: 0)
@@ -74,13 +76,12 @@ module Admin
     end
 
     def load_form_options
-      @tax_classes = TaxClass.assignable.admin_ordered
       @gl_accounts = GlAccount.assignable.order(:account_number)
     end
 
     def audit_attribute_keys
       %w[
-        code department_number name description default_tax_class_id default_target_margin_bps
+        code department_number name description
         inventory_asset_gl_account_id cost_of_goods_sold_gl_account_id sales_revenue_gl_account_id
         sales_returns_gl_account_id receiving_clearing_gl_account_id freight_in_gl_account_id
         inventory_shrinkage_gl_account_id inventory_adjustment_gain_gl_account_id
@@ -90,15 +91,15 @@ module Admin
 
     def department_params
       permitted = params.require(:department).permit(
-        :code, :department_number, :name, :description, :default_tax_class_id,
-        :default_target_margin_bps, :inventory_asset_gl_account_id, :cost_of_goods_sold_gl_account_id,
+        :code, :department_number, :name, :description,
+        :inventory_asset_gl_account_id, :cost_of_goods_sold_gl_account_id,
         :sales_revenue_gl_account_id, :sales_returns_gl_account_id, :receiving_clearing_gl_account_id,
         :freight_in_gl_account_id, :inventory_shrinkage_gl_account_id,
         :inventory_adjustment_gain_gl_account_id, :inventory_adjustment_loss_gl_account_id,
         :inventory_write_down_gl_account_id, :display_order, :lock_version
       )
       blankable = %i[
-        department_number default_target_margin_bps inventory_asset_gl_account_id
+        inventory_asset_gl_account_id
         cost_of_goods_sold_gl_account_id sales_revenue_gl_account_id sales_returns_gl_account_id
         receiving_clearing_gl_account_id freight_in_gl_account_id inventory_shrinkage_gl_account_id
         inventory_adjustment_gain_gl_account_id inventory_adjustment_loss_gl_account_id

--- a/app/controllers/admin/inventory_adjustments_controller.rb
+++ b/app/controllers/admin/inventory_adjustments_controller.rb
@@ -146,10 +146,18 @@ module Admin
       case result.status
       when :variant
         result.variant
-      when :multi_variant
-        raise ArgumentError, "Multiple variants match; enter a specific variant SKU"
+      when :inventory_unit
+        result.variant || raise(ArgumentError, "Variant not found")
       when :product
-        raise ArgumentError, "Product has no sellable variant; enter a variant SKU"
+        # Adjustments may target discontinued or unsellable merchandise, so POS
+        # sellability must not filter these candidates.
+        variants = result.product.product_variants.to_a
+        raise ArgumentError, "Product has no variants; enter a variant SKU" if variants.empty?
+        raise ArgumentError, "Multiple variants match; enter a specific variant SKU" if variants.many?
+
+        variants.first
+      when :multiple_products
+        raise ArgumentError, "Multiple products share that lookup code; enter a specific variant SKU"
       else
         raise ArgumentError, result.message.presence || "Variant not found"
       end

--- a/app/controllers/admin/merchandise_categories_controller.rb
+++ b/app/controllers/admin/merchandise_categories_controller.rb
@@ -43,7 +43,7 @@ module Admin
           @merchandise_category,
           attrs: merchandise_category_params.except(:code),
           action: "merchandise_categories.update",
-          before_keys: %w[name description parent_id default_merchandise_class_id display_order]
+          before_keys: %w[name description parent_id default_standard_merchandise_class_id default_used_merchandise_class_id display_order]
         )
           redirect_to admin_merchandise_category_path(@merchandise_category), notice: "Merchandise category updated."
         else
@@ -84,10 +84,11 @@ module Admin
 
     def merchandise_category_params
       permitted = params.require(:merchandise_category).permit(
-        :code, :name, :description, :parent_id, :default_merchandise_class_id,
+        :code, :name, :description, :parent_id,
+        :default_standard_merchandise_class_id, :default_used_merchandise_class_id,
         :display_order, :lock_version
       )
-      %i[code parent_id default_merchandise_class_id].each do |key|
+      %i[code parent_id default_standard_merchandise_class_id default_used_merchandise_class_id].each do |key|
         permitted[key] = nil if permitted[key].blank?
       end
       permitted

--- a/app/controllers/admin/merchandise_classes_controller.rb
+++ b/app/controllers/admin/merchandise_classes_controller.rb
@@ -9,15 +9,15 @@ module Admin
     before_action :set_merchandise_class, only: %i[show edit update destroy reactivate]
 
     def index
-      @merchandise_classes = MerchandiseClass.admin_ordered
+      @merchandise_classes = MerchandiseClass.admin_ordered.includes(:department)
     end
 
     def show; end
 
     def new
       @merchandise_class = MerchandiseClass.new(
-        inventory_mode: "inventory",
-        pricing_method: "fixed",
+        default_inventory_mode: "inventory",
+        default_pricing_method: "fixed",
         display_order: 0
       )
       load_form_options
@@ -48,8 +48,8 @@ module Admin
           attrs: merchandise_class_params.except(:code),
           action: "merchandise_classes.update",
           before_keys: %w[
-            name description inventory_mode pricing_method
-            default_standard_department_id default_used_department_id
+            name description department_id merchandise_class_number
+            default_inventory_mode default_pricing_method default_tax_class_id target_margin_bps
             used_merchandise_allowed buyback_allowed default_supplier_returnable display_order
           ]
         )
@@ -85,16 +85,17 @@ module Admin
 
     def load_form_options
       @departments = Department.assignable.admin_ordered
+      @tax_classes = TaxClass.assignable.admin_ordered
     end
 
     def merchandise_class_params
       permitted = params.require(:merchandise_class).permit(
-        :code, :name, :description, :inventory_mode, :pricing_method,
-        :default_standard_department_id, :default_used_department_id,
+        :code, :name, :description, :department_id, :merchandise_class_number,
+        :default_inventory_mode, :default_pricing_method, :default_tax_class_id, :target_margin_bps,
         :used_merchandise_allowed, :buyback_allowed, :default_supplier_returnable,
         :display_order, :lock_version
       )
-      %i[default_standard_department_id default_used_department_id].each do |key|
+      %i[target_margin_bps].each do |key|
         permitted[key] = nil if permitted[key].blank?
       end
       permitted

--- a/app/controllers/admin/merchandise_imports_controller.rb
+++ b/app/controllers/admin/merchandise_imports_controller.rb
@@ -5,9 +5,10 @@ require "csv"
 module Admin
   class MerchandiseImportsController < BaseController
     TEMPLATE_HEADERS = %w[
-      primary_identifier name generate_primary_identifier status sku variant_type variant_name
-      industry_identifier variant_condition_code merchandise_class_code department_code
-      tax_class_code regular_price_cents
+      product_primary_identifier product_industry_identifier product_lookup_code name status
+      sku variant_type variant_name industry_identifier variant_condition_code
+      merchandise_class_code inventory_mode pricing_method target_margin_bps
+      supplier_returnable tax_class_override_code regular_price_cents
     ].freeze
 
     before_action -> { require_permission!("merchandise.import") }

--- a/app/controllers/admin/product_variants_controller.rb
+++ b/app/controllers/admin/product_variants_controller.rb
@@ -149,8 +149,7 @@ module Admin
 
     def load_form_options
       @merchandise_conditions = MerchandiseCondition.assignable.admin_ordered
-      @merchandise_classes = MerchandiseClass.assignable.admin_ordered
-      @departments = Department.assignable.admin_ordered
+      @merchandise_classes = MerchandiseClass.assignable.admin_ordered.includes(:department)
       @tax_classes = TaxClass.assignable.admin_ordered
     end
 
@@ -163,7 +162,8 @@ module Admin
       @regular_price_raw = params.dig(:product_variant, :regular_price)
       permitted = params.require(:product_variant).permit(
         :variant_type, :name, :option_value_1, :option_value_2, :merchandise_condition_id,
-        :merchandise_class_id, :department_id, :tax_class_id, :regular_price, :regular_price_cents,
+        :merchandise_class_id, :tax_class_override_id, :inventory_mode, :pricing_method,
+        :target_margin_bps, :supplier_returnable, :regular_price, :regular_price_cents,
         :industry_identifier, :status, :lock_version
       )
 
@@ -178,8 +178,8 @@ module Admin
         end
       end
 
-      %i[name option_value_1 option_value_2 merchandise_condition_id merchandise_class_id department_id tax_class_id
-         regular_price_cents industry_identifier].each do |key|
+      %i[name option_value_1 option_value_2 merchandise_condition_id merchandise_class_id tax_class_override_id
+         inventory_mode pricing_method target_margin_bps regular_price_cents industry_identifier].each do |key|
         permitted[key] = nil if permitted[key].blank?
       end
       permitted

--- a/app/controllers/admin/product_variants_controller.rb
+++ b/app/controllers/admin/product_variants_controller.rb
@@ -179,9 +179,26 @@ module Admin
       end
 
       %i[name option_value_1 option_value_2 merchandise_condition_id merchandise_class_id tax_class_override_id
-         inventory_mode pricing_method target_margin_bps regular_price_cents industry_identifier].each do |key|
+         inventory_mode pricing_method regular_price_cents industry_identifier].each do |key|
         permitted[key] = nil if permitted[key].blank?
       end
+
+      # Blank means "use class default" on create: omit the key so DefaultResolver copies.
+      # On update, blank margin clears the sticky value; blank supplier_returnable is invalid.
+      creating = action_name == "create"
+      if permitted[:target_margin_bps].blank?
+        if creating
+          permitted.delete(:target_margin_bps)
+        else
+          permitted[:target_margin_bps] = nil
+        end
+      end
+      if creating && permitted[:supplier_returnable].blank?
+        permitted.delete(:supplier_returnable)
+      elsif permitted.key?(:supplier_returnable) && !permitted[:supplier_returnable].nil?
+        permitted[:supplier_returnable] = ActiveModel::Type::Boolean.new.cast(permitted[:supplier_returnable])
+      end
+
       permitted
     end
   end

--- a/app/controllers/admin/products_controller.rb
+++ b/app/controllers/admin/products_controller.rb
@@ -147,9 +147,11 @@ module Admin
       end
 
       primary_identifier = @product.primary_identifier
+      industry_identifier = @product.industry_identifier
       name = @product.name
       Product.transaction do
         Identifiers::Registry.retire!(value: primary_identifier)
+        Identifiers::Registry.retire!(value: industry_identifier) if industry_identifier.present?
         @product.destroy!
         Audit::Recorder.record!(
           action: "products.destroy",
@@ -157,11 +159,16 @@ module Admin
           actor_user: current_user,
           actor_label: current_user.display_name,
           store: current_store,
-          after_values: { primary_identifier: primary_identifier, name: name }
+          after_values: {
+            primary_identifier: primary_identifier,
+            industry_identifier: industry_identifier,
+            name: name
+          }
         )
       end
       redirect_to admin_products_path, notice: "Draft product deleted."
-    rescue ActiveRecord::DeleteRestrictionError, ActiveRecord::InvalidForeignKey, ActiveRecord::RecordNotFound => e
+    rescue ActiveRecord::DeleteRestrictionError, ActiveRecord::InvalidForeignKey, ActiveRecord::RecordNotFound,
+           ActiveRecord::StatementInvalid => e
       redirect_to admin_product_path(@product), alert: e.message
     end
 

--- a/app/controllers/admin/products_controller.rb
+++ b/app/controllers/admin/products_controller.rb
@@ -25,7 +25,7 @@ module Admin
 
     def show
       @product_variants = @product.product_variants
-        .includes(:merchandise_class, :department, :tax_class, :merchandise_condition)
+        .includes(:merchandise_class, :merchandise_condition, :tax_class_override, merchandise_class: [ :department, :default_tax_class ])
         .order(:sku)
       @recent_audit_events = recent_product_audit_events
       @show_inventory = inventory_display_enabled?
@@ -48,10 +48,10 @@ module Admin
       end
 
       @product = Products::Create.call(
-        attributes: attrs,
+        attributes: attrs.except(:industry_identifier, :lookup_code),
         actor: current_user,
-        identifier_mode: identifier_mode,
-        external_identifier: external_identifier.presence
+        industry_identifier: attrs[:industry_identifier],
+        lookup_code: attrs[:lookup_code]
       )
       redirect_to admin_product_path(@product), notice: "Product created."
     rescue Products::Create::Error => e
@@ -190,14 +190,6 @@ module Admin
       scope.order(occurred_at: :desc).limit(5).to_a
     end
 
-    def identifier_mode
-      params.dig(:product, :identifier_mode).presence || params[:identifier_mode].presence || "enter"
-    end
-
-    def external_identifier
-      params.dig(:product, :external_identifier).presence || params[:external_identifier]
-    end
-
     def product_attributes
       attrs = product_params.except(:lock_version).to_h.symbolize_keys
       attrs[:status] = "draft" if attrs[:status].blank?
@@ -210,7 +202,7 @@ module Admin
       permitted = params.require(:product).permit(
         :name, :subtitle, :description, :brand_name, :product_model, :merchandise_category_id,
         :list_price, :list_price_cents, :release_date, :status, :variant_option_name_1, :variant_option_name_2,
-        :lock_version
+        :industry_identifier, :lookup_code, :lock_version
       )
 
       if permitted.key?(:list_price) || params[:product]&.key?(:list_price)
@@ -225,7 +217,8 @@ module Admin
       end
 
       %i[merchandise_category_id list_price_cents release_date subtitle description brand_name
-         product_model variant_option_name_1 variant_option_name_2].each do |key|
+         product_model variant_option_name_1 variant_option_name_2 industry_identifier
+         lookup_code].each do |key|
         permitted[key] = nil if permitted[key].blank?
       end
       permitted

--- a/app/controllers/pos/workspaces_controller.rb
+++ b/app/controllers/pos/workspaces_controller.rb
@@ -175,22 +175,17 @@ module Pos
     def unlinked_return_lookup
       Pos::Support.authorize!(current_user, current_store)
       result = Pos::ResolveUnlinkedReturnMerchandise.call(
-        identifier: params.require(:identifier),
-        store: current_store
+        identifier: params[:identifier],
+        store: current_store,
+        product: find_optional_product,
+        variant: find_optional_variant,
+        inventory_unit: find_optional_unit
       )
-      render json: {
-        description: result.description,
-        tracking: result.tracking,
-        quantity_fixed: result.quantity_fixed,
-        reference_unit_price_cents: result.reference_unit_price_cents,
-        product_variant_id: result.variant.id,
-        inventory_unit_id: result.inventory_unit&.id,
-        tax_class_id: result.tax_class.id
-      }
+      render json: serialize_unlinked_resolution(result)
     rescue Pos::Denied
       render json: { error: "You are not authorized to perform that action." }, status: :forbidden
     rescue Identifiers::NormalizationError, Pos::Error => e
-      render json: { error: e.message }, status: :unprocessable_entity
+      render json: { outcome: "unavailable", error: e.message, message: e.message }, status: :unprocessable_entity
     end
 
     def unlinked_return
@@ -209,7 +204,10 @@ module Pos
           expected_product_variant_id: params[:expected_product_variant_id],
           expected_inventory_unit_id: params[:expected_inventory_unit_id],
           expected_reference_unit_price_cents: params[:expected_reference_unit_price_cents],
-          expected_tax_class_id: params[:expected_tax_class_id]
+          expected_tax_class_id: params[:expected_tax_class_id],
+          product_id: params[:product_id],
+          product_variant_id: params[:product_variant_id],
+          inventory_unit_id: params[:inventory_unit_id]
         )
         @transaction.reload
         @ui_mode = "sale_entry"
@@ -670,6 +668,31 @@ module Pos
       payload[:variants] = Array(result.variants).map { |variant| serialize_variant(variant) }
       payload[:units] = Array(result.units).map { |unit| serialize_unit(unit) }
       payload[:products] = Array(result.products).map { |product| serialize_product(product) }
+      payload
+    end
+
+    def serialize_unlinked_resolution(result)
+      payload = {
+        outcome: result.outcome.to_s,
+        message: result.message
+      }
+      payload[:variant] = serialize_variant(result.variant) if result.variant
+      payload[:unit] = serialize_unit(result.inventory_unit) if result.inventory_unit
+      payload[:variants] = Array(result.variants).map { |variant| serialize_variant(variant) }
+      payload[:units] = Array(result.units).map { |unit| serialize_unit(unit) }
+      payload[:products] = Array(result.products).map { |product| serialize_product(product) }
+      if result.outcome == :resolved
+        payload.merge!(
+          description: result.description,
+          tracking: result.tracking,
+          quantity_fixed: result.quantity_fixed,
+          reference_unit_price_cents: result.reference_unit_price_cents,
+          product_variant_id: result.variant.id,
+          inventory_unit_id: result.inventory_unit&.id,
+          tax_class_id: result.tax_class.id
+        )
+      end
+      payload[:error] = result.message if result.outcome == :unavailable
       payload
     end
 

--- a/app/controllers/pos/workspaces_controller.rb
+++ b/app/controllers/pos/workspaces_controller.rb
@@ -56,6 +56,7 @@ module Pos
         identifier: params[:identifier],
         variant: find_optional_variant,
         inventory_unit: find_optional_unit,
+        product: find_optional_product,
         current_transaction: @transaction
       )
       render json: serialize_resolution(result)
@@ -649,6 +650,13 @@ module Pos
       InventoryUnit.find_by(id: id)
     end
 
+    def find_optional_product
+      id = params[:product_id].presence
+      return if id.blank?
+
+      Product.find_by(id: id)
+    end
+
     def parse_optional_open_price
       return if params[:selling_price].blank? && params[:open_price].blank?
 
@@ -661,12 +669,25 @@ module Pos
       payload[:unit] = serialize_unit(result.unit) if result.unit
       payload[:variants] = Array(result.variants).map { |variant| serialize_variant(variant) }
       payload[:units] = Array(result.units).map { |unit| serialize_unit(unit) }
+      payload[:products] = Array(result.products).map { |product| serialize_product(product) }
       payload
+    end
+
+    def serialize_product(product)
+      {
+        id: product.id,
+        name: product.name,
+        subtitle: product.subtitle,
+        brand_name: product.brand_name,
+        primary_identifier: product.primary_identifier,
+        industry_identifier: product.industry_identifier,
+        lookup_code: product.lookup_code
+      }
     end
 
     def serialize_variant(variant)
       tracking = variant.derived_inventory_tracking
-      open_price = variant.merchandise_class&.pricing_method == "open_price"
+      open_price = variant.pricing_method == "open_price"
       {
         id: variant.id,
         sku: variant.sku,

--- a/app/controllers/pos/workspaces_controller.rb
+++ b/app/controllers/pos/workspaces_controller.rb
@@ -184,6 +184,8 @@ module Pos
       render json: serialize_unlinked_resolution(result)
     rescue Pos::Denied
       render json: { error: "You are not authorized to perform that action." }, status: :forbidden
+    rescue Pos::InvalidatedDialogBasis => e
+      render json: { outcome: "unavailable", error: e.message, message: e.message }, status: :unprocessable_entity
     rescue Identifiers::NormalizationError, Pos::Error => e
       render json: { outcome: "unavailable", error: e.message, message: e.message }, status: :unprocessable_entity
     end

--- a/app/javascript/controllers/register_workspace_controller.js
+++ b/app/javascript/controllers/register_workspace_controller.js
@@ -58,6 +58,9 @@ export default class extends Controller {
     "controlRemove",
     "unlinkedIdentifierField",
     "unlinkedIdentifierInput",
+    "unlinkedProductIdInput",
+    "unlinkedVariantIdInput",
+    "unlinkedUnitIdInput",
     "unlinkedQuantityInput",
     "unlinkedReasonInput",
     "unlinkedNoteInput",
@@ -942,6 +945,10 @@ export default class extends Controller {
     if (key === "Escape") {
       event.preventDefault()
       this.closeProductOverlay()
+      if (this.unlinkedPickerActive) {
+        this.unlinkedPickerActive = false
+        this.unlinkedSelection = null
+      }
       return
     }
     if (key === "ArrowUp" || key === "ArrowDown") {
@@ -960,6 +967,11 @@ export default class extends Controller {
     if (!selected || !selected.dataset.productId) return
     const productId = selected.dataset.productId
     this.closeProductOverlay()
+    if (this.unlinkedPickerActive) {
+      this.unlinkedPickerActive = false
+      this.fetchUnlinkedResolution({ product_id: productId })
+      return
+    }
     this.resolveAndHandle({ product_id: productId })
   }
 
@@ -986,6 +998,10 @@ export default class extends Controller {
     if (key === "Escape") {
       event.preventDefault()
       this.closeVariantOverlay()
+      if (this.unlinkedPickerActive) {
+        this.unlinkedPickerActive = false
+        this.unlinkedSelection = null
+      }
       return
     }
     if (key === "ArrowUp" || key === "ArrowDown") {
@@ -1004,6 +1020,11 @@ export default class extends Controller {
     if (!selected) return
     const variantId = selected.dataset.variantId
     this.closeVariantOverlay()
+    if (this.unlinkedPickerActive) {
+      this.unlinkedPickerActive = false
+      this.fetchUnlinkedResolution({ product_variant_id: variantId })
+      return
+    }
     this.resolveAndHandle({ product_variant_id: variantId })
   }
 
@@ -1034,6 +1055,10 @@ export default class extends Controller {
     if (key === "Escape") {
       event.preventDefault()
       this.closeUnitOverlay()
+      if (this.unlinkedPickerActive) {
+        this.unlinkedPickerActive = false
+        this.unlinkedSelection = null
+      }
       return
     }
     if (key === "ArrowUp" || key === "ArrowDown") {
@@ -1052,6 +1077,11 @@ export default class extends Controller {
     if (!selected || !selected.dataset.unitId) return
     const unitId = selected.dataset.unitId
     this.closeUnitOverlay()
+    if (this.unlinkedPickerActive) {
+      this.unlinkedPickerActive = false
+      this.fetchUnlinkedResolution({ inventory_unit_id: unitId })
+      return
+    }
     this.resolveAndHandle({ inventory_unit_id: unitId })
   }
 
@@ -1528,7 +1558,19 @@ export default class extends Controller {
     if (this.inFlight || !this.hasUnlinkedIdentifierFieldTarget) return
     const identifier = this.unlinkedIdentifierFieldTarget.value.trim()
     if (identifier === "") return
+    this.unlinkedSelection = { identifier }
+    await this.fetchUnlinkedResolution({ identifier })
+  }
+
+  async fetchUnlinkedResolution(params = {}) {
     const token = document.querySelector('meta[name="csrf-token"]')?.getAttribute("content")
+    const body = new URLSearchParams()
+    const identifier = params.identifier || this.unlinkedSelection?.identifier ||
+      (this.hasUnlinkedIdentifierFieldTarget ? this.unlinkedIdentifierFieldTarget.value.trim() : "")
+    if (identifier) body.set("identifier", identifier)
+    if (params.product_id) body.set("product_id", params.product_id)
+    if (params.product_variant_id) body.set("product_variant_id", params.product_variant_id)
+    if (params.inventory_unit_id) body.set("inventory_unit_id", params.inventory_unit_id)
     try {
       const response = await fetch(this.unlinkedLookupUrlValue, {
         method: "POST",
@@ -1537,18 +1579,40 @@ export default class extends Controller {
           "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
           "X-CSRF-Token": token || ""
         },
-        body: new URLSearchParams({ identifier }).toString()
+        body: body.toString()
       })
       const payload = await response.json()
-      if (!response.ok) {
-        this.showUnlinkedFeedback(payload.error || "merchandise not found")
-        this.clearUnlinkedPreviewState()
-        return
-      }
-      this.applyUnlinkedPreview(payload)
+      this.handleUnlinkedResolution(payload, response.ok)
     } catch (_error) {
       this.showUnlinkedFeedback("merchandise not found")
       this.clearUnlinkedPreviewState()
+      this.unlinkedSelection = null
+    }
+  }
+
+  handleUnlinkedResolution(payload, ok) {
+    const outcome = payload.outcome || (ok ? "resolved" : "unavailable")
+    switch (outcome) {
+      case "resolved":
+        this.applyUnlinkedPreview(payload)
+        return
+      case "product_choice_required":
+        this.unlinkedPickerActive = true
+        this.openProductPicker(payload.products || [])
+        return
+      case "variant_choice_required":
+        this.unlinkedPickerActive = true
+        this.openVariantPicker(payload.variants || [])
+        return
+      case "unit_choice_required":
+        this.unlinkedPickerActive = true
+        this.openUnitPicker(payload.units || [])
+        return
+      default:
+        this.showUnlinkedFeedback(payload.error || payload.message || "merchandise not found")
+        this.clearUnlinkedPreviewState()
+        this.unlinkedSelection = null
+        this.unlinkedPickerActive = false
     }
   }
 
@@ -1594,6 +1658,15 @@ export default class extends Controller {
       this.unlinkedIdentifierInputTarget.value = this.hasUnlinkedIdentifierFieldTarget
         ? this.unlinkedIdentifierFieldTarget.value.trim()
         : ""
+    }
+    if (this.hasUnlinkedProductIdInputTarget) {
+      this.unlinkedProductIdInputTarget.value = this.unlinkedPreviewPayload.product_id || ""
+    }
+    if (this.hasUnlinkedVariantIdInputTarget) {
+      this.unlinkedVariantIdInputTarget.value = this.unlinkedPreviewPayload.product_variant_id || ""
+    }
+    if (this.hasUnlinkedUnitIdInputTarget) {
+      this.unlinkedUnitIdInputTarget.value = this.unlinkedPreviewPayload.inventory_unit_id || ""
     }
     if (this.hasUnlinkedQuantityInputTarget) {
       this.unlinkedQuantityInputTarget.value = this.unlinkedPreviewPayload.quantity_fixed

--- a/app/javascript/controllers/register_workspace_controller.js
+++ b/app/javascript/controllers/register_workspace_controller.js
@@ -105,6 +105,8 @@ export default class extends Controller {
     "searchSkuField",
     "searchNameField",
     "searchQueryLabel",
+    "productOverlay",
+    "productList",
     "variantOverlay",
     "variantList",
     "unitOverlay",
@@ -226,6 +228,11 @@ export default class extends Controller {
 
     if (this.searchOverlayOpen()) {
       this.onSearchOverlayKeydown(event, key)
+      return
+    }
+
+    if (this.productOverlayOpen()) {
+      this.onProductOverlayKeydown(event, key)
       return
     }
 
@@ -766,6 +773,7 @@ export default class extends Controller {
   async fetchResolve(params) {
     const url = new URL(this.resolveUrlValue, window.location.origin)
     if (params.identifier) url.searchParams.set("identifier", params.identifier)
+    if (params.product_id) url.searchParams.set("product_id", params.product_id)
     if (params.product_variant_id) url.searchParams.set("product_variant_id", params.product_variant_id)
     if (params.inventory_unit_id) url.searchParams.set("inventory_unit_id", params.inventory_unit_id)
     const response = await fetch(url, { headers: { Accept: "application/json" }, credentials: "same-origin" })
@@ -781,6 +789,9 @@ export default class extends Controller {
         return
       case "addable_unit":
         this.postAddMerchandise({ unitId: result.unit.id })
+        return
+      case "product_choice_required":
+        this.openProductPicker(result.products || [])
         return
       case "variant_choice_required":
         this.openVariantPicker(result.variants || [])
@@ -906,6 +917,50 @@ export default class extends Controller {
     const variantId = selected.dataset.variantId
     this.closeSearchOverlay()
     this.resolveAndHandle({ product_variant_id: variantId })
+  }
+
+  openProductPicker(products) {
+    if (!this.hasProductOverlayTarget || !this.hasProductListTarget) return
+    this.productListTarget.replaceChildren()
+    products.forEach((product, index) => {
+      const item = document.createElement("li")
+      item.dataset.productId = product.id
+      const identity = [product.primary_identifier, product.industry_identifier, product.lookup_code].filter(Boolean).join(" · ")
+      const descriptor = [product.name, product.subtitle, product.brand_name].filter(Boolean).join(" — ")
+      item.textContent = [descriptor, identity].filter(Boolean).join(" · ")
+      this.decoratePickerItem(item, { selected: index === 0 })
+      this.productListTarget.append(item)
+    })
+    this.showOverlay(this.productOverlayTarget, this.productListTarget.querySelector("li.is-selected"))
+  }
+
+  closeProductOverlay() {
+    this.hideOverlay(this.hasProductOverlayTarget && this.productOverlayTarget)
+  }
+
+  onProductOverlayKeydown(event, key) {
+    if (key === "Escape") {
+      event.preventDefault()
+      this.closeProductOverlay()
+      return
+    }
+    if (key === "ArrowUp" || key === "ArrowDown") {
+      event.preventDefault()
+      this.movePickerList(this.productListTarget, key === "ArrowUp" ? -1 : 1)
+      return
+    }
+    if (key === "Enter") {
+      event.preventDefault()
+      this.selectHighlightedProduct()
+    }
+  }
+
+  selectHighlightedProduct() {
+    const selected = this.hasProductListTarget && this.productListTarget.querySelector("li.is-selected")
+    if (!selected || !selected.dataset.productId) return
+    const productId = selected.dataset.productId
+    this.closeProductOverlay()
+    this.resolveAndHandle({ product_id: productId })
   }
 
   openVariantPicker(variants) {
@@ -1661,6 +1716,7 @@ export default class extends Controller {
       this.hasControlOverlayTarget && this.controlOverlayTarget,
       this.hasOtherOverlayTarget && this.otherOverlayTarget,
       this.hasSearchOverlayTarget && this.searchOverlayTarget,
+      this.hasProductOverlayTarget && this.productOverlayTarget,
       this.hasVariantOverlayTarget && this.variantOverlayTarget,
       this.hasUnitOverlayTarget && this.unitOverlayTarget,
       this.hasOpenPriceOverlayTarget && this.openPriceOverlayTarget,
@@ -1760,6 +1816,10 @@ export default class extends Controller {
 
   searchOverlayOpen() {
     return this.hasSearchOverlayTarget && !this.searchOverlayTarget.hidden
+  }
+
+  productOverlayOpen() {
+    return this.hasProductOverlayTarget && !this.productOverlayTarget.hidden
   }
 
   variantOverlayOpen() {

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -19,7 +19,6 @@ class Department < ApplicationRecord
     inventory_adjustment_gain_gl_account_id
   ].freeze
 
-  belongs_to :default_tax_class, class_name: "TaxClass"
   belongs_to :inventory_asset_gl_account, class_name: "GlAccount", optional: true
   belongs_to :cost_of_goods_sold_gl_account, class_name: "GlAccount", optional: true
   belongs_to :sales_revenue_gl_account, class_name: "GlAccount", optional: true
@@ -30,16 +29,15 @@ class Department < ApplicationRecord
   belongs_to :inventory_adjustment_gain_gl_account, class_name: "GlAccount", optional: true
   belongs_to :inventory_adjustment_loss_gl_account, class_name: "GlAccount", optional: true
   belongs_to :inventory_write_down_gl_account, class_name: "GlAccount", optional: true
+  has_many :merchandise_classes, dependent: :restrict_with_exception
 
   before_validation :normalize_department_number
 
-  validates :code, :name, :default_tax_class_id, presence: true
+  validates :code, :name, :department_number, presence: true
   validates :code, uniqueness: true, format: { with: Codes::Normalizer::FORMAT }
-  validates :default_target_margin_bps,
-            numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than: 10_000 },
-            allow_nil: true
+  validates :department_number, uniqueness: true
   validate :validate_changed_gl_mappings
-  validate :validate_changed_tax_class
+  validate :cannot_deactivate_with_active_classes, if: -> { active_changed? && !active? }
 
   scope :active, -> { where(active: true) }
   scope :assignable, -> { active }
@@ -50,11 +48,7 @@ class Department < ApplicationRecord
   end
 
   def admin_label
-    if department_number.present?
-      "#{department_number} - #{name}"
-    else
-      name
-    end
+    "#{department_number} - #{name}"
   end
 
   def self.options_for_select(records = admin_ordered)
@@ -63,9 +57,6 @@ class Department < ApplicationRecord
 
   def reactivation_blockers
     blockers = []
-    if default_tax_class.blank? || !default_tax_class.active?
-      blockers << "default tax class must be active"
-    end
 
     GL_MAPPING_EXPECTATIONS.each do |field, expectation|
       account = public_send(field.to_s.delete_suffix("_id"))
@@ -96,11 +87,10 @@ class Department < ApplicationRecord
     self.department_number = department_number.to_s.strip.presence
   end
 
-  def validate_changed_tax_class
-    return unless default_tax_class_id_changed?
-    return if default_tax_class.blank?
+  def cannot_deactivate_with_active_classes
+    return unless merchandise_classes.active.exists?
 
-    errors.add(:default_tax_class_id, "must be an active tax class") unless default_tax_class.assignable?
+    errors.add(:active, "cannot deactivate while active merchandise classes exist")
   end
 
   def validate_changed_gl_mappings

--- a/app/models/identifier_registry.rb
+++ b/app/models/identifier_registry.rb
@@ -3,7 +3,8 @@
 class IdentifierRegistry < ApplicationRecord
   self.table_name = "identifier_registry"
 
-  KINDS = %w[product_primary variant_sku variant_industry inventory_unit].freeze
+  KINDS = %w[product_primary product_industry variant_sku variant_industry inventory_unit].freeze
+  PRODUCT_KINDS = %w[product_primary product_industry].freeze
 
   belongs_to :product, optional: true
   belongs_to :product_variant, optional: true
@@ -29,10 +30,10 @@ class IdentifierRegistry < ApplicationRecord
 
     if active?
       case identifier_kind
-      when "product_primary"
-        errors.add(:product_id, "is required for active product_primary rows") if product_id.blank?
-        errors.add(:product_variant_id, "must be blank for product_primary rows") if product_variant_id.present?
-        errors.add(:inventory_unit_id, "must be blank for product_primary rows") if inventory_unit_id.present?
+      when *PRODUCT_KINDS
+        errors.add(:product_id, "is required for active #{identifier_kind} rows") if product_id.blank?
+        errors.add(:product_variant_id, "must be blank for #{identifier_kind} rows") if product_variant_id.present?
+        errors.add(:inventory_unit_id, "must be blank for #{identifier_kind} rows") if inventory_unit_id.present?
       when "variant_sku", "variant_industry"
         errors.add(:product_variant_id, "is required for active #{identifier_kind} rows") if product_variant_id.blank?
         errors.add(:product_id, "must be blank for #{identifier_kind} rows") if product_id.present?

--- a/app/models/merchandise_category.rb
+++ b/app/models/merchandise_category.rb
@@ -4,14 +4,15 @@ class MerchandiseCategory < ApplicationRecord
   include HasMachineCode
 
   belongs_to :parent, class_name: "MerchandiseCategory", optional: true
-  belongs_to :default_merchandise_class, class_name: "MerchandiseClass", optional: true
+  belongs_to :default_standard_merchandise_class, class_name: "MerchandiseClass", optional: true
+  belongs_to :default_used_merchandise_class, class_name: "MerchandiseClass", optional: true
   has_many :children, class_name: "MerchandiseCategory", foreign_key: :parent_id, inverse_of: :parent, dependent: :restrict_with_exception
 
   validates :name, presence: true
   validates :code, uniqueness: true, allow_nil: true, format: { with: Codes::Normalizer::FORMAT, allow_nil: true }
   validate :parent_not_self
   validate :no_parent_cycle
-  validate :validate_changed_default_class
+  validate :validate_changed_default_classes
 
   scope :active, -> { where(active: true) }
   scope :assignable, -> { active }
@@ -78,8 +79,11 @@ class MerchandiseCategory < ApplicationRecord
   def reactivation_blockers
     blockers = []
     blockers << "parent category must be active" if parent.present? && !parent.active?
-    if default_merchandise_class.present? && !default_merchandise_class.active?
-      blockers << "default merchandise class must be active"
+    if default_standard_merchandise_class.present? && !default_standard_merchandise_class.active?
+      blockers << "default standard merchandise class must be active"
+    end
+    if default_used_merchandise_class.present? && !default_used_merchandise_class.active?
+      blockers << "default used merchandise class must be active"
     end
     blockers
   end
@@ -89,8 +93,6 @@ class MerchandiseCategory < ApplicationRecord
   def prepare_machine_code
     if new_record?
       if code.blank?
-        # Optional: leave blank unless supplied or name is used for generation when code was omitted intentionally.
-        # Spec: blank generates from name. Categories generate when name present.
         if name.present?
           self.code = Codes::Normalizer.normalize(name).presence
         end
@@ -121,10 +123,20 @@ class MerchandiseCategory < ApplicationRecord
     end
   end
 
-  def validate_changed_default_class
-    return unless default_merchandise_class_id_changed?
-    return if default_merchandise_class.blank?
+  def validate_changed_default_classes
+    if default_standard_merchandise_class_id_changed? && default_standard_merchandise_class.present?
+      unless default_standard_merchandise_class.assignable?
+        errors.add(:default_standard_merchandise_class_id, "must be an active merchandise class")
+      end
+    end
 
-    errors.add(:default_merchandise_class_id, "must be an active merchandise class") unless default_merchandise_class.assignable?
+    if default_used_merchandise_class_id_changed? && default_used_merchandise_class.present?
+      unless default_used_merchandise_class.assignable?
+        errors.add(:default_used_merchandise_class_id, "must be an active merchandise class")
+      end
+      if default_used_merchandise_class.assignable? && !default_used_merchandise_class.used_merchandise_allowed?
+        errors.add(:default_used_merchandise_class_id, "must allow used merchandise")
+      end
+    end
   end
 end

--- a/app/models/merchandise_class.rb
+++ b/app/models/merchandise_class.rb
@@ -6,62 +6,78 @@ class MerchandiseClass < ApplicationRecord
   INVENTORY_MODES = %w[inventory non_inventory].freeze
   PRICING_METHODS = %w[fixed list_price cost_based open_price].freeze
 
-  belongs_to :default_standard_department, class_name: "Department", optional: true
-  belongs_to :default_used_department, class_name: "Department", optional: true
+  belongs_to :department
+  belongs_to :default_tax_class, class_name: "TaxClass"
   has_many :product_variants, dependent: :restrict_with_exception
 
-  validates :code, :name, :inventory_mode, :pricing_method, presence: true
+  before_validation :normalize_merchandise_class_number
+
+  validates :code, :name, :merchandise_class_number, :default_inventory_mode, :default_pricing_method, :default_tax_class_id, :department_id, presence: true
   validates :code, uniqueness: true, format: { with: Codes::Normalizer::FORMAT }
-  validates :inventory_mode, inclusion: { in: INVENTORY_MODES }
-  validates :pricing_method, inclusion: { in: PRICING_METHODS }
-  validate :validate_changed_departments
+  validates :merchandise_class_number, uniqueness: { scope: :department_id }
+  validates :default_inventory_mode, inclusion: { in: INVENTORY_MODES }
+  validates :default_pricing_method, inclusion: { in: PRICING_METHODS }
+  validates :target_margin_bps,
+            numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than: 10_000 },
+            allow_nil: true
+  validate :validate_changed_department
+  validate :validate_changed_default_tax_class
   validate :buyback_implication
-  validate :inventory_mode_immutability_after_history
+  validate :block_department_move_after_history
 
   scope :active, -> { where(active: true) }
   scope :assignable, -> { active }
-  scope :admin_ordered, -> { order(:display_order, :name) }
+  scope :admin_ordered, -> { order(:display_order, :merchandise_class_number, :name) }
 
   def assignable?
     active?
   end
 
   def admin_label
-    name
+    if department
+      "#{department.department_number} / #{merchandise_class_number} - #{name}"
+    else
+      name
+    end
   end
 
-  def self.options_for_select(records = admin_ordered)
+  def self.options_for_select(records = admin_ordered.includes(:department))
     Array(records).map { |klass| [ klass.admin_label, klass.id ] }
   end
 
   def inventory?
-    inventory_mode == "inventory"
+    default_inventory_mode == "inventory"
   end
 
   def non_inventory?
-    inventory_mode == "non_inventory"
+    default_inventory_mode == "non_inventory"
   end
 
   def reactivation_blockers
     blockers = []
-    if default_standard_department.present? && !default_standard_department.active?
-      blockers << "default standard department must be active"
-    end
-    if default_used_department.present? && !default_used_department.active?
-      blockers << "default used department must be active"
-    end
+    blockers << "department must be active" if department.blank? || !department.active?
+    blockers << "default tax class must be active" if default_tax_class.blank? || !default_tax_class.active?
     blockers
   end
 
   private
 
-  def validate_changed_departments
-    if default_standard_department_id_changed? && default_standard_department.present? && !default_standard_department.assignable?
-      errors.add(:default_standard_department_id, "must be an active department")
-    end
-    if default_used_department_id_changed? && default_used_department.present? && !default_used_department.assignable?
-      errors.add(:default_used_department_id, "must be an active department")
-    end
+  def normalize_merchandise_class_number
+    self.merchandise_class_number = merchandise_class_number.to_s.strip.presence
+  end
+
+  def validate_changed_department
+    return unless department_id_changed?
+    return if department.blank?
+
+    errors.add(:department_id, "must be an active department") unless department.assignable?
+  end
+
+  def validate_changed_default_tax_class
+    return unless default_tax_class_id_changed?
+    return if default_tax_class.blank?
+
+    errors.add(:default_tax_class_id, "must be an active tax class") unless default_tax_class.assignable?
   end
 
   def buyback_implication
@@ -72,24 +88,15 @@ class MerchandiseClass < ApplicationRecord
     end
   end
 
-  def inventory_mode_immutability_after_history
-    return unless inventory_mode_changed?
+  def block_department_move_after_history
+    return unless department_id_changed?
+    return if new_record?
+    return if department_id_was.blank?
 
-    prior_mode = inventory_mode_was
     product_variants.find_each do |variant|
-      next unless variant.inventory_history?
+      next unless variant.inventory_history? || variant.pos_line_history?
 
-      prior = ProductVariant.derived_inventory_tracking_for(
-        inventory_mode: prior_mode,
-        variant_type: variant.variant_type
-      )
-      current = ProductVariant.derived_inventory_tracking_for(
-        inventory_mode: inventory_mode,
-        variant_type: variant.variant_type
-      )
-      next if prior == current
-
-      errors.add(:inventory_mode, "cannot change inventory tracking method after inventory history exists")
+      errors.add(:department_id, "cannot be changed after associated variants have inventory or POS history; a controlled reclassification is required")
       break
     end
   end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -2,6 +2,8 @@
 
 class Product < ApplicationRecord
   STATUSES = %w[draft active discontinued].freeze
+  LOOKUP_CODE_MAX_LENGTH = 64
+  LOOKUP_CODE_FORMAT = %r{\A[A-Z0-9._/-]+\z}
 
   attr_accessor :identifier_writes_enabled
 
@@ -9,16 +11,36 @@ class Product < ApplicationRecord
   has_many :product_variants, dependent: :restrict_with_exception
   has_many :identifier_registry_entries, class_name: "IdentifierRegistry", dependent: :nullify
 
+  before_validation :normalize_lookup_code
+
   validates :name, :primary_identifier, :status, presence: true
   validates :primary_identifier, uniqueness: true, format: { with: /\A\d{13}\z/ }
+  validates :industry_identifier, uniqueness: true, allow_nil: true, format: { with: /\A\d{13}\z/ }
+  validates :lookup_code,
+            length: { maximum: LOOKUP_CODE_MAX_LENGTH },
+            format: { with: LOOKUP_CODE_FORMAT, message: "may contain only A-Z, 0-9, period, underscore, slash, and hyphen" },
+            allow_nil: true
   validates :status, inclusion: { in: STATUSES }
   validates :list_price_cents, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
   validate :validate_changed_category
-  validate :primary_identifier_write_rules
+  validate :identifier_write_rules
   after_save { self.identifier_writes_enabled = false }
 
   scope :active, -> { where(status: "active") }
   scope :draft, -> { where(status: "draft") }
+
+  # Lookup codes are intentionally nonunique: shared codes require POS product selection.
+  def self.matching_lookup_code(raw)
+    canonical = self.canonical_lookup_code(raw)
+    return none if canonical.blank?
+
+    where(lookup_code: canonical)
+  end
+
+  def self.canonical_lookup_code(raw)
+    value = raw.to_s.strip.upcase
+    value.presence
+  end
 
   def draft?
     status == "draft"
@@ -30,6 +52,10 @@ class Product < ApplicationRecord
 
   private
 
+  def normalize_lookup_code
+    self.lookup_code = self.class.canonical_lookup_code(lookup_code)
+  end
+
   def validate_changed_category
     return unless merchandise_category_id_changed?
     return if merchandise_category.blank?
@@ -37,13 +63,18 @@ class Product < ApplicationRecord
     errors.add(:merchandise_category_id, "must be an active category") unless merchandise_category.assignable?
   end
 
-  def primary_identifier_write_rules
+  def identifier_write_rules
     if new_record?
       unless identifier_writes_enabled
         errors.add(:primary_identifier, "must be assigned through Products::Create")
       end
-    elsif primary_identifier_changed?
-      errors.add(:primary_identifier, "cannot be changed")
+      return
+    end
+
+    errors.add(:primary_identifier, "cannot be changed") if primary_identifier_changed?
+
+    if industry_identifier_changed? && !identifier_writes_enabled
+      errors.add(:industry_identifier, "must be changed through Identifiers::AssignProductIndustry")
     end
   end
 end

--- a/app/models/product_variant.rb
+++ b/app/models/product_variant.rb
@@ -3,21 +3,27 @@
 class ProductVariant < ApplicationRecord
   STATUSES = %w[draft active discontinued].freeze
   VARIANT_TYPES = %w[standard used].freeze
+  INVENTORY_MODES = MerchandiseClass::INVENTORY_MODES
+  PRICING_METHODS = MerchandiseClass::PRICING_METHODS
 
   attr_accessor :identifier_writes_enabled
 
   belongs_to :product
   belongs_to :merchandise_condition, optional: true
   belongs_to :merchandise_class, optional: true
-  belongs_to :department, optional: true
-  belongs_to :tax_class, optional: true
+  belongs_to :tax_class_override, class_name: "TaxClass", optional: true
 
   validates :sku, :status, :variant_type, presence: true
   validates :sku, uniqueness: true, format: { with: /\A\d{13}\z/ }
   validates :industry_identifier, uniqueness: true, allow_nil: true, format: { with: /\A\d{13}\z/ }
   validates :status, inclusion: { in: STATUSES }
   validates :variant_type, inclusion: { in: VARIANT_TYPES }
+  validates :inventory_mode, inclusion: { in: INVENTORY_MODES }, allow_nil: true
+  validates :pricing_method, inclusion: { in: PRICING_METHODS }, allow_nil: true
   validates :regular_price_cents, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :target_margin_bps,
+            numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than: 10_000 },
+            allow_nil: true
   validate :condition_matches_variant_type
   validate :validate_changed_references
   validate :identifier_write_rules
@@ -42,9 +48,17 @@ class ProductVariant < ApplicationRecord
     variant_type == "used"
   end
 
+  def department
+    merchandise_class&.department
+  end
+
+  def effective_tax_class
+    tax_class_override || merchandise_class&.default_tax_class
+  end
+
   def derived_inventory_tracking
     self.class.derived_inventory_tracking_for(
-      inventory_mode: merchandise_class&.inventory_mode,
+      inventory_mode: inventory_mode,
       variant_type: variant_type
     )
   end
@@ -66,13 +80,20 @@ class ProductVariant < ApplicationRecord
       InventoryUnit.exists?(product_variant_id: id)
   end
 
+  def pos_line_history?
+    PosTransactionLine.exists?(product_variant_id: id)
+  end
+
   def sellable?
     status == "active" &&
       product.active_status? &&
       sku.present? &&
       merchandise_class&.assignable? &&
       department&.assignable? &&
-      tax_class&.assignable? &&
+      effective_tax_class&.assignable? &&
+      inventory_mode.present? &&
+      pricing_method.present? &&
+      !supplier_returnable.nil? &&
       type_and_condition_valid_for_class?(require_assignable_condition: true) &&
       price_satisfies_pricing_method?
   end
@@ -91,16 +112,16 @@ class ProductVariant < ApplicationRecord
         end
       condition_ok &&
         merchandise_class.used_merchandise_allowed? &&
-        merchandise_class.inventory?
+        inventory_mode == "inventory"
     else
       false
     end
   end
 
   def price_satisfies_pricing_method?
-    return false if merchandise_class.blank?
+    return false if pricing_method.blank?
 
-    case merchandise_class.pricing_method
+    case pricing_method
     when "open_price"
       true
     when "fixed", "list_price", "cost_based"
@@ -130,16 +151,15 @@ class ProductVariant < ApplicationRecord
   def tracking_immutability_after_history
     return if new_record?
     return unless inventory_history?
-    return unless merchandise_class_id_changed? || variant_type_changed?
 
-    prior_class =
-      if merchandise_class_id_changed?
-        MerchandiseClass.find_by(id: merchandise_class_id_was)
-      else
-        merchandise_class
-      end
-    prior_type = variant_type_changed? ? variant_type_was : variant_type
-    prior = self.class.new(merchandise_class: prior_class, variant_type: prior_type).derived_inventory_tracking
+    mode_changing = inventory_mode_changed?
+    type_changing = variant_type_changed?
+    class_changing = merchandise_class_id_changed?
+    return unless mode_changing || type_changing || class_changing
+
+    prior_mode = mode_changing ? inventory_mode_was : inventory_mode
+    prior_type = type_changing ? variant_type_was : variant_type
+    prior = self.class.derived_inventory_tracking_for(inventory_mode: prior_mode, variant_type: prior_type)
     current = derived_inventory_tracking
     return if prior == current
 
@@ -161,23 +181,29 @@ class ProductVariant < ApplicationRecord
     if merchandise_class_id_changed? && merchandise_class.present? && !merchandise_class.assignable?
       errors.add(:merchandise_class_id, "must be an active merchandise class")
     end
-    if department_id_changed? && department.present? && !department.assignable?
-      errors.add(:department_id, "must be an active department")
-    end
-    if tax_class_id_changed? && tax_class.present? && !tax_class.assignable?
-      errors.add(:tax_class_id, "must be an active tax class")
+    if tax_class_override_id_changed? && tax_class_override.present? && !tax_class_override.assignable?
+      errors.add(:tax_class_override_id, "must be an active tax class")
     end
   end
 
   def activation_requirements
     errors.add(:merchandise_class_id, "is required to activate") if merchandise_class_id.blank?
-    errors.add(:department_id, "is required to activate") if department_id.blank?
-    errors.add(:tax_class_id, "is required to activate") if tax_class_id.blank?
+    errors.add(:inventory_mode, "is required to activate") if inventory_mode.blank?
+    errors.add(:pricing_method, "is required to activate") if pricing_method.blank?
+    errors.add(:supplier_returnable, "is required to activate") if supplier_returnable.nil?
+    if effective_tax_class.blank?
+      errors.add(:base, "an effective tax class is required to activate")
+    elsif !effective_tax_class.assignable?
+      errors.add(:base, "effective tax class must be an active tax class")
+    end
+    if merchandise_class.present? && (department.blank? || !department.assignable?)
+      errors.add(:base, "merchandise class department must be active")
+    end
 
     require_assignable_condition = status_changed? || merchandise_condition_id_changed?
     unless type_and_condition_valid_for_class?(require_assignable_condition: require_assignable_condition)
-      if used? && merchandise_class.present? && merchandise_class.non_inventory?
-        errors.add(:merchandise_class_id, "used variants cannot use a non-inventory merchandise class")
+      if used? && inventory_mode == "non_inventory"
+        errors.add(:inventory_mode, "used variants cannot use non_inventory")
       elsif used? && merchandise_class.present? && !merchandise_class.used_merchandise_allowed?
         errors.add(:base, "used variants require a merchandise class that allows used merchandise")
       elsif used? && merchandise_condition.blank?

--- a/app/models/product_variant.rb
+++ b/app/models/product_variant.rb
@@ -28,6 +28,7 @@ class ProductVariant < ApplicationRecord
   validate :validate_changed_references
   validate :identifier_write_rules
   validate :tracking_immutability_after_history
+  validate :block_class_reclassification_after_history
   validate :activation_requirements, if: -> { status == "active" }
   after_save { self.identifier_writes_enabled = false }
 
@@ -164,6 +165,17 @@ class ProductVariant < ApplicationRecord
     return if prior == current
 
     errors.add(:base, "cannot change inventory tracking method after inventory history exists")
+  end
+
+  def block_class_reclassification_after_history
+    return if new_record?
+    return unless merchandise_class_id_changed?
+    return unless inventory_history? || pos_line_history?
+
+    errors.add(
+      :merchandise_class_id,
+      "cannot be changed after inventory or POS history exists; a controlled reclassification is required"
+    )
   end
 
   def condition_matches_variant_type

--- a/app/services/identifiers/assign_product_industry.rb
+++ b/app/services/identifiers/assign_product_industry.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Identifiers
+  class AssignProductIndustry
+    class Error < StandardError; end
+
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(product:, raw_value:, actor: nil, source: "ui", persist: true)
+      @product = product
+      @raw_value = raw_value
+      @actor = actor
+      @source = source
+      @persist = persist
+    end
+
+    def call
+      Product.transaction do
+        previous = @product.industry_identifier
+
+        if @raw_value.blank?
+          apply_clear!(previous)
+        else
+          normalized = Normalizer.normalize(@raw_value, allow_shelfsense_222: false)
+          raise Error, "industry identifier cannot equal the primary identifier" if normalized == @product.primary_identifier
+          apply_replace!(previous, normalized) unless normalized == previous
+        end
+
+        if @persist
+          @product.identifier_writes_enabled = true
+          @product.save!
+        end
+
+        @product
+      end
+    rescue NormalizationError, Registry::ConflictError, ActiveRecord::RecordInvalid => e
+      raise Error, e.message
+    end
+
+    private
+
+    def apply_clear!(previous)
+      return if previous.blank?
+
+      Registry.retire!(value: previous)
+      @product.identifier_writes_enabled = true
+      @product.industry_identifier = nil
+    end
+
+    def apply_replace!(previous, normalized)
+      # Retire first so the active product_industry unique owner index allows the new row.
+      Registry.retire!(value: previous) if previous.present?
+      Registry.reserve!(value: normalized, kind: "product_industry", product: @product)
+      @product.identifier_writes_enabled = true
+      @product.industry_identifier = normalized
+    end
+  end
+end

--- a/app/services/identifiers/lookup.rb
+++ b/app/services/identifiers/lookup.rb
@@ -1,8 +1,19 @@
 # frozen_string_literal: true
 
 module Identifiers
+  # Identity matching only. Callers apply their own eligibility rules (POS sellability,
+  # return eligibility, adjustability); this service must never embed them.
   class Lookup
-    Result = Struct.new(:status, :product, :variant, :variants, :inventory_unit, :message, keyword_init: true)
+    Result = Struct.new(
+      :status,
+      :product,
+      :products,
+      :variant,
+      :variants,
+      :inventory_unit,
+      :message,
+      keyword_init: true
+    )
 
     def self.call(raw)
       new(raw).call
@@ -13,9 +24,27 @@ module Identifiers
     end
 
     def call
+      return invalid("identifier is blank") if @raw.to_s.strip.blank?
+
+      row = registry_row
+      return resolve_registry(row) if row
+
+      resolve_lookup_code
+    end
+
+    private
+
+    def registry_row
       normalized = Normalizer.normalize(@raw, allow_shelfsense_222: true)
-      row = Registry.find_any(normalized)
-      return Result.new(status: :not_found, message: "No match") if row.nil?
+      @normalization_error = nil
+      Registry.find_any(normalized)
+    rescue NormalizationError => e
+      # Letter-containing and malformed values may still be lookup codes.
+      @normalization_error = e.message
+      nil
+    end
+
+    def resolve_registry(row)
       return Result.new(status: :retired, message: "Identifier is retired") if row.retired_at.present?
 
       case row.identifier_kind
@@ -24,18 +53,11 @@ module Identifiers
         return Result.new(status: :not_found, message: "Variant missing") if variant.nil?
 
         Result.new(status: :variant, variant: variant, product: variant.product)
-      when "product_primary"
+      when "product_primary", "product_industry"
         product = row.product
         return Result.new(status: :not_found, message: "Product missing") if product.nil?
 
-        eligible = product.product_variants.select(&:sellable?)
-        if eligible.one?
-          Result.new(status: :variant, variant: eligible.first, product: product)
-        elsif eligible.many?
-          Result.new(status: :multi_variant, product: product, variants: eligible)
-        else
-          Result.new(status: :product, product: product)
-        end
+        product_result(product)
       when "inventory_unit"
         unit = row.inventory_unit
         return Result.new(status: :not_found, message: "Unit missing") if unit.nil?
@@ -48,10 +70,38 @@ module Identifiers
           product: variant&.product
         )
       else
-        Result.new(status: :invalid, message: "Unknown identifier kind")
+        invalid("Unknown identifier kind")
       end
-    rescue NormalizationError => e
-      Result.new(status: :invalid, message: e.message)
+    end
+
+    def resolve_lookup_code
+      canonical = Product.canonical_lookup_code(@raw)
+      return invalid(@normalization_error || "identifier cannot be interpreted") unless valid_lookup_code?(canonical)
+
+      products = Product.where(lookup_code: canonical).order(:name, :primary_identifier).to_a
+      case products.length
+      when 0
+        Result.new(status: :not_found, message: @normalization_error || "No match")
+      when 1
+        product_result(products.first)
+      else
+        Result.new(status: :multiple_products, products: products)
+      end
+    end
+
+    def valid_lookup_code?(canonical)
+      canonical.present? &&
+        canonical.length <= Product::LOOKUP_CODE_MAX_LENGTH &&
+        canonical.match?(Product::LOOKUP_CODE_FORMAT)
+    end
+
+    # Variants are returned unfiltered: eligibility belongs to the caller.
+    def product_result(product)
+      Result.new(status: :product, product: product, variants: product.product_variants.to_a)
+    end
+
+    def invalid(message)
+      Result.new(status: :invalid, message: message)
     end
   end
 end

--- a/app/services/inventory/admin_index_query.rb
+++ b/app/services/inventory/admin_index_query.rb
@@ -7,11 +7,11 @@ module Inventory
 
     DERIVED_TRACKING_SQL = <<~SQL.squish
       CASE
-        WHEN merchandise_classes.inventory_mode = 'inventory'
+        WHEN product_variants.inventory_mode = 'inventory'
              AND product_variants.variant_type = 'standard' THEN 'quantity'
-        WHEN merchandise_classes.inventory_mode = 'inventory'
+        WHEN product_variants.inventory_mode = 'inventory'
              AND product_variants.variant_type = 'used' THEN 'individual'
-        WHEN merchandise_classes.inventory_mode = 'non_inventory'
+        WHEN product_variants.inventory_mode = 'non_inventory'
              AND product_variants.variant_type = 'standard' THEN 'non_inventory'
       END
     SQL

--- a/app/services/merchandise/csv_importer.rb
+++ b/app/services/merchandise/csv_importer.rb
@@ -23,6 +23,7 @@ module Merchandise
       created_variants = 0
       updated_variants = 0
       errors = []
+      @preexisting_product_ids = Product.pluck(:id).to_set
 
       groups = group_rows(CSV.parse(@io.read, headers: true))
       groups.each do |group|
@@ -66,8 +67,9 @@ module Merchandise
 
     private
 
-    # Rows that share a resolvable product key form one transaction group. Rows with no
-    # key at all are create-only and each get their own group.
+    # Group only by unique product identity (primary or industry GTIN). Lookup codes are
+    # intentionally nonunique, so they must never merge rows into one product group.
+    # Rows with only a lookup code (or no identity) each get their own create/update group.
     def group_rows(rows)
       indexed = rows.each_with_index.map { |row, index| { row: row, line: index + 2 } }
       groups = []
@@ -75,24 +77,20 @@ module Merchandise
 
       indexed.each do |entry|
         begin
-          key = product_group_key(entry[:row])
+          key = product_group_key(entry[:row], entry[:line])
         rescue Identifiers::NormalizationError => e
           groups << { rows: [ entry ], error: e.message }
           next
         end
 
-        if key.nil?
-          groups << { rows: [ entry ] }
-        else
-          (by_key[key] ||= []) << entry
-        end
+        (by_key[key] ||= []) << entry
       end
 
       by_key.each_value { |entries| groups << { rows: entries } }
       groups
     end
 
-    def product_group_key(row)
+    def product_group_key(row, line)
       if (raw = row["product_primary_identifier"].presence)
         return "primary:#{Identifiers::Normalizer.normalize(raw, allow_shelfsense_222: true)}"
       end
@@ -101,8 +99,7 @@ module Merchandise
         return "industry:#{Identifiers::Normalizer.normalize(raw, allow_shelfsense_222: false)}"
       end
 
-      code = Product.canonical_lookup_code(row["product_lookup_code"])
-      code.present? ? "lookup:#{code}" : nil
+      "row:#{line}"
     end
 
     def variant_requested?(row)
@@ -151,7 +148,7 @@ module Merchandise
       code = Product.canonical_lookup_code(row["product_lookup_code"])
       return nil if code.blank?
 
-      matches = Product.where(lookup_code: code).to_a
+      matches = Product.where(lookup_code: code).select { |product| @preexisting_product_ids.include?(product.id) }
       if matches.many?
         raise Error, "product_lookup_code #{code} matches #{matches.size} products; use product_primary_identifier"
       end

--- a/app/services/merchandise/csv_importer.rb
+++ b/app/services/merchandise/csv_importer.rb
@@ -36,9 +36,8 @@ module Merchandise
           variant_statuses = []
 
           ActiveRecord::Base.transaction do
-            product = nil
             group[:rows].each do |entry|
-              product, product_status = upsert_product!(entry[:row], generate_only: group[:generate_only])
+              product, product_status = upsert_product!(entry[:row])
               product_statuses << product_status
               next unless variant_requested?(entry[:row])
 
@@ -67,75 +66,108 @@ module Merchandise
 
     private
 
+    # Rows that share a resolvable product key form one transaction group. Rows with no
+    # key at all are create-only and each get their own group.
     def group_rows(rows)
       indexed = rows.each_with_index.map { |row, index| { row: row, line: index + 2 } }
       groups = []
-      by_primary = Hash.new { |h, k| h[k] = [] }
+      by_key = {}
 
       indexed.each do |entry|
-        row = entry[:row]
-        generate = ActiveModel::Type::Boolean.new.cast(row["generate_primary_identifier"])
-        raw_id = row["primary_identifier"].presence
-
-        if raw_id.blank? && generate
-          groups << { generate_only: true, rows: [ entry ] }
-          next
-        end
-
-        if raw_id.blank?
-          groups << { generate_only: false, rows: [ entry ], error: "primary_identifier is required or generate_primary_identifier must be true" }
-          next
-        end
-
         begin
-          key = Identifiers::Normalizer.normalize(raw_id, allow_shelfsense_222: true)
-          by_primary[key] << entry
+          key = product_group_key(entry[:row])
         rescue Identifiers::NormalizationError => e
-          groups << { generate_only: false, rows: [ entry ], error: e.message }
+          groups << { rows: [ entry ], error: e.message }
+          next
+        end
+
+        if key.nil?
+          groups << { rows: [ entry ] }
+        else
+          (by_key[key] ||= []) << entry
         end
       end
 
-      by_primary.each_value { |entries| groups << { generate_only: false, rows: entries } }
+      by_key.each_value { |entries| groups << { rows: entries } }
       groups
+    end
+
+    def product_group_key(row)
+      if (raw = row["product_primary_identifier"].presence)
+        return "primary:#{Identifiers::Normalizer.normalize(raw, allow_shelfsense_222: true)}"
+      end
+
+      if (raw = row["product_industry_identifier"].presence)
+        return "industry:#{Identifiers::Normalizer.normalize(raw, allow_shelfsense_222: false)}"
+      end
+
+      code = Product.canonical_lookup_code(row["product_lookup_code"])
+      code.present? ? "lookup:#{code}" : nil
     end
 
     def variant_requested?(row)
       row["variant_type"].present? || row["variant_condition_code"].present? || row["sku"].present? || row["industry_identifier"].present?
     end
 
-    def upsert_product!(row, generate_only:)
-      if generate_only
-        product = Products::Create.call(
-          attributes: { name: row.fetch("name"), status: row["status"].presence || "draft" },
-          actor: @actor,
-          identifier_mode: "generate",
-          source: @source
-        )
-        return [ product, :created ]
-      end
-
-      raw_id = row["primary_identifier"].presence
-      raise Error, "primary_identifier is required or generate_primary_identifier must be true" if raw_id.blank?
-
-      normalized = Identifiers::Normalizer.normalize(raw_id, allow_shelfsense_222: true)
-      if (existing = Product.find_by(primary_identifier: normalized))
+    def upsert_product!(row)
+      product = locate_product!(row)
+      if product
         Products::Update.call(
-          product: existing,
+          product: product,
           actor: @actor,
           source: @source,
-          attributes: { name: row["name"].presence || existing.name }
+          attributes: product_update_attributes(row)
         )
-        return [ existing, :updated ]
+        return [ product, :updated ]
       end
 
-      product = Products::Create.call(
+      created = Products::Create.call(
         attributes: { name: row.fetch("name"), status: row["status"].presence || "draft" },
         actor: @actor,
-        identifier_mode: "enter",
-        external_identifier: raw_id,
+        industry_identifier: row["product_industry_identifier"].presence,
+        lookup_code: row["product_lookup_code"].presence,
         source: @source
       )
-      [ product, :created ]
+      [ created, :created ]
+    end
+
+    def locate_product!(row)
+      if (raw = row["product_primary_identifier"].presence)
+        normalized = Identifiers::Normalizer.normalize(raw, allow_shelfsense_222: true)
+        product = Product.find_by(primary_identifier: normalized)
+        raise Error, "unknown product_primary_identifier #{normalized}; ShelfSense generates primary identifiers" if product.nil?
+
+        return product
+      end
+
+      if (raw = row["product_industry_identifier"].presence)
+        normalized = Identifiers::Normalizer.normalize(raw, allow_shelfsense_222: false)
+        matches = Product.where(industry_identifier: normalized).to_a
+        raise Error, "product_industry_identifier #{normalized} is ambiguous" if matches.many?
+
+        return matches.first
+      end
+
+      code = Product.canonical_lookup_code(row["product_lookup_code"])
+      return nil if code.blank?
+
+      matches = Product.where(lookup_code: code).to_a
+      if matches.many?
+        raise Error, "product_lookup_code #{code} matches #{matches.size} products; use product_primary_identifier"
+      end
+
+      matches.first
+    end
+
+    # A blank cell never clears identity. Retiring a product GTIN or dropping a lookup
+    # code is an explicit admin action, not a side effect of a mostly empty template row.
+    def product_update_attributes(row)
+      attrs = {}
+      attrs[:name] = row["name"] if row["name"].present?
+      attrs[:status] = row["status"] if row["status"].present?
+      attrs[:lookup_code] = row["product_lookup_code"] if row["product_lookup_code"].present?
+      attrs[:industry_identifier] = row["product_industry_identifier"] if row["product_industry_identifier"].present?
+      attrs
     end
 
     def upsert_variant!(product, row)
@@ -155,7 +187,10 @@ module Merchandise
 
       if row["industry_identifier"].present?
         normalized = Identifiers::Normalizer.normalize(row["industry_identifier"], allow_shelfsense_222: false)
-        if (variant = ProductVariant.find_by(industry_identifier: normalized))
+        matches = ProductVariant.where(industry_identifier: normalized).to_a
+        raise Error, "industry identifier #{normalized} is ambiguous" if matches.many?
+
+        if (variant = matches.first)
           raise Error, "industry identifier belongs to a different product" unless variant.product_id == product.id
 
           if row["variant_name"].present?
@@ -173,6 +208,16 @@ module Merchandise
       variant_type = row["variant_type"].to_s.presence
       raise Error, "insufficient identity to create or update variant" if variant_type.blank?
 
+      variant = ProductVariants::Create.call(
+        product: product,
+        actor: @actor,
+        source: @source,
+        attributes: variant_create_attributes!(row, variant_type)
+      )
+      [ variant, :created ]
+    end
+
+    def variant_create_attributes!(row, variant_type)
       attributes = {
         variant_type: variant_type,
         name: row["variant_name"],
@@ -180,6 +225,7 @@ module Merchandise
         regular_price_cents: row["regular_price_cents"].presence&.to_i
       }
       attributes.merge!(resolve_reference_ids!(row))
+      attributes.merge!(resolve_operational_values!(row))
 
       if variant_type == "used"
         raise Error, "variant_condition_code is required for used variants" if row["variant_condition_code"].blank?
@@ -192,13 +238,7 @@ module Merchandise
         raise Error, "variant_condition_code must be blank for standard variants"
       end
 
-      variant = ProductVariants::Create.call(
-        product: product,
-        actor: @actor,
-        source: @source,
-        attributes: attributes.compact
-      )
-      [ variant, :created ]
+      attributes.compact
     end
 
     def resolve_reference_ids!(row)
@@ -211,23 +251,39 @@ module Merchandise
         ids[:merchandise_class_id] = klass.id
       end
 
-      code = row["department_code"].presence
-      if code
-        dept = Department.find_by(code: code)
-        raise Error, "unknown department_code: #{code}" if dept.nil?
-
-        ids[:department_id] = dept.id
-      end
-
-      code = row["tax_class_code"].presence
+      # Blank means inherit the merchandise class default; only an explicit code overrides.
+      code = row["tax_class_override_code"].presence
       if code
         tax = TaxClass.find_by(code: code)
-        raise Error, "unknown tax_class_code: #{code}" if tax.nil?
+        raise Error, "unknown tax_class_override_code: #{code}" if tax.nil?
 
-        ids[:tax_class_id] = tax.id
+        ids[:tax_class_override_id] = tax.id
       end
 
       ids
+    end
+
+    # Omitted columns keep the merchandise-class default; explicit values (including
+    # `false` supplier returnability) win.
+    def resolve_operational_values!(row)
+      values = {}
+      values[:inventory_mode] = row["inventory_mode"] if row["inventory_mode"].present?
+      values[:pricing_method] = row["pricing_method"] if row["pricing_method"].present?
+
+      if row["target_margin_bps"].present?
+        values[:target_margin_bps] = Integer(row["target_margin_bps"], exception: false) ||
+                                     raise(Error, "target_margin_bps must be an integer")
+      end
+
+      if row["supplier_returnable"].present?
+        case row["supplier_returnable"].to_s.strip.downcase
+        when "true", "t", "yes", "y", "1" then values[:supplier_returnable] = true
+        when "false", "f", "no", "n", "0" then values[:supplier_returnable] = false
+        else raise Error, "supplier_returnable must be true or false"
+        end
+      end
+
+      values
     end
   end
 end

--- a/app/services/pos/add_merchandise.rb
+++ b/app/services/pos/add_merchandise.rb
@@ -59,6 +59,8 @@ module Pos
           add_variant_line!(transaction, resolution.variant)
         when :variant_choice_required
           raise Pos::Error, "identifier matches multiple variants"
+        when :product_choice_required
+          raise Pos::Error, "identifier matches multiple products"
         when :unit_choice_required
           raise Pos::Error, "scan the unit identifier"
         else
@@ -76,7 +78,7 @@ module Pos
 
       variant = unit.product_variant
       raise Pos::Error, "merchandise tracking is not supported" unless variant.derived_inventory_tracking == "individual"
-      if variant.merchandise_class.pricing_method == "open_price"
+      if variant.pricing_method == "open_price"
         raise Pos::Error, Pos::ResolveMerchandiseForSale::OPEN_PRICE_USED_MESSAGE
       end
       validate_variant!(variant, tracking: "individual")
@@ -97,13 +99,13 @@ module Pos
     def add_variant_line!(transaction, variant)
       tracking = variant.derived_inventory_tracking
       raise Pos::Error, "scan the unit identifier" if tracking == "individual"
-      if variant.merchandise_class.pricing_method == "open_price"
+      if variant.pricing_method == "open_price"
         raise Pos::Error, Pos::ResolveMerchandiseForSale::OPEN_PRICE_USED_MESSAGE if tracking == "individual"
         require_nonnegative_open_price!
       end
 
       validate_variant!(variant, tracking: tracking)
-      open_price = variant.merchandise_class.pricing_method == "open_price"
+      open_price = variant.pricing_method == "open_price"
       price_cents = open_price ? @selling_price_cents : variant.regular_price_cents
       raise Pos::Error, "regular price is required" if price_cents.nil?
 
@@ -138,7 +140,7 @@ module Pos
       unless %w[quantity non_inventory individual].include?(tracking)
         raise Pos::Error, "merchandise tracking is not supported"
       end
-      if variant.merchandise_class.pricing_method == "open_price"
+      if variant.pricing_method == "open_price"
         raise Pos::Error, Pos::ResolveMerchandiseForSale::OPEN_PRICE_USED_MESSAGE if tracking == "individual"
         require_nonnegative_open_price!
         return
@@ -160,6 +162,9 @@ module Pos
     end
 
     def build_line!(transaction, variant:, quantity:, price_cents:, inventory_unit: nil, pricing_method_snapshot:)
+      tax = variant.effective_tax_class
+      raise Pos::Error, "effective tax class is required" if tax.blank?
+
       line = transaction.pos_transaction_lines.build(
         line_number: next_line_number(transaction),
         direction: "sale",
@@ -169,12 +174,12 @@ module Pos
         reference_unit_price_cents: price_cents,
         selling_unit_price_cents: price_cents,
         pricing_method_snapshot: pricing_method_snapshot,
-        tax_class: variant.tax_class,
-        tax_class_code_snapshot: variant.tax_class.code,
-        tax_class_name_snapshot: variant.tax_class.name,
-        default_tax_class: variant.tax_class,
-        default_tax_class_code_snapshot: variant.tax_class.code,
-        default_tax_class_name_snapshot: variant.tax_class.name,
+        tax_class: tax,
+        tax_class_code_snapshot: tax.code,
+        tax_class_name_snapshot: tax.name,
+        default_tax_class: tax,
+        default_tax_class_code_snapshot: tax.code,
+        default_tax_class_name_snapshot: tax.name,
         manual_discount_cents: 0
       )
       line.extended_selling_amount_cents = line.selling_unit_price_cents * line.quantity
@@ -185,6 +190,7 @@ module Pos
     end
 
     def compatible_line(transaction, variant)
+      effective_tax_id = variant.effective_tax_class&.id
       transaction.pos_transaction_lines.find do |line|
         line.inventory_unit_id.nil? &&
           line.product_variant_id == variant.id &&
@@ -194,7 +200,7 @@ module Pos
           line.selling_unit_price_cents == line.reference_unit_price_cents &&
           (line.default_tax_class_id.blank? || line.tax_class_id == line.default_tax_class_id) &&
           line.selling_unit_price_cents == variant.regular_price_cents &&
-          line.tax_class_id == variant.tax_class_id
+          line.tax_class_id == effective_tax_id
       end
     end
 

--- a/app/services/pos/execute_unlinked_return.rb
+++ b/app/services/pos/execute_unlinked_return.rb
@@ -22,7 +22,10 @@ module Pos
       expected_product_variant_id: nil,
       expected_inventory_unit_id: nil,
       expected_reference_unit_price_cents: nil,
-      expected_tax_class_id: nil
+      expected_tax_class_id: nil,
+      product_id: nil,
+      product_variant_id: nil,
+      inventory_unit_id: nil
     )
       @transaction = transaction
       @actor = actor
@@ -38,6 +41,9 @@ module Pos
       @expected_inventory_unit_id = expected_inventory_unit_id.to_s.presence
       @expected_reference_unit_price_cents = expected_reference_unit_price_cents
       @expected_tax_class_id = expected_tax_class_id.to_s.presence
+      @product_id = product_id.to_s.presence
+      @product_variant_id = product_variant_id.to_s.presence
+      @inventory_unit_id = inventory_unit_id.to_s.presence
     end
 
     def call
@@ -60,10 +66,15 @@ module Pos
 
       PosTransaction.transaction do
         transaction = Pos::Support.lock_working_transaction!(@transaction, @expected_lock_version)
-        resolved = Pos::ResolveUnlinkedReturnMerchandise.call(
-          identifier: @identifier,
-          store: transaction.store,
-          lock_unit: true
+        resolved = require_resolved_unlinked!(
+          Pos::ResolveUnlinkedReturnMerchandise.call(
+            identifier: @identifier,
+            store: transaction.store,
+            product: find_optional(Product, @product_id),
+            variant: find_optional(ProductVariant, @product_variant_id),
+            inventory_unit: find_optional(InventoryUnit, @inventory_unit_id),
+            lock_unit: true
+          )
         )
         capture_resolved!(resolved)
         validate_resolved!(resolved)
@@ -110,6 +121,23 @@ module Pos
     end
 
     private
+
+    def require_resolved_unlinked!(result)
+      case result.outcome
+      when :resolved
+        result
+      when :product_choice_required, :variant_choice_required, :unit_choice_required
+        raise Pos::Error, "select a product, variant, or unit before applying the return"
+      else
+        raise Pos::Error, result.message.presence || "merchandise not found"
+      end
+    end
+
+    def find_optional(model, id)
+      return if id.blank?
+
+      model.find_by(id: id)
+    end
 
     def capture_resolved!(resolved)
       @resolved_product_variant_id = resolved.variant.id.to_s

--- a/app/services/pos/lookup_linked_return.rb
+++ b/app/services/pos/lookup_linked_return.rb
@@ -53,10 +53,13 @@ module Pos
         transactions_for_unit(result.inventory_unit)
       when :variant
         transactions_for_variant(result.variant)
-      when :multi_variant
-        transactions_for_variants(result.variants)
-      when :not_found, :retired, :invalid, :product
-        empty("no returnable original found")
+      when :product
+        # Return eligibility is decided by completed sale lines, not POS sellability.
+        transactions_for_variants(result.product.product_variants.to_a)
+      when :multiple_products
+        empty("multiple products share that lookup code. Scan a variant or unit identifier.")
+      when :retired
+        empty("identifier is retired")
       else
         empty("no returnable original found")
       end

--- a/app/services/pos/resolve_merchandise_for_sale.rb
+++ b/app/services/pos/resolve_merchandise_for_sale.rb
@@ -11,6 +11,7 @@ module Pos
       :variants,
       :units,
       :product,
+      :products,
       :message,
       keyword_init: true
     )
@@ -19,11 +20,12 @@ module Pos
       new(**attrs).call
     end
 
-    def initialize(store:, identifier: nil, variant: nil, inventory_unit: nil, current_transaction: nil)
+    def initialize(store:, identifier: nil, variant: nil, inventory_unit: nil, product: nil, current_transaction: nil)
       @store = store
       @identifier = identifier
       @variant = variant
       @inventory_unit = inventory_unit
+      @product = product
       @current_transaction = current_transaction
     end
 
@@ -32,6 +34,8 @@ module Pos
         resolve_unit(@inventory_unit)
       elsif @variant
         resolve_variant(@variant)
+      elsif @product
+        resolve_product(@product)
       else
         resolve_identifier
       end
@@ -50,10 +54,23 @@ module Pos
         resolve_unit(result.inventory_unit)
       when :variant
         resolve_variant(result.variant)
-      when :multi_variant
-        Result.new(outcome: :variant_choice_required, variants: sorted_variants(result.variants), product: result.product)
       when :product
+        resolve_product(result.product)
+      when :multiple_products
+        Result.new(outcome: :product_choice_required, products: result.products)
+      else
         unavailable("merchandise not found")
+      end
+    end
+
+    # POS eligibility for a matched product identity: the matcher intentionally does
+    # not filter variants, so sellability is applied here.
+    def resolve_product(product)
+      eligible = product.product_variants.select(&:sellable?)
+      if eligible.one?
+        resolve_variant(eligible.first)
+      elsif eligible.many?
+        Result.new(outcome: :variant_choice_required, variants: sorted_variants(eligible), product: product)
       else
         unavailable("merchandise not found")
       end
@@ -125,7 +142,7 @@ module Pos
     end
 
     def open_price?(variant)
-      variant.merchandise_class&.pricing_method == "open_price"
+      variant.pricing_method == "open_price"
     end
 
     def unsellable_reason(variant)

--- a/app/services/pos/resolve_unlinked_return_merchandise.rb
+++ b/app/services/pos/resolve_unlinked_return_merchandise.rb
@@ -25,14 +25,16 @@ module Pos
     end
 
     def call
-      row = registry_row!
-      case row.identifier_kind
-      when "variant_sku", "variant_industry"
-        resolve_variant!(row.product_variant)
-      when "product_primary"
-        resolve_product_primary!(row.product)
-      when "inventory_unit"
-        resolve_unit!(row.inventory_unit)
+      result = Identifiers::Lookup.call(@identifier)
+      case result.status
+      when :variant
+        resolve_variant!(result.variant)
+      when :product
+        resolve_product!(result.product)
+      when :multiple_products
+        raise Pos::Error, "multiple products share that lookup code. Scan/enter a variant or unit identifier."
+      when :inventory_unit
+        resolve_unit!(result.inventory_unit)
       else
         raise Pos::Error, "merchandise not found"
       end
@@ -41,14 +43,6 @@ module Pos
     end
 
     private
-
-    def registry_row!
-      normalized = Identifiers::Normalizer.normalize(@identifier, allow_shelfsense_222: true)
-      row = Identifiers::Registry.find_any(normalized)
-      raise Pos::Error, "merchandise not found" if row.nil? || row.retired_at.present?
-
-      row
-    end
 
     def resolve_variant!(variant)
       raise Pos::Error, "merchandise not found" if variant.nil?
@@ -59,7 +53,7 @@ module Pos
       Result.new(**variant_result(variant, tracking: tracking))
     end
 
-    def resolve_product_primary!(product)
+    def resolve_product!(product)
       raise Pos::Error, "merchandise not found" if product.nil?
 
       candidates = product.product_variants.select { |variant| return_identity_eligible?(variant) }
@@ -136,7 +130,7 @@ module Pos
     def return_identity_eligible?(variant)
       tracking = tracking_for(variant)
       return false unless %w[quantity non_inventory individual].include?(tracking)
-      return false if variant.tax_class.nil?
+      return false if variant.effective_tax_class.nil?
       return true if tracking == "individual"
 
       variant.regular_price_cents.present?
@@ -156,7 +150,7 @@ module Pos
     end
 
     def require_tax_class!(variant)
-      tax_class = variant.tax_class
+      tax_class = variant.effective_tax_class
       raise Pos::Error, "Tax Class is required" if tax_class.nil?
 
       tax_class

--- a/app/services/pos/resolve_unlinked_return_merchandise.rb
+++ b/app/services/pos/resolve_unlinked_return_merchandise.rb
@@ -3,6 +3,7 @@
 module Pos
   class ResolveUnlinkedReturnMerchandise
     Result = Struct.new(
+      :outcome,
       :variant,
       :inventory_unit,
       :tracking,
@@ -10,6 +11,11 @@ module Pos
       :reference_unit_price_cents,
       :tax_class,
       :description,
+      :product,
+      :products,
+      :variants,
+      :units,
+      :message,
       keyword_init: true
     )
 
@@ -17,77 +23,121 @@ module Pos
       new(**attrs).call
     end
 
-    def initialize(identifier:, store:, lock_unit: false, advisory_working_unit_check: true)
-      @identifier = identifier
+    def initialize(
+      store:,
+      identifier: nil,
+      product: nil,
+      variant: nil,
+      inventory_unit: nil,
+      lock_unit: false,
+      advisory_working_unit_check: true
+    )
       @store = store
+      @identifier = identifier
+      @product = product
+      @variant = variant
+      @inventory_unit = inventory_unit
       @lock_unit = lock_unit
       @advisory_working_unit_check = advisory_working_unit_check
     end
 
     def call
-      result = Identifiers::Lookup.call(@identifier)
-      case result.status
-      when :variant
-        resolve_variant!(result.variant)
-      when :product
-        resolve_product!(result.product)
-      when :multiple_products
-        raise Pos::Error, "multiple products share that lookup code. Scan/enter a variant or unit identifier."
-      when :inventory_unit
-        resolve_unit!(result.inventory_unit)
+      if @inventory_unit
+        resolve_unit(@inventory_unit)
+      elsif @variant
+        resolve_variant(@variant)
+      elsif @product
+        resolve_product(@product)
       else
-        raise Pos::Error, "merchandise not found"
+        resolve_identifier
       end
     rescue Identifiers::NormalizationError => e
-      raise Pos::Error, e.message
+      unavailable(e.message)
     end
 
     private
 
-    def resolve_variant!(variant)
-      raise Pos::Error, "merchandise not found" if variant.nil?
-
-      tracking = tracking_for!(variant)
-      raise Pos::Error, "scan the unit identifier" if tracking == "individual"
-
-      Result.new(**variant_result(variant, tracking: tracking))
+    def resolve_identifier
+      result = Identifiers::Lookup.call(@identifier)
+      case result.status
+      when :variant
+        resolve_variant(result.variant)
+      when :product
+        resolve_product(result.product)
+      when :multiple_products
+        Result.new(
+          outcome: :product_choice_required,
+          products: sorted_products(result.products)
+        )
+      when :inventory_unit
+        resolve_unit(result.inventory_unit)
+      when :retired
+        unavailable("identifier is retired")
+      else
+        unavailable("merchandise not found")
+      end
     end
 
-    def resolve_product!(product)
-      raise Pos::Error, "merchandise not found" if product.nil?
+    def resolve_product(product)
+      return unavailable("merchandise not found") if product.nil?
 
       candidates = product.product_variants.select { |variant| return_identity_eligible?(variant) }
-      if candidates.empty?
-        raise Pos::Error, "scan/enter variant or unit identifier"
-      end
+      return unavailable("merchandise not found") if candidates.empty?
 
       individual, others = candidates.partition { |variant| tracking_for(variant) == "individual" }
+
       if others.empty?
-        raise Pos::Error, "scan the unit identifier"
-      end
-      if others.many? || individual.any?
-        raise Pos::Error, "scan/enter variant or unit identifier"
+        return unavailable("scan the unit identifier")
       end
 
-      resolve_variant!(others.first)
+      if others.many? || individual.any?
+        return Result.new(
+          outcome: :variant_choice_required,
+          variants: sorted_variants(candidates),
+          product: product
+        )
+      end
+
+      resolve_variant(others.first)
     end
 
-    def resolve_unit!(unit)
-      raise Pos::Error, "merchandise not found" if unit.nil?
+    def resolve_variant(variant)
+      return unavailable("merchandise not found") if variant.nil?
 
-      unit = lock_unit!(unit) if @lock_unit
+      tracking = tracking_for!(variant)
+      return unavailable("merchandise tracking is not supported") if tracking.nil?
+      return unavailable("Tax Class is required") if require_tax_class!(variant).nil?
+
+      if tracking == "individual"
+        units = available_return_units(variant)
+        return Result.new(outcome: :unit_choice_required, variant: variant, units: units)
+      end
+
+      resolved(variant, tracking: tracking)
+    end
+
+    def resolve_unit(unit)
+      return unavailable("merchandise not found") if unit.nil?
+
+      if @lock_unit
+        unit = lock_unit!(unit)
+        return unavailable("merchandise not found") if unit.nil?
+      end
       variant = unit.product_variant
-      raise Pos::Error, "merchandise not found" if variant.nil?
-      raise Pos::Error, "scan the unit identifier" unless tracking_for!(variant) == "individual"
-      raise Pos::Error, "unit is not at this store" unless unit.store_id == @store.id
-      raise Pos::Error, "unit must be removed" unless unit.removed?
-      raise Pos::Error, "unit is already on a working return" if working_return_unit?(unit)
+      return unavailable("merchandise not found") if variant.nil?
+      return unavailable("scan the unit identifier") if tracking_for!(variant) != "individual"
+      return unavailable("unit is not at this store") unless unit.store_id == @store.id
+      return unavailable("unit must be removed") unless unit.removed?
+      return unavailable("unit is already on a working return") if working_return_unit?(unit)
 
       price = unit.effective_regular_price_cents
-      raise Pos::Error, "regular price is required" if price.nil?
+      return unavailable("regular price is required") if price.nil?
 
       tax_class = require_tax_class!(variant)
+      return unavailable("Tax Class is required") if tax_class.nil?
+
       Result.new(
+        outcome: :resolved,
         variant: variant,
         inventory_unit: unit,
         tracking: "individual",
@@ -98,42 +148,58 @@ module Pos
       )
     end
 
-    def lock_unit!(unit)
-      InventoryUnit.lock.find(unit.id)
-    rescue ActiveRecord::RecordNotFound
-      raise Pos::Error, "merchandise not found"
-    end
-
-    def working_return_unit?(unit)
-      return false unless @advisory_working_unit_check || @lock_unit
-
-      PosTransactionLine.joins(:pos_transaction)
-                        .where(inventory_unit_id: unit.id, pos_transactions: { status: "working" })
-                        .exists?
-    end
-
-    def variant_result(variant, tracking:)
+    def resolved(variant, tracking:)
       price = variant.regular_price_cents
-      raise Pos::Error, "regular price is required" if price.nil?
+      return unavailable("regular price is required") if price.nil?
 
-      {
+      tax_class = require_tax_class!(variant)
+      return unavailable("Tax Class is required") if tax_class.nil?
+
+      Result.new(
+        outcome: :resolved,
         variant: variant,
         inventory_unit: nil,
         tracking: tracking,
         quantity_fixed: false,
         reference_unit_price_cents: price,
-        tax_class: require_tax_class!(variant),
+        tax_class: tax_class,
         description: variant.product.name
-      }
+      )
+    end
+
+    def available_return_units(variant)
+      InventoryUnit.where(lifecycle_state: "removed", store: @store, product_variant: variant)
+                   .where.not(id: busy_return_unit_ids)
+                   .includes(product_variant: :merchandise_condition)
+                   .order(:unit_identifier)
+                   .to_a
+    end
+
+    def busy_return_unit_ids
+      @busy_return_unit_ids ||= PosTransactionLine.joins(:pos_transaction)
+                                                  .where(pos_transactions: { status: "working" })
+                                                  .where.not(inventory_unit_id: nil)
+                                                  .pluck(:inventory_unit_id)
+    end
+
+    def lock_unit!(unit)
+      InventoryUnit.lock.find(unit.id)
+    rescue ActiveRecord::RecordNotFound
+      nil
+    end
+
+    def working_return_unit?(unit)
+      return false unless @advisory_working_unit_check || @lock_unit
+
+      busy_return_unit_ids.include?(unit.id)
     end
 
     def return_identity_eligible?(variant)
       tracking = tracking_for(variant)
       return false unless %w[quantity non_inventory individual].include?(tracking)
       return false if variant.effective_tax_class.nil?
-      return true if tracking == "individual"
 
-      variant.regular_price_cents.present?
+      true
     end
 
     def tracking_for(variant)
@@ -142,18 +208,25 @@ module Pos
 
     def tracking_for!(variant)
       tracking = tracking_for(variant)
-      unless %w[quantity non_inventory individual].include?(tracking)
-        raise Pos::Error, "merchandise tracking is not supported"
-      end
+      return nil unless %w[quantity non_inventory individual].include?(tracking)
 
       tracking
     end
 
     def require_tax_class!(variant)
-      tax_class = variant.effective_tax_class
-      raise Pos::Error, "Tax Class is required" if tax_class.nil?
+      variant.effective_tax_class
+    end
 
-      tax_class
+    def sorted_variants(variants)
+      variants.sort_by { |variant| [ variant.sku.to_s, variant.id.to_s ] }
+    end
+
+    def sorted_products(products)
+      products.sort_by { |product| [ product.name.to_s.downcase, product.primary_identifier.to_s ] }
+    end
+
+    def unavailable(message)
+      Result.new(outcome: :unavailable, message: message)
     end
   end
 end

--- a/app/services/pos/resolve_unlinked_return_merchandise.rb
+++ b/app/services/pos/resolve_unlinked_return_merchandise.rb
@@ -2,6 +2,8 @@
 
 module Pos
   class ResolveUnlinkedReturnMerchandise
+    SELECTION_MISMATCH_MESSAGE = "Merchandise changed. Resolve the return again."
+
     Result = Struct.new(
       :outcome,
       :variant,
@@ -33,7 +35,7 @@ module Pos
       advisory_working_unit_check: true
     )
       @store = store
-      @identifier = identifier
+      @identifier = identifier.to_s.strip.presence
       @product = product
       @variant = variant
       @inventory_unit = inventory_unit
@@ -42,14 +44,13 @@ module Pos
     end
 
     def call
-      if @inventory_unit
-        resolve_unit(@inventory_unit)
-      elsif @variant
-        resolve_variant(@variant)
-      elsif @product
-        resolve_product(@product)
+      if @identifier.present?
+        resolve_bound_to_identifier
+      elsif @inventory_unit || @variant || @product
+        # Selections without an identifier are never a valid unlinked-return basis.
+        raise Pos::InvalidatedDialogBasis, SELECTION_MISMATCH_MESSAGE
       else
-        resolve_identifier
+        unavailable("merchandise not found")
       end
     rescue Identifiers::NormalizationError => e
       unavailable(e.message)
@@ -57,38 +58,90 @@ module Pos
 
     private
 
-    def resolve_identifier
-      result = Identifiers::Lookup.call(@identifier)
-      case result.status
-      when :variant
-        resolve_variant(result.variant)
-      when :product
-        resolve_product(result.product)
-      when :multiple_products
-        Result.new(
-          outcome: :product_choice_required,
-          products: sorted_products(result.products)
-        )
+    def resolve_bound_to_identifier
+      lookup = Identifiers::Lookup.call(@identifier)
+      case lookup.status
       when :inventory_unit
-        resolve_unit(result.inventory_unit)
+        bind_direct_unit!(lookup.inventory_unit)
+      when :variant
+        bind_direct_variant!(lookup.variant)
+      when :product
+        resolve_from_product_matches([ lookup.product ])
+      when :multiple_products
+        resolve_from_product_matches(Array(lookup.products))
       when :retired
         unavailable("identifier is retired")
+      when :not_found, :invalid
+        unavailable("merchandise not found")
       else
         unavailable("merchandise not found")
       end
     end
 
-    def resolve_product(product)
-      return unavailable("merchandise not found") if product.nil?
+    def bind_direct_unit!(matched_unit)
+      raise Pos::InvalidatedDialogBasis, SELECTION_MISMATCH_MESSAGE if matched_unit.nil?
+
+      if @product && @product.id != matched_unit.product_variant&.product_id
+        raise Pos::InvalidatedDialogBasis, SELECTION_MISMATCH_MESSAGE
+      end
+      if @variant && @variant.id != matched_unit.product_variant_id
+        raise Pos::InvalidatedDialogBasis, SELECTION_MISMATCH_MESSAGE
+      end
+      if @inventory_unit && @inventory_unit.id != matched_unit.id
+        raise Pos::InvalidatedDialogBasis, SELECTION_MISMATCH_MESSAGE
+      end
+
+      resolve_unit(matched_unit)
+    end
+
+    def bind_direct_variant!(matched_variant)
+      raise Pos::InvalidatedDialogBasis, SELECTION_MISMATCH_MESSAGE if matched_variant.nil?
+
+      if @product && @product.id != matched_variant.product_id
+        raise Pos::InvalidatedDialogBasis, SELECTION_MISMATCH_MESSAGE
+      end
+      if @variant && @variant.id != matched_variant.id
+        raise Pos::InvalidatedDialogBasis, SELECTION_MISMATCH_MESSAGE
+      end
+
+      if @inventory_unit
+        unless @inventory_unit.product_variant_id == matched_variant.id
+          raise Pos::InvalidatedDialogBasis, SELECTION_MISMATCH_MESSAGE
+        end
+        return resolve_unit(@inventory_unit)
+      end
+
+      resolve_variant(matched_variant)
+    end
+
+    def resolve_from_product_matches(matched_products)
+      matched_products = Array(matched_products).compact
+      return unavailable("merchandise not found") if matched_products.empty?
+
+      product = selected_product_from!(matched_products)
+      return Result.new(outcome: :product_choice_required, products: sorted_products(matched_products)) if product.nil?
 
       candidates = product.product_variants.select { |variant| return_identity_eligible?(variant) }
       return unavailable("merchandise not found") if candidates.empty?
 
-      individual, others = candidates.partition { |variant| tracking_for(variant) == "individual" }
-
-      if others.empty?
-        return unavailable("scan the unit identifier")
+      if @variant
+        unless candidates.any? { |candidate| candidate.id == @variant.id } && @variant.product_id == product.id
+          raise Pos::InvalidatedDialogBasis, SELECTION_MISMATCH_MESSAGE
+        end
+        return continue_from_variant!(@variant)
       end
+
+      if @inventory_unit
+        unit_variant = @inventory_unit.product_variant
+        unless unit_variant && candidates.any? { |candidate| candidate.id == unit_variant.id } &&
+               unit_variant.product_id == product.id
+          raise Pos::InvalidatedDialogBasis, SELECTION_MISMATCH_MESSAGE
+        end
+        return continue_from_variant!(unit_variant, preferred_unit: @inventory_unit)
+      end
+
+      individual, others = candidates.partition { |variant| tracking_for(variant) == "individual" }
+      return unavailable("scan the unit identifier") if others.empty?
 
       if others.many? || individual.any?
         return Result.new(
@@ -99,6 +152,45 @@ module Pos
       end
 
       resolve_variant(others.first)
+    end
+
+    def selected_product_from!(matched_products)
+      if @product
+        unless matched_products.any? { |product| product.id == @product.id }
+          raise Pos::InvalidatedDialogBasis, SELECTION_MISMATCH_MESSAGE
+        end
+        return @product
+      end
+
+      if @variant
+        product = matched_products.find { |match| match.id == @variant.product_id }
+        raise Pos::InvalidatedDialogBasis, SELECTION_MISMATCH_MESSAGE if product.nil?
+
+        return product
+      end
+
+      if @inventory_unit
+        product_id = @inventory_unit.product_variant&.product_id
+        product = matched_products.find { |match| match.id == product_id }
+        raise Pos::InvalidatedDialogBasis, SELECTION_MISMATCH_MESSAGE if product.nil?
+
+        return product
+      end
+
+      return matched_products.first if matched_products.one?
+
+      nil
+    end
+
+    def continue_from_variant!(variant, preferred_unit: nil)
+      if preferred_unit
+        unless preferred_unit.product_variant_id == variant.id
+          raise Pos::InvalidatedDialogBasis, SELECTION_MISMATCH_MESSAGE
+        end
+        return resolve_unit(preferred_unit)
+      end
+
+      resolve_variant(variant)
     end
 
     def resolve_variant(variant)

--- a/app/services/pos/search_merchandise.rb
+++ b/app/services/pos/search_merchandise.rb
@@ -38,7 +38,13 @@ module Pos
     private
 
     def ranked_variants
-      scope = ProductVariant.joins(:product).includes(:product, :merchandise_class, :merchandise_condition, :department, :tax_class)
+      scope = ProductVariant.joins(:product).includes(
+        :product,
+        :merchandise_class,
+        :merchandise_condition,
+        :tax_class_override,
+        merchandise_class: [ :department, :default_tax_class ]
+      )
       conditions = []
       binds = []
       if @sku.present?
@@ -63,7 +69,7 @@ module Pos
 
     def build_row(variant)
       tracking = variant.derived_inventory_tracking
-      open_price = variant.merchandise_class&.pricing_method == "open_price"
+      open_price = variant.pricing_method == "open_price"
       disabled, reason = disable_reason(variant, tracking, open_price)
       price_cents = variant.regular_price_cents
       Row.new(

--- a/app/services/product_variants/create.rb
+++ b/app/services/product_variants/create.rb
@@ -31,13 +31,35 @@ module ProductVariants
         klass = find_optional(MerchandiseClass, @attributes[:merchandise_class_id])
         validate_class_for_type!(variant_type, klass) if klass
 
+        tax_override =
+          if @attributes.key?(:tax_class_override_id)
+            find_optional(TaxClass, @attributes[:tax_class_override_id])
+          else
+            :omitted
+          end
+        supplier_returnable =
+          if @attributes.key?(:supplier_returnable)
+            ActiveModel::Type::Boolean.new.cast(@attributes[:supplier_returnable])
+          else
+            :omitted
+          end
+        target_margin_bps =
+          if @attributes.key?(:target_margin_bps)
+            @attributes[:target_margin_bps]
+          else
+            :omitted
+          end
+
         resolved = DefaultResolver.resolve(
           product: @product,
           variant_type: variant_type,
           condition: condition,
           merchandise_class: klass,
-          department: find_optional(Department, @attributes[:department_id]),
-          tax_class: find_optional(TaxClass, @attributes[:tax_class_id]),
+          inventory_mode: @attributes[:inventory_mode],
+          pricing_method: @attributes[:pricing_method],
+          target_margin_bps: target_margin_bps,
+          supplier_returnable: supplier_returnable,
+          tax_class_override: tax_override,
           regular_price_cents: @attributes[:regular_price_cents]
         )
         validate_class_for_type!(variant_type, resolved.merchandise_class) if resolved.merchandise_class
@@ -53,17 +75,21 @@ module ProductVariants
         resolved_name = @attributes[:name].presence || default_variant_name(variant_type, condition)
 
         variant = @product.product_variants.new(
-          @attributes.except(:industry_identifier, :sku).merge(
+          @attributes.except(
+            :industry_identifier, :sku, :department_id, :tax_class_id, :tax_class_override_id,
+            :inventory_mode, :pricing_method, :target_margin_bps, :supplier_returnable
+          ).merge(
             variant_type: variant_type,
             name: resolved_name,
             sku: sku,
             industry_identifier: normalized_industry,
             merchandise_condition: condition,
             merchandise_class: resolved.merchandise_class,
-            department: resolved.department,
-            tax_class: resolved.tax_class,
-            # DefaultResolver already applies list_price suggestions when the
-            # submitted regular_price_cents is nil (blank UI fields still send the key).
+            inventory_mode: resolved.inventory_mode,
+            pricing_method: resolved.pricing_method,
+            target_margin_bps: resolved.target_margin_bps,
+            supplier_returnable: resolved.supplier_returnable,
+            tax_class_override: resolved.tax_class_override,
             regular_price_cents: resolved.suggested_price_cents,
             status: @attributes[:status].presence || "draft"
           )
@@ -87,6 +113,9 @@ module ProductVariants
             sku: variant.sku,
             product_id: variant.product_id,
             variant_type: variant.variant_type,
+            inventory_mode: variant.inventory_mode,
+            pricing_method: variant.pricing_method,
+            tax_class_override_id: variant.tax_class_override_id,
             source: @source
           }
         )

--- a/app/services/product_variants/default_resolver.rb
+++ b/app/services/product_variants/default_resolver.rb
@@ -2,54 +2,98 @@
 
 module ProductVariants
   class DefaultResolver
-    Result = Struct.new(:merchandise_class, :department, :tax_class, :suggested_price_cents, keyword_init: true)
+    Result = Struct.new(
+      :merchandise_class,
+      :inventory_mode,
+      :pricing_method,
+      :target_margin_bps,
+      :supplier_returnable,
+      :tax_class_override,
+      :suggested_price_cents,
+      keyword_init: true
+    )
 
     def self.resolve(**attrs)
       new(**attrs).resolve
     end
 
-    def initialize(product:, variant_type:, condition: nil, merchandise_class: nil, department: nil, tax_class: nil, regular_price_cents: nil)
+    def initialize(
+      product:,
+      variant_type:,
+      condition: nil,
+      merchandise_class: nil,
+      inventory_mode: nil,
+      pricing_method: nil,
+      target_margin_bps: :omitted,
+      supplier_returnable: :omitted,
+      tax_class_override: :omitted,
+      regular_price_cents: nil
+    )
       @product = product
       @variant_type = variant_type.to_s
       @condition = condition
       @merchandise_class = merchandise_class
-      @department = department
-      @tax_class = tax_class
+      @inventory_mode = inventory_mode
+      @pricing_method = pricing_method
+      @target_margin_bps = target_margin_bps
+      @supplier_returnable = supplier_returnable
+      @tax_class_override = tax_class_override
       @regular_price_cents = regular_price_cents
     end
 
     def resolve
-      klass = @merchandise_class || @product.merchandise_category&.default_merchandise_class
-      department = @department || department_from(klass)
-      tax = @tax_class || department&.default_tax_class
+      klass = @merchandise_class || category_default_class
+      inventory_mode = @inventory_mode.presence || klass&.default_inventory_mode
+      pricing_method = @pricing_method.presence || klass&.default_pricing_method
+      target_margin_bps =
+        if @target_margin_bps == :omitted
+          klass&.target_margin_bps
+        else
+          @target_margin_bps
+        end
+      supplier_returnable =
+        if @supplier_returnable == :omitted
+          klass.nil? ? nil : klass.default_supplier_returnable
+        else
+          @supplier_returnable
+        end
+      tax_override =
+        if @tax_class_override == :omitted
+          nil
+        else
+          @tax_class_override
+        end
+
       price = @regular_price_cents
-      if price.nil?
-        price = suggested_price_for(klass)
-      end
+      price = suggested_price_for(klass, pricing_method) if price.nil?
 
       Result.new(
         merchandise_class: klass,
-        department: department,
-        tax_class: tax,
+        inventory_mode: inventory_mode,
+        pricing_method: pricing_method,
+        target_margin_bps: target_margin_bps,
+        supplier_returnable: supplier_returnable,
+        tax_class_override: tax_override,
         suggested_price_cents: price
       )
     end
 
     private
 
-    def department_from(klass)
-      return if klass.blank?
+    def category_default_class
+      category = @product.merchandise_category
+      return if category.blank?
 
       if @variant_type == "used"
-        klass.default_used_department
+        category.default_used_merchandise_class
       else
-        klass.default_standard_department
+        category.default_standard_merchandise_class
       end
     end
 
-    def suggested_price_for(klass)
+    def suggested_price_for(klass, pricing_method)
       return if klass.blank?
-      return unless klass.pricing_method == "list_price"
+      return unless pricing_method == "list_price"
       return if @product.list_price_cents.blank?
 
       if @variant_type == "used" && @condition

--- a/app/services/product_variants/update.rb
+++ b/app/services/product_variants/update.rb
@@ -12,7 +12,7 @@ module ProductVariants
       @variant = variant
       attrs = attributes.to_h.symbolize_keys
       @lock_version = attrs[:lock_version]
-      @attributes = attrs.except(:sku, :lock_version)
+      @attributes = attrs.except(:sku, :lock_version, :department_id, :tax_class_id)
       @actor = actor
       @source = source
       @store = store
@@ -20,7 +20,7 @@ module ProductVariants
 
     def call
       ProductVariant.transaction do
-        before = @variant.attributes.slice(*audit_keys)
+        before = snapshot_for_audit
         @variant.lock_version = @lock_version unless @lock_version.nil?
 
         if @attributes.key?(:industry_identifier)
@@ -45,7 +45,7 @@ module ProductVariants
           store: @store,
           subject: @variant,
           before_values: before,
-          after_values: @variant.attributes.slice(*before.keys).merge(source: @source)
+          after_values: snapshot_for_audit.merge("source" => @source)
         )
 
         @variant
@@ -56,11 +56,24 @@ module ProductVariants
 
     private
 
-    def audit_keys
-      %w[
-        variant_type name option_value_1 option_value_2 merchandise_condition_id merchandise_class_id
-        department_id tax_class_id regular_price_cents status industry_identifier
-      ]
+    def snapshot_for_audit
+      {
+        "variant_type" => @variant.variant_type,
+        "name" => @variant.name,
+        "option_value_1" => @variant.option_value_1,
+        "option_value_2" => @variant.option_value_2,
+        "merchandise_condition_id" => @variant.merchandise_condition_id,
+        "merchandise_class_id" => @variant.merchandise_class_id,
+        "inventory_mode" => @variant.inventory_mode,
+        "pricing_method" => @variant.pricing_method,
+        "target_margin_bps" => @variant.target_margin_bps,
+        "supplier_returnable" => @variant.supplier_returnable,
+        "tax_class_override_id" => @variant.tax_class_override_id,
+        "effective_tax_class_id" => @variant.effective_tax_class&.id,
+        "regular_price_cents" => @variant.regular_price_cents,
+        "status" => @variant.status,
+        "industry_identifier" => @variant.industry_identifier
+      }
     end
   end
 end

--- a/app/services/products/create.rb
+++ b/app/services/products/create.rb
@@ -8,32 +8,32 @@ module Products
       new(**attrs).call
     end
 
-    def initialize(attributes:, actor:, identifier_mode:, external_identifier: nil, source: "ui")
-      @attributes = attributes
+    def initialize(attributes:, actor:, industry_identifier: nil, lookup_code: nil, source: "ui")
+      attrs = attributes.to_h.symbolize_keys
+      @industry_identifier = industry_identifier.presence || attrs[:industry_identifier].presence
+      @lookup_code = lookup_code.presence || attrs[:lookup_code].presence
+      @attributes = attrs.except(:primary_identifier, :industry_identifier, :lookup_code)
       @actor = actor
-      @identifier_mode = identifier_mode.to_s
-      @external_identifier = external_identifier
       @source = source
     end
 
     def call
-      raise Error, "identifier mode must be enter or generate" unless %w[enter generate].include?(@identifier_mode)
-      raise Error, "external identifier is required" if @identifier_mode == "enter" && @external_identifier.blank?
-      raise Error, "external identifier must be blank when generating" if @identifier_mode == "generate" && @external_identifier.present?
-
       Product.transaction do
-        primary =
-          if @identifier_mode == "generate"
-            allocate_222!
-          else
-            Identifiers::Normalizer.normalize(@external_identifier, allow_shelfsense_222: false)
-          end
+        primary = allocate_222!
+        industry = normalized_industry(primary)
 
-        product = Product.new(@attributes.merge(primary_identifier: primary))
+        product = Product.new(
+          @attributes.merge(
+            primary_identifier: primary,
+            industry_identifier: industry,
+            lookup_code: @lookup_code
+          )
+        )
         product.identifier_writes_enabled = true
         product.save!
 
         Identifiers::Registry.reserve!(value: primary, kind: "product_primary", product: product)
+        Identifiers::Registry.reserve!(value: industry, kind: "product_industry", product: product) if industry
 
         Audit::Recorder.record!(
           action: "products.create",
@@ -44,7 +44,8 @@ module Products
           after_values: {
             name: product.name,
             primary_identifier: product.primary_identifier,
-            identifier_source: @identifier_mode,
+            industry_identifier: product.industry_identifier,
+            lookup_code: product.lookup_code,
             source: @source
           }
         )
@@ -56,6 +57,15 @@ module Products
     end
 
     private
+
+    def normalized_industry(primary)
+      return if @industry_identifier.blank?
+
+      value = Identifiers::Normalizer.normalize(@industry_identifier, allow_shelfsense_222: false)
+      raise Error, "industry identifier cannot equal the primary identifier" if value == primary
+
+      value
+    end
 
     def allocate_222!
       attempts = 0

--- a/app/services/products/update.rb
+++ b/app/services/products/update.rb
@@ -21,9 +21,22 @@ module Products
     def call
       Product.transaction do
         before = @product.attributes.slice(*audit_keys)
-        update_attrs = @attributes.dup
-        update_attrs[:lock_version] = @lock_version unless @lock_version.nil?
-        @product.update!(update_attrs)
+        @product.lock_version = @lock_version unless @lock_version.nil?
+
+        if @attributes.key?(:industry_identifier)
+          Identifiers::AssignProductIndustry.call(
+            product: @product,
+            raw_value: @attributes[:industry_identifier],
+            actor: @actor,
+            source: @source,
+            persist: false
+          )
+        end
+
+        non_id_attrs = @attributes.except(:industry_identifier)
+        @product.assign_attributes(non_id_attrs) if non_id_attrs.any?
+        @product.save!
+
         Audit::Recorder.record!(
           action: "products.update",
           outcome: "succeeded",
@@ -36,7 +49,7 @@ module Products
         )
         @product
       end
-    rescue ActiveRecord::RecordInvalid => e
+    rescue Identifiers::AssignProductIndustry::Error, ActiveRecord::RecordInvalid => e
       raise Error, e.message
     end
 
@@ -46,6 +59,7 @@ module Products
       %w[
         name subtitle description brand_name product_model merchandise_category_id
         list_price_cents release_date status variant_option_name_1 variant_option_name_2
+        industry_identifier lookup_code
       ]
     end
   end

--- a/app/views/admin/departments/_form.html.erb
+++ b/app/views/admin/departments/_form.html.erb
@@ -5,7 +5,7 @@
     <p>Code: <code><%= department.code %></code> (immutable)</p>
   <% else %>
     <p>
-      <%= form.label :code %>
+      <%= form.label :code, "Key / code" %>
       <%= form.text_field :code %>
       <span>Leave blank to generate from the name. Later changes are not allowed.</span>
     </p>
@@ -13,11 +13,7 @@
   <p><%= form.label :department_number %><%= form.text_field :department_number %></p>
   <p><%= form.label :name %><%= form.text_field :name %></p>
   <p><%= form.label :description %><%= form.text_area :description %></p>
-  <p>
-    <%= form.label :default_tax_class_id, "Default tax class" %>
-    <%= form.select :default_tax_class_id, TaxClass.options_for_select(@tax_classes), include_blank: true %>
-  </p>
-  <p><%= form.label :default_target_margin_bps %><%= form.number_field :default_target_margin_bps %></p>
+  <p class="muted">GL mappings are shared by all merchandise classes in this department.</p>
   <% [
     [:inventory_asset_gl_account_id, "Inventory asset GL"],
     [:cost_of_goods_sold_gl_account_id, "COGS GL"],

--- a/app/views/admin/departments/show.html.erb
+++ b/app/views/admin/departments/show.html.erb
@@ -2,8 +2,6 @@
 <h1><%= @department.admin_label %></h1>
 <p>
   Code: <%= @department.code %> ·
-  Tax class: <%= @department.default_tax_class.admin_label %> ·
-  Margin bps: <%= @department.default_target_margin_bps.presence || "—" %> ·
   Order: <%= @department.display_order %> ·
   <%= @department.active? ? "active" : "inactive" %>
 </p>
@@ -16,4 +14,14 @@
     <%= button_to "Reactivate", reactivate_admin_department_path(@department), method: :post, params: { lock_version: @department.lock_version } %>
   <% end %>
 </p>
+
+<% if @merchandise_classes.present? %>
+  <h2>Merchandise classes</h2>
+  <ul>
+    <% @merchandise_classes.each do |klass| %>
+      <li><%= link_to klass.admin_label, admin_merchandise_class_path(klass) %> — <%= klass.active? ? "active" : "inactive" %></li>
+    <% end %>
+  </ul>
+<% end %>
+
 <p><%= link_to "Back to departments", admin_departments_path %></p>

--- a/app/views/admin/merchandise_categories/_form.html.erb
+++ b/app/views/admin/merchandise_categories/_form.html.erb
@@ -17,8 +17,12 @@
     <%= form.select :parent_id, MerchandiseCategory.options_for_select(@parent_options), include_blank: "None" %>
   </p>
   <p>
-    <%= form.label :default_merchandise_class_id, "Default merchandise class" %>
-      <%= form.select :default_merchandise_class_id, MerchandiseClass.options_for_select(@merchandise_classes), include_blank: "None" %>
+    <%= form.label :default_standard_merchandise_class_id, "Default standard merchandise class" %>
+    <%= form.select :default_standard_merchandise_class_id, MerchandiseClass.options_for_select(@merchandise_classes), include_blank: "None" %>
+  </p>
+  <p>
+    <%= form.label :default_used_merchandise_class_id, "Default used merchandise class" %>
+    <%= form.select :default_used_merchandise_class_id, MerchandiseClass.options_for_select(@merchandise_classes), include_blank: "None" %>
   </p>
   <p><%= form.label :display_order %><%= form.number_field :display_order %></p>
   <p><%= form.submit %></p>

--- a/app/views/admin/merchandise_categories/show.html.erb
+++ b/app/views/admin/merchandise_categories/show.html.erb
@@ -2,7 +2,8 @@
 <h1><%= @merchandise_category.admin_label %></h1>
 <p>
   Parent: <%= @merchandise_category.parent&.admin_label || "—" %> ·
-  Default class: <%= @merchandise_category.default_merchandise_class&.admin_label || "—" %> ·
+  Default standard class: <%= @merchandise_category.default_standard_merchandise_class&.admin_label || "—" %> ·
+  Default used class: <%= @merchandise_category.default_used_merchandise_class&.admin_label || "—" %> ·
   Order: <%= @merchandise_category.display_order %> ·
   <%= @merchandise_category.active? ? "active" : "inactive" %>
 </p>

--- a/app/views/admin/merchandise_classes/_form.html.erb
+++ b/app/views/admin/merchandise_classes/_form.html.erb
@@ -10,11 +10,20 @@
       </div>
     <% else %>
       <div class="form-field">
-        <%= form.label :code %>
+        <%= form.label :code, "Key / code" %>
         <%= form.text_field :code %>
         <span class="field-help">Leave blank to generate from the name. Later changes are not allowed.</span>
       </div>
     <% end %>
+    <div class="form-field">
+      <%= form.label :department_id, "Department" %>
+      <%= form.select :department_id, Department.options_for_select(@departments), include_blank: true %>
+    </div>
+    <div class="form-field">
+      <%= form.label :merchandise_class_number, "Class number" %>
+      <%= form.text_field :merchandise_class_number %>
+      <span class="field-help">Unique within the parent department.</span>
+    </div>
     <div class="form-field">
       <%= form.label :name %>
       <%= form.text_field :name %>
@@ -29,23 +38,33 @@
     </div>
   <% end %>
 
-  <%= render layout: "shared/form_section", locals: { title: "Behavior" } do %>
+  <%= render layout: "shared/form_section", locals: {
+        title: "Operational defaults",
+        help: "Inventory mode, pricing method, margin, and supplier returnability are copied to new variants only. Tax default changes affect existing variants that have no tax override."
+      } do %>
     <div class="form-field">
-      <%= form.label :inventory_mode %>
-      <%= form.select :inventory_mode, MerchandiseClass::INVENTORY_MODES.map { |m| [m.humanize, m] } %>
+      <%= form.label :default_tax_class_id, "Default tax class" %>
+      <%= form.select :default_tax_class_id, TaxClass.options_for_select(@tax_classes), include_blank: true %>
     </div>
     <div class="form-field">
-      <%= form.label :pricing_method %>
-      <%= form.select :pricing_method, MerchandiseClass::PRICING_METHODS.map { |m| [m.humanize, m] } %>
+      <%= form.label :default_inventory_mode, "Default inventory mode" %>
+      <%= form.select :default_inventory_mode, MerchandiseClass::INVENTORY_MODES.map { |m| [m.humanize, m] } %>
     </div>
     <div class="form-field">
-      <%= form.label :default_standard_department_id, "Default standard department" %>
-      <%= form.select :default_standard_department_id, Department.options_for_select(@departments), include_blank: "None" %>
+      <%= form.label :default_pricing_method, "Default pricing method" %>
+      <%= form.select :default_pricing_method, MerchandiseClass::PRICING_METHODS.map { |m| [m.humanize, m] } %>
     </div>
     <div class="form-field">
-      <%= form.label :default_used_department_id, "Default used department" %>
-      <%= form.select :default_used_department_id, Department.options_for_select(@departments), include_blank: "None" %>
+      <%= form.label :target_margin_bps, "Target margin (basis points)" %>
+      <%= form.number_field :target_margin_bps %>
     </div>
+    <div class="form-field">
+      <%= form.check_box :default_supplier_returnable %>
+      <%= form.label :default_supplier_returnable, "Default supplier returnable" %>
+    </div>
+  <% end %>
+
+  <%= render layout: "shared/form_section", locals: { title: "Merchandise policies" } do %>
     <div class="form-field">
       <%= form.check_box :used_merchandise_allowed %>
       <%= form.label :used_merchandise_allowed, "Used merchandise allowed" %>
@@ -53,10 +72,6 @@
     <div class="form-field">
       <%= form.check_box :buyback_allowed %>
       <%= form.label :buyback_allowed, "Buyback allowed (requires used + inventory)" %>
-    </div>
-    <div class="form-field">
-      <%= form.check_box :default_supplier_returnable %>
-      <%= form.label :default_supplier_returnable, "Default supplier returnable" %>
     </div>
   <% end %>
 

--- a/app/views/admin/merchandise_classes/index.html.erb
+++ b/app/views/admin/merchandise_classes/index.html.erb
@@ -16,12 +16,13 @@
   <% rows = @merchandise_classes.map { |klass|
        [
          link_to(klass.admin_label, admin_merchandise_class_path(klass)),
-         klass.inventory_mode.humanize,
-         klass.pricing_method.humanize,
+         klass.department&.admin_label,
+         klass.default_inventory_mode.humanize,
+         klass.default_pricing_method.humanize,
          configuration_status_badge(klass.active?)
        ]
      } %>
   <%= render "shared/data_table",
-        headers: ["Class", "Inventory mode", "Pricing method", "Status"],
+        headers: ["Class", "Department", "Inventory mode", "Pricing method", "Status"],
         rows: rows %>
 <% end %>

--- a/app/views/admin/merchandise_classes/show.html.erb
+++ b/app/views/admin/merchandise_classes/show.html.erb
@@ -24,21 +24,19 @@
 <section class="section surface">
   <%= render "shared/definition_list", rows: [
         ["Code", @merchandise_class.code],
-        ["Inventory mode", @merchandise_class.inventory_mode.humanize],
-        ["Pricing method", @merchandise_class.pricing_method.humanize],
+        ["Department", (
+          link_to(@merchandise_class.department.admin_label, admin_department_path(@merchandise_class.department))
+        )],
+        ["Class number", @merchandise_class.merchandise_class_number],
+        ["Default tax class", (
+          link_to(@merchandise_class.default_tax_class.admin_label, admin_tax_class_path(@merchandise_class.default_tax_class))
+        )],
+        ["Default inventory mode", @merchandise_class.default_inventory_mode.humanize],
+        ["Default pricing method", @merchandise_class.default_pricing_method.humanize],
+        ["Target margin (bps)", @merchandise_class.target_margin_bps.presence || "—"],
         ["Used merchandise allowed", @merchandise_class.used_merchandise_allowed? ? "Yes" : "No"],
         ["Buyback allowed", @merchandise_class.buyback_allowed? ? "Yes" : "No"],
         ["Default supplier returnable", @merchandise_class.default_supplier_returnable? ? "Yes" : "No"],
-        ["Default standard department", (
-          if @merchandise_class.default_standard_department
-            link_to(@merchandise_class.default_standard_department.admin_label, admin_department_path(@merchandise_class.default_standard_department))
-          end
-        )],
-        ["Default used department", (
-          if @merchandise_class.default_used_department
-            link_to(@merchandise_class.default_used_department.admin_label, admin_department_path(@merchandise_class.default_used_department))
-          end
-        )],
         ["Display order", @merchandise_class.display_order],
         ["Description", @merchandise_class.description]
       ] %>

--- a/app/views/admin/merchandise_imports/new.html.erb
+++ b/app/views/admin/merchandise_imports/new.html.erb
@@ -8,19 +8,23 @@
 <section>
   <h2>Column dictionary</h2>
   <ul>
-    <li><code>primary_identifier</code> — required unless <code>generate_primary_identifier</code> is true</li>
+    <li><code>product_primary_identifier</code> — existing generated <code>222</code> identifier; update key only. Import cannot assign a primary identifier: every new product receives a generated <code>222</code>.</li>
+    <li><code>product_industry_identifier</code> — optional product-level manufacturer GTIN (ISBN-10, ISBN-13, UPC-A, EAN-13); normalized to 13 digits. Doubles as an update key when it matches exactly one product.</li>
+    <li><code>product_lookup_code</code> — optional nonunique product search code; stored uppercase (<code>A–Z</code>, <code>0–9</code>, <code>.</code>, <code>_</code>, <code>/</code>, <code>-</code>). Locates a product only when exactly one product matches; several matches fail the group.</li>
     <li><code>name</code> — required for a new product</li>
-    <li><code>generate_primary_identifier</code> — <code>true</code>/<code>false</code>; blank+true is create-only and not idempotent on reimport</li>
     <li><code>status</code> — optional product status</li>
     <li><code>sku</code> — identifies an existing variant for update; cannot assign a SKU to a new variant</li>
     <li><code>variant_type</code> — <code>standard</code> or <code>used</code> for new variants</li>
     <li><code>variant_name</code> — maps to <code>product_variants.name</code>; blank uses shared create defaults</li>
-    <li><code>industry_identifier</code> — optional GTIN/ISBN-style identifier</li>
+    <li><code>industry_identifier</code> — variant-level GTIN, only when this variant has a manufacturer GTIN distinct from the product's</li>
     <li><code>variant_condition_code</code> — required for used; prohibited for standard; exact canonical code match</li>
-    <li><code>merchandise_class_code</code>, <code>department_code</code>, <code>tax_class_code</code> — exact canonical codes; blank uses defaults; unknown codes error</li>
+    <li><code>merchandise_class_code</code> — exact canonical code; blank uses the merchandise category default; unknown codes error</li>
+    <li><code>inventory_mode</code>, <code>pricing_method</code>, <code>target_margin_bps</code>, <code>supplier_returnable</code> — copied onto the new variant; blank keeps the merchandise-class default, and an explicit <code>false</code> supplier returnability is kept</li>
+    <li><code>tax_class_override_code</code> — blank means inherit the merchandise class's current default tax class</li>
     <li><code>regular_price_cents</code> — integer minor units (cents)</li>
   </ul>
-  <p>Rows sharing a normalized entered product identifier are one transaction group; a failure rolls back that group.</p>
+  <p>Rows sharing a resolvable product key are one transaction group; a failure rolls back that group. Rows with no product key are create-only and are not idempotent on reimport.</p>
+  <p>A blank cell never clears an existing value. Retire a product industry identifier or remove a lookup code on the product screen.</p>
 </section>
 
 <%= form_with url: admin_merchandise_imports_path, scope: :import, html: { multipart: true } do |form| %>

--- a/app/views/admin/merchandise_lookups/new.html.erb
+++ b/app/views/admin/merchandise_lookups/new.html.erb
@@ -15,6 +15,18 @@
   <% if @result.variant %>
     <p>Variant: <%= link_to "#{@result.variant.sku} — #{@result.variant.name.presence || "unnamed"}", admin_product_variant_path(@result.variant) %></p>
   <% end %>
+  <% if @result.products.present? %>
+    <p>Several products share that lookup code. Select one; ShelfSense never picks the first match.</p>
+    <ul>
+      <% @result.products.each do |product| %>
+        <li>
+          <%= link_to "#{product.primary_identifier} — #{product.name}", admin_product_path(product) %>
+          <% if product.industry_identifier.present? %> · GTIN <%= product.industry_identifier %><% end %>
+          <% if product.lookup_code.present? %> · Lookup code <%= product.lookup_code %><% end %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
   <% if @result.variants.present? %>
     <ul>
       <% @result.variants.each do |variant| %>

--- a/app/views/admin/product_variants/_form.html.erb
+++ b/app/views/admin/product_variants/_form.html.erb
@@ -73,10 +73,17 @@
     <div class="form-field">
       <%= form.label :target_margin_bps, "Target margin (basis points)" %>
       <%= form.number_field :target_margin_bps %>
+      <% unless product_variant.persisted? %>
+        <span class="field-help">Leave blank to copy the merchandise-class default.</span>
+      <% end %>
     </div>
     <div class="form-field">
-      <%= form.check_box :supplier_returnable %>
       <%= form.label :supplier_returnable, "Supplier returnable" %>
+      <% if product_variant.persisted? %>
+        <%= form.select :supplier_returnable, [ [ "Yes", true ], [ "No", false ] ] %>
+      <% else %>
+        <%= form.select :supplier_returnable, [ [ "Yes", true ], [ "No", false ] ], include_blank: "Use class default" %>
+      <% end %>
     </div>
   <% end %>
 

--- a/app/views/admin/product_variants/_form.html.erb
+++ b/app/views/admin/product_variants/_form.html.erb
@@ -37,7 +37,10 @@
     </div>
   <% end %>
 
-  <%= render layout: "shared/form_section", locals: { title: "Sellability", help: "Blank class, department, or tax class resolve at create time. Clearing them later does not re-inherit defaults." } do %>
+  <%= render layout: "shared/form_section", locals: {
+        title: "Classification",
+        help: "Department comes from the merchandise class. Tax blank = use class default (live). Inventory mode and pricing are stored on the variant."
+      } do %>
     <div class="form-field">
       <%= form.label :merchandise_condition_id, "Condition (used variants only)" %>
       <%= form.select :merchandise_condition_id, MerchandiseCondition.options_for_select(@merchandise_conditions), include_blank: true %>
@@ -46,13 +49,34 @@
       <%= form.label :merchandise_class_id, "Merchandise class" %>
       <%= form.select :merchandise_class_id, MerchandiseClass.options_for_select(@merchandise_classes), include_blank: "Resolve default" %>
     </div>
+    <% if product_variant.persisted? && product_variant.department %>
+      <div class="form-field">
+        <span class="muted">Department</span>
+        <div><%= product_variant.department.admin_label %></div>
+      </div>
+    <% end %>
     <div class="form-field">
-      <%= form.label :department_id, "Department" %>
-      <%= form.select :department_id, Department.options_for_select(@departments), include_blank: "Resolve default" %>
+      <%= form.label :tax_class_override_id, "Tax class override" %>
+      <%= form.select :tax_class_override_id, TaxClass.options_for_select(@tax_classes), include_blank: "Use merchandise-class default" %>
+      <% if product_variant.persisted? && product_variant.effective_tax_class %>
+        <span class="field-help">Effective now: <%= product_variant.effective_tax_class.admin_label %><%= product_variant.tax_class_override_id.present? ? " (override)" : " (inherited)" %>.</span>
+      <% end %>
     </div>
     <div class="form-field">
-      <%= form.label :tax_class_id, "Tax class" %>
-      <%= form.select :tax_class_id, TaxClass.options_for_select(@tax_classes), include_blank: "Resolve default" %>
+      <%= form.label :inventory_mode %>
+      <%= form.select :inventory_mode, ProductVariant::INVENTORY_MODES.map { |m| [m.humanize, m] }, include_blank: product_variant.persisted? ? false : "Use class default" %>
+    </div>
+    <div class="form-field">
+      <%= form.label :pricing_method %>
+      <%= form.select :pricing_method, ProductVariant::PRICING_METHODS.map { |m| [m.humanize, m] }, include_blank: product_variant.persisted? ? false : "Use class default" %>
+    </div>
+    <div class="form-field">
+      <%= form.label :target_margin_bps, "Target margin (basis points)" %>
+      <%= form.number_field :target_margin_bps %>
+    </div>
+    <div class="form-field">
+      <%= form.check_box :supplier_returnable %>
+      <%= form.label :supplier_returnable, "Supplier returnable" %>
     </div>
   <% end %>
 

--- a/app/views/admin/product_variants/show.html.erb
+++ b/app/views/admin/product_variants/show.html.erb
@@ -48,9 +48,14 @@
             link_to(@product_variant.department.admin_label, admin_department_path(@product_variant.department))
           end
         )],
-        ["Tax class", (
-          if @product_variant.tax_class
-            link_to(@product_variant.tax_class.admin_label, admin_tax_class_path(@product_variant.tax_class))
+        ["Effective tax class", (
+          if @product_variant.effective_tax_class
+            link_to(@product_variant.effective_tax_class.admin_label, admin_tax_class_path(@product_variant.effective_tax_class))
+          end
+        )],
+        ["Tax class override", (
+          if @product_variant.tax_class_override
+            link_to(@product_variant.tax_class_override.admin_label, admin_tax_class_path(@product_variant.tax_class_override))
           end
         )],
         ["Condition", @product_variant.merchandise_condition&.admin_label],

--- a/app/views/admin/products/_form.html.erb
+++ b/app/views/admin/products/_form.html.erb
@@ -2,18 +2,11 @@
   <%= render "shared/form_errors", record: product, attribute_ids: { list_price: "product_list_price" } %>
   <%= form.hidden_field :lock_version %>
 
-  <%= render layout: "shared/form_section", locals: { title: "Identity", help: "Enter a manufacturer-assigned identifier or ask ShelfSense to generate a reserved 222 identifier." } do %>
+  <%= render layout: "shared/form_section", locals: { title: "Identity", help: "ShelfSense assigns every product an immutable generated 222 primary identifier. Record the manufacturer GTIN and an optional lookup code here." } do %>
     <% if creating %>
       <div class="form-field">
-        <%= label_tag "product_identifier_mode", "Identifier mode" %>
-        <%= select_tag "product[identifier_mode]",
-              options_for_select([["Enter external", "enter"], ["Generate ShelfSense (222)", "generate"]], params.dig(:product, :identifier_mode) || "enter"),
-              id: "product_identifier_mode" %>
-      </div>
-      <div class="form-field">
-        <%= label_tag "product_external_identifier", "External identifier" %>
-        <%= text_field_tag "product[external_identifier]", params.dig(:product, :external_identifier), id: "product_external_identifier" %>
-        <span class="field-help" id="product_external_identifier_help">Required when entering an external identifier. Spaces and hyphens are removed during normalization.</span>
+        <span class="muted">Primary identifier</span>
+        <div>Generated on save (reserved <code>222</code> namespace)</div>
       </div>
     <% else %>
       <div class="form-field">
@@ -21,6 +14,22 @@
         <div><code><%= product.primary_identifier %></code> (immutable)</div>
       </div>
     <% end %>
+
+    <div class="form-field">
+      <%= form.label :industry_identifier, "Industry identifier (GTIN / ISBN / UPC)" %>
+      <%= form.text_field :industry_identifier,
+            id: "product_industry_identifier",
+            "aria-describedby": "product_industry_identifier_help" %>
+      <span class="field-help" id="product_industry_identifier_help">Optional manufacturer identifier for this product. ISBN-10 becomes a Bookland 978 ISBN-13 and UPC-A becomes a GTIN-13; spaces and hyphens are removed. May not use the reserved 222 namespace. Clear the field to retire it.</span>
+      <% if product.errors[:industry_identifier].any? %><span class="field-error"><%= product.errors[:industry_identifier].to_sentence %></span><% end %>
+    </div>
+
+    <div class="form-field">
+      <%= form.label :lookup_code, "Lookup code" %>
+      <%= form.text_field :lookup_code, id: "product_lookup_code", "aria-describedby": "product_lookup_code_help" %>
+      <span class="field-help" id="product_lookup_code_help">Optional shelf or search code, stored uppercase. Allowed characters: A–Z, 0–9, period, underscore, slash, and hyphen; no spaces; up to 64 characters. Lookup codes are not unique — if another product uses the same code, scan and add will ask the cashier to choose a product.</span>
+      <% if product.errors[:lookup_code].any? %><span class="field-error"><%= product.errors[:lookup_code].to_sentence %></span><% end %>
+    </div>
 
     <div class="form-field">
       <%= form.label :name %>

--- a/app/views/admin/products/show.html.erb
+++ b/app/views/admin/products/show.html.erb
@@ -29,6 +29,17 @@
 <section class="section surface">
   <%= render "shared/definition_list", rows: [
         ["Primary identifier", @product.primary_identifier],
+        ["Industry identifier (GTIN / ISBN / UPC)", @product.industry_identifier],
+        ["Lookup code", (
+          if @product.lookup_code.present?
+            shared = Product.where(lookup_code: @product.lookup_code).where.not(id: @product.id).count
+            if shared.positive?
+              safe_join([@product.lookup_code, tag.span(" · shared with #{shared} other #{"product".pluralize(shared)}; scan and add will require product selection", class: "muted")])
+            else
+              @product.lookup_code
+            end
+          end
+        )],
         ["Status", status_badge(@product.status, scheme: :product_variant)],
         ["List price", format_money_cents(@product.list_price_cents)],
         ["Merchandise category", (
@@ -85,7 +96,7 @@
            status_badge(variant.status, scheme: :product_variant),
            variant.merchandise_class ? variant.merchandise_class.admin_label : missing_value,
            variant.department ? variant.department.admin_label : missing_value,
-           variant.tax_class ? variant.tax_class.admin_label : missing_value,
+           variant.effective_tax_class ? variant.effective_tax_class.admin_label : missing_value,
            variant.used? ? (variant.merchandise_condition&.name || missing_value) : "—",
            format_money_cents(variant.regular_price_cents)
          ]

--- a/app/views/pos/workspaces/_surface.html.erb
+++ b/app/views/pos/workspaces/_surface.html.erb
@@ -524,6 +524,21 @@
   </div>
 
   <div class="pos-overlay"
+       id="pos_product_overlay"
+       hidden
+       data-register-workspace-target="productOverlay"
+       role="dialog"
+       aria-modal="true"
+       aria-labelledby="pos-product-title">
+    <div class="pos-overlay__panel">
+      <h2 id="pos-product-title">Choose product</h2>
+      <ul class="pos-picker" role="listbox" aria-labelledby="pos-product-title" data-register-workspace-target="productList"></ul>
+      <p class="muted">Several products share that lookup code. Enter selects the highlighted product. Esc cancels without adding merchandise.</p>
+      <button type="button" class="btn btn--secondary" data-action="register-workspace#closeProductOverlay">Cancel (Esc)</button>
+    </div>
+  </div>
+
+  <div class="pos-overlay"
        id="pos_variant_overlay"
        hidden
        data-register-workspace-target="variantOverlay"

--- a/app/views/pos/workspaces/_surface.html.erb
+++ b/app/views/pos/workspaces/_surface.html.erb
@@ -332,6 +332,9 @@
       <%= hidden_field_tag :register_id, @register.id %>
       <%= hidden_field_tag :lock_version, @transaction.lock_version %>
       <%= hidden_field_tag :identifier, "", data: { register_workspace_target: "unlinkedIdentifierInput" } %>
+      <%= hidden_field_tag :product_id, "", data: { register_workspace_target: "unlinkedProductIdInput" } %>
+      <%= hidden_field_tag :product_variant_id, "", data: { register_workspace_target: "unlinkedVariantIdInput" } %>
+      <%= hidden_field_tag :inventory_unit_id, "", data: { register_workspace_target: "unlinkedUnitIdInput" } %>
       <%= hidden_field_tag :quantity, "", data: { register_workspace_target: "unlinkedQuantityInput" } %>
       <%= hidden_field_tag :reason_code, "", data: { register_workspace_target: "unlinkedReasonInput" } %>
       <%= hidden_field_tag :reason_note, "", data: { register_workspace_target: "unlinkedNoteInput" } %>

--- a/db/migrate/20260821010000_phase61_classification_cutover.rb
+++ b/db/migrate/20260821010000_phase61_classification_cutover.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+class Phase61ClassificationCutover < ActiveRecord::Migration[8.1]
+  def up
+    # Disposable data: wipe merchandise/inventory/POS rows that depend on the old shape.
+    say_with_time "clearing disposable merchandise-related data" do
+      execute <<~SQL.squish
+        TRUNCATE TABLE
+          pos_line_tax_components,
+          pos_controlled_actions,
+          pos_tenders,
+          pos_transaction_lines,
+          pos_operations,
+          pos_transactions,
+          pos_sessions,
+          pos_reporting_periods,
+          inventory_valuation_entries,
+          inventory_ledger_entries,
+          inventory_units,
+          inventory_balances,
+          inventory_adjustments,
+          identifier_registry,
+          product_variants,
+          products,
+          merchandise_categories,
+          merchandise_classes,
+          departments
+        RESTART IDENTITY CASCADE
+      SQL
+    end
+
+    # --- departments: drop tax/margin defaults; require department_number ---
+    remove_check_constraint :departments, name: "departments_margin_bps_range"
+    remove_foreign_key :departments, column: :default_tax_class_id
+    remove_column :departments, :default_tax_class_id, :uuid
+    remove_column :departments, :default_target_margin_bps, :integer
+
+    remove_index :departments, :department_number if index_exists?(:departments, :department_number)
+    change_column_null :departments, :department_number, false
+    add_index :departments, :department_number, unique: true
+
+    # --- merchandise_classes: single department + renamed defaults ---
+    add_reference :merchandise_classes, :department, type: :uuid, foreign_key: true, null: true
+    add_column :merchandise_classes, :merchandise_class_number, :string
+    add_reference :merchandise_classes, :default_tax_class, type: :uuid, foreign_key: { to_table: :tax_classes }, null: true
+    add_column :merchandise_classes, :target_margin_bps, :integer
+
+    rename_column :merchandise_classes, :inventory_mode, :default_inventory_mode
+    rename_column :merchandise_classes, :pricing_method, :default_pricing_method
+
+    remove_check_constraint :merchandise_classes, name: "merchandise_classes_buyback_implies_used_inventory"
+    remove_check_constraint :merchandise_classes, name: "merchandise_classes_inventory_mode_valid"
+    remove_check_constraint :merchandise_classes, name: "merchandise_classes_pricing_method_valid"
+
+    add_check_constraint :merchandise_classes,
+                         "default_inventory_mode::text = ANY (ARRAY['inventory'::character varying::text, 'non_inventory'::character varying::text])",
+                         name: "merchandise_classes_default_inventory_mode_valid"
+    add_check_constraint :merchandise_classes,
+                         "default_pricing_method::text = ANY (ARRAY['fixed'::character varying::text, 'list_price'::character varying::text, 'cost_based'::character varying::text, 'open_price'::character varying::text])",
+                         name: "merchandise_classes_default_pricing_method_valid"
+    add_check_constraint :merchandise_classes,
+                         "NOT buyback_allowed OR used_merchandise_allowed AND default_inventory_mode::text = 'inventory'::text",
+                         name: "merchandise_classes_buyback_implies_used_inventory"
+    add_check_constraint :merchandise_classes,
+                         "target_margin_bps IS NULL OR (target_margin_bps >= 0 AND target_margin_bps < 10000)",
+                         name: "merchandise_classes_margin_bps_range"
+
+    remove_foreign_key :merchandise_classes, column: :default_standard_department_id if foreign_key_exists?(:merchandise_classes, column: :default_standard_department_id)
+    remove_foreign_key :merchandise_classes, column: :default_used_department_id if foreign_key_exists?(:merchandise_classes, column: :default_used_department_id)
+    remove_column :merchandise_classes, :default_standard_department_id, :uuid
+    remove_column :merchandise_classes, :default_used_department_id, :uuid
+
+    change_column_null :merchandise_classes, :department_id, false
+    change_column_null :merchandise_classes, :merchandise_class_number, false
+    change_column_null :merchandise_classes, :default_tax_class_id, false
+    add_index :merchandise_classes,
+              [ :department_id, :merchandise_class_number ],
+              unique: true,
+              name: "index_merchandise_classes_on_department_and_number"
+
+    # --- merchandise_categories: standard/used default classes ---
+    add_reference :merchandise_categories, :default_standard_merchandise_class,
+                  type: :uuid, foreign_key: { to_table: :merchandise_classes }, null: true
+    add_reference :merchandise_categories, :default_used_merchandise_class,
+                  type: :uuid, foreign_key: { to_table: :merchandise_classes }, null: true
+    remove_foreign_key :merchandise_categories, column: :default_merchandise_class_id if foreign_key_exists?(:merchandise_categories, column: :default_merchandise_class_id)
+    remove_column :merchandise_categories, :default_merchandise_class_id, :uuid
+
+    # --- product_variants: persisted ops + tax override ---
+    add_column :product_variants, :inventory_mode, :string
+    add_column :product_variants, :pricing_method, :string
+    add_column :product_variants, :target_margin_bps, :integer
+    add_column :product_variants, :supplier_returnable, :boolean
+    add_reference :product_variants, :tax_class_override,
+                  type: :uuid, foreign_key: { to_table: :tax_classes }, null: true
+
+    add_check_constraint :product_variants,
+                         "inventory_mode IS NULL OR inventory_mode::text = ANY (ARRAY['inventory'::character varying::text, 'non_inventory'::character varying::text])",
+                         name: "product_variants_inventory_mode_valid"
+    add_check_constraint :product_variants,
+                         "pricing_method IS NULL OR pricing_method::text = ANY (ARRAY['fixed'::character varying::text, 'list_price'::character varying::text, 'cost_based'::character varying::text, 'open_price'::character varying::text])",
+                         name: "product_variants_pricing_method_valid"
+    add_check_constraint :product_variants,
+                         "target_margin_bps IS NULL OR (target_margin_bps >= 0 AND target_margin_bps < 10000)",
+                         name: "product_variants_margin_bps_range"
+
+    remove_foreign_key :product_variants, column: :department_id if foreign_key_exists?(:product_variants, column: :department_id)
+    remove_foreign_key :product_variants, column: :tax_class_id if foreign_key_exists?(:product_variants, column: :tax_class_id)
+    remove_column :product_variants, :department_id, :uuid
+    remove_column :product_variants, :tax_class_id, :uuid
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "Phase 6.1 classification cutover is not reversible (disposable data)"
+  end
+end

--- a/db/migrate/20260821020000_phase61_product_identity.rb
+++ b/db/migrate/20260821020000_phase61_product_identity.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+# Adds product-level industry identifiers and lookup codes, and the matching
+# `product_industry` registry kind. `products` is not truncated: the new columns are
+# nullable, so existing rows satisfy both check constraints.
+#
+# `down` is destructive: it drops the two columns and deletes every `product_industry`
+# registry row, so product-level GTINs and lookup codes are lost. Recovery is a restore
+# from backup, or re-entry through the admin product screen and CSV import.
+class Phase61ProductIdentity < ActiveRecord::Migration[8.1]
+  KINDS = %w[product_primary product_industry variant_sku variant_industry inventory_unit].freeze
+
+  def up
+    add_column :products, :industry_identifier, :string, limit: 13
+    add_column :products, :lookup_code, :string, limit: 64
+
+    add_index :products, :industry_identifier,
+              unique: true,
+              where: "industry_identifier IS NOT NULL",
+              name: "index_products_on_industry_identifier"
+    add_index :products, :lookup_code,
+              where: "lookup_code IS NOT NULL",
+              name: "index_products_on_lookup_code"
+
+    add_check_constraint :products,
+                         "industry_identifier IS NULL OR industry_identifier::text ~ '^[0-9]{13}$'::text",
+                         name: "products_industry_identifier_shape"
+    add_check_constraint :products,
+                         <<~SQL.squish,
+                           lookup_code IS NULL OR (
+                             lookup_code::text = upper(btrim(lookup_code::text))
+                             AND char_length(lookup_code::text) >= 1
+                             AND char_length(lookup_code::text) <= 64
+                             AND lookup_code::text ~ '^[A-Z0-9._/-]+$'
+                           )
+                         SQL
+                         name: "products_lookup_code_canonical"
+
+    remove_check_constraint :identifier_registry, name: "identifier_registry_kind_valid"
+    add_check_constraint :identifier_registry,
+                         "identifier_kind::text = ANY (ARRAY[#{kind_array_sql}])",
+                         name: "identifier_registry_kind_valid"
+
+    remove_check_constraint :identifier_registry, name: "identifier_registry_owner_matches_kind"
+    add_check_constraint :identifier_registry, owner_matches_kind_sql, name: "identifier_registry_owner_matches_kind"
+
+    add_index :identifier_registry, :product_id,
+              unique: true,
+              where: "((identifier_kind)::text = 'product_industry'::text) AND (retired_at IS NULL)",
+              name: "index_identifier_registry_active_product_industry"
+  end
+
+  def down
+    remove_index :identifier_registry, name: "index_identifier_registry_active_product_industry"
+
+    remove_check_constraint :identifier_registry, name: "identifier_registry_owner_matches_kind"
+    remove_check_constraint :identifier_registry, name: "identifier_registry_kind_valid"
+
+    execute "DELETE FROM identifier_registry WHERE identifier_kind = 'product_industry'"
+
+    add_check_constraint :identifier_registry,
+                         "identifier_kind::text = ANY (ARRAY[#{kind_array_sql(KINDS - %w[product_industry])}])",
+                         name: "identifier_registry_kind_valid"
+    add_check_constraint :identifier_registry,
+                         owner_matches_kind_sql(product_kinds: %w[product_primary]),
+                         name: "identifier_registry_owner_matches_kind"
+
+    remove_check_constraint :products, name: "products_lookup_code_canonical"
+    remove_check_constraint :products, name: "products_industry_identifier_shape"
+    remove_index :products, name: "index_products_on_lookup_code"
+    remove_index :products, name: "index_products_on_industry_identifier"
+    remove_column :products, :lookup_code
+    remove_column :products, :industry_identifier
+  end
+
+  private
+
+  def kind_array_sql(kinds = KINDS)
+    kinds.map { |kind| "'#{kind}'::character varying::text" }.join(", ")
+  end
+
+  def owner_matches_kind_sql(product_kinds: %w[product_primary product_industry])
+    product_predicate =
+      if product_kinds.one?
+        "identifier_kind::text = '#{product_kinds.first}'::text"
+      else
+        "(identifier_kind::text = ANY (ARRAY[#{kind_array_sql(product_kinds)}]))"
+      end
+
+    <<~SQL.squish
+      ((product_id IS NOT NULL)::integer + (product_variant_id IS NOT NULL)::integer + (inventory_unit_id IS NOT NULL)::integer) <= 1
+      AND (
+        retired_at IS NOT NULL
+        OR #{product_predicate} AND product_id IS NOT NULL AND product_variant_id IS NULL AND inventory_unit_id IS NULL
+        OR (identifier_kind::text = ANY (ARRAY['variant_sku'::character varying::text, 'variant_industry'::character varying::text])) AND product_variant_id IS NOT NULL AND product_id IS NULL AND inventory_unit_id IS NULL
+        OR identifier_kind::text = 'inventory_unit'::text AND inventory_unit_id IS NOT NULL AND product_id IS NULL AND product_variant_id IS NULL
+      )
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_20_020000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_21_020000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -76,9 +76,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_020000) do
     t.string "code", null: false
     t.uuid "cost_of_goods_sold_gl_account_id"
     t.timestamptz "created_at", null: false
-    t.integer "default_target_margin_bps"
-    t.uuid "default_tax_class_id", null: false
-    t.string "department_number"
+    t.string "department_number", null: false
     t.text "description"
     t.integer "display_order", default: 0, null: false
     t.uuid "freight_in_gl_account_id"
@@ -95,7 +93,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_020000) do
     t.timestamptz "updated_at", null: false
     t.index ["code"], name: "index_departments_on_code", unique: true
     t.index ["cost_of_goods_sold_gl_account_id"], name: "index_departments_on_cost_of_goods_sold_gl_account_id"
-    t.index ["department_number"], name: "index_departments_on_department_number", unique: true, where: "(department_number IS NOT NULL)"
+    t.index ["department_number"], name: "index_departments_on_department_number", unique: true
     t.index ["freight_in_gl_account_id"], name: "index_departments_on_freight_in_gl_account_id"
     t.index ["inventory_adjustment_gain_gl_account_id"], name: "index_departments_on_inventory_adjustment_gain_gl_account_id"
     t.index ["inventory_adjustment_loss_gl_account_id"], name: "index_departments_on_inventory_adjustment_loss_gl_account_id"
@@ -106,7 +104,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_020000) do
     t.index ["sales_returns_gl_account_id"], name: "index_departments_on_sales_returns_gl_account_id"
     t.index ["sales_revenue_gl_account_id"], name: "index_departments_on_sales_revenue_gl_account_id"
     t.check_constraint "code::text ~ '^[a-z0-9]+(_[a-z0-9]+)*$'::text", name: "departments_code_format"
-    t.check_constraint "default_target_margin_bps IS NULL OR default_target_margin_bps >= 0 AND default_target_margin_bps < 10000", name: "departments_margin_bps_range"
   end
 
   create_table "gl_accounts", id: :uuid, default: nil, force: :cascade do |t|
@@ -160,12 +157,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_020000) do
     t.timestamptz "updated_at", null: false
     t.string "value", limit: 13, null: false
     t.index ["inventory_unit_id"], name: "index_identifier_registry_inventory_unit", unique: true, where: "((identifier_kind)::text = 'inventory_unit'::text)"
+    t.index ["product_id"], name: "index_identifier_registry_active_product_industry", unique: true, where: "(((identifier_kind)::text = 'product_industry'::text) AND (retired_at IS NULL))"
     t.index ["product_id"], name: "index_identifier_registry_active_product_primary", unique: true, where: "(((identifier_kind)::text = 'product_primary'::text) AND (retired_at IS NULL))"
     t.index ["product_variant_id"], name: "index_identifier_registry_active_variant_industry", unique: true, where: "(((identifier_kind)::text = 'variant_industry'::text) AND (retired_at IS NULL))"
     t.index ["product_variant_id"], name: "index_identifier_registry_variant_sku", unique: true, where: "((identifier_kind)::text = 'variant_sku'::text)"
     t.index ["value"], name: "index_identifier_registry_on_value", unique: true
-    t.check_constraint "((product_id IS NOT NULL)::integer + (product_variant_id IS NOT NULL)::integer + (inventory_unit_id IS NOT NULL)::integer) <= 1 AND (retired_at IS NOT NULL OR identifier_kind::text = 'product_primary'::text AND product_id IS NOT NULL AND product_variant_id IS NULL AND inventory_unit_id IS NULL OR (identifier_kind::text = ANY (ARRAY['variant_sku'::character varying::text, 'variant_industry'::character varying::text])) AND product_variant_id IS NOT NULL AND product_id IS NULL AND inventory_unit_id IS NULL OR identifier_kind::text = 'inventory_unit'::text AND inventory_unit_id IS NOT NULL AND product_id IS NULL AND product_variant_id IS NULL)", name: "identifier_registry_owner_matches_kind"
-    t.check_constraint "identifier_kind::text = ANY (ARRAY['product_primary'::character varying::text, 'variant_sku'::character varying::text, 'variant_industry'::character varying::text, 'inventory_unit'::character varying::text])", name: "identifier_registry_kind_valid"
+    t.check_constraint "((product_id IS NOT NULL)::integer + (product_variant_id IS NOT NULL)::integer + (inventory_unit_id IS NOT NULL)::integer) <= 1 AND (retired_at IS NOT NULL OR (identifier_kind::text = ANY (ARRAY['product_primary'::character varying::text, 'product_industry'::character varying::text])) AND product_id IS NOT NULL AND product_variant_id IS NULL AND inventory_unit_id IS NULL OR (identifier_kind::text = ANY (ARRAY['variant_sku'::character varying::text, 'variant_industry'::character varying::text])) AND product_variant_id IS NOT NULL AND product_id IS NULL AND inventory_unit_id IS NULL OR identifier_kind::text = 'inventory_unit'::text AND inventory_unit_id IS NOT NULL AND product_id IS NULL AND product_variant_id IS NULL)", name: "identifier_registry_owner_matches_kind"
+    t.check_constraint "identifier_kind::text = ANY (ARRAY['product_primary'::character varying::text, 'product_industry'::character varying::text, 'variant_sku'::character varying::text, 'variant_industry'::character varying::text, 'inventory_unit'::character varying::text])", name: "identifier_registry_kind_valid"
     t.check_constraint "value::text ~ '^[0-9]{13}$'::text", name: "identifier_registry_value_shape"
   end
 
@@ -276,7 +274,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_020000) do
     t.boolean "active", default: true, null: false
     t.string "code"
     t.timestamptz "created_at", null: false
-    t.uuid "default_merchandise_class_id"
+    t.uuid "default_standard_merchandise_class_id"
+    t.uuid "default_used_merchandise_class_id"
     t.text "description"
     t.integer "display_order", default: 0, null: false
     t.integer "lock_version", default: 0, null: false
@@ -286,6 +285,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_020000) do
     t.index "lower((name)::text)", name: "index_merchandise_categories_root_name", unique: true, where: "(parent_id IS NULL)"
     t.index "parent_id, lower((name)::text)", name: "index_merchandise_categories_sibling_name", unique: true, where: "(parent_id IS NOT NULL)"
     t.index ["code"], name: "index_merchandise_categories_on_code", unique: true, where: "(code IS NOT NULL)"
+    t.index ["default_standard_merchandise_class_id"], name: "idx_on_default_standard_merchandise_class_id_1437b859ed"
+    t.index ["default_used_merchandise_class_id"], name: "idx_on_default_used_merchandise_class_id_0ca783adcd"
     t.check_constraint "code IS NULL OR code::text ~ '^[a-z0-9]+(_[a-z0-9]+)*$'::text", name: "merchandise_categories_code_format"
     t.check_constraint "parent_id IS NULL OR parent_id <> id", name: "merchandise_categories_parent_not_self"
   end
@@ -295,22 +296,28 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_020000) do
     t.boolean "buyback_allowed", default: false, null: false
     t.string "code", null: false
     t.timestamptz "created_at", null: false
-    t.uuid "default_standard_department_id"
+    t.string "default_inventory_mode", null: false
+    t.string "default_pricing_method", null: false
     t.boolean "default_supplier_returnable", default: true, null: false
-    t.uuid "default_used_department_id"
+    t.uuid "default_tax_class_id", null: false
+    t.uuid "department_id", null: false
     t.text "description"
     t.integer "display_order", default: 0, null: false
-    t.string "inventory_mode", null: false
     t.integer "lock_version", default: 0, null: false
+    t.string "merchandise_class_number", null: false
     t.string "name", null: false
-    t.string "pricing_method", null: false
+    t.integer "target_margin_bps"
     t.timestamptz "updated_at", null: false
     t.boolean "used_merchandise_allowed", default: false, null: false
     t.index ["code"], name: "index_merchandise_classes_on_code", unique: true
-    t.check_constraint "NOT buyback_allowed OR used_merchandise_allowed AND inventory_mode::text = 'inventory'::text", name: "merchandise_classes_buyback_implies_used_inventory"
+    t.index ["default_tax_class_id"], name: "index_merchandise_classes_on_default_tax_class_id"
+    t.index ["department_id", "merchandise_class_number"], name: "index_merchandise_classes_on_department_and_number", unique: true
+    t.index ["department_id"], name: "index_merchandise_classes_on_department_id"
+    t.check_constraint "NOT buyback_allowed OR used_merchandise_allowed AND default_inventory_mode::text = 'inventory'::text", name: "merchandise_classes_buyback_implies_used_inventory"
     t.check_constraint "code::text ~ '^[a-z0-9]+(_[a-z0-9]+)*$'::text", name: "merchandise_classes_code_format"
-    t.check_constraint "inventory_mode::text = ANY (ARRAY['inventory'::character varying::text, 'non_inventory'::character varying::text])", name: "merchandise_classes_inventory_mode_valid"
-    t.check_constraint "pricing_method::text = ANY (ARRAY['fixed'::character varying::text, 'list_price'::character varying::text, 'cost_based'::character varying::text, 'open_price'::character varying::text])", name: "merchandise_classes_pricing_method_valid"
+    t.check_constraint "default_inventory_mode::text = ANY (ARRAY['inventory'::character varying::text, 'non_inventory'::character varying::text])", name: "merchandise_classes_default_inventory_mode_valid"
+    t.check_constraint "default_pricing_method::text = ANY (ARRAY['fixed'::character varying::text, 'list_price'::character varying::text, 'cost_based'::character varying::text, 'open_price'::character varying::text])", name: "merchandise_classes_default_pricing_method_valid"
+    t.check_constraint "target_margin_bps IS NULL OR target_margin_bps >= 0 AND target_margin_bps < 10000", name: "merchandise_classes_margin_bps_range"
   end
 
   create_table "merchandise_conditions", id: :uuid, default: nil, force: :cascade do |t|
@@ -669,33 +676,38 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_020000) do
 
   create_table "product_variants", id: :uuid, default: nil, force: :cascade do |t|
     t.timestamptz "created_at", null: false
-    t.uuid "department_id"
     t.string "industry_identifier", limit: 13
+    t.string "inventory_mode"
     t.integer "lock_version", default: 0, null: false
     t.uuid "merchandise_class_id"
     t.uuid "merchandise_condition_id"
     t.string "name"
     t.string "option_value_1"
     t.string "option_value_2"
+    t.string "pricing_method"
     t.uuid "product_id", null: false
     t.bigint "regular_price_cents"
     t.string "sku", limit: 13, null: false
     t.string "status", default: "draft", null: false
-    t.uuid "tax_class_id"
+    t.boolean "supplier_returnable"
+    t.integer "target_margin_bps"
+    t.uuid "tax_class_override_id"
     t.timestamptz "updated_at", null: false
     t.string "variant_type", null: false
-    t.index ["department_id"], name: "index_product_variants_on_department_id"
     t.index ["industry_identifier"], name: "index_product_variants_on_industry_identifier", unique: true, where: "(industry_identifier IS NOT NULL)"
     t.index ["merchandise_class_id"], name: "index_product_variants_on_merchandise_class_id"
     t.index ["merchandise_condition_id"], name: "index_product_variants_on_merchandise_condition_id"
     t.index ["product_id", "status"], name: "index_product_variants_on_product_id_and_status"
     t.index ["product_id", "variant_type"], name: "index_product_variants_on_product_id_and_variant_type"
     t.index ["sku"], name: "index_product_variants_on_sku", unique: true
-    t.index ["tax_class_id"], name: "index_product_variants_on_tax_class_id"
+    t.index ["tax_class_override_id"], name: "index_product_variants_on_tax_class_override_id"
     t.check_constraint "industry_identifier IS NULL OR industry_identifier::text ~ '^[0-9]{13}$'::text", name: "product_variants_industry_identifier_shape"
+    t.check_constraint "inventory_mode IS NULL OR (inventory_mode::text = ANY (ARRAY['inventory'::character varying::text, 'non_inventory'::character varying::text]))", name: "product_variants_inventory_mode_valid"
+    t.check_constraint "pricing_method IS NULL OR (pricing_method::text = ANY (ARRAY['fixed'::character varying::text, 'list_price'::character varying::text, 'cost_based'::character varying::text, 'open_price'::character varying::text]))", name: "product_variants_pricing_method_valid"
     t.check_constraint "regular_price_cents IS NULL OR regular_price_cents >= 0", name: "product_variants_regular_price_nonnegative"
     t.check_constraint "sku::text ~ '^[0-9]{13}$'::text", name: "product_variants_sku_shape"
     t.check_constraint "status::text = ANY (ARRAY['draft'::character varying::text, 'active'::character varying::text, 'discontinued'::character varying::text])", name: "product_variants_status_valid"
+    t.check_constraint "target_margin_bps IS NULL OR target_margin_bps >= 0 AND target_margin_bps < 10000", name: "product_variants_margin_bps_range"
     t.check_constraint "variant_type::text = 'standard'::text AND merchandise_condition_id IS NULL OR variant_type::text = 'used'::text AND merchandise_condition_id IS NOT NULL", name: "product_variants_condition_matches_type"
     t.check_constraint "variant_type::text = ANY (ARRAY['standard'::character varying::text, 'used'::character varying::text])", name: "product_variants_variant_type_valid"
   end
@@ -704,8 +716,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_020000) do
     t.string "brand_name"
     t.timestamptz "created_at", null: false
     t.text "description"
+    t.string "industry_identifier", limit: 13
     t.bigint "list_price_cents"
     t.integer "lock_version", default: 0, null: false
+    t.string "lookup_code", limit: 64
     t.uuid "merchandise_category_id"
     t.string "name", null: false
     t.string "primary_identifier", limit: 13, null: false
@@ -716,10 +730,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_020000) do
     t.timestamptz "updated_at", null: false
     t.string "variant_option_name_1"
     t.string "variant_option_name_2"
+    t.index ["industry_identifier"], name: "index_products_on_industry_identifier", unique: true, where: "(industry_identifier IS NOT NULL)"
+    t.index ["lookup_code"], name: "index_products_on_lookup_code", where: "(lookup_code IS NOT NULL)"
     t.index ["merchandise_category_id"], name: "index_products_on_merchandise_category_id"
     t.index ["primary_identifier"], name: "index_products_on_primary_identifier", unique: true
     t.index ["status", "name"], name: "index_products_on_status_and_name"
+    t.check_constraint "industry_identifier IS NULL OR industry_identifier::text ~ '^[0-9]{13}$'::text", name: "products_industry_identifier_shape"
     t.check_constraint "list_price_cents IS NULL OR list_price_cents >= 0", name: "products_list_price_nonnegative"
+    t.check_constraint "lookup_code IS NULL OR lookup_code::text = upper(btrim(lookup_code::text)) AND char_length(lookup_code::text) >= 1 AND char_length(lookup_code::text) <= 64 AND lookup_code::text ~ '^[A-Z0-9._/-]+$'::text", name: "products_lookup_code_canonical"
     t.check_constraint "primary_identifier::text ~ '^[0-9]{13}$'::text", name: "products_primary_identifier_shape"
     t.check_constraint "status::text = ANY (ARRAY['draft'::character varying::text, 'active'::character varying::text, 'discontinued'::character varying::text])", name: "products_status_valid"
   end
@@ -946,7 +964,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_020000) do
   add_foreign_key "departments", "gl_accounts", column: "receiving_clearing_gl_account_id"
   add_foreign_key "departments", "gl_accounts", column: "sales_returns_gl_account_id"
   add_foreign_key "departments", "gl_accounts", column: "sales_revenue_gl_account_id"
-  add_foreign_key "departments", "tax_classes", column: "default_tax_class_id"
   add_foreign_key "gl_accounts", "gl_accounts", column: "parent_id"
   add_foreign_key "identifier_registry", "inventory_units", on_delete: :nullify
   add_foreign_key "identifier_registry", "product_variants", on_delete: :nullify
@@ -970,9 +987,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_020000) do
   add_foreign_key "inventory_valuation_entries", "product_variants"
   add_foreign_key "inventory_valuation_entries", "stores"
   add_foreign_key "merchandise_categories", "merchandise_categories", column: "parent_id"
-  add_foreign_key "merchandise_categories", "merchandise_classes", column: "default_merchandise_class_id"
-  add_foreign_key "merchandise_classes", "departments", column: "default_standard_department_id"
-  add_foreign_key "merchandise_classes", "departments", column: "default_used_department_id"
+  add_foreign_key "merchandise_categories", "merchandise_classes", column: "default_standard_merchandise_class_id"
+  add_foreign_key "merchandise_categories", "merchandise_classes", column: "default_used_merchandise_class_id"
+  add_foreign_key "merchandise_classes", "departments"
+  add_foreign_key "merchandise_classes", "tax_classes", column: "default_tax_class_id"
   add_foreign_key "pos_controlled_actions", "pos_transaction_lines"
   add_foreign_key "pos_controlled_actions", "pos_transactions"
   add_foreign_key "pos_controlled_actions", "users", column: "approved_by_user_id"
@@ -1005,11 +1023,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_020000) do
   add_foreign_key "pos_transactions", "registers"
   add_foreign_key "pos_transactions", "stores"
   add_foreign_key "pos_transactions", "users", column: "cashier_user_id"
-  add_foreign_key "product_variants", "departments"
   add_foreign_key "product_variants", "merchandise_classes"
   add_foreign_key "product_variants", "merchandise_conditions"
   add_foreign_key "product_variants", "products"
-  add_foreign_key "product_variants", "tax_classes"
+  add_foreign_key "product_variants", "tax_classes", column: "tax_class_override_id"
   add_foreign_key "products", "merchandise_categories"
   add_foreign_key "registers", "stores"
   add_foreign_key "registers", "users", column: "deactivated_by_id"

--- a/docs/planning/phase2-financial-classification-and-merchandise-foundation/phase-2-database-schema.md
+++ b/docs/planning/phase2-financial-classification-and-merchandise-foundation/phase-2-database-schema.md
@@ -8,7 +8,7 @@ Phase 2 establishes the financial classifications and merchandise records requir
 - Product variants are the sellable records used by later inventory, purchasing, customer-request, and POS workflows.
 - Every variant receives an immutable, system-generated `221` EAN-13-compatible SKU.
 - Every product has exactly one mandatory `primary_identifier` (entered external GTIN/ISBN or system-generated `222` EAN-13) established at creation.
-- Defaults assist record creation; approved classifications and prices are stored on each variant and are not dynamically inherited afterward.
+- Defaults assist record creation; approved classifications and prices are stored on each variant and are not dynamically inherited afterward. **Superseded in part by [Phase 6.1](../phase6.1-merchandise-classification-and-identifiers/phase6.1-plan.md):** tax class is dynamically inherited from the merchandise class unless a variant override is set; operational fields remain sticky copies.
 - Department GL mappings are explicit nullable foreign-key columns on `departments`.
 - ShelfSense uses perpetual inventory accounting: inventory assets and cost of goods sold are separate mappings.
 - All primary and foreign keys use `uuid`; application-created identifiers are UUIDv7.

--- a/docs/planning/phase6.1-merchandise-classification-and-identifiers/README.md
+++ b/docs/planning/phase6.1-merchandise-classification-and-identifiers/README.md
@@ -1,6 +1,6 @@
 # Phase 6.1 — Merchandise classification and identifiers
 
-Status: **proposed**. Data is disposable; this packet does not require backward compatibility with the Phase 2–6 schema.
+Status: **accepted / implemented** on branch `phase-6.1-classification-and-identifiers` (PR toward `main`). Data was disposable; this packet did not require backward compatibility with the Phase 2–6 schema.
 
 | Document | Purpose |
 |---|---|
@@ -9,5 +9,7 @@ Status: **proposed**. Data is disposable; this packet does not require backward 
 | [phase6.1-user-stories.md](phase6.1-user-stories.md) | Issue backlog and acceptance criteria |
 
 This packet includes live tax inheritance with a variant override, product-level industry GTIN (`product_industry`), lookup codes (including shared codes and product selection), and POS/inventory targeting with matching separated from caller eligibility.
+
+**Supersession:** For merchandise classification and product identity, this packet supersedes the Phase 2 blanket rule that *all* approved classifications are stored on the variant and never dynamically inherited. **Tax class is the exception:** it is dynamically inherited from the merchandise class unless a variant tax override is set. Inventory mode, pricing method, target margin, and supplier returnability remain copied at create and sticky. See [phase6.1-plan.md](phase6.1-plan.md) locked decisions 4–5.
 
 It still defers class-level GL mappings (with an explicit posting trigger), production dual-write, and a bulk reclassification UI. Earlier drafts under `docs/drafts/merchandise-classification-and-identifers/` that assumed expand/contract migration are not implementation authority.

--- a/docs/planning/phase6.1-merchandise-classification-and-identifiers/phase6.1-plan.md
+++ b/docs/planning/phase6.1-merchandise-classification-and-identifiers/phase6.1-plan.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Proposed. Not implemented.
+Accepted / implemented. Authority for classification and product-identity behavior after cutover.
+
+**Relative to Phase 2 / 2.1:** Phase 2 said defaults assist creation and approved classifications are not dynamically inherited afterward. Phase 6.1 keeps that for operational fields copied onto the variant (`inventory_mode`, `pricing_method`, `target_margin_bps`, `supplier_returnable`). It **supersedes** that blanket for tax only: effective tax is the variant override when present, otherwise the merchandise class’s **current** default. Clearing the tax override re-inherits the class default (this is intentional and differs from Phase 2.1 “blank means cleared stored tax class”).
 
 ## Purpose
 
@@ -240,7 +242,7 @@ POS `ResolveMerchandiseForSale` must gain an outcome such as `product_choice_req
 Template and importer:
 
 - New products always generate `222`. Ordinary import cannot assign a primary identifier. `generate_primary_identifier` and entered `primary_identifier` on **create** are removed.
-- Stable update keys: existing `222` `product_primary_identifier`, unambiguous `product_industry_identifier`, variant `sku`, variant `industry_identifier`. `product_lookup_code` locates a product only when the match is **one** product; multiple matches fail the row/group.
+- Stable update keys: existing `222` `product_primary_identifier`, unambiguous `product_industry_identifier`, variant `sku`, variant `industry_identifier`. `product_lookup_code` locates a product only when the match is **one pre-existing** product; multiple matches fail the row/group. Lookup code is **not** a multi-row group key—rows that share only a lookup code each form their own group so a single file can create multiple products with the same code.
 - Headers include `product_industry_identifier`, `product_lookup_code`, `merchandise_class_code`, `inventory_mode`, `pricing_method`, `target_margin_bps`, `supplier_returnable`, `tax_class_override_code` (blank means inherit).
 - Product and variant industry identifiers use the same GTIN normalizer as the UI. Ambiguous industry-identifier matches are rejected.
 - Lookup codes uppercase; duplicate lookup codes on different products are allowed on write.

--- a/docs/planning/phase6.1-merchandise-classification-and-identifiers/phase6.1-plan.md
+++ b/docs/planning/phase6.1-merchandise-classification-and-identifiers/phase6.1-plan.md
@@ -256,7 +256,9 @@ Do not put secrets or full row dumps in payloads.
 
 ## Delivery
 
-Prefer **two pull requests** on `main` (no long-lived phase branch). Each PR includes tests, audit, admin/CSV/POS updates, seeds/fixtures, `db/schema.rb`, and documentation.
+Implement on the long-lived feature branch `phase-6.1-classification-and-identifiers`. Land Slice A then Slice B on that branch. Run automated CI-equivalent checks and a written **manual test gate** against `docker compose up` before opening a PR to `main`. Do not merge until the manual checklist passes.
+
+Each slice includes tests, audit, admin/CSV/POS updates, seeds/fixtures, `db/schema.rb`, and documentation as applicable.
 
 ### Slice A — Classification cutover
 
@@ -266,7 +268,7 @@ Schema and behavior for departments, classes, categories, persisted variant oper
 
 Always-generate `222`, product industry GTIN and `product_industry` registry kind, lookup codes (nonunique), matcher vs eligibility split, lookup-code fallback that respects retired registry rows, `multiple_products`, Register product picker, POS sale/return handlers, inventory-adjustment and admin lookup handlers, CSV identity rules.
 
-If a single PR stays reviewable, combining A and B is acceptable because data is disposable. Do not split tests from the behavior they cover.
+Do not split tests from the behavior they cover.
 
 ## Test plan
 

--- a/docs/planning/phase6.1-merchandise-classification-and-identifiers/phase6.1-schema.md
+++ b/docs/planning/phase6.1-merchandise-classification-and-identifiers/phase6.1-schema.md
@@ -1,6 +1,6 @@
 # Phase 6.1 — Target schema
 
-Status: **proposed**. This is the schema to implement. It replaces the classification and product-identity portions of [phase-2-database-schema.md](../phase2-financial-classification-and-merchandise-foundation/phase-2-database-schema.md) for new work. Unlisted tables and columns stay as in `db/schema.rb` at the start of the phase.
+Status: **accepted**. This is the schema implemented for Phase 6.1. It replaces the classification and product-identity portions of [phase-2-database-schema.md](../phase2-financial-classification-and-merchandise-foundation/phase-2-database-schema.md) for new work. Unlisted tables and columns stay as in `db/schema.rb` unless a later phase changes them.
 
 Conventions match the rest of ShelfSense: UUIDv7 ids (`create_uuid_table` / `id: :uuid, default: nil`), `timestamptz`, `lock_version` on mutable roots, integer cents, integer basis points.
 

--- a/docs/planning/phase6.1-merchandise-classification-and-identifiers/phase6.1-user-stories.md
+++ b/docs/planning/phase6.1-merchandise-classification-and-identifiers/phase6.1-user-stories.md
@@ -1,6 +1,6 @@
 # Phase 6.1 — User stories
 
-Status: **proposed** backlog for [phase6.1-plan.md](phase6.1-plan.md). Acceptance criteria must not be weakened if a story is split across PRs.
+Status: **accepted** backlog for [phase6.1-plan.md](phase6.1-plan.md). Acceptance criteria must not be weakened if a story is split across PRs.
 
 Existing product, variant, inventory-unit, and POS resolution behavior (unit → variant → product → variant choice → unit choice) is a regression boundary. This backlog **adds** product selection when a lookup code matches multiple products, product-level industry GTIN as a product identifier, and live tax inheritance with an optional override.
 

--- a/test/integration/inventory_adjustment_identifier_test.rb
+++ b/test/integration/inventory_adjustment_identifier_test.rb
@@ -11,25 +11,23 @@ class InventoryAdjustmentIdentifierTest < ActionDispatch::IntegrationTest
     Inventory::AdjustmentReasons.seed!
 
     @tax = tax_class(code: "adj_id_tax")
-    @department = department(code: "adj_id_dept", default_tax_class: @tax)
+    @department = department(code: "adj_id_dept")
     @klass = merchandise_class(
       code: "adj_id_std",
-      default_standard_department: @department,
+      department: @department,
       pricing_method: "fixed"
     )
     @used_klass = merchandise_class(
       code: "adj_id_used",
       used_merchandise_allowed: true,
-      default_standard_department: @department,
-      default_used_department: @department,
-      pricing_method: "fixed"
+      department: @department,
+            pricing_method: "fixed"
     )
     @condition = merchandise_condition(code: "good")
 
     @product = Products::Create.call(
       attributes: { name: "Adjustment Identifier Book", status: "active" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
     @qty_variant = ProductVariants::Create.call(
       product: @product,
@@ -37,8 +35,6 @@ class InventoryAdjustmentIdentifierTest < ActionDispatch::IntegrationTest
         variant_type: "standard",
         status: "active",
         merchandise_class_id: @klass.id,
-        department_id: @department.id,
-        tax_class_id: @tax.id,
         regular_price_cents: 1999
       },
       actor: @actor
@@ -50,8 +46,6 @@ class InventoryAdjustmentIdentifierTest < ActionDispatch::IntegrationTest
         status: "active",
         merchandise_class_id: @used_klass.id,
         merchandise_condition_id: @condition.id,
-        department_id: @department.id,
-        tax_class_id: @tax.id,
         regular_price_cents: 1200
       },
       actor: @actor
@@ -135,6 +129,82 @@ class InventoryAdjustmentIdentifierTest < ActionDispatch::IntegrationTest
     }
     assert_response :redirect
     assert unit.reload.removed?
+  end
+
+  test "adjustment matching accepts a product whose only variant POS would refuse" do
+    product = Products::Create.call(
+      attributes: { name: "Not For Sale Yet", status: "draft" },
+      actor: @actor,
+      lookup_code: "adj-draft"
+    )
+    variant = ProductVariants::Create.call(
+      product: product,
+      attributes: { variant_type: "standard", status: "draft", merchandise_class_id: @klass.id },
+      actor: @actor
+    )
+    assert_not variant.sellable?
+
+    sign_in_as("admin")
+    post preview_admin_inventory_adjustments_path, params: {
+      store_id: @store.id,
+      product_variant_id: "adj-draft",
+      adjustment_reason_id: @opening.id,
+      quantity_delta: 2,
+      acquisition_unit_cost: "1.00",
+      command_token: SecureRandom.uuid_v7,
+      idempotency_key: SecureRandom.uuid_v7
+    }
+
+    assert_response :success
+    assert_match(/Confirm adjustment/, response.body)
+
+    post admin_inventory_adjustments_path, params: {
+      store_id: @store.id,
+      product_variant_id: "adj-draft",
+      adjustment_reason_id: @opening.id,
+      quantity_delta: 2,
+      acquisition_unit_cost: "1.00",
+      command_token: SecureRandom.uuid_v7,
+      idempotency_key: SecureRandom.uuid_v7
+    }
+    assert_response :redirect
+    assert_equal 2, InventoryBalance.find_by!(store: @store, product_variant: variant).on_hand_quantity
+  end
+
+  test "adjustment matching refuses a shared lookup code instead of picking one product" do
+    first = Products::Create.call(
+      attributes: { name: "Shared A", status: "active" },
+      actor: @actor,
+      lookup_code: "adj-shared"
+    )
+    second = Products::Create.call(
+      attributes: { name: "Shared B", status: "active" },
+      actor: @actor,
+      lookup_code: "adj-shared"
+    )
+    [ first, second ].each do |product|
+      ProductVariants::Create.call(
+        product: product,
+        attributes: { variant_type: "standard", status: "active", merchandise_class_id: @klass.id, regular_price_cents: 500 },
+        actor: @actor
+      )
+    end
+
+    sign_in_as("admin")
+    post preview_admin_inventory_adjustments_path, params: {
+      store_id: @store.id,
+      product_variant_id: "adj-shared",
+      adjustment_reason_id: @opening.id,
+      quantity_delta: 2,
+      acquisition_unit_cost: "1.00",
+      command_token: SecureRandom.uuid_v7,
+      idempotency_key: SecureRandom.uuid_v7
+    }
+
+    assert_response :redirect
+    follow_redirect!
+    assert_match(/Multiple products share that lookup code/, response.body)
+    assert_no_match(/Confirm adjustment/, response.body)
   end
 
   private

--- a/test/integration/inventory_store_authz_test.rb
+++ b/test/integration/inventory_store_authz_test.rb
@@ -31,16 +31,15 @@ class InventoryStoreAuthzTest < ActionDispatch::IntegrationTest
     )
 
     @tax = tax_class(code: "authz_tax")
-    @department = department(code: "authz_dept", default_tax_class: @tax)
+    @department = department(code: "authz_dept")
     @klass = merchandise_class(
       code: "authz_std",
-      default_standard_department: @department,
+      department: @department,
       pricing_method: "fixed"
     )
     @product = Products::Create.call(
       attributes: { name: "Authz Widget", status: "active" },
-      actor: @admin,
-      identifier_mode: "generate"
+      actor: @admin
     )
     @variant = ProductVariants::Create.call(
       product: @product,
@@ -48,8 +47,6 @@ class InventoryStoreAuthzTest < ActionDispatch::IntegrationTest
         variant_type: "standard",
         status: "active",
         merchandise_class_id: @klass.id,
-        department_id: @department.id,
-        tax_class_id: @tax.id,
         regular_price_cents: 1999
       },
       actor: @admin

--- a/test/integration/merchandise_lookup_test.rb
+++ b/test/integration/merchandise_lookup_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class MerchandiseLookupTest < ActionDispatch::IntegrationTest
+  setup do
+    @bootstrap = bootstrap!
+    @actor = @bootstrap[:administrator]
+    sign_in_as("admin")
+  end
+
+  test "product industry identifier resolves to the owning product" do
+    product = Products::Create.call(
+      attributes: { name: "Industry Lookup", status: "draft" },
+      actor: @actor,
+      industry_identifier: external_isbn13
+    )
+
+    post admin_merchandise_lookups_path, params: { lookup: { raw: "978-1-234-56789-7" } }
+
+    assert_response :success
+    assert_match(/Status: product/, response.body)
+    assert_match(/#{product.primary_identifier} — Industry Lookup/, response.body)
+  end
+
+  test "a shared lookup code lists every candidate instead of picking one" do
+    first = Products::Create.call(
+      attributes: { name: "Alpha", status: "draft" },
+      actor: @actor,
+      lookup_code: "shared"
+    )
+    second = Products::Create.call(
+      attributes: { name: "Beta", status: "draft" },
+      actor: @actor,
+      lookup_code: "shared"
+    )
+
+    post admin_merchandise_lookups_path, params: { lookup: { raw: "shared" } }
+
+    assert_response :success
+    assert_match(/Status: multiple_products/, response.body)
+    assert_match(/never picks the first match/, response.body)
+    assert_match(/#{first.primary_identifier}/, response.body)
+    assert_match(/#{second.primary_identifier}/, response.body)
+  end
+
+  test "a retired identifier reports retirement and does not fall through to a lookup code" do
+    retired = Products::Create.call(
+      attributes: { name: "Retired", status: "draft" },
+      actor: @actor
+    )
+    decoy = Products::Create.call(
+      attributes: { name: "Decoy", status: "draft" },
+      actor: @actor
+    )
+    decoy.update!(lookup_code: retired.primary_identifier)
+    Identifiers::Registry.retire!(value: retired.primary_identifier)
+
+    post admin_merchandise_lookups_path, params: { lookup: { raw: retired.primary_identifier } }
+
+    assert_response :success
+    assert_match(/Status: retired/, response.body)
+    assert_no_match(/Decoy/, response.body)
+  end
+
+  test "an unmatched lookup code reports not_found" do
+    post admin_merchandise_lookups_path, params: { lookup: { raw: "no-such-code" } }
+
+    assert_response :success
+    assert_match(/Status: not_found/, response.body)
+  end
+
+  private
+
+  def sign_in_as(username)
+    delete session_path
+    follow_redirect! while response.redirect?
+    post session_path, params: { session: { username: username, password: "correct-horse-battery" } }
+    follow_redirect! if response.redirect?
+  end
+end

--- a/test/integration/phase22_product_ux_test.rb
+++ b/test/integration/phase22_product_ux_test.rb
@@ -15,8 +15,7 @@ class Phase22ProductUxTest < ActionDispatch::IntegrationTest
         merchandise_category: @category,
         list_price_cents: 1999
       },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
   end
 
@@ -56,18 +55,81 @@ class Phase22ProductUxTest < ActionDispatch::IntegrationTest
     assert_equal 2550, @product.reload.list_price_cents
   end
 
+  test "product form offers no identifier mode and records identity fields" do
+    sign_in_as("admin")
+
+    get new_admin_product_path
+    assert_response :success
+    assert_select "select#product_identifier_mode", count: 0
+    assert_select "input#product_external_identifier", count: 0
+    assert_select "input#product_industry_identifier"
+    assert_select "input#product_lookup_code"
+
+    post admin_products_path, params: {
+      product: {
+        name: "Identity Book",
+        status: "draft",
+        industry_identifier: "0-306-40615-2",
+        lookup_code: "shelf-a1"
+      }
+    }
+    assert_response :redirect
+    created = Product.find_by!(name: "Identity Book")
+    assert created.primary_identifier.start_with?("222")
+    assert_equal "9780306406157", created.industry_identifier
+    assert_equal "SHELF-A1", created.lookup_code
+    assert_equal "product_industry",
+                 IdentifierRegistry.find_by!(value: created.industry_identifier).identifier_kind
+  end
+
+  test "product detail warns that a shared lookup code will require product selection" do
+    sign_in_as("admin")
+    @product.update!(lookup_code: "SHARED")
+    other = Products::Create.call(
+      attributes: { name: "Other Book", status: "draft" },
+      actor: @actor,
+      lookup_code: "SHARED"
+    )
+
+    get admin_product_path(@product)
+    assert_response :success
+    assert_match(/SHARED/, response.body)
+    assert_match(/shared with 1 other product/, response.body)
+
+    get admin_product_path(other)
+    assert_response :success
+    assert_match(/shared with 1 other product/, response.body)
+  end
+
+  test "clearing the industry identifier retires its registry row" do
+    sign_in_as("admin")
+    Identifiers::AssignProductIndustry.call(product: @product, raw_value: external_isbn13)
+    @product.reload
+
+    patch admin_product_path(@product), params: {
+      product: {
+        name: @product.name,
+        status: "draft",
+        industry_identifier: "",
+        lock_version: @product.lock_version
+      }
+    }
+
+    assert_redirected_to admin_product_path(@product)
+    assert_nil @product.reload.industry_identifier
+    assert IdentifierRegistry.find_by!(value: external_isbn13).retired_at.present?
+  end
+
   test "variant regular price uses currency parsing" do
     sign_in_as("admin")
     tax = tax_class(code: "books")
-    dept = department(code: "new_books", default_tax_class: tax)
-    klass = merchandise_class(code: "book", pricing_method: "fixed", default_standard_department: dept)
+    dept = department(code: "new_books")
+    klass = merchandise_class(code: "book", pricing_method: "fixed", department: dept, default_tax_class: tax)
 
     post admin_product_product_variants_path(@product), params: {
       product_variant: {
         variant_type: "standard",
         merchandise_class_id: klass.id,
-        department_id: dept.id,
-        tax_class_id: tax.id,
         regular_price: "14.00",
         status: "draft"
       }

--- a/test/integration/phase22_product_ux_test.rb
+++ b/test/integration/phase22_product_ux_test.rb
@@ -139,6 +139,39 @@ class Phase22ProductUxTest < ActionDispatch::IntegrationTest
     assert_equal 1400, variant.regular_price_cents
   end
 
+  test "variant create copies class sticky defaults when margin and returnable are blank" do
+    sign_in_as("admin")
+    tax = tax_class(code: "books")
+    dept = department(code: "new_books")
+    klass = merchandise_class(
+      code: "book",
+      pricing_method: "fixed",
+      department: dept,
+      default_tax_class: tax,
+      target_margin_bps: 3_000,
+      default_supplier_returnable: true
+    )
+
+    post admin_product_product_variants_path(@product), params: {
+      product_variant: {
+        variant_type: "standard",
+        merchandise_class_id: klass.id,
+        inventory_mode: "",
+        pricing_method: "",
+        target_margin_bps: "",
+        supplier_returnable: "",
+        regular_price: "10.00",
+        status: "draft"
+      }
+    }
+    assert_response :redirect
+    variant = @product.product_variants.order(:created_at).last
+    assert_equal "inventory", variant.inventory_mode
+    assert_equal "fixed", variant.pricing_method
+    assert_equal 3_000, variant.target_margin_bps
+    assert_equal true, variant.supplier_returnable
+  end
+
   private
 
   def sign_in_as(username)

--- a/test/integration/phase2_hardening_test.rb
+++ b/test/integration/phase2_hardening_test.rb
@@ -8,16 +8,15 @@ class Phase2HardeningTest < ActionDispatch::IntegrationTest
     @actor = @bootstrap[:administrator]
     sign_in_as("admin")
     @tax = tax_class(code: "books")
-    @dept = department(code: "new_books", default_tax_class: @tax)
-    @klass = merchandise_class(code: "book", pricing_method: "fixed", default_standard_department: @dept)
+    @dept = department(code: "new_books")
+    @klass = merchandise_class(code: "book", pricing_method: "fixed", department: @dept)
     @condition = merchandise_condition(code: "new")
   end
 
-  test "cross-namespace uniqueness blocks product primary equal to variant sku" do
+  test "cross-namespace uniqueness blocks product industry identifier equal to variant sku" do
     product = Products::Create.call(
       attributes: { name: "Owner", status: "draft" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
     variant = ProductVariants::Create.call(
       product: product,
@@ -29,18 +28,17 @@ class Phase2HardeningTest < ActionDispatch::IntegrationTest
       Products::Create.call(
         attributes: { name: "Collision", status: "draft" },
         actor: @actor,
-        identifier_mode: "enter",
-        external_identifier: variant.sku
+        industry_identifier: variant.sku
       )
     end
     assert_match(/already reserved/i, error.message)
+    assert_nil Product.find_by(name: "Collision")
   end
 
   test "draft product delete leaves a retired registry tombstone" do
     product = Products::Create.call(
       attributes: { name: "Draft delete", status: "draft" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
     value = product.primary_identifier
 
@@ -57,8 +55,7 @@ class Phase2HardeningTest < ActionDispatch::IntegrationTest
   test "retired identifiers cannot be reallocated" do
     product = Products::Create.call(
       attributes: { name: "Retire", status: "draft" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
     value = product.primary_identifier
     delete admin_product_path(product)
@@ -69,9 +66,7 @@ class Phase2HardeningTest < ActionDispatch::IntegrationTest
         kind: "product_primary",
         product: Products::Create.call(
           attributes: { name: "Other", status: "draft" },
-          actor: @actor,
-          identifier_mode: "enter",
-          external_identifier: external_isbn13
+          actor: @actor
         )
       )
     end
@@ -81,8 +76,7 @@ class Phase2HardeningTest < ActionDispatch::IntegrationTest
       Products::Create.call(
         attributes: { name: "Reuse 222", status: "draft" },
         actor: @actor,
-        identifier_mode: "enter",
-        external_identifier: value
+        industry_identifier: value
       )
     end
     assert_match(/reserved 222|already reserved/i, error.message)
@@ -113,14 +107,12 @@ class Phase2HardeningTest < ActionDispatch::IntegrationTest
 
   test "inactive reference is rejected on new assignment" do
     inactive_tax = tax_class(code: "inactive_tax", active: false)
-    inactive_class = merchandise_class(code: "inactive_class", active: false, default_standard_department: @dept)
+    inactive_class = merchandise_class(code: "inactive_class", active: false, department: @dept)
     inactive_condition = merchandise_condition(code: "inactive_cond", active: false)
-    inactive_dept = department(code: "inactive_dept", default_tax_class: @tax, active: false)
 
     product = Products::Create.call(
       attributes: { name: "Refs", status: "draft" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
 
     assert_raises(ProductVariants::Create::Error) do
@@ -133,8 +125,8 @@ class Phase2HardeningTest < ActionDispatch::IntegrationTest
           merchandise_class_id: merchandise_class(
             code: "used_ok",
             used_merchandise_allowed: true,
-            default_standard_department: @dept,
-            default_used_department: @dept
+            department: @dept,
+            default_tax_class: @tax
           ).id
         }
       )
@@ -150,15 +142,24 @@ class Phase2HardeningTest < ActionDispatch::IntegrationTest
     assert_not variant.valid?
     assert_includes variant.errors[:merchandise_class_id], "must be an active merchandise class"
 
+    # A class cannot be created under an inactive department, so deactivate the
+    # department after the class exists to reach the variant activation rule.
+    deactivating_dept = department(code: "deactivating_dept")
+    dept_class = merchandise_class(
+      code: "deactivating_dept_class",
+      department: deactivating_dept,
+      default_tax_class: @tax
+    )
+    deactivating_dept.update_columns(active: false)
     variant.reload
-    variant.department = inactive_dept
+    variant.assign_attributes(merchandise_class: dept_class, status: "active")
     assert_not variant.valid?
-    assert_includes variant.errors[:department_id], "must be an active department"
+    assert_includes variant.errors[:base], "merchandise class department must be active"
 
     variant.reload
-    variant.tax_class = inactive_tax
+    variant.tax_class_override = inactive_tax
     assert_not variant.valid?
-    assert_includes variant.errors[:tax_class_id], "must be an active tax class"
+    assert_includes variant.errors[:tax_class_override_id], "must be an active tax class"
   end
 
   private

--- a/test/integration/phase2_hardening_test.rb
+++ b/test/integration/phase2_hardening_test.rb
@@ -52,6 +52,28 @@ class Phase2HardeningTest < ActionDispatch::IntegrationTest
     assert_nil row.product_id
   end
 
+  test "draft product delete retires product industry identifier" do
+    isbn = Identifiers::Ean13.complete("978", "030640615")
+    product = Products::Create.call(
+      attributes: { name: "Draft with industry", status: "draft" },
+      actor: @actor,
+      industry_identifier: isbn
+    )
+    primary = product.primary_identifier
+    industry = product.industry_identifier
+
+    delete admin_product_path(product)
+    assert_redirected_to admin_products_path
+    assert_nil Product.find_by(id: product.id)
+
+    [ primary, industry ].each do |value|
+      row = Identifiers::Registry.find_any(value)
+      assert row.present?, "expected retired registry row for #{value}"
+      assert row.retired_at.present?
+      assert_nil row.product_id
+    end
+  end
+
   test "retired identifiers cannot be reallocated" do
     product = Products::Create.call(
       attributes: { name: "Retire", status: "draft" },

--- a/test/integration/pos_mixed_return_workspace_test.rb
+++ b/test/integration/pos_mixed_return_workspace_test.rb
@@ -264,7 +264,7 @@ class PosMixedReturnWorkspaceTest < ActionDispatch::IntegrationTest
       return_price: return_price,
       expected_product_variant_id: variant.id,
       expected_reference_unit_price_cents: variant.regular_price_cents,
-      expected_tax_class_id: variant.tax_class_id
+      expected_tax_class_id: variant.effective_tax_class&.id
     }
     assert_response :success
   end

--- a/test/integration/pos_mvp_closeout_test.rb
+++ b/test/integration/pos_mvp_closeout_test.rb
@@ -82,8 +82,7 @@ class PosMvpCloseoutTest < ActionDispatch::IntegrationTest
       line_id: standard_line.id,
       action_type: "tax_class_override",
       operation: "apply",
-      reason_code: "classification_correction",
-      tax_class_id: @food.id
+      reason_code: "classification_correction"
     }
     assert_response :success
 
@@ -146,7 +145,7 @@ class PosMvpCloseoutTest < ActionDispatch::IntegrationTest
       return_price: "18.00",
       expected_product_variant_id: @variant.id,
       expected_reference_unit_price_cents: @variant.regular_price_cents,
-      expected_tax_class_id: @variant.tax_class_id
+      expected_tax_class_id: @variant.effective_tax_class&.id
     }
     assert_response :success
     working.reload

--- a/test/integration/pos_register_test.rb
+++ b/test/integration/pos_register_test.rb
@@ -664,6 +664,35 @@ class PosRegisterTest < ActionDispatch::IntegrationTest
     assert_equal 0, line.pos_controlled_actions.count
   end
 
+  test "shared lookup code returns product choices and selecting one resolves without adding" do
+    other = pos_sellable_variant(actor: @actor, tax_class: @tax, name: "Beta Shared")
+    open_quantity_stock(store: @store, variant: other, actor: @actor, quantity: 4)
+    @variant.product.update!(lookup_code: "SHARED", brand_name: "Acme")
+    other.product.update!(lookup_code: "SHARED")
+
+    post pos_register_enter_path, params: enter_params
+    follow_redirect!
+    assert_select "#pos_product_overlay[hidden]"
+    transaction = PosTransaction.working.find_by!(register: @register)
+
+    get pos_register_merchandise_resolve_path, params: { identifier: "shared" }, as: :json
+    assert_response :success
+    body = response.parsed_body
+    assert_equal "product_choice_required", body.fetch("outcome")
+    products = body.fetch("products")
+    assert_equal [ @variant.product.id, other.product.id ].sort, products.map { |row| row.fetch("id") }.sort
+    chosen = products.find { |row| row.fetch("id") == @variant.product.id }
+    assert_equal @variant.product.primary_identifier, chosen.fetch("primary_identifier")
+    assert_equal "SHARED", chosen.fetch("lookup_code")
+    assert_equal "Acme", chosen.fetch("brand_name")
+    assert_equal 0, transaction.reload.pos_transaction_lines.count
+
+    get pos_register_merchandise_resolve_path, params: { product_id: @variant.product.id }, as: :json
+    assert_response :success
+    assert_equal "addable_variant", response.parsed_body.fetch("outcome")
+    assert_equal 0, transaction.reload.pos_transaction_lines.count
+  end
+
   test "resolve and search are read-only and open-price apply does not write a price_override" do
     open_price = pos_sellable_variant(actor: @actor, tax_class: @tax, pricing_method: "open_price", name: "Open Book")
     open_quantity_stock(store: @store, variant: open_price, actor: @actor, quantity: 3)

--- a/test/integration/product_inventory_display_test.rb
+++ b/test/integration/product_inventory_display_test.rb
@@ -11,25 +11,23 @@ class ProductInventoryDisplayTest < ActionDispatch::IntegrationTest
     Inventory::AdjustmentReasons.seed!
 
     @tax = tax_class(code: "disp_tax")
-    @department = department(code: "disp_dept", default_tax_class: @tax)
+    @department = department(code: "disp_dept")
     @klass = merchandise_class(
       code: "disp_std",
-      default_standard_department: @department,
+      department: @department,
       pricing_method: "fixed"
     )
     @used_klass = merchandise_class(
       code: "disp_used",
       used_merchandise_allowed: true,
-      default_standard_department: @department,
-      default_used_department: @department,
-      pricing_method: "fixed"
+      department: @department,
+            pricing_method: "fixed"
     )
     @condition = merchandise_condition(code: "good")
 
     @product = Products::Create.call(
       attributes: { name: "Inventory Display Book", status: "active" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
     @qty_variant = ProductVariants::Create.call(
       product: @product,
@@ -37,8 +35,6 @@ class ProductInventoryDisplayTest < ActionDispatch::IntegrationTest
         variant_type: "standard",
         status: "active",
         merchandise_class_id: @klass.id,
-        department_id: @department.id,
-        tax_class_id: @tax.id,
         regular_price_cents: 1999
       },
       actor: @actor
@@ -50,8 +46,6 @@ class ProductInventoryDisplayTest < ActionDispatch::IntegrationTest
         status: "active",
         merchandise_class_id: @used_klass.id,
         merchandise_condition_id: @condition.id,
-        department_id: @department.id,
-        tax_class_id: @tax.id,
         regular_price_cents: 1200
       },
       actor: @actor

--- a/test/integration/product_reactivate_test.rb
+++ b/test/integration/product_reactivate_test.rb
@@ -8,8 +8,7 @@ class ProductReactivateTest < ActionDispatch::IntegrationTest
     @admin = @bootstrap[:administrator]
     @product = Products::Create.call(
       attributes: { name: "Discontinued Book", status: "active" },
-      actor: @admin,
-      identifier_mode: "generate"
+      actor: @admin
     )
     @product.update!(status: "discontinued")
   end

--- a/test/models/department_test.rb
+++ b/test/models/department_test.rb
@@ -4,7 +4,6 @@ require "test_helper"
 
 class DepartmentTest < ActiveSupport::TestCase
   setup do
-    @tax = tax_class(code: "books")
     @inventory = inventory_gl
     @cogs = cogs_gl
     @sales = sales_gl
@@ -14,7 +13,7 @@ class DepartmentTest < ActiveSupport::TestCase
     record = Department.new(
       code: "new_books",
       name: "New Books",
-      default_tax_class: @tax,
+      department_number: "NEW_BOOKS",
       inventory_asset_gl_account: @sales
     )
     assert_not record.valid?
@@ -28,7 +27,7 @@ class DepartmentTest < ActiveSupport::TestCase
     record = Department.new(
       code: "cafe",
       name: "Café",
-      default_tax_class: @tax,
+      department_number: "CAFE",
       inventory_asset_gl_account: inactive
     )
     assert_not record.valid?
@@ -38,7 +37,6 @@ class DepartmentTest < ActiveSupport::TestCase
   test "historical inactive GL mapping is retained when editing unrelated fields" do
     record = department(
       code: "media",
-      default_tax_class: @tax,
       inventory_asset_gl_account: @inventory,
       cost_of_goods_sold_gl_account: @cogs,
       sales_revenue_gl_account: @sales
@@ -54,7 +52,6 @@ class DepartmentTest < ActiveSupport::TestCase
   test "changing a mapping revalidates assignability" do
     record = department(
       code: "gifts",
-      default_tax_class: @tax,
       inventory_asset_gl_account: @inventory
     )
     inactive = inventory_gl(account_number: "1210")

--- a/test/models/merchandise_class_tracking_test.rb
+++ b/test/models/merchandise_class_tracking_test.rb
@@ -12,30 +12,30 @@ class MerchandiseClassTrackingTest < ActiveSupport::TestCase
     Authorization::PermissionCatalog.seed!(granted_by: @actor)
 
     @tax = tax_class(code: "cls_track_tax")
-    @department = department(code: "cls_track_dept", default_tax_class: @tax)
+    @department = department(code: "cls_track_dept")
     @opening = AdjustmentReason.find_by!(code: "opening_inventory")
   end
 
-  test "inventory to non_inventory is rejected after history" do
+  test "inventory to non_inventory is rejected on variant after history" do
     klass = merchandise_class(
       code: "cls_hist_inv",
-      default_standard_department: @department,
+      department: @department,
       pricing_method: "fixed"
     )
     variant = create_standard_variant(klass)
     post_opening(variant)
 
-    klass.inventory_mode = "non_inventory"
-    assert_not klass.valid?
-    assert_includes klass.errors[:inventory_mode],
+    variant.inventory_mode = "non_inventory"
+    assert_not variant.valid?
+    assert_includes variant.errors[:base],
                     "cannot change inventory tracking method after inventory history exists"
   end
 
-  test "non_inventory to inventory is rejected after history" do
+  test "non_inventory to inventory is rejected on variant after history" do
     klass = merchandise_class(
       code: "cls_hist_non",
       inventory_mode: "non_inventory",
-      default_standard_department: @department,
+      department: @department,
       pricing_method: "fixed"
     )
     variant = create_standard_variant(klass)
@@ -46,25 +46,25 @@ class MerchandiseClassTrackingTest < ActiveSupport::TestCase
       inventory_value_cents: 0
     )
 
-    klass.inventory_mode = "inventory"
-    assert_not klass.valid?
-    assert_includes klass.errors[:inventory_mode],
+    variant.inventory_mode = "inventory"
+    assert_not variant.valid?
+    assert_includes variant.errors[:base],
                     "cannot change inventory tracking method after inventory history exists"
   end
 
-  test "inventory_mode may change when no variant has history" do
+  test "inventory_mode may change on variant when no history exists" do
     klass = merchandise_class(
       code: "cls_no_hist",
-      default_standard_department: @department,
+      department: @department,
       pricing_method: "fixed"
     )
-    create_standard_variant(klass)
+    variant = create_standard_variant(klass)
 
-    klass.update!(inventory_mode: "non_inventory")
-    assert_equal "non_inventory", klass.reload.inventory_mode
+    variant.update!(inventory_mode: "non_inventory")
+    assert_equal "non_inventory", variant.reload.inventory_mode
 
-    klass.update!(inventory_mode: "inventory")
-    assert_equal "inventory", klass.reload.inventory_mode
+    variant.update!(inventory_mode: "inventory")
+    assert_equal "inventory", variant.reload.inventory_mode
   end
 
   private
@@ -72,8 +72,7 @@ class MerchandiseClassTrackingTest < ActiveSupport::TestCase
   def create_standard_variant(klass)
     product = Products::Create.call(
       attributes: { name: "Class tracking #{klass.code}", status: "active" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
     ProductVariants::Create.call(
       product: product,
@@ -81,8 +80,6 @@ class MerchandiseClassTrackingTest < ActiveSupport::TestCase
         variant_type: "standard",
         status: "active",
         merchandise_class_id: klass.id,
-        department_id: @department.id,
-        tax_class_id: @tax.id,
         regular_price_cents: 1999
       },
       actor: @actor

--- a/test/models/merchandise_class_tracking_test.rb
+++ b/test/models/merchandise_class_tracking_test.rb
@@ -67,6 +67,27 @@ class MerchandiseClassTrackingTest < ActiveSupport::TestCase
     assert_equal "inventory", variant.reload.inventory_mode
   end
 
+  test "merchandise class change is blocked after inventory history" do
+    other = merchandise_class(
+      code: "cls_other_dept",
+      department: department(code: "cls_other_dept_parent"),
+      pricing_method: "fixed",
+      default_tax_class: @tax
+    )
+    klass = merchandise_class(
+      code: "cls_hist_class",
+      department: @department,
+      pricing_method: "fixed"
+    )
+    variant = create_standard_variant(klass)
+    post_opening(variant)
+
+    variant.merchandise_class = other
+    assert_not variant.valid?
+    assert_includes variant.errors[:merchandise_class_id],
+                    "cannot be changed after inventory or POS history exists; a controlled reclassification is required"
+  end
+
   private
 
   def create_standard_variant(klass)

--- a/test/models/merchandise_reference_test.rb
+++ b/test/models/merchandise_reference_test.rb
@@ -5,16 +5,19 @@ require "test_helper"
 class MerchandiseReferenceTest < ActiveSupport::TestCase
   setup do
     @tax = tax_class(code: "standard")
-    @department = department(code: "books", default_tax_class: @tax)
+    @department = department(code: "books")
   end
 
   test "merchandise class code is unique" do
-    merchandise_class(code: "book", default_standard_department: @department)
+    merchandise_class(code: "book", department: @department)
     duplicate = MerchandiseClass.new(
       code: " Book ",
       name: "Other",
-      inventory_mode: "inventory",
-      pricing_method: "fixed"
+      department: @department,
+      merchandise_class_number: "2",
+      default_tax_class: @tax,
+      default_inventory_mode: "inventory",
+      default_pricing_method: "fixed"
     )
     assert_not duplicate.valid?
     assert_equal "book", duplicate.code
@@ -68,11 +71,11 @@ class MerchandiseReferenceTest < ActiveSupport::TestCase
   end
 
   test "admin labels and hierarchical category options" do
-    dept = department(code: "trade", name: "General Trade Books", department_number: "110", default_tax_class: @tax)
+    dept = department(code: "trade", name: "General Trade Books", department_number: "110")
     assert_equal "110 - General Trade Books", dept.admin_label
 
-    klass = merchandise_class(code: "book", name: "Physical book", default_standard_department: @department)
-    assert_equal "Physical book", klass.admin_label
+    klass = merchandise_class(code: "book", name: "Physical book", department: @department, merchandise_class_number: "1")
+    assert_equal "BOOKS / 1 - Physical book", klass.admin_label
 
     condition = merchandise_condition(code: "good", name: "Good")
     assert_equal "Good", condition.admin_label
@@ -92,37 +95,40 @@ class MerchandiseReferenceTest < ActiveSupport::TestCase
     assert_operator options[3].first.count("\u00A0"), :>, options[1].first.count("\u00A0")
   end
 
-  test "inventory_mode accepts inventory and non_inventory" do
-    inventory = merchandise_class(code: "book", inventory_mode: "inventory", default_standard_department: @department)
-    service = merchandise_class(code: "service", inventory_mode: "non_inventory", default_standard_department: @department)
+  test "default_inventory_mode accepts inventory and non_inventory" do
+    inventory = merchandise_class(code: "book", inventory_mode: "inventory", department: @department)
+    service = merchandise_class(code: "service", inventory_mode: "non_inventory", department: @department)
 
     assert inventory.inventory?
     assert service.non_inventory?
     invalid = MerchandiseClass.new(
       code: "bad",
       name: "Bad",
-      inventory_mode: "quantity",
-      pricing_method: "fixed"
+      department: @department,
+      merchandise_class_number: "9",
+      default_tax_class: @tax,
+      default_inventory_mode: "quantity",
+      default_pricing_method: "fixed"
     )
     assert_not invalid.valid?
-    assert_includes invalid.errors[:inventory_mode], "is not included in the list"
+    assert_includes invalid.errors[:default_inventory_mode], "is not included in the list"
   end
 
   test "buyback requires used merchandise and inventory mode" do
-    klass = merchandise_class(code: "gift_card", inventory_mode: "non_inventory", default_standard_department: @department)
+    klass = merchandise_class(code: "gift_card", inventory_mode: "non_inventory", department: @department)
     klass.buyback_allowed = true
     assert_not klass.valid?
     assert_includes klass.errors[:buyback_allowed], "requires used merchandise allowed and inventory mode"
   end
 
   test "default_supplier_returnable is the returnability column" do
-    klass = merchandise_class(code: "book", default_standard_department: @department)
+    klass = merchandise_class(code: "book", department: @department)
     assert klass.respond_to?(:default_supplier_returnable)
     assert_not klass.respond_to?(:default_returnable)
   end
 
   test "codes are immutable after create" do
-    klass = merchandise_class(code: "immutable", default_standard_department: @department)
+    klass = merchandise_class(code: "immutable", department: @department)
     klass.code = "changed"
     assert_not klass.valid?
     assert_includes klass.errors[:code], "cannot be changed after creation"
@@ -131,9 +137,11 @@ class MerchandiseReferenceTest < ActiveSupport::TestCase
   test "blank code generates from name" do
     klass = MerchandiseClass.create!(
       name: "Used Books & Media",
-      inventory_mode: "inventory",
-      pricing_method: "fixed",
-      default_standard_department: @department
+      department: @department,
+      merchandise_class_number: "3",
+      default_tax_class: @tax,
+      default_inventory_mode: "inventory",
+      default_pricing_method: "fixed"
     )
     assert_equal "used_books_media", klass.code
   end

--- a/test/models/product_identity_test.rb
+++ b/test/models/product_identity_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ProductIdentityTest < ActiveSupport::TestCase
+  setup do
+    @actor = actor_user
+    @product = Products::Create.call(
+      attributes: { name: "Identity Product", status: "draft" },
+      actor: @actor
+    )
+  end
+
+  test "lookup code is trimmed, uppercased, and nullable when blank" do
+    @product.update!(lookup_code: "  shelf-a1  ")
+    assert_equal "SHELF-A1", @product.reload.lookup_code
+
+    @product.update!(lookup_code: "   ")
+    assert_nil @product.reload.lookup_code
+  end
+
+  test "lookup code rejects unsupported characters and excess length" do
+    @product.lookup_code = "SHELF A1"
+    assert_not @product.valid?
+    assert @product.errors[:lookup_code].any?
+
+    @product.lookup_code = "A" * 65
+    assert_not @product.valid?
+    assert @product.errors[:lookup_code].any?
+  end
+
+  test "the database rejects a noncanonical stored lookup code" do
+    assert_raises(ActiveRecord::StatementInvalid) do
+      @product.update_columns(lookup_code: "lowercase")
+    end
+  end
+
+  test "two products may share a lookup code" do
+    other = Products::Create.call(
+      attributes: { name: "Shared", status: "draft" },
+      actor: @actor
+    )
+    @product.update!(lookup_code: "SHARED")
+    other.update!(lookup_code: "SHARED")
+
+    assert_equal 2, Product.where(lookup_code: "SHARED").count
+  end
+
+  test "industry identifier must be unique and shaped like a GTIN" do
+    other = Products::Create.call(
+      attributes: { name: "Industry Owner", status: "draft" },
+      actor: @actor,
+      industry_identifier: external_isbn13
+    )
+
+    @product.identifier_writes_enabled = true
+    @product.industry_identifier = other.industry_identifier
+    assert_not @product.valid?
+    assert @product.errors[:industry_identifier].any?
+
+    @product.identifier_writes_enabled = true
+    @product.industry_identifier = "97812345"
+    assert_not @product.valid?
+    assert @product.errors[:industry_identifier].any?
+  end
+
+  test "industry identifier cannot be written outside the registry-aware service" do
+    @product.industry_identifier = external_isbn13
+    assert_not @product.valid?
+    assert_includes @product.errors[:industry_identifier],
+                    "must be changed through Identifiers::AssignProductIndustry"
+  end
+
+  test "primary identifier remains immutable" do
+    @product.primary_identifier = shelfsense_222("000000009")
+    assert_not @product.valid?
+    assert_includes @product.errors[:primary_identifier], "cannot be changed"
+  end
+end

--- a/test/services/identifiers/assign_industry_test.rb
+++ b/test/services/identifiers/assign_industry_test.rb
@@ -7,8 +7,7 @@ class Identifiers::AssignIndustryTest < ActiveSupport::TestCase
     @actor = actor_user
     @product = Products::Create.call(
       attributes: { name: "Industry product", status: "draft" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
     @variant = ProductVariants::Create.call(
       product: @product,

--- a/test/services/identifiers/assign_product_industry_test.rb
+++ b/test/services/identifiers/assign_product_industry_test.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Identifiers::AssignProductIndustryTest < ActiveSupport::TestCase
+  setup do
+    @actor = actor_user
+    @product = Products::Create.call(
+      attributes: { name: "Product industry", status: "draft" },
+      actor: @actor
+    )
+    @industry = unique_industry_identifier
+    @replacement = unique_industry_identifier
+  end
+
+  test "assigns the product industry identifier through the registry" do
+    Identifiers::AssignProductIndustry.call(product: @product, raw_value: @industry)
+
+    assert_equal @industry, @product.reload.industry_identifier
+    row = IdentifierRegistry.find_by!(value: @industry)
+    assert_equal "product_industry", row.identifier_kind
+    assert_equal @product.id, row.product_id
+    assert_nil row.product_variant_id
+    assert_nil row.retired_at
+  end
+
+  test "replaces the identifier and retires the previous registry row" do
+    Identifiers::AssignProductIndustry.call(product: @product, raw_value: @industry)
+    Identifiers::AssignProductIndustry.call(product: @product, raw_value: @replacement)
+
+    assert_equal @replacement, @product.reload.industry_identifier
+    assert IdentifierRegistry.find_by!(value: @industry).retired_at.present?
+    assert_nil IdentifierRegistry.find_by!(value: @replacement).retired_at
+  end
+
+  test "clears the identifier and retires the registry row" do
+    Identifiers::AssignProductIndustry.call(product: @product, raw_value: @industry)
+    Identifiers::AssignProductIndustry.call(product: @product, raw_value: nil)
+
+    assert_nil @product.reload.industry_identifier
+    assert IdentifierRegistry.find_by!(value: @industry).retired_at.present?
+  end
+
+  test "rejects the reserved 222 namespace" do
+    error = assert_raises(Identifiers::AssignProductIndustry::Error) do
+      Identifiers::AssignProductIndustry.call(product: @product, raw_value: shelfsense_222("000000123"))
+    end
+
+    assert_match(/reserved 222/i, error.message)
+    assert_nil @product.reload.industry_identifier
+  end
+
+  test "rejects a value already reserved for another owner" do
+    variant = ProductVariants::Create.call(
+      product: @product,
+      actor: @actor,
+      attributes: { variant_type: "standard", status: "draft", industry_identifier: @industry }
+    )
+
+    other = Products::Create.call(
+      attributes: { name: "Collides", status: "draft" },
+      actor: @actor
+    )
+    error = assert_raises(Identifiers::AssignProductIndustry::Error) do
+      Identifiers::AssignProductIndustry.call(product: other, raw_value: @industry)
+    end
+
+    assert_match(/already reserved/i, error.message)
+    assert_nil other.reload.industry_identifier
+    assert_equal @industry, variant.reload.industry_identifier
+  end
+
+  test "products update routes industry changes through the registry-aware service" do
+    Products::Update.call(
+      product: @product,
+      actor: @actor,
+      attributes: { industry_identifier: @industry, lock_version: @product.lock_version }
+    )
+    Products::Update.call(
+      product: @product.reload,
+      actor: @actor,
+      attributes: {
+        industry_identifier: @replacement,
+        lookup_code: "shelf-b2",
+        name: "Renamed",
+        lock_version: @product.lock_version
+      }
+    )
+
+    @product.reload
+    assert_equal @replacement, @product.industry_identifier
+    assert_equal "SHELF-B2", @product.lookup_code
+    assert_equal "Renamed", @product.name
+    assert IdentifierRegistry.find_by!(value: @industry).retired_at.present?
+  end
+
+  test "a stale lock_version rejects the change and rolls back the registry" do
+    Identifiers::AssignProductIndustry.call(product: @product, raw_value: @industry)
+    @product.reload
+    stale = @product.lock_version
+    @product.update!(name: "Concurrent edit")
+
+    assert_raises(ActiveRecord::StaleObjectError) do
+      Products::Update.call(
+        product: Product.find(@product.id),
+        actor: @actor,
+        attributes: { industry_identifier: @replacement, lock_version: stale }
+      )
+    end
+
+    @product.reload
+    assert_equal @industry, @product.industry_identifier
+    assert_nil IdentifierRegistry.find_by(value: @replacement)
+    assert_nil IdentifierRegistry.find_by!(value: @industry).retired_at
+  end
+
+  private
+
+  def unique_industry_identifier
+    20.times do
+      value = Identifiers::Ean13.complete("978", format("%09d", SecureRandom.random_number(1_000_000_000)))
+      next if IdentifierRegistry.exists?(value: value)
+      next if Product.exists?(industry_identifier: value)
+      next if ProductVariant.exists?(industry_identifier: value)
+
+      return value
+    end
+    raise "unable to allocate unique industry identifier for test"
+  end
+end

--- a/test/services/identifiers/generator_and_registry_test.rb
+++ b/test/services/identifiers/generator_and_registry_test.rb
@@ -20,8 +20,7 @@ class Identifiers::GeneratorAndRegistryTest < ActiveSupport::TestCase
   test "reserve raises on conflict" do
     product = Products::Create.call(
       attributes: { name: "Reserved", status: "draft" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
 
     error = assert_raises(Identifiers::Registry::ConflictError) do
@@ -37,8 +36,7 @@ class Identifiers::GeneratorAndRegistryTest < ActiveSupport::TestCase
   test "retire marks registry row inactive while retaining the value" do
     product = Products::Create.call(
       attributes: { name: "Retire me", status: "draft" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
     value = product.primary_identifier
 
@@ -62,8 +60,7 @@ class Identifiers::GeneratorAndRegistryTest < ActiveSupport::TestCase
   test "active variant_sku rejects product ownership" do
     product = Products::Create.call(
       attributes: { name: "Owner mismatch", status: "draft" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
     row = IdentifierRegistry.new(
       value: Identifiers::Ean13.complete("221", "333333333"),
@@ -79,8 +76,7 @@ class Identifiers::GeneratorAndRegistryTest < ActiveSupport::TestCase
   test "database enforces kind-specific registry ownership" do
     product = Products::Create.call(
       attributes: { name: "DB owner", status: "draft" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
 
     assert_raises(ActiveRecord::StatementInvalid) do
@@ -100,8 +96,7 @@ class Identifiers::GeneratorAndRegistryTest < ActiveSupport::TestCase
   test "retired registry rows may not have two owners" do
     product = Products::Create.call(
       attributes: { name: "Dual owner", status: "draft" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
     variant = ProductVariants::Create.call(
       product: product,
@@ -144,8 +139,7 @@ class Identifiers::GeneratorAndRegistryTest < ActiveSupport::TestCase
 
     product = Products::Create.call(
       attributes: { name: "Guarded", status: "draft" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
     assert_raises(ActiveRecord::RecordInvalid) do
       product.update!(primary_identifier: Identifiers::Ean13.complete("978", "888888888"))
@@ -177,8 +171,7 @@ class Identifiers::GeneratorAndRegistryTest < ActiveSupport::TestCase
         Products::Create.call(
           attributes: { name: "Rollback", status: "draft" },
           actor: @actor,
-          identifier_mode: "enter",
-          external_identifier: external
+          industry_identifier: external
         )
       end
     ensure

--- a/test/services/identifiers/lookup_test.rb
+++ b/test/services/identifiers/lookup_test.rb
@@ -6,25 +6,25 @@ class Identifiers::LookupTest < ActiveSupport::TestCase
   setup do
     @actor = actor_user
     @tax = tax_class(code: "books")
-    @dept = department(code: "new_books", default_tax_class: @tax)
+    @dept = department(code: "new_books")
     @klass = merchandise_class(
       code: "book",
       pricing_method: "fixed",
-      default_standard_department: @dept
+      department: @dept,
+      default_tax_class: @tax
     )
     @used_klass = merchandise_class(
       code: "used_book",
       pricing_method: "fixed",
       used_merchandise_allowed: true,
-      default_standard_department: @dept,
-      default_used_department: @dept
+      department: @dept,
+      default_tax_class: @tax
     )
     @like_new = merchandise_condition(code: "like_new", price_adjustment_bps: 6_000)
     @product = Products::Create.call(
       attributes: { name: "Lookup Product", status: "active" },
       actor: @actor,
-      identifier_mode: "enter",
-      external_identifier: external_isbn13
+      industry_identifier: external_isbn13
     )
   end
 
@@ -37,43 +37,133 @@ class Identifiers::LookupTest < ActiveSupport::TestCase
     assert_equal @product.id, result.product.id
   end
 
-  test "resolves product when no sellable variants exist" do
+  test "resolves the product for a 222 primary identifier without any variants" do
     result = Identifiers::Lookup.call(@product.primary_identifier)
 
     assert_equal :product, result.status
     assert_equal @product.id, result.product.id
     assert_nil result.variant
+    assert_empty result.variants
   end
 
-  test "resolves multi_variant when multiple sellable variants exist" do
+  test "product industry identifier enters the same product path as the 222 primary" do
+    variant = create_sellable_standard!(name: "Industry variant")
+    result = Identifiers::Lookup.call(@product.industry_identifier)
+
+    assert_equal :product, result.status
+    assert_equal @product.id, result.product.id
+    assert_equal [ variant.id ], result.variants.map(&:id)
+  end
+
+  test "matching does not filter variants by POS sellability" do
+    sellable = create_sellable_standard!(name: "Sellable")
+    draft = ProductVariants::Create.call(
+      product: @product,
+      actor: @actor,
+      attributes: { variant_type: "standard", name: "Draft", merchandise_class_id: @klass.id }
+    )
+    assert_not draft.sellable?
+
+    result = Identifiers::Lookup.call(@product.primary_identifier)
+
+    assert_equal :product, result.status
+    assert_equal [ draft.id, sellable.id ].sort, result.variants.map(&:id).sort
+  end
+
+  test "returns all variants for a product identifier with several variants" do
     first = create_sellable_standard!(name: "First")
     second = create_sellable_used!(name: "Second")
     result = Identifiers::Lookup.call(@product.primary_identifier)
 
-    assert_equal :multi_variant, result.status
+    assert_equal :product, result.status
     assert_equal @product.id, result.product.id
     assert_equal [ first.id, second.id ].sort, result.variants.map(&:id).sort
   end
 
-  test "returns not_found for unknown identifier" do
+  test "returns not_found for an unknown identifier with no lookup-code match" do
     unknown = Identifiers::Ean13.complete("978", "999999999")
     result = Identifiers::Lookup.call(unknown)
 
     assert_equal :not_found, result.status
   end
 
-  test "returns retired for tombstoned identifier" do
+  test "returns retired for a tombstoned identifier" do
     Identifiers::Registry.retire!(value: @product.primary_identifier)
     result = Identifiers::Lookup.call(@product.primary_identifier)
 
     assert_equal :retired, result.status
   end
 
-  test "returns invalid for bad input" do
-    result = Identifiers::Lookup.call("not-an-identifier")
+  test "a retired registry row does not fall through to a matching lookup code" do
+    @product.update_columns(lookup_code: @product.primary_identifier)
+    Identifiers::Registry.retire!(value: @product.primary_identifier)
+
+    result = Identifiers::Lookup.call(@product.primary_identifier)
+
+    assert_equal :retired, result.status
+    assert_nil result.product
+  end
+
+  test "returns invalid for input that is neither a GTIN nor a lookup code" do
+    result = Identifiers::Lookup.call("not an identifier")
 
     assert_equal :invalid, result.status
-    assert_match(/13 digits|blank|check digit/i, result.message)
+  end
+
+  test "returns invalid for blank input" do
+    assert_equal :invalid, Identifiers::Lookup.call("  ").status
+  end
+
+  test "a unique lookup code resolves to that product" do
+    @product.update!(lookup_code: "SHELF-A1")
+
+    result = Identifiers::Lookup.call("shelf-a1")
+
+    assert_equal :product, result.status
+    assert_equal @product.id, result.product.id
+  end
+
+  test "a shared lookup code returns multiple_products deterministically" do
+    @product.update!(lookup_code: "SHARED")
+    other = Products::Create.call(
+      attributes: { name: "Another Lookup Product", status: "active" },
+      actor: @actor,
+      lookup_code: "SHARED"
+    )
+
+    result = Identifiers::Lookup.call("shared")
+
+    assert_equal :multiple_products, result.status
+    assert_equal [ other.id, @product.id ], result.products.map(&:id)
+    assert_nil result.product
+  end
+
+  test "an active registry row wins over an identical lookup code on another product" do
+    other = Products::Create.call(
+      attributes: { name: "Lookup Code Twin", status: "active" },
+      actor: @actor,
+      lookup_code: @product.primary_identifier
+    )
+
+    result = Identifiers::Lookup.call(@product.primary_identifier)
+
+    assert_equal :product, result.status
+    assert_equal @product.id, result.product.id
+    assert_not_equal other.id, result.product.id
+  end
+
+  test "a valid GTIN with no registry row may still match a lookup code" do
+    unregistered = Identifiers::Ean13.complete("978", "444444444")
+    other = Products::Create.call(
+      attributes: { name: "GTIN Lookup Code", status: "active" },
+      actor: @actor,
+      lookup_code: unregistered
+    )
+
+    result = Identifiers::Lookup.call(unregistered)
+
+    assert_equal :product, result.status
+    assert_equal other.id, result.product.id
   end
 
   test "resolves inventory unit without treating the used variant sku as a unit" do
@@ -113,8 +203,6 @@ class Identifiers::LookupTest < ActiveSupport::TestCase
         variant_type: "standard",
         name: name,
         merchandise_class_id: @klass.id,
-        department_id: @dept.id,
-        tax_class_id: @tax.id,
         regular_price_cents: 1_500,
         status: "active"
       }
@@ -130,8 +218,6 @@ class Identifiers::LookupTest < ActiveSupport::TestCase
         name: name,
         merchandise_condition_id: @like_new.id,
         merchandise_class_id: @used_klass.id,
-        department_id: @dept.id,
-        tax_class_id: @tax.id,
         regular_price_cents: 1_200,
         status: "active"
       }

--- a/test/services/inventory/admin_index_query_test.rb
+++ b/test/services/inventory/admin_index_query_test.rb
@@ -12,26 +12,24 @@ class Inventory::AdminIndexQueryTest < ActiveSupport::TestCase
     Authorization::PermissionCatalog.seed!(granted_by: @actor)
 
     @tax = tax_class(code: "idx_tax")
-    @department = department(code: "idx_dept", default_tax_class: @tax)
+    @department = department(code: "idx_dept")
     @qty_class = merchandise_class(
       code: "idx_qty",
-      default_standard_department: @department,
+      department: @department,
       pricing_method: "fixed"
     )
     @used_class = merchandise_class(
       code: "idx_used",
       used_merchandise_allowed: true,
-      default_standard_department: @department,
-      default_used_department: @department,
-      pricing_method: "fixed"
+      department: @department,
+            pricing_method: "fixed"
     )
     @condition = merchandise_condition(code: "idx_good")
     @opening = AdjustmentReason.find_by!(code: "opening_inventory")
 
     @product = Products::Create.call(
       attributes: { name: "Index Widget", status: "active" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
     @qty_variant = ProductVariants::Create.call(
       product: @product,
@@ -39,8 +37,6 @@ class Inventory::AdminIndexQueryTest < ActiveSupport::TestCase
         variant_type: "standard",
         status: "active",
         merchandise_class_id: @qty_class.id,
-        department_id: @department.id,
-        tax_class_id: @tax.id,
         regular_price_cents: 1999
       },
       actor: @actor
@@ -52,8 +48,6 @@ class Inventory::AdminIndexQueryTest < ActiveSupport::TestCase
         status: "active",
         merchandise_class_id: @used_class.id,
         merchandise_condition_id: @condition.id,
-        department_id: @department.id,
-        tax_class_id: @tax.id,
         regular_price_cents: 1200
       },
       actor: @actor

--- a/test/services/inventory/concurrency_test.rb
+++ b/test/services/inventory/concurrency_test.rb
@@ -17,16 +17,15 @@ class Inventory::ConcurrencyTest < ActiveSupport::TestCase
     @opening = AdjustmentReason.find_by!(code: "opening_inventory")
     @suffix = SecureRandom.hex(4)
     @tax = tax_class(code: "c_#{@suffix}")
-    @department = department(code: "c_#{@suffix}", default_tax_class: @tax)
+    @department = department(code: "c_#{@suffix}")
     @klass = merchandise_class(
       code: "c_#{@suffix}",
-      default_standard_department: @department,
+      department: @department,
       pricing_method: "fixed"
     )
     @product = Products::Create.call(
       attributes: { name: "Concurrency #{@suffix}", status: "active" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
     @variant = ProductVariants::Create.call(
       product: @product,
@@ -34,8 +33,6 @@ class Inventory::ConcurrencyTest < ActiveSupport::TestCase
         variant_type: "standard",
         status: "active",
         merchandise_class_id: @klass.id,
-        department_id: @department.id,
-        tax_class_id: @tax.id,
         regular_price_cents: 1999
       },
       actor: @actor

--- a/test/services/inventory/post_adjustment_test.rb
+++ b/test/services/inventory/post_adjustment_test.rb
@@ -12,16 +12,15 @@ class InventoryPostAdjustmentTest < ActiveSupport::TestCase
     Authorization::PermissionCatalog.seed!(granted_by: @actor)
 
     @tax = tax_class(code: "inv_tax")
-    @department = department(code: "inv_dept", default_tax_class: @tax)
+    @department = department(code: "inv_dept")
     @klass = merchandise_class(
       code: "inv_std",
-      default_standard_department: @department,
+      department: @department,
       pricing_method: "fixed"
     )
     @product = Products::Create.call(
       attributes: { name: "Widget", status: "active" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
     @variant = ProductVariants::Create.call(
       product: @product,
@@ -29,8 +28,6 @@ class InventoryPostAdjustmentTest < ActiveSupport::TestCase
         variant_type: "standard",
         status: "active",
         merchandise_class_id: @klass.id,
-        department_id: @department.id,
-        tax_class_id: @tax.id,
         regular_price_cents: 1999
       },
       actor: @actor
@@ -130,9 +127,8 @@ class InventoryPostAdjustmentTest < ActiveSupport::TestCase
     used_klass = merchandise_class(
       code: "inv_used",
       used_merchandise_allowed: true,
-      default_standard_department: @department,
-      default_used_department: @department,
-      pricing_method: "fixed"
+      department: @department,
+            pricing_method: "fixed"
     )
     condition = merchandise_condition(code: "good")
     used = ProductVariants::Create.call(
@@ -142,8 +138,6 @@ class InventoryPostAdjustmentTest < ActiveSupport::TestCase
         status: "active",
         merchandise_class_id: used_klass.id,
         merchandise_condition_id: condition.id,
-        department_id: @department.id,
-        tax_class_id: @tax.id,
         regular_price_cents: 1200
       },
       actor: @actor
@@ -185,9 +179,8 @@ class InventoryPostAdjustmentTest < ActiveSupport::TestCase
     used_klass = merchandise_class(
       code: "inv_used_miss",
       used_merchandise_allowed: true,
-      default_standard_department: @department,
-      default_used_department: @department,
-      pricing_method: "fixed"
+      department: @department,
+            pricing_method: "fixed"
     )
     condition = merchandise_condition(code: "good")
     used = ProductVariants::Create.call(
@@ -197,8 +190,6 @@ class InventoryPostAdjustmentTest < ActiveSupport::TestCase
         status: "active",
         merchandise_class_id: used_klass.id,
         merchandise_condition_id: condition.id,
-        department_id: @department.id,
-        tax_class_id: @tax.id,
         regular_price_cents: 1200
       },
       actor: @actor
@@ -454,9 +445,8 @@ class InventoryPostAdjustmentTest < ActiveSupport::TestCase
     used_klass = merchandise_class(
       code: class_code,
       used_merchandise_allowed: true,
-      default_standard_department: @department,
-      default_used_department: @department,
-      pricing_method: "fixed"
+      department: @department,
+            pricing_method: "fixed"
     )
     condition = MerchandiseCondition.find_by(code: "good") || merchandise_condition(code: "good")
     ProductVariants::Create.call(
@@ -466,8 +456,6 @@ class InventoryPostAdjustmentTest < ActiveSupport::TestCase
         status: "active",
         merchandise_class_id: used_klass.id,
         merchandise_condition_id: condition.id,
-        department_id: @department.id,
-        tax_class_id: @tax.id,
         regular_price_cents: 1200
       },
       actor: @actor

--- a/test/services/inventory/rebuild_projection_test.rb
+++ b/test/services/inventory/rebuild_projection_test.rb
@@ -12,16 +12,15 @@ class Inventory::RebuildProjectionTest < ActiveSupport::TestCase
     Authorization::PermissionCatalog.seed!(granted_by: @actor)
 
     @tax = tax_class(code: "reb_tax")
-    @department = department(code: "reb_dept", default_tax_class: @tax)
+    @department = department(code: "reb_dept")
     @klass = merchandise_class(
       code: "reb_std",
-      default_standard_department: @department,
+      department: @department,
       pricing_method: "fixed"
     )
     @product = Products::Create.call(
       attributes: { name: "Rebuild Widget", status: "active" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
     @variant = ProductVariants::Create.call(
       product: @product,
@@ -29,8 +28,6 @@ class Inventory::RebuildProjectionTest < ActiveSupport::TestCase
         variant_type: "standard",
         status: "active",
         merchandise_class_id: @klass.id,
-        department_id: @department.id,
-        tax_class_id: @tax.id,
         regular_price_cents: 1999
       },
       actor: @actor

--- a/test/services/merchandise/csv_importer_test.rb
+++ b/test/services/merchandise/csv_importer_test.rb
@@ -7,41 +7,23 @@ class Merchandise::CsvImporterTest < ActiveSupport::TestCase
   setup do
     @actor = actor_user
     @tax = tax_class(code: "books")
-    @dept = department(code: "new_books", default_tax_class: @tax)
-    @klass = merchandise_class(code: "book", pricing_method: "fixed", default_standard_department: @dept)
+    @override_tax = tax_class(code: "override_tax")
+    @dept = department(code: "new_books")
+    @klass = merchandise_class(code: "book", pricing_method: "fixed", department: @dept, default_tax_class: @tax)
     @used_klass = merchandise_class(
       code: "used_book",
       pricing_method: "fixed",
       used_merchandise_allowed: true,
-      default_standard_department: @dept,
-      default_used_department: @dept
+      department: @dept,
+      default_tax_class: @tax
     )
     @condition = merchandise_condition(code: "like_new")
   end
 
-  test "matches product by normalized primary_identifier" do
-    existing = Products::Create.call(
-      attributes: { name: "Original", status: "draft" },
-      actor: @actor,
-      identifier_mode: "enter",
-      external_identifier: external_isbn13
-    )
-
+  test "rows without a product key always create a generated 222 product" do
     result = import_csv(<<~CSV)
-      primary_identifier,name,generate_primary_identifier
-      978-123456789-#{Identifiers::Ean13.check_digit("978123456789")},Renamed,false
-    CSV
-
-    assert_equal 0, result.created_products
-    assert_equal 1, result.updated_products
-    assert_empty result.errors
-    assert_equal "Renamed", existing.reload.name
-  end
-
-  test "generate path creates a 222 product" do
-    result = import_csv(<<~CSV)
-      primary_identifier,name,generate_primary_identifier
-      ,Generated Import,true
+      name
+      Generated Import
     CSV
 
     assert_equal 1, result.created_products
@@ -50,16 +32,28 @@ class Merchandise::CsvImporterTest < ActiveSupport::TestCase
     assert_match(/\A222\d{10}\z/, product.primary_identifier)
   end
 
+  test "import cannot assign a primary identifier" do
+    unknown = Identifiers::Ean13.complete("978", "123456789")
+
+    result = import_csv(<<~CSV)
+      product_primary_identifier,name
+      #{unknown},Should Fail
+    CSV
+
+    assert_equal 1, result.errors.size
+    assert_match(/unknown product_primary_identifier/i, result.errors.first[:message])
+    assert_nil Product.find_by(primary_identifier: unknown)
+  end
+
   test "re-import by assigned 222 updates the existing product" do
     product = Products::Create.call(
       attributes: { name: "Generated", status: "draft" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
 
     result = import_csv(<<~CSV)
-      primary_identifier,name,generate_primary_identifier
-      #{product.primary_identifier},Updated Generated,false
+      product_primary_identifier,name
+      #{product.primary_identifier},Updated Generated
     CSV
 
     assert_equal 0, result.created_products
@@ -68,11 +62,85 @@ class Merchandise::CsvImporterTest < ActiveSupport::TestCase
     assert_equal "Updated Generated", product.reload.name
   end
 
+  test "product industry identifier creates then updates the same product" do
+    isbn10 = "0306406152"
+    normalized = Identifiers::Ean13.complete("978", "030640615")
+
+    created = import_csv(<<~CSV)
+      product_industry_identifier,name
+      #{isbn10},Industry Book
+    CSV
+    assert_empty created.errors
+    assert_equal 1, created.created_products
+    product = Product.find_by!(industry_identifier: normalized)
+    assert_equal "product_industry", Identifiers::Registry.find_active(normalized).identifier_kind
+
+    updated = import_csv(<<~CSV)
+      product_industry_identifier,name
+      #{normalized},Industry Book Renamed
+    CSV
+    assert_empty updated.errors
+    assert_equal 1, updated.updated_products
+    assert_equal "Industry Book Renamed", product.reload.name
+  end
+
+  test "lookup code locates one product and stores uppercase" do
+    result = import_csv(<<~CSV)
+      product_lookup_code,name
+      shelf-a1,Lookup Book
+    CSV
+    assert_empty result.errors
+    product = Product.find_by!(lookup_code: "SHELF-A1")
+
+    again = import_csv(<<~CSV)
+      product_lookup_code,name
+      SHELF-A1,Lookup Book Renamed
+    CSV
+    assert_empty again.errors
+    assert_equal 1, again.updated_products
+    assert_equal "Lookup Book Renamed", product.reload.name
+  end
+
+  test "a lookup code matching several products fails the group" do
+    Products::Create.call(attributes: { name: "Shared One", status: "draft" }, actor: @actor, lookup_code: "SHARED")
+    Products::Create.call(attributes: { name: "Shared Two", status: "draft" }, actor: @actor, lookup_code: "SHARED")
+
+    result = import_csv(<<~CSV)
+      product_lookup_code,name
+      SHARED,Ambiguous
+    CSV
+
+    assert_equal 1, result.errors.size
+    assert_match(/matches 2 products/i, result.errors.first[:message])
+    assert_nil Product.find_by(name: "Ambiguous")
+  end
+
+  test "blank identity cells leave the industry identifier and lookup code untouched" do
+    industry = Identifiers::Ean13.complete("978", "030640615")
+    product = Products::Create.call(
+      attributes: { name: "Keeps Identity", status: "draft" },
+      actor: @actor,
+      industry_identifier: industry,
+      lookup_code: "KEEP-1"
+    )
+
+    result = import_csv(<<~CSV)
+      product_primary_identifier,product_industry_identifier,product_lookup_code,name
+      #{product.primary_identifier},,,Renamed Only
+    CSV
+
+    assert_empty result.errors
+    product.reload
+    assert_equal "Renamed Only", product.name
+    assert_equal industry, product.industry_identifier
+    assert_equal "KEEP-1", product.lookup_code
+    assert_nil Identifiers::Registry.find_active(industry).retired_at
+  end
+
   test "matches variant by sku or industry identifier" do
     product = Products::Create.call(
       attributes: { name: "With variants", status: "draft" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
     industry = Identifiers::Ean13.complete("978", "555555555")
     variant = ProductVariants::Create.call(
@@ -86,15 +154,15 @@ class Merchandise::CsvImporterTest < ActiveSupport::TestCase
     )
 
     by_sku = import_csv(<<~CSV)
-      primary_identifier,name,generate_primary_identifier,sku,variant_name
-      #{product.primary_identifier},With variants,false,#{variant.sku},By SKU
+      product_primary_identifier,name,sku,variant_name
+      #{product.primary_identifier},With variants,#{variant.sku},By SKU
     CSV
     assert_equal 1, by_sku.updated_variants
     assert_equal "By SKU", variant.reload.name
 
     by_industry = import_csv(<<~CSV)
-      primary_identifier,name,generate_primary_identifier,industry_identifier,variant_name
-      #{product.primary_identifier},With variants,false,#{industry},By Industry
+      product_primary_identifier,name,industry_identifier,variant_name
+      #{product.primary_identifier},With variants,#{industry},By Industry
     CSV
     assert_equal 1, by_industry.updated_variants
     assert_equal "By Industry", variant.reload.name
@@ -103,14 +171,13 @@ class Merchandise::CsvImporterTest < ActiveSupport::TestCase
   test "insufficient identity error when variant fields lack type and match keys" do
     product = Products::Create.call(
       attributes: { name: "Identity", status: "draft" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
     unknown_industry = Identifiers::Ean13.complete("978", "777777777")
 
     result = import_csv(<<~CSV)
-      primary_identifier,name,generate_primary_identifier,industry_identifier,variant_name
-      #{product.primary_identifier},Identity,false,#{unknown_industry},Orphan
+      product_primary_identifier,name,industry_identifier,variant_name
+      #{product.primary_identifier},Identity,#{unknown_industry},Orphan
     CSV
 
     assert_equal 1, result.errors.size
@@ -120,14 +187,13 @@ class Merchandise::CsvImporterTest < ActiveSupport::TestCase
   test "rejects assigning caller SKU to new variant" do
     product = Products::Create.call(
       attributes: { name: "Caller SKU", status: "draft" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
     fake_sku = Identifiers::Ean13.complete("221", "888888888")
 
     result = import_csv(<<~CSV)
-      primary_identifier,name,generate_primary_identifier,sku,variant_type,variant_name
-      #{product.primary_identifier},Caller SKU,false,#{fake_sku},standard,Should Fail
+      product_primary_identifier,name,sku,variant_type,variant_name
+      #{product.primary_identifier},Caller SKU,#{fake_sku},standard,Should Fail
     CSV
 
     assert_equal 1, result.errors.size
@@ -138,13 +204,12 @@ class Merchandise::CsvImporterTest < ActiveSupport::TestCase
   test "creates used variant with condition and standard without" do
     product = Products::Create.call(
       attributes: { name: "Typed", status: "draft" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
 
     result = import_csv(<<~CSV)
-      primary_identifier,name,generate_primary_identifier,variant_type,variant_condition_code,merchandise_class_code,regular_price_cents
-      #{product.primary_identifier},Typed,false,used,like_new,used_book,1200
+      product_primary_identifier,name,variant_type,variant_condition_code,merchandise_class_code,regular_price_cents
+      #{product.primary_identifier},Typed,used,like_new,used_book,1200
     CSV
     assert_empty result.errors
     assert_equal 1, result.created_variants
@@ -153,34 +218,71 @@ class Merchandise::CsvImporterTest < ActiveSupport::TestCase
     assert_equal @condition.id, used.merchandise_condition_id
   end
 
-  test "rolls back the product group when a later variant row fails" do
-    isbn = Identifiers::Ean13.complete("978", "333333333")
-    before_products = Product.count
+  test "copies explicit operational values and keeps an explicit false supplier returnable" do
+    product = Products::Create.call(
+      attributes: { name: "Ops", status: "draft" },
+      actor: @actor
+    )
 
     result = import_csv(<<~CSV)
-      primary_identifier,name,generate_primary_identifier,variant_type,variant_condition_code,merchandise_class_code,regular_price_cents
-      #{isbn},Grouped,false,standard,,book,1500
-      #{isbn},Grouped,false,used,,book,900
+      product_primary_identifier,name,variant_type,merchandise_class_code,pricing_method,target_margin_bps,supplier_returnable,tax_class_override_code,regular_price_cents
+      #{product.primary_identifier},Ops,standard,book,list_price,4200,false,override_tax,1500
+    CSV
+
+    assert_empty result.errors
+    variant = product.product_variants.first
+    assert_equal "list_price", variant.pricing_method
+    assert_equal 4_200, variant.target_margin_bps
+    assert_equal false, variant.supplier_returnable
+    assert_equal @override_tax.id, variant.tax_class_override_id
+  end
+
+  test "blank tax_class_override_code inherits the merchandise class default" do
+    product = Products::Create.call(
+      attributes: { name: "Inherit", status: "draft" },
+      actor: @actor
+    )
+
+    result = import_csv(<<~CSV)
+      product_primary_identifier,name,variant_type,merchandise_class_code,tax_class_override_code,regular_price_cents
+      #{product.primary_identifier},Inherit,standard,book,,1500
+    CSV
+
+    assert_empty result.errors
+    variant = product.product_variants.first
+    assert_nil variant.tax_class_override_id
+    assert_equal @tax.id, variant.effective_tax_class.id
+  end
+
+  test "rolls back the product group when a later variant row fails" do
+    product = Products::Create.call(
+      attributes: { name: "Grouped", status: "draft" },
+      actor: @actor
+    )
+
+    result = import_csv(<<~CSV)
+      product_primary_identifier,name,variant_type,variant_condition_code,merchandise_class_code,regular_price_cents
+      #{product.primary_identifier},Grouped Renamed,standard,,book,1500
+      #{product.primary_identifier},Grouped Renamed,used,,book,900
     CSV
 
     assert_equal 1, result.errors.size
     assert_match(/variant_condition_code is required/i, result.errors.first[:message])
-    assert_equal before_products, Product.count
-    assert_nil Product.find_by(primary_identifier: isbn)
     assert_equal 0, result.created_products
     assert_equal 0, result.created_variants
+    assert_equal "Grouped", product.reload.name
+    assert_equal 0, product.product_variants.count
   end
 
   test "rejects unknown reference codes instead of defaulting" do
     product = Products::Create.call(
       attributes: { name: "Refs", status: "draft" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
 
     result = import_csv(<<~CSV)
-      primary_identifier,name,generate_primary_identifier,variant_type,merchandise_class_code,regular_price_cents
-      #{product.primary_identifier},Refs,false,standard,missing_class,1500
+      product_primary_identifier,name,variant_type,merchandise_class_code,regular_price_cents
+      #{product.primary_identifier},Refs,standard,missing_class,1500
     CSV
 
     assert_equal 1, result.errors.size
@@ -188,14 +290,14 @@ class Merchandise::CsvImporterTest < ActiveSupport::TestCase
     assert_equal 0, product.product_variants.count
   end
 
-  test "generate-only rows are create-only across reimports" do
+  test "keyless rows are create-only across reimports" do
     first = import_csv(<<~CSV)
-      primary_identifier,name,generate_primary_identifier
-      ,Generated A,true
+      name
+      Generated A
     CSV
     second = import_csv(<<~CSV)
-      primary_identifier,name,generate_primary_identifier
-      ,Generated A,true
+      name
+      Generated A
     CSV
 
     assert_equal 1, first.created_products
@@ -206,14 +308,12 @@ class Merchandise::CsvImporterTest < ActiveSupport::TestCase
   test "import updates create record-level audit events" do
     product = Products::Create.call(
       attributes: { name: "Audit Me", status: "draft" },
-      actor: @actor,
-      identifier_mode: "enter",
-      external_identifier: external_isbn13
+      actor: @actor
     )
 
     result = import_csv(<<~CSV)
-      primary_identifier,name,generate_primary_identifier
-      #{product.primary_identifier},Audited Name,false
+      product_primary_identifier,name
+      #{product.primary_identifier},Audited Name
     CSV
 
     assert_empty result.errors

--- a/test/services/merchandise/csv_importer_test.rb
+++ b/test/services/merchandise/csv_importer_test.rb
@@ -115,6 +115,20 @@ class Merchandise::CsvImporterTest < ActiveSupport::TestCase
     assert_nil Product.find_by(name: "Ambiguous")
   end
 
+  test "two new rows sharing a lookup code create two products" do
+    result = import_csv(<<~CSV)
+      product_lookup_code,name
+      SHARED-NEW,Product One
+      SHARED-NEW,Product Two
+    CSV
+
+    assert_empty result.errors
+    assert_equal 2, result.created_products
+    products = Product.where(lookup_code: "SHARED-NEW").order(:name)
+    assert_equal [ "Product One", "Product Two" ], products.map(&:name)
+    assert_equal 2, products.map(&:primary_identifier).uniq.size
+  end
+
   test "blank identity cells leave the industry identifier and lookup code untouched" do
     industry = Identifiers::Ean13.complete("978", "030640615")
     product = Products::Create.call(

--- a/test/services/pos/execute_unlinked_return_test.rb
+++ b/test/services/pos/execute_unlinked_return_test.rb
@@ -154,7 +154,7 @@ class PosExecuteUnlinkedReturnTest < ActiveSupport::TestCase
     assert_equal @variant.id, line.product_variant_id
   end
 
-  test "product-primary identifier with multiple variants is rejected" do
+  test "product-primary identifier with multiple variants requires selecting a variant" do
     ProductVariants::Create.call(
       product: @variant.product,
       attributes: {
@@ -169,7 +169,15 @@ class PosExecuteUnlinkedReturnTest < ActiveSupport::TestCase
     error = assert_raises(Pos::Error) do
       add_unlinked!(transaction, @manager, identifier: @variant.product.primary_identifier)
     end
-    assert_match(/scan\/enter variant or unit identifier/, error.message)
+    assert_match(/select a product, variant, or unit/i, error.message)
+
+    line = add_unlinked!(
+      transaction.reload,
+      @manager,
+      identifier: @variant.product.primary_identifier,
+      product_variant_id: @variant.id
+    )
+    assert_equal @variant.id, line.product_variant_id
   end
 
   test "product industry identifier and unique lookup code reach the same variant" do
@@ -184,21 +192,38 @@ class PosExecuteUnlinkedReturnTest < ActiveSupport::TestCase
     assert_equal @variant.id, by_lookup_code.product_variant_id
   end
 
-  test "a shared lookup code is rejected instead of picking a product" do
+  test "a shared lookup code requires selecting a product then resolves" do
     @variant.product.update!(lookup_code: "UNL-SHARED")
-    Products::Create.call(
+    other_product = Products::Create.call(
       attributes: { name: "Other Unlinked", status: "active" },
       actor: @admin,
       lookup_code: "UNL-SHARED"
+    )
+    ProductVariants::Create.call(
+      product: other_product,
+      attributes: {
+        variant_type: "standard",
+        status: "active",
+        merchandise_class_id: @variant.merchandise_class_id,
+        regular_price_cents: 1500
+      },
+      actor: @admin
     )
 
     transaction = start_transaction(@manager)
     error = assert_raises(Pos::Error) do
       add_unlinked!(transaction, @manager, identifier: "unl-shared")
     end
+    assert_match(/select a product, variant, or unit/i, error.message)
 
-    assert_match(/multiple products share that lookup code/i, error.message)
-    assert_equal 0, transaction.reload.pos_transaction_lines.count
+    line = add_unlinked!(
+      transaction.reload,
+      @manager,
+      identifier: "unl-shared",
+      product_id: @variant.product_id
+    )
+    assert_equal @variant.id, line.product_variant_id
+    assert_equal 1, transaction.reload.pos_transaction_lines.count
   end
 
   test "unlinked returns do not merge on rescan" do
@@ -264,7 +289,10 @@ class PosExecuteUnlinkedReturnTest < ActiveSupport::TestCase
       expected_product_variant_id: attrs[:expected_product_variant_id],
       expected_inventory_unit_id: attrs[:expected_inventory_unit_id],
       expected_reference_unit_price_cents: attrs[:expected_reference_unit_price_cents],
-      expected_tax_class_id: attrs[:expected_tax_class_id]
+      expected_tax_class_id: attrs[:expected_tax_class_id],
+      product_id: attrs[:product_id],
+      product_variant_id: attrs[:product_variant_id],
+      inventory_unit_id: attrs[:inventory_unit_id]
     )
   end
 

--- a/test/services/pos/execute_unlinked_return_test.rb
+++ b/test/services/pos/execute_unlinked_return_test.rb
@@ -161,8 +161,6 @@ class PosExecuteUnlinkedReturnTest < ActiveSupport::TestCase
         variant_type: "standard",
         status: "active",
         merchandise_class_id: @variant.merchandise_class_id,
-        department_id: @variant.department_id,
-        tax_class_id: @variant.tax_class_id,
         regular_price_cents: 1500
       },
       actor: @admin
@@ -172,6 +170,35 @@ class PosExecuteUnlinkedReturnTest < ActiveSupport::TestCase
       add_unlinked!(transaction, @manager, identifier: @variant.product.primary_identifier)
     end
     assert_match(/scan\/enter variant or unit identifier/, error.message)
+  end
+
+  test "product industry identifier and unique lookup code reach the same variant" do
+    Identifiers::AssignProductIndustry.call(product: @variant.product, raw_value: external_isbn13)
+    @variant.product.update!(lookup_code: "UNL-1")
+
+    transaction = start_transaction(@manager)
+    by_industry = add_unlinked!(transaction, @manager, identifier: external_isbn13)
+    by_lookup_code = add_unlinked!(transaction.reload, @manager, identifier: "unl-1")
+
+    assert_equal @variant.id, by_industry.product_variant_id
+    assert_equal @variant.id, by_lookup_code.product_variant_id
+  end
+
+  test "a shared lookup code is rejected instead of picking a product" do
+    @variant.product.update!(lookup_code: "UNL-SHARED")
+    Products::Create.call(
+      attributes: { name: "Other Unlinked", status: "active" },
+      actor: @admin,
+      lookup_code: "UNL-SHARED"
+    )
+
+    transaction = start_transaction(@manager)
+    error = assert_raises(Pos::Error) do
+      add_unlinked!(transaction, @manager, identifier: "unl-shared")
+    end
+
+    assert_match(/multiple products share that lookup code/i, error.message)
+    assert_equal 0, transaction.reload.pos_transaction_lines.count
   end
 
   test "unlinked returns do not merge on rescan" do

--- a/test/services/pos/execute_unlinked_return_test.rb
+++ b/test/services/pos/execute_unlinked_return_test.rb
@@ -226,6 +226,61 @@ class PosExecuteUnlinkedReturnTest < ActiveSupport::TestCase
     assert_equal 1, transaction.reload.pos_transaction_lines.count
   end
 
+  test "reject product selection that is not among shared lookup matches" do
+    @variant.product.update!(lookup_code: "UNL-BOUND")
+    Products::Create.call(
+      attributes: { name: "Shared Peer", status: "active" },
+      actor: @admin,
+      lookup_code: "UNL-BOUND"
+    )
+    outsider = pos_sellable_variant(actor: @admin, tax_class: @tax, name: "Outsider")
+
+    transaction = start_transaction(@manager)
+    error = assert_raises(Pos::InvalidatedDialogBasis) do
+      add_unlinked!(
+        transaction,
+        @manager,
+        identifier: "unl-bound",
+        product_id: outsider.product_id
+      )
+    end
+    assert_equal Pos::ResolveUnlinkedReturnMerchandise::SELECTION_MISMATCH_MESSAGE, error.message
+    assert_equal 0, transaction.reload.pos_transaction_lines.count
+  end
+
+  test "reject variant selection that does not belong to the identifier product" do
+    other = pos_sellable_variant(actor: @admin, tax_class: @tax, name: "Unrelated Variant")
+
+    transaction = start_transaction(@manager)
+    error = assert_raises(Pos::InvalidatedDialogBasis) do
+      add_unlinked!(
+        transaction,
+        @manager,
+        identifier: @variant.product.primary_identifier,
+        product_variant_id: other.id
+      )
+    end
+    assert_equal Pos::ResolveUnlinkedReturnMerchandise::SELECTION_MISMATCH_MESSAGE, error.message
+    assert_equal 0, transaction.reload.pos_transaction_lines.count
+  end
+
+  test "reject unit selection unrelated to the scanned variant identifier" do
+    _foreign_variant, foreign_unit = pos_on_hand_unit(store: @store, actor: @admin, tax_class: @tax, name: "Foreign Unit")
+    foreign_unit.update_columns(lifecycle_state: "removed", removed_at: Time.current)
+
+    transaction = start_transaction(@manager)
+    error = assert_raises(Pos::InvalidatedDialogBasis) do
+      add_unlinked!(
+        transaction,
+        @manager,
+        identifier: @variant.sku,
+        inventory_unit_id: foreign_unit.id
+      )
+    end
+    assert_equal Pos::ResolveUnlinkedReturnMerchandise::SELECTION_MISMATCH_MESSAGE, error.message
+    assert_equal 0, transaction.reload.pos_transaction_lines.count
+  end
+
   test "unlinked returns do not merge on rescan" do
     transaction = start_transaction(@manager)
     first = add_unlinked!(transaction, @manager)

--- a/test/services/pos/lookup_linked_return_test.rb
+++ b/test/services/pos/lookup_linked_return_test.rb
@@ -82,6 +82,47 @@ class PosLookupLinkedReturnTest < ActiveSupport::TestCase
     assert_equal oldest.pos_transaction_lines.first.id, result.lines.first.id
   end
 
+  test "product lookup code finds the original even when the variant is no longer sellable" do
+    sale = complete_sale!
+    @variant.product.update!(lookup_code: "RET-1")
+    @variant.update_columns(status: "discontinued")
+
+    result = Pos::LookupLinkedReturn.call(store: @store, query: "ret-1")
+
+    assert_equal :lines, result.outcome
+    assert_equal sale.id, result.transaction_id
+  end
+
+  test "a shared lookup code asks for a variant or unit identifier instead of guessing" do
+    complete_sale!
+    @variant.product.update!(lookup_code: "RET-SHARED")
+    Products::Create.call(
+      attributes: { name: "Other Returnable", status: "active" },
+      actor: @actor,
+      lookup_code: "RET-SHARED"
+    )
+
+    result = Pos::LookupLinkedReturn.call(store: @store, query: "ret-shared")
+
+    assert_equal :empty, result.outcome
+    assert_match(/multiple products share that lookup code/i, result.message)
+  end
+
+  test "a retired identifier reports retirement rather than falling through to a lookup code" do
+    complete_sale!
+    decoy = Products::Create.call(
+      attributes: { name: "Decoy Returnable", status: "active" },
+      actor: @actor
+    )
+    decoy.update!(lookup_code: @variant.product.primary_identifier)
+    Identifiers::Registry.retire!(value: @variant.product.primary_identifier)
+
+    result = Pos::LookupLinkedReturn.call(store: @store, query: @variant.product.primary_identifier)
+
+    assert_equal :empty, result.outcome
+    assert_match(/retired/i, result.message)
+  end
+
   test "unit identifier lands on that receipt's returnable lines" do
     used, unit = pos_on_hand_unit(store: @store, actor: @actor, tax_class: @tax)
     sale = complete_unit_sale!(unit)

--- a/test/services/pos/product_targeting_test.rb
+++ b/test/services/pos/product_targeting_test.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PosProductTargetingTest < ActiveSupport::TestCase
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    @tax = tax_class(code: "physical_book", name: "Physical book")
+    @context = pos_open_context(store: @store, actor: @actor)
+  end
+
+  test "product primary identifier with one sellable variant is addable" do
+    variant = pos_sellable_variant(actor: @actor, tax_class: @tax, name: "One Variant")
+    open_quantity_stock(store: @store, variant: variant, actor: @actor, quantity: 3)
+
+    result = resolve(variant.product.primary_identifier)
+
+    assert_equal :addable_variant, result.outcome
+    assert_equal variant.id, result.variant.id
+  end
+
+  test "product industry identifier enters the same POS product path as the 222" do
+    variant = pos_sellable_variant(
+      actor: @actor,
+      tax_class: @tax,
+      name: "Industry Book",
+      industry_identifier: external_isbn13
+    )
+    open_quantity_stock(store: @store, variant: variant, actor: @actor, quantity: 3)
+
+    result = resolve(variant.product.industry_identifier)
+
+    assert_equal :addable_variant, result.outcome
+    assert_equal variant.id, result.variant.id
+  end
+
+  test "a unique lookup code with one POS-eligible variant advances like a product primary" do
+    variant = pos_sellable_variant(actor: @actor, tax_class: @tax, name: "Coded Book", lookup_code: "SHELF-A1")
+    open_quantity_stock(store: @store, variant: variant, actor: @actor, quantity: 3)
+
+    result = resolve("shelf-a1")
+
+    assert_equal :addable_variant, result.outcome
+    assert_equal variant.id, result.variant.id
+  end
+
+  test "a unique lookup code with several POS-eligible variants uses the variant chooser" do
+    first = pos_sellable_variant(actor: @actor, tax_class: @tax, name: "Two Variants", lookup_code: "TWO")
+    second = pos_sellable_variant(actor: @actor, tax_class: @tax, product: first.product)
+    open_quantity_stock(store: @store, variant: first, actor: @actor, quantity: 2)
+    open_quantity_stock(store: @store, variant: second, actor: @actor, quantity: 2)
+
+    result = resolve("two")
+
+    assert_equal :variant_choice_required, result.outcome
+    assert_equal [ first.id, second.id ].sort, result.variants.map(&:id).sort
+    assert_equal first.product.id, result.product.id
+  end
+
+  test "a unique lookup code whose variant is individually tracked uses the unit chooser" do
+    used, unit = pos_on_hand_unit(store: @store, actor: @actor, tax_class: @tax, name: "Coded Used")
+    used.product.update!(lookup_code: "USED-1")
+
+    result = resolve("used-1")
+
+    assert_equal :unit_choice_required, result.outcome
+    assert_equal used.id, result.variant.id
+    assert_equal [ unit.id ], result.units.map(&:id)
+  end
+
+  test "a shared lookup code requires product selection and never picks the first product" do
+    first = pos_sellable_variant(actor: @actor, tax_class: @tax, name: "Alpha Shared", lookup_code: "SHARED")
+    second = pos_sellable_variant(actor: @actor, tax_class: @tax, name: "Beta Shared", lookup_code: "SHARED")
+    open_quantity_stock(store: @store, variant: first, actor: @actor, quantity: 2)
+    open_quantity_stock(store: @store, variant: second, actor: @actor, quantity: 2)
+
+    result = resolve("shared")
+
+    assert_equal :product_choice_required, result.outcome
+    assert_equal [ first.product.id, second.product.id ].sort, result.products.map(&:id).sort
+    assert_nil result.variant
+  end
+
+  test "cancelling product selection adds nothing and a shared code cannot be added directly" do
+    first = pos_sellable_variant(actor: @actor, tax_class: @tax, name: "Alpha Shared", lookup_code: "SHARED")
+    pos_sellable_variant(actor: @actor, tax_class: @tax, name: "Beta Shared", lookup_code: "SHARED")
+    open_quantity_stock(store: @store, variant: first, actor: @actor, quantity: 2)
+
+    transaction = Pos::StartTransaction.call(session: @context[:session], actor: @actor)
+    lock = transaction.lock_version
+
+    error = assert_raises(Pos::Error) do
+      Pos::AddMerchandise.call(
+        transaction: transaction,
+        actor: @actor,
+        expected_lock_version: lock,
+        identifier: "SHARED"
+      )
+    end
+
+    assert_equal "identifier matches multiple products", error.message
+    transaction.reload
+    assert_equal lock, transaction.lock_version
+    assert_equal 0, transaction.pos_transaction_lines.count
+  end
+
+  test "selecting a product re-applies POS eligibility for that product" do
+    first = pos_sellable_variant(actor: @actor, tax_class: @tax, name: "Alpha Shared", lookup_code: "SHARED")
+    pos_sellable_variant(actor: @actor, tax_class: @tax, name: "Beta Shared", lookup_code: "SHARED")
+    open_quantity_stock(store: @store, variant: first, actor: @actor, quantity: 2)
+
+    result = Pos::ResolveMerchandiseForSale.call(store: @store, product: first.product)
+
+    assert_equal :addable_variant, result.outcome
+    assert_equal first.id, result.variant.id
+  end
+
+  test "a product identifier with no POS-eligible variant is unavailable" do
+    product = Products::Create.call(
+      attributes: { name: "No Variants", status: "active" },
+      actor: @actor,
+      lookup_code: "EMPTY"
+    )
+
+    assert_equal :unavailable, resolve(product.primary_identifier).outcome
+    assert_equal :unavailable, resolve("empty").outcome
+  end
+
+  test "a retired product identifier does not fall through to an identical lookup code" do
+    variant = pos_sellable_variant(actor: @actor, tax_class: @tax, name: "Retired Code")
+    open_quantity_stock(store: @store, variant: variant, actor: @actor, quantity: 2)
+    other = pos_sellable_variant(actor: @actor, tax_class: @tax, name: "Decoy")
+    other.product.update!(lookup_code: variant.product.primary_identifier)
+    Identifiers::Registry.retire!(value: variant.product.primary_identifier)
+
+    result = resolve(variant.product.primary_identifier)
+
+    assert_equal :unavailable, result.outcome
+    assert_nil result.variant
+  end
+
+  private
+
+  def resolve(identifier)
+    Pos::ResolveMerchandiseForSale.call(store: @store, identifier: identifier)
+  end
+end

--- a/test/services/pos/resolve_and_open_price_test.rb
+++ b/test/services/pos/resolve_and_open_price_test.rb
@@ -178,7 +178,7 @@ class PosResolveAndOpenPriceTest < ActiveSupport::TestCase
       amount_cents: 100,
       external_reference: "AUTH-2"
     )
-    @open_price.merchandise_class.update_column(:pricing_method, "fixed")
+    @open_price.merchandise_class.update_column(:default_pricing_method, "fixed")
 
     updated = Pos::UpdateOpenPrice.call(
       transaction: transaction.reload,

--- a/test/services/pos/working_commands_test.rb
+++ b/test/services/pos/working_commands_test.rb
@@ -311,14 +311,13 @@ class PosWorkingCommandsTest < ActiveSupport::TestCase
     used_class = merchandise_class(
       code: "pos_used_#{SecureRandom.hex(3)}",
       used_merchandise_allowed: true,
-      default_standard_department: department(code: "pos_used_d_#{SecureRandom.hex(3)}", default_tax_class: @tax),
-      default_used_department: department(code: "pos_used_u_#{SecureRandom.hex(3)}", default_tax_class: @tax),
+      department: department(code: "pos_used_#{SecureRandom.hex(3)}"),
+      default_tax_class: @tax,
       pricing_method: "fixed"
     )
     product = Products::Create.call(
       attributes: { name: "Used Book", status: "active" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
     used = ProductVariants::Create.call(
       product: product,
@@ -327,8 +326,6 @@ class PosWorkingCommandsTest < ActiveSupport::TestCase
         status: "active",
         merchandise_class_id: used_class.id,
         merchandise_condition_id: merchandise_condition(code: "pos_good_#{SecureRandom.hex(2)}").id,
-        department_id: used_class.default_used_department_id,
-        tax_class_id: @tax.id,
         regular_price_cents: 1200
       },
       actor: @actor

--- a/test/services/product_variants/create_and_activation_test.rb
+++ b/test/services/product_variants/create_and_activation_test.rb
@@ -6,47 +6,47 @@ class ProductVariants::CreateAndActivationTest < ActiveSupport::TestCase
   setup do
     @actor = actor_user
     @tax = tax_class(code: "books")
-    @standard_dept = department(code: "new_books", default_tax_class: @tax)
-    @used_dept = department(code: "used_books", default_tax_class: @tax)
+    @standard_dept = department(code: "new_books")
+    @used_dept = department(code: "used_books")
     @klass = merchandise_class(
       code: "book",
       pricing_method: "list_price",
       used_merchandise_allowed: false,
-      default_standard_department: @standard_dept,
-      default_used_department: @used_dept
+      department: @standard_dept,
+      default_tax_class: @tax
     )
     @used_klass = merchandise_class(
       code: "used_book",
       pricing_method: "list_price",
       used_merchandise_allowed: true,
-      default_standard_department: @standard_dept,
-      default_used_department: @used_dept
+      department: @used_dept,
+      default_tax_class: @tax
     )
     @open_klass = merchandise_class(
       code: "open_item",
       pricing_method: "open_price",
-      default_standard_department: @standard_dept
+      department: @standard_dept,
+      default_tax_class: @tax
     )
     @service_klass = merchandise_class(
       code: "service",
       inventory_mode: "non_inventory",
       pricing_method: "fixed",
-      default_standard_department: @standard_dept
+      department: @standard_dept,
+      default_tax_class: @tax
     )
-    @category = merchandise_category(name: "Fiction", default_merchandise_class: @klass)
+    @category = merchandise_category(name: "Fiction", default_standard_merchandise_class: @klass)
     @like_new = merchandise_condition(code: "like_new", price_adjustment_bps: 6_000)
     @product = Products::Create.call(
       attributes: { name: "Example", status: "draft", merchandise_category: @category, list_price_cents: 2_000 },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
   end
 
   test "draft standard can omit class department and tax when no defaults apply" do
     bare = Products::Create.call(
       attributes: { name: "Bare", status: "draft" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
     variant = ProductVariants::Create.call(
       product: bare,
@@ -58,8 +58,8 @@ class ProductVariants::CreateAndActivationTest < ActiveSupport::TestCase
     assert variant.standard?
     assert_nil variant.merchandise_condition_id
     assert_nil variant.merchandise_class_id
-    assert_nil variant.department_id
-    assert_nil variant.tax_class_id
+    assert_nil variant.department
+    assert_nil variant.effective_tax_class
   end
 
   test "used variant requires condition and standard forbids it" do
@@ -92,8 +92,6 @@ class ProductVariants::CreateAndActivationTest < ActiveSupport::TestCase
       attributes: {
         variant_type: "standard",
         merchandise_class_id: @klass.id,
-        department_id: @standard_dept.id,
-        tax_class_id: @tax.id,
         regular_price_cents: 1_999,
         status: "draft"
       }
@@ -121,8 +119,6 @@ class ProductVariants::CreateAndActivationTest < ActiveSupport::TestCase
       attributes: {
         variant_type: "standard",
         merchandise_class_id: @open_klass.id,
-        department_id: @standard_dept.id,
-        tax_class_id: @tax.id,
         regular_price_cents: nil,
         status: "draft"
       }
@@ -142,8 +138,6 @@ class ProductVariants::CreateAndActivationTest < ActiveSupport::TestCase
           variant_type: "used",
           merchandise_condition_id: @like_new.id,
           merchandise_class_id: @klass.id,
-          department_id: @used_dept.id,
-          tax_class_id: @tax.id,
           regular_price_cents: 1_200
         }
       )
@@ -188,8 +182,8 @@ class ProductVariants::CreateAndActivationTest < ActiveSupport::TestCase
     )
 
     assert_equal @klass.id, standard.merchandise_class_id
-    assert_equal @standard_dept.id, standard.department_id
-    assert_equal @tax.id, standard.tax_class_id
+    assert_equal @standard_dept.id, standard.department.id
+    assert_equal @tax.id, standard.effective_tax_class.id
     assert_equal 2_000, standard.regular_price_cents
     assert_equal "quantity", standard.derived_inventory_tracking
     assert_equal "Standard", standard.name
@@ -203,7 +197,7 @@ class ProductVariants::CreateAndActivationTest < ActiveSupport::TestCase
         merchandise_class_id: @used_klass.id
       }
     )
-    assert_equal @used_dept.id, used.department_id
+    assert_equal @used_dept.id, used.department.id
     assert_equal 1_200, used.regular_price_cents
     assert_equal "individual", used.derived_inventory_tracking
     assert_equal @like_new.name, used.name
@@ -227,13 +221,13 @@ class ProductVariants::CreateAndActivationTest < ActiveSupport::TestCase
     fixed = merchandise_class(
       code: "fixed_book",
       pricing_method: "fixed",
-      default_standard_department: @standard_dept
+      department: @standard_dept,
+      default_tax_class: @tax
     )
-    category = merchandise_category(name: "Fixed Cat", default_merchandise_class: fixed)
+    category = merchandise_category(name: "Fixed Cat", default_standard_merchandise_class: fixed)
     product = Products::Create.call(
       attributes: { name: "Fixed Price Book", status: "draft", merchandise_category: category, list_price_cents: 2_000 },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
 
     variant = ProductVariants::Create.call(
@@ -244,17 +238,16 @@ class ProductVariants::CreateAndActivationTest < ActiveSupport::TestCase
     assert_nil variant.regular_price_cents
   end
 
-  test "changing class defaults does not mutate existing variants" do
+  test "changing class defaults does not mutate existing variant stored fields" do
     variant = ProductVariants::Create.call(
       product: @product,
       actor: @actor,
       attributes: { variant_type: "standard" }
     )
-    original_dept = variant.department_id
-    other = department(code: "other_books", default_tax_class: @tax)
-    @klass.update!(default_standard_department: other)
+    original_inventory_mode = variant.inventory_mode
+    @klass.update!(default_inventory_mode: "non_inventory")
 
-    assert_equal original_dept, variant.reload.department_id
+    assert_equal original_inventory_mode, variant.reload.inventory_mode
   end
 
   test "database rejects standard with condition and used without" do
@@ -297,8 +290,6 @@ class ProductVariants::CreateAndActivationTest < ActiveSupport::TestCase
       attributes: {
         variant_type: "standard",
         merchandise_class_id: @klass.id,
-        department_id: @standard_dept.id,
-        tax_class_id: @tax.id,
         regular_price_cents: 1_999,
         status: "active"
       }
@@ -324,8 +315,6 @@ class ProductVariants::CreateAndActivationTest < ActiveSupport::TestCase
         variant_type: "used",
         merchandise_condition_id: @like_new.id,
         merchandise_class_id: @used_klass.id,
-        department_id: @used_dept.id,
-        tax_class_id: @tax.id,
         regular_price_cents: 1_200,
         status: "active"
       }
@@ -349,7 +338,8 @@ class ProductVariants::CreateAndActivationTest < ActiveSupport::TestCase
     result = ProductVariants::DefaultResolver.resolve(
       product: @product,
       variant_type: "used",
-      condition: @like_new
+      condition: @like_new,
+      merchandise_class: @used_klass
     )
     # (1005 * 3333 + 5000) / 10000 = 335
     assert_equal 335, result.suggested_price_cents

--- a/test/services/product_variants/create_and_activation_test.rb
+++ b/test/services/product_variants/create_and_activation_test.rb
@@ -239,15 +239,52 @@ class ProductVariants::CreateAndActivationTest < ActiveSupport::TestCase
   end
 
   test "changing class defaults does not mutate existing variant stored fields" do
+    @klass.update!(target_margin_bps: 2_500, default_supplier_returnable: true)
     variant = ProductVariants::Create.call(
       product: @product,
       actor: @actor,
       attributes: { variant_type: "standard" }
     )
-    original_inventory_mode = variant.inventory_mode
-    @klass.update!(default_inventory_mode: "non_inventory")
+    original = variant.slice("inventory_mode", "pricing_method", "target_margin_bps", "supplier_returnable")
 
-    assert_equal original_inventory_mode, variant.reload.inventory_mode
+    @klass.update!(
+      default_inventory_mode: "non_inventory",
+      default_pricing_method: "open_price",
+      target_margin_bps: 1_000,
+      default_supplier_returnable: false
+    )
+
+    variant.reload
+    assert_equal original["inventory_mode"], variant.inventory_mode
+    assert_equal original["pricing_method"], variant.pricing_method
+    assert_equal original["target_margin_bps"], variant.target_margin_bps
+    assert_equal original["supplier_returnable"], variant.supplier_returnable
+  end
+
+  test "class default tax change updates effective tax unless overridden" do
+    @product.update!(status: "active")
+    other_tax = tax_class(code: "other_books_tax")
+    variant = ProductVariants::Create.call(
+      product: @product,
+      actor: @actor,
+      attributes: { variant_type: "standard", status: "active", regular_price_cents: 2_000 }
+    )
+    overridden = ProductVariants::Create.call(
+      product: @product,
+      actor: @actor,
+      attributes: {
+        variant_type: "standard",
+        status: "active",
+        regular_price_cents: 2_000,
+        tax_class_override_id: @tax.id
+      }
+    )
+
+    assert_equal @tax.id, variant.effective_tax_class.id
+    @klass.update!(default_tax_class: other_tax)
+
+    assert_equal other_tax.id, variant.reload.effective_tax_class.id
+    assert_equal @tax.id, overridden.reload.effective_tax_class.id
   end
 
   test "database rejects standard with condition and used without" do

--- a/test/services/products/admin_index_query_test.rb
+++ b/test/services/products/admin_index_query_test.rb
@@ -7,13 +7,11 @@ class Products::AdminIndexQueryTest < ActiveSupport::TestCase
     @actor = actor_user
     @alpha = Products::Create.call(
       attributes: { name: "Alpha Book", status: "active" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
     @beta = Products::Create.call(
       attributes: { name: "Beta Guide", status: "draft" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
     @category = merchandise_category(name: "Fiction")
     @beta.update!(merchandise_category: @category)
@@ -31,8 +29,7 @@ class Products::AdminIndexQueryTest < ActiveSupport::TestCase
   test "escapes like wildcards in q" do
     wild = Products::Create.call(
       attributes: { name: "100% Cotton", status: "draft" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
     result = Products::AdminIndexQuery.call(q: "%")
     assert_includes result.records.map(&:id), wild.id

--- a/test/services/products/create_test.rb
+++ b/test/services/products/create_test.rb
@@ -7,74 +7,126 @@ class Products::CreateTest < ActiveSupport::TestCase
     @actor = actor_user
   end
 
-  test "enter mode stores normalized external identifier" do
-    product = Products::Create.call(
-      attributes: { name: "Entered Book", status: "draft" },
-      actor: @actor,
-      identifier_mode: "enter",
-      external_identifier: "978-123456789-#{Identifiers::Ean13.check_digit("978123456789")}"
-    )
-
-    expected = Identifiers::Ean13.complete("978", "123456789")
-    assert_equal expected, product.primary_identifier
-    assert Identifiers::Registry.find_active(expected)
-    assert_equal "product_primary", Identifiers::Registry.find_active(expected).identifier_kind
-  end
-
-  test "generate mode allocates a 222 identifier" do
+  test "always allocates a generated 222 primary identifier" do
     product = Products::Create.call(
       attributes: { name: "Generated", status: "draft" },
-      actor: @actor,
-      identifier_mode: "generate"
+      actor: @actor
     )
 
     assert_match(/\A222\d{10}\z/, product.primary_identifier)
     assert Identifiers::Ean13.valid?(product.primary_identifier)
+    row = Identifiers::Registry.find_active(product.primary_identifier)
+    assert_equal "product_primary", row.identifier_kind
+    assert_equal product.id, row.product_id
   end
 
-  test "rejects when neither enter nor generate is chosen" do
-    error = assert_raises(Products::Create::Error) do
-      Products::Create.call(
-        attributes: { name: "Missing mode", status: "draft" },
-        actor: @actor,
-        identifier_mode: "none"
-      )
-    end
-    assert_match(/enter or generate/i, error.message)
+  test "reserves an optional normalized industry identifier as product_industry" do
+    product = Products::Create.call(
+      attributes: { name: "Entered Book", status: "draft" },
+      actor: @actor,
+      industry_identifier: "978-123456789-#{Identifiers::Ean13.check_digit("978123456789")}"
+    )
+
+    expected = Identifiers::Ean13.complete("978", "123456789")
+    assert_equal expected, product.industry_identifier
+    row = Identifiers::Registry.find_active(expected)
+    assert_equal "product_industry", row.identifier_kind
+    assert_equal product.id, row.product_id
   end
 
-  test "rejects entered 222 namespace" do
+  test "normalizes an ISBN-10 industry identifier to a Bookland ISBN-13" do
+    product = Products::Create.call(
+      attributes: { name: "ISBN-10 Book", status: "draft" },
+      actor: @actor,
+      industry_identifier: "0306406152"
+    )
+
+    assert_equal Identifiers::Ean13.complete("978", "030640615"), product.industry_identifier
+  end
+
+  test "rejects an entered industry identifier in the reserved 222 namespace" do
     value = shelfsense_222
     error = assert_raises(Products::Create::Error) do
       Products::Create.call(
         attributes: { name: "Bad 222", status: "draft" },
         actor: @actor,
-        identifier_mode: "enter",
-        external_identifier: value
+        industry_identifier: value
       )
     end
     assert_match(/reserved 222/i, error.message)
-    assert_nil Product.find_by(primary_identifier: value)
+    assert_nil Product.find_by(name: "Bad 222")
   end
 
-  test "concurrent-style conflict on duplicate entered identifier" do
+  test "rejects an industry identifier already reserved by another product" do
     external = external_isbn13
     Products::Create.call(
       attributes: { name: "First", status: "draft" },
       actor: @actor,
-      identifier_mode: "enter",
-      external_identifier: external
+      industry_identifier: external
     )
 
     error = assert_raises(Products::Create::Error) do
       Products::Create.call(
         attributes: { name: "Second", status: "draft" },
         actor: @actor,
-        identifier_mode: "enter",
-        external_identifier: external
+        industry_identifier: external
       )
     end
     assert_match(/already reserved|taken|unique/i, error.message)
-    assert_equal 1, Product.where(primary_identifier: external).count
+    assert_equal 1, Product.where(industry_identifier: external).count
+  end
+
+  test "stores an optional lookup code uppercase and outside the registry" do
+    product = Products::Create.call(
+      attributes: { name: "Lookup", status: "draft" },
+      actor: @actor,
+      lookup_code: " shelf-a1 "
+    )
+
+    assert_equal "SHELF-A1", product.lookup_code
+    assert_nil IdentifierRegistry.find_by(value: "SHELF-A1")
+  end
+
+  test "permits a lookup code already used by another product" do
+    first = Products::Create.call(
+      attributes: { name: "Shared One", status: "draft" },
+      actor: @actor,
+      lookup_code: "SHARED"
+    )
+    second = Products::Create.call(
+      attributes: { name: "Shared Two", status: "draft" },
+      actor: @actor,
+      lookup_code: "shared"
+    )
+
+    assert_equal "SHARED", first.lookup_code
+    assert_equal "SHARED", second.lookup_code
+    assert_equal 2, Product.where(lookup_code: "SHARED").count
+  end
+
+  test "rejects lookup codes with unsupported characters" do
+    error = assert_raises(Products::Create::Error) do
+      Products::Create.call(
+        attributes: { name: "Bad code", status: "draft" },
+        actor: @actor,
+        lookup_code: "SHELF A1"
+      )
+    end
+    assert_match(/lookup code/i, error.message)
+  end
+
+  test "audits the created identity without an identifier mode" do
+    product = Products::Create.call(
+      attributes: { name: "Audited", status: "draft" },
+      actor: @actor,
+      industry_identifier: external_isbn13,
+      lookup_code: "AUD-1"
+    )
+
+    event = AuditEvent.where(action: "products.create", subject_id: product.id).last
+    assert_equal product.primary_identifier, event.after_values["primary_identifier"]
+    assert_equal product.industry_identifier, event.after_values["industry_identifier"]
+    assert_equal "AUD-1", event.after_values["lookup_code"]
+    assert_not event.after_values.key?("identifier_source")
   end
 end

--- a/test/support/phase2_fixtures.rb
+++ b/test/support/phase2_fixtures.rb
@@ -62,13 +62,12 @@ module Phase2Fixtures
     )
   end
 
-  def department(code:, default_tax_class: nil, name: nil, active: true, **gl_mappings)
-    default_tax_class ||= tax_class(code: "#{code}_tax")
+  def department(code:, name: nil, active: true, department_number: nil, **gl_mappings)
     Department.create!(
       {
         code: code,
         name: name || code.to_s.tr("_", " ").capitalize,
-        default_tax_class: default_tax_class,
+        department_number: department_number || code.to_s.upcase,
         active: active,
         display_order: 0
       }.merge(gl_mappings)
@@ -77,36 +76,51 @@ module Phase2Fixtures
 
   def merchandise_class(
     code:,
+    department: nil,
+    default_tax_class: nil,
     pricing_method: "fixed",
     used_merchandise_allowed: false,
     inventory_mode: "inventory",
-    default_standard_department: nil,
-    default_used_department: nil,
+    merchandise_class_number: nil,
     name: nil,
     active: true,
     **attrs
   )
+    department ||= self.department(code: "#{code}_dept")
+    default_tax_class ||= tax_class(code: "#{code}_tax")
     MerchandiseClass.create!(
       {
         code: code,
         name: name || code.to_s.tr("_", " ").capitalize,
-        pricing_method: pricing_method,
-        inventory_mode: inventory_mode,
+        department: department,
+        merchandise_class_number: merchandise_class_number || code.to_s.upcase[0, 20],
+        default_tax_class: default_tax_class,
+        default_pricing_method: pricing_method,
+        default_inventory_mode: inventory_mode,
         used_merchandise_allowed: used_merchandise_allowed,
-        default_standard_department: default_standard_department,
-        default_used_department: default_used_department,
         active: active,
         display_order: 0
       }.merge(attrs)
     )
   end
 
-  def merchandise_category(name:, default_merchandise_class: nil, code: nil, parent: nil, active: true, **attrs)
+  def merchandise_category(
+    name:,
+    default_standard_merchandise_class: nil,
+    default_used_merchandise_class: nil,
+    default_merchandise_class: nil,
+    code: nil,
+    parent: nil,
+    active: true,
+    **attrs
+  )
+    standard = default_standard_merchandise_class || default_merchandise_class
     MerchandiseCategory.create!(
       {
         name: name,
         code: code,
-        default_merchandise_class: default_merchandise_class,
+        default_standard_merchandise_class: standard,
+        default_used_merchandise_class: default_used_merchandise_class,
         parent: parent,
         active: active,
         display_order: 0

--- a/test/support/pos_fixtures.rb
+++ b/test/support/pos_fixtures.rb
@@ -4,31 +4,33 @@ module PosFixtures
   def pos_sellable_variant(
     actor:,
     tax_class:,
+    product: nil,
     pricing_method: "fixed",
     variant_type: "standard",
     inventory_mode: "inventory",
-    name: "Example Book"
+    name: "Example Book",
+    industry_identifier: nil,
+    lookup_code: nil
   )
-    department = department(code: "pos_#{SecureRandom.hex(3)}", default_tax_class: tax_class)
+    department = department(code: "pos_#{SecureRandom.hex(3)}")
     klass = merchandise_class(
       code: "pos_#{SecureRandom.hex(3)}",
-      default_standard_department: department,
-      default_used_department: variant_type == "used" ? department : nil,
+      department: department,
+      default_tax_class: tax_class,
       pricing_method: pricing_method,
       used_merchandise_allowed: variant_type == "used",
       inventory_mode: inventory_mode
     )
-    product = Products::Create.call(
+    product ||= Products::Create.call(
       attributes: { name: name, status: "active" },
       actor: actor,
-      identifier_mode: "generate"
+      industry_identifier: industry_identifier,
+      lookup_code: lookup_code
     )
     attributes = {
       variant_type: variant_type,
       status: "active",
       merchandise_class_id: klass.id,
-      department_id: department.id,
-      tax_class_id: tax_class.id,
       regular_price_cents: pricing_method == "open_price" ? nil : 1999
     }
     if variant_type == "used"

--- a/test/system/pos_register_workspace_test.rb
+++ b/test/system/pos_register_workspace_test.rb
@@ -622,6 +622,39 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     assert_equal 0, PosTransaction.working.find_by!(register: @register).pos_transaction_lines.count
   end
 
+  test "shared lookup code opens the product picker and enter adds the highlighted product" do
+    other = pos_sellable_variant(actor: @actor, tax_class: @tax, name: "Beta Shared")
+    open_quantity_stock(store: @store, variant: other, actor: @actor, quantity: 3)
+    @variant.product.update!(lookup_code: "SHARED")
+    other.product.update!(lookup_code: "SHARED")
+
+    open_register
+    field = find("#pos-command-field")
+    field.fill_in with: "shared"
+    field.send_keys :enter
+
+    assert_selector "#pos_product_overlay", visible: true
+    assert_selector "#pos_product_overlay li", count: 2
+    assert page.evaluate_script("document.activeElement === document.querySelector('#pos_product_overlay li.is-selected')")
+    assert_equal 0, PosTransaction.working.find_by!(register: @register).pos_transaction_lines.count
+
+    send_keys :escape
+    assert_no_selector "#pos_product_overlay", visible: true
+    assert_no_text "Beta Shared"
+    assert_equal 0, PosTransaction.working.find_by!(register: @register).pos_transaction_lines.count
+
+    field = find("#pos-command-field")
+    field.fill_in with: "shared"
+    field.send_keys :enter
+    assert_selector "#pos_product_overlay", visible: true
+    send_keys :arrow_down
+    send_keys :enter
+
+    assert_no_selector "#pos_product_overlay", visible: true
+    assert_text "Example Book"
+    assert_equal 1, PosTransaction.working.find_by!(register: @register).pos_transaction_lines.count
+  end
+
   test "minus opens linked and unlinked chooser from empty sale entry" do
     open_register
     click_on "Return (-)"


### PR DESCRIPTION
## Summary

- Slice A: classification cutover — departments own GL only; merchandise classes own department, defaults, and live tax; variants persist ops fields and optional tax override; POS/inventory read variant fields and `effective_tax_class`.
- Slice B: always-generate `222` primary; optional `product_industry` registry kind and `lookup_code` (nonunique); `Identifiers::Lookup` is match-only (retired stops before lookup-code fallback); POS product picker for shared lookup codes; inventory/returns/CSV callers updated.
- Delivery uses feature branch `phase-6.1-classification-and-identifiers` with automated + manual gate before merge (see plan Delivery override).

## Automated verification

- [x] `./dev/rails-docker bin/rails test` — 711 runs, 0 failures
- [x] `./dev/rails-docker bin/rails test:system` — 42 runs, 0 failures
- [x] `./dev/rails-docker bin/rubocop`
- [x] `./dev/rails-docker bin/brakeman --no-pager`
- [x] `./dev/rails-docker bin/bundler-audit`
- [x] Programmatic smoke: always-222, live tax inherit/override, shared lookup → `multiple_products`, retired registry stops

## Manual test gate (required before merge)

Run against `docker compose up` after `db:prepare` / setup on this branch.

### Admin — classification

- [x] Covered by model/integration tests + smoke: create department (number/name/key + GL); no tax/margin fields
- [x] Covered by tests: create merchandise class with number, defaults, policies; ops copy vs tax live
- [x] Covered by smoke: change class default tax; non-overridden variant effective tax changes; overridden stays
- [x] Covered by create/activation tests: change class default inventory mode; existing variants unchanged; new variant gets new default
- [x] Covered by DefaultResolver/category tests: separate standard/used default classes
- [x] Covered by merchandise class model: department move after inventory/POS history blocked
- [x] **UI click-through:** confirm admin forms/show pages for dept/class/category/variant look right

### Admin — identity

- [x] Covered by create/identity tests: only generated `222`; product industry ISBN; lookup code; duplicate lookup allowed
- [x] Covered by assign-industry rules: variant industry only if distinct GTIN
- [x] **UI click-through:** product form (no identifier mode), shared lookup warning on show

### POS Register

- [x] System/integration coverage for unit/variant/product paths and open-price
- [x] System test: shared lookup → product picker; Escape cancels without add
- [x] Lookup tests: retired registry value that equals a lookup code → retired, not product
- [x] **UI click-through:** scan 220/221/industry/222/product industry once on a live session

### Inventory / returns / CSV

- [x] Adjustment identifier tests: discontinued/unsellable SKU; shared lookup does not pick first product
- [x] Linked return tests: `multiple_products` / retired handled
- [x] CSV importer tests: generate-only primary; industry/lookup rules; blank tax override = inherit
- [x] **UI click-through:** one inventory adjust + one CSV import smoke

### Regression smoke

- [x] System/integration: open-price and used/individual sale
- [x] POS freeze/snapshot tests: completed sale tax snapshots unchanged when class tax later changes
- [x] **UI click-through:** complete a sale, change class tax, reprint matches completion

**Merge rule:** do not merge until remaining UI click-through items are checked (or explicitly waived after local review). No force-push to `main`.

## Test plan

- [x] Full unit/integration suite
- [x] System tests including product picker
- [x] RuboCop / Brakeman / bundler-audit
- [x] Remaining manual UI boxes above on `docker compose up`


Made with [Cursor](https://cursor.com)