### PR TITLE
Add keyboard-first purchasing operations interactions

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -117,6 +117,80 @@ summary:focus-visible {
   flex: 1;
 }
 
+.ops-header,
+.ops-content {
+  width: min(100% - 2rem, var(--content-max));
+  margin-inline: auto;
+}
+
+.ops-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding-block: var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.ops-content {
+  padding-block: var(--space-4);
+}
+
+.ops-shortcuts {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  padding: var(--space-2);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+}
+
+.ops-shortcuts__buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.ops-shortcuts__help {
+  margin-top: var(--space-2);
+  padding: var(--space-3);
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+}
+
+.ops-shortcuts__help h2 {
+  margin-top: 0;
+}
+
+.ops-shortcuts__help dl div {
+  display: flex;
+  gap: var(--space-3);
+  margin-block: var(--space-2);
+}
+
+.ops-shortcuts__help dt {
+  min-width: 10rem;
+}
+
+.ops-shortcuts__help dd {
+  margin: 0;
+}
+
+.ops-queue tr.is-selected > * {
+  background: color-mix(in srgb, var(--color-action) 12%, var(--color-surface));
+}
+
+.ops-queue tr:focus-visible {
+  outline: 3px solid var(--color-action);
+  outline-offset: -3px;
+}
+
+form[data-dirty="true"] {
+  border-inline-start: 3px solid var(--color-warning);
+  padding-inline-start: var(--space-2);
+}
+
 .surface {
   background: var(--color-surface);
   border: 1px solid var(--color-border);

--- a/app/javascript/controllers/dirty_form_controller.js
+++ b/app/javascript/controllers/dirty_form_controller.js
@@ -1,0 +1,43 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.dirtyForms = new Set()
+  }
+
+  change(event) {
+    const form = event.target.closest("form[data-dirty-track]")
+    if (!form) return
+    this.dirtyForms.add(form)
+    form.dataset.dirty = "true"
+  }
+
+  submit(event) {
+    this.clear(event.target)
+  }
+
+  beforeVisit(event) {
+    if (!this.dirty || window.confirm("Discard unsaved purchasing changes?")) return
+    event.preventDefault()
+  }
+
+  beforeUnload(event) {
+    if (!this.dirty) return
+    event.preventDefault()
+    event.returnValue = ""
+  }
+
+  cancel(event) {
+    this.clear(event.detail.form)
+  }
+
+  clear(form) {
+    if (!form?.matches("form[data-dirty-track]")) return
+    this.dirtyForms.delete(form)
+    delete form.dataset.dirty
+  }
+
+  get dirty() {
+    return this.dirtyForms.size > 0
+  }
+}

--- a/app/javascript/controllers/escape_cancel_controller.js
+++ b/app/javascript/controllers/escape_cancel_controller.js
@@ -1,0 +1,41 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  keydown(event) {
+    if (event.key !== "Escape") return
+
+    this.cancel(event)
+  }
+
+  cancel(event) {
+
+    const dialog = this.element.querySelector("dialog[open]")
+    if (dialog) {
+      event.preventDefault()
+      dialog.close()
+      return
+    }
+
+    const help = this.element.querySelector("[data-ops-shortcuts-target='help']:not([hidden])")
+    if (help) {
+      event.preventDefault()
+      this.element.querySelector("[data-action~='ops-shortcuts#toggleHelp']")?.click()
+      return
+    }
+
+    const selected = this.element.querySelector("[data-row-selection-target='row'].is-selected")
+    if (selected) {
+      event.preventDefault()
+      selected.classList.remove("is-selected")
+      selected.setAttribute("aria-selected", "false")
+      this.element.querySelector("[data-focus-restore-target='lookup']")?.focus()
+      return
+    }
+
+    const dirtyForm = document.activeElement?.closest("form[data-dirty='true']") || this.element.querySelector("form[data-dirty='true']")
+    if (!dirtyForm) return
+    event.preventDefault()
+    dirtyForm.reset()
+    dirtyForm.dispatchEvent(new CustomEvent("ops:dirty-cancel", { bubbles: true, detail: { form: dirtyForm } }))
+  }
+}

--- a/app/javascript/controllers/focus_restore_controller.js
+++ b/app/javascript/controllers/focus_restore_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "lookup" ]
+
+  connect() {
+    requestAnimationFrame(() => this.focus())
+  }
+
+  focus() {
+    if (!this.hasLookupTarget || this.lookupTarget.disabled || this.lookupTarget.closest("[hidden]")) return
+    if (this.element.querySelector(":popover-open, dialog[open]")) return
+
+    this.lookupTarget.focus({ preventScroll: true })
+    if (typeof this.lookupTarget.select === "function") this.lookupTarget.select()
+  }
+}

--- a/app/javascript/controllers/ops_shortcuts_controller.js
+++ b/app/javascript/controllers/ops_shortcuts_controller.js
@@ -1,0 +1,47 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "help", "helpButton" ]
+
+  keydown(event) {
+    if (event.defaultPrevented) return
+    if (event.key === "/" && !this.editable(event.target)) {
+      event.preventDefault()
+      this.focusLookup()
+    } else if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "s") {
+      event.preventDefault()
+      this.save()
+    } else if ((event.ctrlKey || event.metaKey) && event.key === "Enter") {
+      event.preventDefault()
+      this.primary()
+    }
+  }
+
+  focusLookup() {
+    const lookup = this.element.querySelector("[data-focus-restore-target='lookup']")
+    lookup?.focus()
+    lookup?.select?.()
+  }
+
+  save() {
+    const activeForm = document.activeElement?.closest("form[data-dirty-track]")
+    const save = activeForm?.querySelector("[data-ops-save]") || this.element.querySelector("[data-ops-save]")
+    save?.click()
+  }
+
+  primary() {
+    this.element.querySelector("[data-ops-primary]")?.click()
+  }
+
+  toggleHelp() {
+    const opening = !this.helpTarget.hidden
+    this.helpTarget.hidden = opening
+    this.helpButtonTarget.setAttribute("aria-expanded", (!opening).toString())
+    if (!opening) this.helpTarget.querySelector("button")?.focus()
+    else this.helpButtonTarget.focus()
+  }
+
+  editable(target) {
+    return target.matches("input, textarea, select, [contenteditable='true']")
+  }
+}

--- a/app/javascript/controllers/row_selection_controller.js
+++ b/app/javascript/controllers/row_selection_controller.js
@@ -1,0 +1,44 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "row" ]
+
+  connect() {
+    this.selectedIndex = this.rowTargets.findIndex((row) => row.classList.contains("is-selected"))
+  }
+
+  keydown(event) {
+    if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return
+    if (![ "ArrowUp", "ArrowDown", "Enter" ].includes(event.key)) return
+    if (this.editingText(event.target) && event.key !== "Enter") return
+
+    if (event.key === "Enter") {
+      const row = this.rowTargets[this.selectedIndex]
+      const action = row?.querySelector("[data-row-primary]")
+      if (!action || this.editingText(event.target)) return
+      event.preventDefault()
+      action.click()
+      return
+    }
+
+    event.preventDefault()
+    const step = event.key === "ArrowDown" ? 1 : -1
+    const start = this.selectedIndex < 0 ? (step > 0 ? -1 : 0) : this.selectedIndex
+    this.select((start + step + this.rowTargets.length) % this.rowTargets.length)
+  }
+
+  select(index) {
+    this.rowTargets.forEach((row, rowIndex) => {
+      const selected = rowIndex === index
+      row.classList.toggle("is-selected", selected)
+      row.setAttribute("aria-selected", selected.toString())
+      row.tabIndex = selected ? 0 : -1
+    })
+    this.selectedIndex = index
+    this.rowTargets[index]?.focus({ preventScroll: true })
+  }
+
+  editingText(target) {
+    return target.matches("input, textarea, select, [contenteditable='true']")
+  }
+}

--- a/app/javascript/purchasing_ops.js
+++ b/app/javascript/purchasing_ops.js
@@ -1,0 +1,2 @@
+import "@hotwired/turbo-rails"
+import "controllers"

--- a/app/views/layouts/ops.html.erb
+++ b/app/views/layouts/ops.html.erb
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
-<html lang="en" data-turbo="false">
+<html lang="en">
   <head>
     <title><%= content_for?(:title) ? "#{content_for(:title)} · ShelfSense" : "Ops · ShelfSense" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag "application" %>
+    <%= javascript_importmap_tags "purchasing_ops" %>
   </head>
   <body class="ops-body">
     <header class="ops-header">
@@ -31,7 +32,30 @@
       </nav>
     </header>
     <%= render "shared/flash" %>
-    <main class="ops-content">
+    <main class="ops-content"
+          data-controller="ops-shortcuts dirty-form escape-cancel"
+          data-action="keydown@window->ops-shortcuts#keydown keydown@window->escape-cancel#keydown input->dirty-form#change change->dirty-form#change submit->dirty-form#submit ops:dirty-cancel->dirty-form#cancel turbo:before-visit@document->dirty-form#beforeVisit beforeunload@window->dirty-form#beforeUnload">
+      <aside class="ops-shortcuts" aria-label="Purchasing operations keyboard shortcuts">
+        <div class="ops-shortcuts__buttons">
+          <button type="button" class="btn btn--ghost" data-action="ops-shortcuts#focusLookup">Focus lookup <kbd>/</kbd></button>
+          <button type="button" class="btn btn--ghost" data-action="ops-shortcuts#save">Save <kbd>Ctrl/⌘ S</kbd></button>
+          <button type="button" class="btn btn--ghost" data-action="ops-shortcuts#primary">Primary action <kbd>Ctrl/⌘ Enter</kbd></button>
+          <button type="button" class="btn btn--ghost" data-action="escape-cancel#cancel">Cancel current selection/edit <kbd>Esc</kbd></button>
+          <button type="button" class="btn btn--ghost" aria-expanded="false" aria-controls="ops-shortcut-help" data-ops-shortcuts-target="helpButton" data-action="ops-shortcuts#toggleHelp">Shortcut help</button>
+        </div>
+        <div id="ops-shortcut-help" class="ops-shortcuts__help" data-ops-shortcuts-target="help" hidden>
+          <h2>Keyboard shortcuts</h2>
+          <dl>
+            <div><dt><kbd>/</kbd></dt><dd>Focus lookup or scan input</dd></div>
+            <div><dt><kbd>↑</kbd> <kbd>↓</kbd></dt><dd>Select a row</dd></div>
+            <div><dt><kbd>Enter</kbd></dt><dd>Activate the selected row or submit the current scan</dd></div>
+            <div><dt><kbd>Esc</kbd></dt><dd>Close help or cancel the current selection/edit without saving</dd></div>
+            <div><dt><kbd>Ctrl/⌘ S</kbd></dt><dd>Save the current edit</dd></div>
+            <div><dt><kbd>Ctrl/⌘ Enter</kbd></dt><dd>Run the labeled primary action</dd></div>
+          </dl>
+          <button type="button" data-action="ops-shortcuts#toggleHelp">Close shortcut help</button>
+        </div>
+      </aside>
       <%= yield %>
     </main>
   </body>

--- a/app/views/ops/draft_pos/show.html.erb
+++ b/app/views/ops/draft_pos/show.html.erb
@@ -24,7 +24,7 @@
     <% unless @purchase_order.generated? %>
       <%= form_with url: ops_purchase_order_generate_path(@purchase_order), method: :post, local: true do %>
         <%= hidden_field_tag :lock_version, @purchase_order.lock_version %>
-        <button type="submit">Generate PO number</button>
+        <button type="submit" data-ops-primary>Generate PO number</button>
       <% end %>
     <% else %>
       <p>Generated #<%= @purchase_order.number %> (revision <%= @purchase_order.document_revision %>).</p>
@@ -50,13 +50,13 @@
 <% end %>
 
 <% if effective_permissions.include?("orders.manage") && !@purchase_order.generated? %>
-  <section class="ops-scan">
+  <section class="ops-scan" data-controller="focus-restore">
     <h2>Add stock line</h2>
     <%= form_with url: ops_purchase_order_add_line_path(@purchase_order), method: :post, local: true do %>
       <%= hidden_field_tag :lock_version, @purchase_order.lock_version %>
       <label>
         Scan / identifier
-        <input type="text" name="identifier" autocomplete="off" autofocus inputmode="text">
+        <input type="text" name="identifier" autocomplete="off" inputmode="text" data-focus-restore-target="lookup">
       </label>
       <label>
         or variant ID
@@ -81,7 +81,7 @@
   <% if @lines.empty? %>
     <p>No lines yet.</p>
   <% else %>
-    <table class="ops-queue">
+    <table class="ops-queue" data-controller="row-selection" data-action="keydown->row-selection#keydown">
       <thead>
         <tr>
           <th scope="col">Order</th>
@@ -96,7 +96,7 @@
       <tbody>
         <% @lines.each do |line| %>
           <% order = line.order %>
-          <tr>
+          <tr tabindex="-1" aria-selected="false" data-row-selection-target="row">
             <td><%= link_to "##{order.number}", admin_order_path(order) %></td>
             <td>
               <%= line.product_variant.product.name %>
@@ -114,7 +114,7 @@
             <td><%= line.notes_snapshot.presence || "—" %></td>
             <% if effective_permissions.include?("orders.manage") && !@purchase_order.generated? && !order.cancelled? %>
               <td>
-                <%= form_with url: ops_purchase_order_update_line_path(@purchase_order, line), method: :patch, local: true, html: { class: "ops-inline-form" } do %>
+                <%= form_with url: ops_purchase_order_update_line_path(@purchase_order, line), method: :patch, local: true, html: { class: "ops-inline-form", data: { dirty_track: true } } do %>
                   <%= hidden_field_tag :lock_version, order.lock_version %>
                   <label>
                     Qty
@@ -128,7 +128,7 @@
                     Notes
                     <input type="text" name="notes" value="<%= order.notes %>">
                   </label>
-                  <button type="submit">Save</button>
+                  <button type="submit" data-ops-save data-row-primary>Save</button>
                 <% end %>
               </td>
             <% end %>

--- a/app/views/ops/locations/show.html.erb
+++ b/app/views/ops/locations/show.html.erb
@@ -5,7 +5,7 @@
 <% if @pending_requests.empty? %>
   <p>No pending location requests.</p>
 <% else %>
-  <table class="ops-queue">
+  <table class="ops-queue" data-controller="focus-restore row-selection" data-action="keydown->row-selection#keydown">
     <thead>
       <tr>
         <th scope="col">#</th>
@@ -18,7 +18,7 @@
     <tbody>
       <% @pending_requests.each do |request| %>
         <% variant = request.product_variant %>
-        <tr>
+        <tr tabindex="-1" aria-selected="false" data-row-selection-target="row">
           <td><%= request.number %></td>
           <td><%= request.customer.display_name %></td>
           <td>
@@ -42,10 +42,10 @@
                 </label>
                 <label>
                   or scan
-                  <input type="text" name="unit_identifier" autocomplete="off" inputmode="numeric">
+                  <input type="text" name="unit_identifier" autocomplete="off" inputmode="numeric"<%= " data-focus-restore-target=lookup" if request == @pending_requests.first %>>
                 </label>
               <% end %>
-              <button type="submit"<%= " autofocus" if request == @pending_requests.first %>>Located</button>
+              <button type="submit" data-row-primary<%= " data-focus-restore-target=lookup" if request == @pending_requests.first && variant.standard? %>>Located</button>
             <% end %>
             <%= form_with url: ops_location_not_located_path(request), method: :post, local: true, html: { class: "ops-inline-form" } do %>
               <%= hidden_field_tag :lock_version, request.lock_version %>

--- a/app/views/ops/receiving/show.html.erb
+++ b/app/views/ops/receiving/show.html.erb
@@ -20,7 +20,8 @@
 <% if @receipt.draft? && effective_permissions.include?("purchase_receipts.manage") %>
   <section class="ops-actions">
     <h2>Receipt header</h2>
-    <%= form_with url: ops_receiving_update_path(@receipt), method: :patch, local: true do %>
+    <%= form_with url: ops_receiving_update_path(@receipt), method: :patch, local: true, html: { data: { dirty_track: true } } do %>
+      <%= hidden_field_tag :lock_version, @receipt.lock_version %>
       <label>
         Received at
         <input type="datetime-local" name="received_at" value="<%= @receipt.received_at&.strftime("%Y-%m-%dT%H:%M") %>">
@@ -57,12 +58,12 @@
         Notes
         <input type="text" name="notes" value="<%= @receipt.notes %>">
       </label>
-      <button type="submit">Save header</button>
+      <button type="submit" data-ops-save>Save header</button>
     <% end %>
     <p class="ops-hint">Ancillary charges are recorded but never enter inventory valuation.</p>
   </section>
 
-  <section class="ops-scan">
+  <section class="ops-scan" data-controller="focus-restore">
     <h2>Add open PO line</h2>
     <% if @open_po_lines.empty? %>
       <p>No open sent PO lines for this supplier/store.</p>
@@ -71,7 +72,7 @@
         <%= hidden_field_tag :lock_version, @receipt.lock_version %>
         <label>
           PO line
-          <select name="purchase_order_line_id" required>
+          <select name="purchase_order_line_id" required data-focus-restore-target="lookup">
             <option value="">Select…</option>
             <% @open_po_lines.each do |po_line| %>
               <option value="<%= po_line.id %>">
@@ -105,7 +106,7 @@
   <% if @lines.empty? %>
     <p>No lines yet.</p>
   <% else %>
-    <table class="ops-queue">
+    <table class="ops-queue" data-controller="row-selection" data-action="keydown->row-selection#keydown">
       <thead>
         <tr>
           <th scope="col">PO</th>
@@ -123,7 +124,7 @@
       <tbody>
         <% @lines.each do |line| %>
           <% po_line = line.purchase_order_line %>
-          <tr>
+          <tr tabindex="-1" aria-selected="false" data-row-selection-target="row">
             <td>#<%= po_line.purchase_order.number %></td>
             <td>
               <%= line.product_variant.product.name %>
@@ -142,7 +143,7 @@
             </td>
             <% if @receipt.draft? && effective_permissions.include?("purchase_receipts.manage") %>
               <td>
-                <%= form_with url: ops_receiving_update_line_path(@receipt, line), method: :patch, local: true, html: { class: "ops-inline-form" } do %>
+                <%= form_with url: ops_receiving_update_line_path(@receipt, line), method: :patch, local: true, html: { class: "ops-inline-form", data: { dirty_track: true } } do %>
                   <%= hidden_field_tag :lock_version, @receipt.lock_version %>
                   <label>
                     Qty
@@ -152,7 +153,7 @@
                     Cost
                     <input type="number" name="actual_unit_cost_cents" value="<%= line.actual_unit_cost_cents %>" min="0" required>
                   </label>
-                  <button type="submit">Save</button>
+                  <button type="submit" data-ops-save data-row-primary>Save</button>
                 <% end %>
               </td>
             <% end %>
@@ -167,7 +168,7 @@
 <% if @receipt.draft? && effective_permissions.include?("purchase_receipts.post") && @lines.any? %>
   <section class="ops-actions">
     <h2>Post</h2>
-    <p><%= link_to "Review and post", ops_receiving_review_path(@receipt) %></p>
+    <p><%= link_to "Review and post", ops_receiving_review_path(@receipt), data: { ops_primary: true } %></p>
   </section>
 <% end %>
 

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -3,6 +3,7 @@
 pin "application"
 pin "admin_store_receipt_messages"
 pin "pos"
+pin "purchasing_ops"
 pin "@hotwired/turbo-rails", to: "turbo.min.js"
 pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"

--- a/test/integration/purchasing_ops_layout_test.rb
+++ b/test/integration/purchasing_ops_layout_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PurchasingOpsLayoutTest < ActionDispatch::IntegrationTest
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    sign_in
+  end
+
+  test "ops loads its dedicated Turbo entry point while admin remains server rendered" do
+    get ops_location_path
+
+    assert_response :success
+    assert_select "html:not([data-turbo='false'])"
+    assert_select "script[type='module']", text: /import \"purchasing_ops\"/
+    assert_select "[data-controller~='ops-shortcuts']"
+
+    get root_path
+
+    assert_response :success
+    assert_select "html[data-turbo='false']"
+    assert_select "script[type='module']", text: /import \"application\"/
+    assert_select "script[type='module']", text: /purchasing_ops/, count: 0
+  end
+
+  private
+
+  def sign_in
+    post session_path, params: { session: { username: @actor.username, password: "correct-horse-battery" } }
+  end
+end

--- a/test/system/purchasing_ops_workspace_test.rb
+++ b/test/system/purchasing_ops_workspace_test.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class PurchasingOpsWorkspaceTest < ApplicationSystemTestCase
+  setup do
+    bootstrap = bootstrap!
+    @store = bootstrap[:store]
+    @actor = bootstrap[:administrator]
+    tax = tax_class(code: "ops_#{SecureRandom.hex(3)}")
+    @variant = pos_sellable_variant(actor: @actor, tax_class: tax, name: "Keyboard Purchasing Book")
+    @supplier = Supplier.create!(name: "Keyboard Supplier", code: "key_#{SecureRandom.hex(3)}")
+    SupplierVariantSource.create!(
+      supplier: @supplier,
+      product_variant: @variant,
+      pricing_method: "direct_unit_cost",
+      expected_unit_cost_cents: 725,
+      organization_preferred: true
+    )
+    @purchase_order = Purchasing::CreateStockOrder.call(
+      store: @store,
+      product_variant: @variant,
+      actor: @actor,
+      quantity: 1
+    ).purchase_order
+    sign_in_admin
+  end
+
+  test "scan Enter adds repeatedly and restores lookup focus after success and recoverable failure" do
+    visit ops_purchase_order_path(@purchase_order)
+    lookup = find("input[name='identifier']")
+    assert_equal "identifier", page.evaluate_script("document.activeElement && document.activeElement.name")
+
+    lookup.fill_in with: @variant.sku
+    lookup.send_keys :enter
+    assert_text "Added stock order"
+    assert_equal "identifier", page.evaluate_script("document.activeElement && document.activeElement.name")
+
+    find("input[name='identifier']").fill_in with: "not-a-real-identifier"
+    find("input[name='identifier']").send_keys :enter
+    assert_selector ".flash--alert"
+    assert_equal "identifier", page.evaluate_script("document.activeElement && document.activeElement.name")
+  end
+
+  test "visible shortcuts focus lookup, save the active row, and invoke the primary action" do
+    visit ops_purchase_order_path(@purchase_order)
+    assert_button "Focus lookup /"
+    assert_button "Save Ctrl/⌘ S"
+    assert_button "Primary action Ctrl/⌘ Enter"
+    click_on "Shortcut help"
+    assert_text "Keyboard shortcuts"
+    send_keys :escape
+    assert_no_text "Keyboard shortcuts"
+
+    find("input[name='quantity']", match: :first).click
+    send_keys [ :control, "s" ]
+    assert_text "Line updated"
+
+    find("body").send_keys [ :control, :enter ]
+    assert_text "Purchase order generated"
+  end
+
+  test "arrow selection, Enter activation, and Escape cancellation do not change a draft" do
+    visit ops_purchase_order_path(@purchase_order)
+    original_version = @purchase_order.purchase_order_lines.first.order.lock_version
+
+    find("h2", text: "Lines").click
+    send_keys :arrow_down
+    assert_selector "tr.is-selected"
+    send_keys :escape
+    assert_no_selector "tr.is-selected"
+    assert_equal original_version, @purchase_order.purchase_order_lines.first.order.reload.lock_version
+
+    send_keys :arrow_down
+    find("tr.is-selected").send_keys :enter
+    assert_text "Line updated"
+  end
+
+  test "dirty receipt or PO edits require confirmation before Turbo navigation" do
+    visit ops_purchase_order_path(@purchase_order)
+    notes = find("input[name='notes']", match: :first)
+    notes.fill_in with: "unsaved buyer note"
+
+    dismiss_confirm("Discard unsaved purchasing changes?") do
+      click_on "All drafts"
+    end
+    assert_current_path ops_purchase_order_path(@purchase_order)
+    assert_field "notes", with: "unsaved buyer note"
+
+    accept_confirm("Discard unsaved purchasing changes?") do
+      click_on "All drafts"
+    end
+    assert_current_path ops_draft_pos_path
+    assert_nil @purchase_order.purchase_order_lines.first.order.reload.notes
+  end
+
+  private
+
+  def sign_in_admin
+    visit new_session_path
+    fill_in "session_username", with: @actor.username
+    fill_in "session_password", with: "correct-horse-battery"
+    find_field("session_password").send_keys :enter
+    assert_text "Signed in successfully"
+  end
+end


### PR DESCRIPTION
### Motivation

- Provide Phase‑7 compliant, Register‑class ops workspaces that are keyboard- and scanner-first while keeping admin chrome server‑rendered and POS on its independent layout.
- Improve operator efficiency and accessibility for purchasing flows (location queue, draft PO builder, receiving) with predictable focus, shortcuts, and unsaved-draft protection.

### Description

- Load a dedicated Importmap entry point `purchasing_ops` and enable Turbo/Stimulus for the ops layout by updating `config/importmap.rb` and `app/views/layouts/ops.html.erb` and leaving admin and POS layouts unchanged. 
- Add focused Stimulus controllers under `app/javascript/controllers/` for focus restoration (`focus_restore_controller.js`), arrow-key row selection (`row_selection_controller.js`), Escape cancel behavior (`escape_cancel_controller.js`), shortcut handling/help (`ops_shortcuts_controller.js`), and dirty-form tracking/confirmation (`dirty_form_controller.js`), plus a small `app/javascript/purchasing_ops.js` entry file.
- Apply controllers and attributes to purchasing ops views to restore lookup focus, support arrow/Enter row navigation, Esc cancel that does not mutate drafts, `/` focus lookup, Ctrl/⌘+S save, Ctrl/⌘+Enter primary action, visible shortcut help and button equivalents, and dirty-form tracking on editable draft forms in `app/views/ops/locations/show.html.erb`, `app/views/ops/draft_pos/show.html.erb`, and `app/views/ops/receiving/show.html.erb`.
- Add supportive CSS for ops chrome and selected-row/dirty-form visuals in `app/assets/stylesheets/application.css` and add automated coverage: `test/integration/purchasing_ops_layout_test.rb` and `test/system/purchasing_ops_workspace_test.rb` that assert the new entry point, visible shortcuts, focus restoration, scan+Enter loops, row selection/activation, Escape behavior, and unsaved-draft protection.

### Testing

- Ran static and repository checks: `git diff --check` completed without errors and ERB parsing of modified templates succeeded. 
- Performed JavaScript syntax checks (`node --check`) on the new controllers and `purchasing_ops.js` and they passed in this environment. 
- Added an integration test (`test/integration/purchasing_ops_layout_test.rb`) and a system test (`test/system/purchasing_ops_workspace_test.rb`) exercising the layout, focus, shortcuts, scan/Enter loop, selection, Escape, and dirty-form confirmation behaviors, but the Rails/system tests could not be executed here because Docker is not available in the execution environment. 
- Commit recorded as `Add keyboard-first purchasing ops interactions` and the modified files were staged and committed in this branch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a890ee91310832cb9a822bd51576227)