### PR TITLE
Replace receiving PO dropdown with scanner lookup

### DIFF
--- a/app/controllers/ops/receiving_controller.rb
+++ b/app/controllers/ops/receiving_controller.rb
@@ -3,10 +3,10 @@
 module Ops
   class ReceivingController < BaseController
     before_action -> { require_permission!("purchase_receipts.view") }, only: %i[index show]
-    before_action -> { require_permission!("purchase_receipts.manage") }, only: %i[create add_line update update_line]
+    before_action -> { require_permission!("purchase_receipts.manage") }, only: %i[create line_lookup add_line update update_line]
     before_action -> { require_permission!("purchase_receipts.post") }, only: %i[review post]
     before_action -> { require_permission!("purchase_receipts.correct") }, only: %i[reverse reverse_line correct_cost]
-    before_action :set_receipt, only: %i[show add_line update update_line review post reverse reverse_line correct_cost]
+    before_action :set_receipt, only: %i[show line_lookup add_line update update_line review post reverse reverse_line correct_cost]
 
     def index
       @draft_receipts = PurchaseReceipt.draft
@@ -24,9 +24,38 @@ module Ops
           product_variant: :product
         )
         .order(:created_at)
-      @open_po_lines = open_po_lines_for(@receipt) if @receipt.draft?
       @can_correct = effective_permissions.include?("purchase_receipts.correct")
       @can_compensate = effective_permissions.include?("purchase_receipts.compensate")
+    end
+
+    def line_lookup
+      unless @receipt.draft?
+        render json: { outcome: "ineligible", message: "Only draft receipts can be edited." }, status: :unprocessable_entity
+        return
+      end
+
+      query = params[:query].to_s.strip
+      if query.blank?
+        render json: { outcome: "no_match", message: "Enter or scan an identifier." }
+        return
+      end
+
+      variants, used_variant = lookup_variants(query)
+      lines = eligible_open_po_lines(@receipt, variants, query)
+
+      if lines.empty?
+        message = if used_variant
+          "Used variants are not eligible for purchase-order receiving."
+        else
+          "No eligible open Standard PO line matches this receipt's store and supplier."
+        end
+        render json: { outcome: used_variant ? "ineligible" : "no_match", message: message }
+      else
+        render json: {
+          outcome: lines.one? ? "selected" : "multiple",
+          matches: lines.map { |line| serialize_lookup_line(line) }
+        }
+      end
     end
 
     def create
@@ -87,7 +116,14 @@ module Ops
         notes: params[:notes],
         expected_lock_version: params[:lock_version]
       )
-      redirect_to ops_receiving_path(@receipt), notice: "Line added."
+      respond_to do |format|
+        format.html { redirect_to ops_receiving_path(@receipt), notice: "Line added." }
+        format.turbo_stream do
+          load_receipt_lines
+          @scan_notice = "Line added. Scanner ready."
+          render :add_line
+        end
+      end
     rescue Purchasing::Error, ActiveRecord::RecordInvalid => e
       redirect_to ops_receiving_path(@receipt), alert: e.message
     rescue ActiveRecord::StaleObjectError
@@ -188,6 +224,71 @@ module Ops
 
     private
 
+    def load_receipt_lines
+      @receipt.reload
+      @lines = @receipt.purchase_receipt_lines
+        .includes(
+          :corrections,
+          purchase_order_line: { order: :customer_request, product_variant: :product, purchase_order: [] },
+          product_variant: :product
+        )
+        .order(:created_at)
+    end
+
+    def lookup_variants(query)
+      result = Identifiers::Lookup.call(query)
+      variants = case result.status
+      when :variant, :inventory_unit then [ result.variant ].compact
+      when :product then result.variants
+      else []
+      end
+
+      if variants.empty?
+        pattern = "%#{ActiveRecord::Base.sanitize_sql_like(query)}%"
+        variants = ProductVariant.joins(:product)
+          .where("products.name ILIKE :pattern OR products.lookup_code = :code", pattern: pattern, code: Product.canonical_lookup_code(query))
+          .limit(50)
+          .to_a
+      end
+      [ variants.select(&:standard?), variants.any?(&:used?) ]
+    end
+
+    def eligible_open_po_lines(receipt, variants, query)
+      scope = PurchaseOrderLine
+        .joins(:purchase_order, :order)
+        .left_joins(order: :customer_request)
+        .includes(:cancellations, :purchase_receipt_lines, { order: :customer_request }, product_variant: :product, purchase_order: [])
+        .where(product_variant_id: variants.map(&:id))
+        .where(purchase_orders: { store_id: receipt.store_id, supplier_id: receipt.supplier_id, status: %w[sent closed] })
+
+      # A request number is also a useful receiving search term; preserve all
+      # identifier matches while adding an exact customer-request match.
+      request_number = Integer(query, exception: false)
+      if variants.empty? && request_number
+        scope = PurchaseOrderLine
+          .joins(:purchase_order, order: :customer_request)
+          .includes(:cancellations, :purchase_receipt_lines, { order: :customer_request }, product_variant: :product, purchase_order: [])
+          .where(customer_requests: { number: request_number })
+          .where(purchase_orders: { store_id: receipt.store_id, supplier_id: receipt.supplier_id, status: %w[sent closed] })
+      end
+
+      scope.order(Arel.sql("purchase_orders.number NULLS LAST"), :created_at).to_a.select { |line| line.open_quantity.positive? }
+    end
+
+    def serialize_lookup_line(line)
+      request = line.order.customer_request
+      {
+        id: line.id,
+        po_number: line.purchase_order.number,
+        product: line.product_variant.product.name,
+        sku: line.product_variant.sku,
+        customer_request: request&.number,
+        order_date: line.purchase_order.sent_at&.to_date || line.purchase_order.created_at.to_date,
+        open_quantity: line.open_quantity,
+        expected_unit_cost_cents: line.expected_unit_cost_cents_snapshot
+      }
+    end
+
     def set_receipt
       @receipt = PurchaseReceipt.for_store(current_store).find(params[:id])
     end
@@ -195,23 +296,6 @@ module Ops
     def compensate_authorized?
       ActiveModel::Type::Boolean.new.cast(params[:authorize_compensate]) &&
         effective_permissions.include?("purchase_receipts.compensate")
-    end
-
-    def open_po_lines_for(receipt)
-      PurchaseOrderLine
-        .joins(:purchase_order)
-        .includes(:order, :cancellations, :purchase_receipt_lines, product_variant: :product, purchase_order: [])
-        .where(purchase_orders: {
-          store_id: receipt.store_id,
-          supplier_id: receipt.supplier_id,
-          status: %w[sent closed]
-        })
-        .order(Arel.sql("purchase_orders.number NULLS LAST"), :created_at)
-        .to_a
-        .select do |line|
-          line.open_quantity.positive? ||
-            receipt.purchase_receipt_lines.any? { |rl| rl.purchase_order_line_id == line.id }
-        end
     end
 
     def preview_line(line)

--- a/app/javascript/controllers/receiving_lookup_controller.js
+++ b/app/javascript/controllers/receiving_lookup_controller.js
@@ -1,0 +1,125 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "query", "message", "picker", "selection", "form", "lineId", "quantity", "cost", "confirm" ]
+  static values = { url: String }
+
+  connect() {
+    this.matches = []
+    this.selectedIndex = -1
+  }
+
+  async search(event) {
+    event.preventDefault()
+    const query = this.queryTarget.value.trim()
+    if (!query) return this.showMessage("Enter or scan an identifier.")
+
+    this.showMessage("Searching…")
+    this.clearSelection()
+    try {
+      const response = await fetch(`${this.urlValue}?query=${encodeURIComponent(query)}`, {
+        headers: { Accept: "application/json" }, credentials: "same-origin"
+      })
+      const payload = await response.json()
+      if (payload.outcome === "selected") {
+        this.selectMatch(payload.matches[0])
+      } else if (payload.outcome === "multiple") {
+        this.showPicker(payload.matches)
+      } else {
+        this.showMessage(payload.message || "No eligible open PO line found.")
+      }
+    } catch (_error) {
+      this.showMessage("Lookup could not be completed. Try again.")
+    }
+  }
+
+  clearMessage() {
+    this.messageTarget.textContent = ""
+  }
+
+  showPicker(matches) {
+    this.matches = matches
+    this.selectedIndex = 0
+    this.pickerTarget.replaceChildren()
+    const heading = document.createElement("h3")
+    heading.textContent = `${matches.length} open PO lines match. Use Up/Down and Enter to select.`
+    this.pickerTarget.append(heading)
+
+    const list = document.createElement("div")
+    list.setAttribute("role", "listbox")
+    list.addEventListener("keydown", (event) => this.pickerKeydown(event))
+    matches.forEach((match, index) => {
+      const button = document.createElement("button")
+      button.type = "button"
+      button.setAttribute("role", "option")
+      button.dataset.index = index
+      button.textContent = this.description(match)
+      button.addEventListener("click", () => this.selectMatch(match))
+      list.append(button)
+    })
+    this.pickerTarget.append(list)
+    this.pickerTarget.hidden = false
+    this.updatePickerSelection()
+    this.showMessage("Multiple eligible lines found; select the correct purchase-order line.")
+  }
+
+  pickerKeydown(event) {
+    if (![ "ArrowUp", "ArrowDown", "Enter", "Escape" ].includes(event.key)) return
+    event.preventDefault()
+    if (event.key === "Escape") {
+      this.pickerTarget.hidden = true
+      this.queryTarget.focus()
+    } else if (event.key === "Enter") {
+      this.selectMatch(this.matches[this.selectedIndex])
+    } else {
+      const step = event.key === "ArrowDown" ? 1 : -1
+      this.selectedIndex = (this.selectedIndex + step + this.matches.length) % this.matches.length
+      this.updatePickerSelection()
+    }
+  }
+
+  updatePickerSelection() {
+    const options = Array.from(this.pickerTarget.querySelectorAll("[role='option']"))
+    options.forEach((option, index) => {
+      const selected = index === this.selectedIndex
+      option.setAttribute("aria-selected", selected.toString())
+      option.classList.toggle("is-selected", selected)
+      option.tabIndex = selected ? 0 : -1
+    })
+    options[this.selectedIndex]?.focus({ preventScroll: true })
+  }
+
+  selectMatch(match) {
+    this.pickerTarget.hidden = true
+    this.lineIdTarget.value = match.id
+    this.quantityTarget.value = match.open_quantity
+    this.costTarget.value = match.expected_unit_cost_cents
+    this.quantityTarget.disabled = false
+    this.costTarget.disabled = false
+    this.confirmTarget.disabled = false
+    this.selectionTarget.textContent = this.description(match)
+    this.showMessage("Line selected. Confirm quantity and actual cost before adding.")
+    this.quantityTarget.focus()
+    this.quantityTarget.select()
+  }
+
+  clearSelection() {
+    this.pickerTarget.hidden = true
+    this.lineIdTarget.value = ""
+    this.quantityTarget.value = ""
+    this.costTarget.value = ""
+    this.quantityTarget.disabled = true
+    this.costTarget.disabled = true
+    this.confirmTarget.disabled = true
+    this.selectionTarget.textContent = "Scan or search to select an eligible PO line."
+  }
+
+  description(match) {
+    const request = match.customer_request ? ` · customer request #${match.customer_request}` : " · stock order"
+    return `PO #${match.po_number} · ${match.product} · SKU ${match.sku}${request} · ordered ${match.order_date} · open ${match.open_quantity} · expected ${match.expected_unit_cost_cents}¢`
+  }
+
+  showMessage(message) {
+    this.messageTarget.textContent = message
+  }
+}

--- a/app/views/ops/receiving/_line_grid.html.erb
+++ b/app/views/ops/receiving/_line_grid.html.erb
@@ -1,0 +1,40 @@
+<section id="receiving_line_grid">
+  <h2>Lines</h2>
+  <% if @lines.empty? %>
+    <p>No lines yet.</p>
+  <% else %>
+    <table class="ops-queue" data-controller="row-selection" data-action="keydown->row-selection#keydown">
+      <thead><tr>
+        <th scope="col">PO</th><th scope="col">Item</th><th scope="col">Open</th><th scope="col">Received</th>
+        <th scope="col">Matched*</th><th scope="col">Unplanned*</th><th scope="col">Over-shipment</th>
+        <th scope="col">Unit cost</th><th scope="col">Customer</th>
+        <% if @receipt.draft? && effective_permissions.include?("purchase_receipts.manage") %><th scope="col">Edit</th><% end %>
+      </tr></thead>
+      <tbody>
+        <% @lines.each do |line| %>
+          <% po_line = line.purchase_order_line %>
+          <% open_quantity = po_line.open_quantity %>
+          <% over_shipment = [line.received_quantity - open_quantity, 0].max %>
+          <tr tabindex="-1" aria-selected="false" data-row-selection-target="row">
+            <td>#<%= po_line.purchase_order.number %></td>
+            <td><%= line.product_variant.product.name %> <code><%= line.product_variant.sku %></code></td>
+            <td><%= open_quantity %></td><td><%= line.received_quantity %></td>
+            <td><%= line.matched_quantity %></td><td><%= line.unplanned_quantity %></td>
+            <td><% if over_shipment.positive? %><strong>Yes — <%= over_shipment %> over open quantity</strong><% else %>No<% end %></td>
+            <td><%= line.actual_unit_cost_cents %></td>
+            <td><%= po_line.order.customer_request.present? ? "Req ##{po_line.order.customer_request.number}" : "—" %></td>
+            <% if @receipt.draft? && effective_permissions.include?("purchase_receipts.manage") %>
+              <td><%= form_with url: ops_receiving_update_line_path(@receipt, line), method: :patch, local: true, html: { class: "ops-inline-form", data: { dirty_track: true } } do %>
+                <%= hidden_field_tag :lock_version, @receipt.lock_version %>
+                <label>Qty <input type="number" name="received_quantity" value="<%= line.received_quantity %>" min="1" required></label>
+                <label>Cost <input type="number" name="actual_unit_cost_cents" value="<%= line.actual_unit_cost_cents %>" min="0" required></label>
+                <button type="submit" data-ops-save data-row-primary>Save</button>
+              <% end %></td>
+            <% end %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <p class="ops-hint">* Matched/unplanned are provisional on drafts and frozen at post. Quantity may exceed the open quantity; the excess is an over-shipment and becomes unplanned stock.</p>
+  <% end %>
+</section>

--- a/app/views/ops/receiving/_line_scanner.html.erb
+++ b/app/views/ops/receiving/_line_scanner.html.erb
@@ -1,0 +1,33 @@
+<section id="receiving_line_scanner" class="ops-scan" data-controller="receiving-lookup focus-restore" data-receiving-lookup-url-value="<%= ops_receiving_line_lookup_path(@receipt) %>" data-action="turbo:submit-end->focus-restore#focus">
+  <h2>Scan or search open PO lines</h2>
+  <label>
+    Product identifier, name, lookup code, or customer request #
+    <input type="search" name="receiving_lookup" autocomplete="off" autofocus
+           data-focus-restore-target="lookup" data-receiving-lookup-target="query"
+           data-action="keydown.enter->receiving-lookup#search input->receiving-lookup#clearMessage">
+  </label>
+  <button type="button" data-action="receiving-lookup#search">Search</button>
+  <p class="ops-hint">Results are limited to open Standard purchase-order lines for <%= @receipt.supplier.admin_label %> at <%= current_store.admin_label %>.</p>
+  <p role="status" aria-live="polite" data-receiving-lookup-target="message"><%= @scan_notice %></p>
+
+  <div data-receiving-lookup-target="picker" hidden></div>
+
+  <div data-receiving-lookup-target="editor">
+    <h3>Current line</h3>
+    <p data-receiving-lookup-target="selection">Scan or search to select an eligible PO line.</p>
+    <%= form_with url: ops_receiving_add_line_path(@receipt), method: :post,
+          data: { receiving_lookup_target: "form" } do %>
+      <%= hidden_field_tag :lock_version, @receipt.lock_version %>
+      <input type="hidden" name="purchase_order_line_id" data-receiving-lookup-target="lineId">
+      <label>
+        Qty received
+        <input type="number" name="received_quantity" min="1" required disabled data-receiving-lookup-target="quantity">
+      </label>
+      <label>
+        Actual unit cost (cents)
+        <input type="number" name="actual_unit_cost_cents" min="0" required disabled data-receiving-lookup-target="cost">
+      </label>
+      <button type="submit" disabled data-receiving-lookup-target="confirm">Confirm and add line</button>
+    <% end %>
+  </div>
+</section>

--- a/app/views/ops/receiving/add_line.turbo_stream.erb
+++ b/app/views/ops/receiving/add_line.turbo_stream.erb
@@ -1,0 +1,6 @@
+<%= turbo_stream.replace "receiving_line_scanner" do %>
+  <%= render "line_scanner" %>
+<% end %>
+<%= turbo_stream.replace "receiving_line_grid" do %>
+  <%= render "line_grid" %>
+<% end %>

--- a/app/views/ops/receiving/show.html.erb
+++ b/app/views/ops/receiving/show.html.erb
@@ -63,107 +63,10 @@
     <p class="ops-hint">Ancillary charges are recorded but never enter inventory valuation.</p>
   </section>
 
-  <section class="ops-scan" data-controller="focus-restore">
-    <h2>Add open PO line</h2>
-    <% if @open_po_lines.empty? %>
-      <p>No open sent PO lines for this supplier/store.</p>
-    <% else %>
-      <%= form_with url: ops_receiving_add_line_path(@receipt), method: :post, local: true do %>
-        <%= hidden_field_tag :lock_version, @receipt.lock_version %>
-        <label>
-          PO line
-          <select name="purchase_order_line_id" required data-focus-restore-target="lookup">
-            <option value="">Select…</option>
-            <% @open_po_lines.each do |po_line| %>
-              <option value="<%= po_line.id %>">
-                PO #<%= po_line.purchase_order.number %>
-                · <%= po_line.product_variant.product.name %>
-                · open <%= po_line.open_quantity %>
-                · expected <%= po_line.expected_unit_cost_cents_snapshot %>¢
-                <% if po_line.order.customer_request.present? %>
-                  · request #<%= po_line.order.customer_request.number %>
-                <% end %>
-              </option>
-            <% end %>
-          </select>
-        </label>
-        <label>
-          Qty received
-          <input type="number" name="received_quantity" min="1" value="1" required>
-        </label>
-        <label>
-          Actual unit cost (cents)
-          <input type="number" name="actual_unit_cost_cents" min="0" required>
-        </label>
-        <button type="submit">Add line</button>
-      <% end %>
-    <% end %>
-  </section>
+  <%= render "line_scanner" %>
 <% end %>
 
-<section>
-  <h2>Lines</h2>
-  <% if @lines.empty? %>
-    <p>No lines yet.</p>
-  <% else %>
-    <table class="ops-queue" data-controller="row-selection" data-action="keydown->row-selection#keydown">
-      <thead>
-        <tr>
-          <th scope="col">PO</th>
-          <th scope="col">Item</th>
-          <th scope="col">Received</th>
-          <th scope="col">Matched*</th>
-          <th scope="col">Unplanned*</th>
-          <th scope="col">Unit cost</th>
-          <th scope="col">Customer</th>
-          <% if @receipt.draft? && effective_permissions.include?("purchase_receipts.manage") %>
-            <th scope="col">Edit</th>
-          <% end %>
-        </tr>
-      </thead>
-      <tbody>
-        <% @lines.each do |line| %>
-          <% po_line = line.purchase_order_line %>
-          <tr tabindex="-1" aria-selected="false" data-row-selection-target="row">
-            <td>#<%= po_line.purchase_order.number %></td>
-            <td>
-              <%= line.product_variant.product.name %>
-              <code><%= line.product_variant.sku %></code>
-            </td>
-            <td><%= line.received_quantity %></td>
-            <td><%= line.matched_quantity %></td>
-            <td><%= line.unplanned_quantity %></td>
-            <td><%= line.actual_unit_cost_cents %></td>
-            <td>
-              <% if po_line.order.customer_request.present? %>
-                Req #<%= po_line.order.customer_request.number %>
-              <% else %>
-                —
-              <% end %>
-            </td>
-            <% if @receipt.draft? && effective_permissions.include?("purchase_receipts.manage") %>
-              <td>
-                <%= form_with url: ops_receiving_update_line_path(@receipt, line), method: :patch, local: true, html: { class: "ops-inline-form", data: { dirty_track: true } } do %>
-                  <%= hidden_field_tag :lock_version, @receipt.lock_version %>
-                  <label>
-                    Qty
-                    <input type="number" name="received_quantity" value="<%= line.received_quantity %>" min="1" required>
-                  </label>
-                  <label>
-                    Cost
-                    <input type="number" name="actual_unit_cost_cents" value="<%= line.actual_unit_cost_cents %>" min="0" required>
-                  </label>
-                  <button type="submit" data-ops-save data-row-primary>Save</button>
-                <% end %>
-              </td>
-            <% end %>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-    <p class="ops-hint">* Matched/unplanned are provisional on drafts and frozen at post.</p>
-  <% end %>
-</section>
+<%= render "line_grid" %>
 
 <% if @receipt.draft? && effective_permissions.include?("purchase_receipts.post") && @lines.any? %>
   <section class="ops-actions">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,6 +123,7 @@ Rails.application.routes.draw do
     get "receiving", to: "receiving#index", as: :receiving_index
     post "receiving", to: "receiving#create", as: :receiving_create
     get "receiving/:id", to: "receiving#show", as: :receiving
+    get "receiving/:id/line_lookup", to: "receiving#line_lookup", as: :receiving_line_lookup
     patch "receiving/:id", to: "receiving#update", as: :receiving_update
     post "receiving/:id/lines", to: "receiving#add_line", as: :receiving_add_line
     patch "receiving/:id/lines/:line_id", to: "receiving#update_line", as: :receiving_update_line

--- a/test/integration/receiving_line_lookup_test.rb
+++ b/test/integration/receiving_line_lookup_test.rb
@@ -37,7 +37,7 @@ class ReceivingLineLookupTest < ActionDispatch::IntegrationTest
     get ops_receiving_line_lookup_path(receipt), params: { query: @variant.sku }, as: :json
     body = response.parsed_body
     assert_equal "multiple", body["outcome"]
-    assert_equal [first.purchase_order.number, second.purchase_order.number].sort, body["matches"].pluck("po_number").sort
+    assert_equal [ first.purchase_order.number, second.purchase_order.number ].sort, body["matches"].pluck("po_number").sort
     assert body["matches"].all? { |match| match.key?("order_date") && match.key?("product") }
 
     get ops_receiving_line_lookup_path(receipt), params: { query: "DOES-NOT-EXIST" }, as: :json

--- a/test/integration/receiving_line_lookup_test.rb
+++ b/test/integration/receiving_line_lookup_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ReceivingLineLookupTest < ActionDispatch::IntegrationTest
+  setup do
+    bootstrap = bootstrap!
+    @store = bootstrap[:store]
+    @actor = bootstrap[:administrator]
+    @tax = tax_class(code: "rlu_#{SecureRandom.hex(2)}")
+    @supplier = Supplier.create!(name: "Lookup Supplier", code: "rlu_#{SecureRandom.hex(2)}")
+    @variant = pos_sellable_variant(actor: @actor, tax_class: @tax, name: "Scannable Receiving Book")
+    SupplierVariantSource.create!(supplier: @supplier, product_variant: @variant,
+      pricing_method: "direct_unit_cost", expected_unit_cost_cents: 725, organization_preferred: true)
+    sign_in_as("admin")
+    post store_selection_path, params: { store_id: @store.id }
+  end
+
+  test "single, ambiguous, repeated, no-match, and customer-request lookups are scoped and serialized" do
+    first = sent_order(@variant, quantity: 3)
+    receipt = Purchasing::CreateDraftPurchaseReceipt.call(store: @store, supplier: @supplier, actor: @actor)
+
+    get ops_receiving_line_lookup_path(receipt), params: { query: @variant.sku }, as: :json
+    assert_response :success
+    body = response.parsed_body
+    assert_equal "selected", body["outcome"]
+    assert_equal 3, body.dig("matches", 0, "open_quantity")
+    assert_equal 725, body.dig("matches", 0, "expected_unit_cost_cents")
+
+    Purchasing::AddPurchaseReceiptLine.call(purchase_receipt: receipt,
+      purchase_order_line: first.purchase_order_line, actor: @actor,
+      received_quantity: 4, actual_unit_cost_cents: 700)
+    get ops_receiving_line_lookup_path(receipt), params: { query: @variant.sku }, as: :json
+    assert_equal "selected", response.parsed_body["outcome"], "a repeated scan remains eligible while the PO is open"
+
+    second = sent_order(@variant, quantity: 2)
+    get ops_receiving_line_lookup_path(receipt), params: { query: @variant.sku }, as: :json
+    body = response.parsed_body
+    assert_equal "multiple", body["outcome"]
+    assert_equal [first.purchase_order.number, second.purchase_order.number].sort, body["matches"].pluck("po_number").sort
+    assert body["matches"].all? { |match| match.key?("order_date") && match.key?("product") }
+
+    get ops_receiving_line_lookup_path(receipt), params: { query: "DOES-NOT-EXIST" }, as: :json
+    assert_equal "no_match", response.parsed_body["outcome"]
+
+    customer = Customer.create!(display_name: "Lookup Reader", email: "lookup-reader@example.com")
+    customer_variant = pos_sellable_variant(actor: @actor, tax_class: @tax, name: "Customer Lookup Book")
+    SupplierVariantSource.create!(supplier: @supplier, product_variant: customer_variant,
+      pricing_method: "direct_unit_cost", expected_unit_cost_cents: 515, organization_preferred: true)
+    request = Customers::CreateRequest.call(store: @store, customer: customer,
+      product_variant: customer_variant, actor: @actor)
+    po = request.orders.first.purchase_order
+    Purchasing::GeneratePurchaseOrder.call(purchase_order: po, actor: @actor)
+    Purchasing::SendPurchaseOrder.call(purchase_order: po.reload, actor: @actor, transmission_method: "email")
+
+    get ops_receiving_line_lookup_path(receipt), params: { query: request.number }, as: :json
+    match = response.parsed_body.fetch("matches").first
+    assert_equal request.number, match["customer_request"]
+  end
+
+  test "used identifier is reported as ineligible" do
+    used = pos_sellable_variant(actor: @actor, tax_class: @tax, variant_type: "used", name: "Used Lookup Book")
+    receipt = Purchasing::CreateDraftPurchaseReceipt.call(store: @store, supplier: @supplier, actor: @actor)
+
+    get ops_receiving_line_lookup_path(receipt), params: { query: used.sku }, as: :json
+
+    assert_equal "ineligible", response.parsed_body["outcome"]
+    assert_match(/Used variants/, response.parsed_body["message"])
+  end
+
+  private
+
+  def sent_order(variant, quantity:)
+    order = Purchasing::CreateStockOrder.call(store: @store, product_variant: variant,
+      supplier: @supplier, actor: @actor, quantity: quantity)
+    po = order.purchase_order
+    Purchasing::GeneratePurchaseOrder.call(purchase_order: po, actor: @actor)
+    Purchasing::SendPurchaseOrder.call(purchase_order: po.reload, actor: @actor, transmission_method: "email")
+    order
+  end
+
+  def sign_in_as(username)
+    post session_path, params: { session: { username: username, password: "correct-horse-battery" } }
+  end
+end

--- a/test/system/purchasing_ops_workspace_test.rb
+++ b/test/system/purchasing_ops_workspace_test.rb
@@ -94,6 +94,25 @@ class PurchasingOpsWorkspaceTest < ApplicationSystemTestCase
     assert_nil @purchase_order.purchase_order_lines.first.order.reload.notes
   end
 
+  test "receiving scan selects defaults, updates through Turbo, and restores scanner focus" do
+    Purchasing::GeneratePurchaseOrder.call(purchase_order: @purchase_order, actor: @actor)
+    Purchasing::SendPurchaseOrder.call(purchase_order: @purchase_order.reload, actor: @actor, transmission_method: "email")
+    receipt = Purchasing::CreateDraftPurchaseReceipt.call(store: @store, supplier: @supplier, actor: @actor)
+
+    visit ops_receiving_path(receipt)
+    lookup = find("input[name='receiving_lookup']")
+    assert_equal "receiving_lookup", page.evaluate_script("document.activeElement && document.activeElement.name")
+    lookup.fill_in with: @variant.sku
+    lookup.send_keys :enter
+    assert_field "received_quantity", with: "1"
+    assert_field "actual_unit_cost_cents", with: "725"
+    click_on "Confirm and add line"
+
+    assert_text "Line added. Scanner ready."
+    assert_selector "#receiving_line_grid", text: "Keyboard Purchasing Book"
+    assert_equal "receiving_lookup", page.evaluate_script("document.activeElement && document.activeElement.name")
+  end
+
   private
 
   def sign_in_admin


### PR DESCRIPTION
### Motivation

- Replace the slow PO-line dropdown flow with a scanner/search-first workflow to support keyboard- and barcode-scanner-driven fast receiving. 
- Ensure lookups are scoped to the receipt's store and supplier and exclude ineligible Used variants while surfacing ambiguous matches for keyboard selection.

### Description

- Added a receipt-scoped lookup endpoint `GET /ops/receiving/:id/line_lookup` and `line_lookup` action in `Ops::ReceivingController` that resolves only eligible open Standard PO lines and returns `selected`, `multiple`, `no_match`, or `ineligible` outcomes. 
- Replaced the PO-line dropdown in `app/views/ops/receiving/show.html.erb` with new partials `app/views/ops/receiving/_line_scanner.html.erb` and `app/views/ops/receiving/_line_grid.html.erb`, and added `add_line.turbo_stream.erb` to turbo-replace the scanner and grid after success. 
- Implemented a Stimulus controller `app/javascript/controllers/receiving_lookup_controller.js` that drives search/scan, auto-selects single matches, presents a keyboard-selectable picker for ambiguous matches, defaults `received_quantity` to the line open quantity, initializes `actual_unit_cost_cents` from `expected_unit_cost_cents_snapshot`, and requires explicit confirm before posting. 
- Updated `add_line` to respond with Turbo Streams (replacing scanner and grid and restoring focus), added helper methods in the controller for variant lookup, eligible PO-line selection, and JSON serialization, and preserved support for over-shipment by showing open quantity and an explicit over-shipment indicator in the grid. 
- Added integration and system tests: `test/integration/receiving_line_lookup_test.rb` (single/multiple/repeat/no-match/customer-request/used cases) and a system test addition to `test/system/purchasing_ops_workspace_test.rb` to cover scanner defaults, Turbo update, and refocus behavior.

### Testing

- Verified Ruby syntax for changed files with `ruby -c` and JavaScript parser check for the new Stimulus controller with `node --check`, and ran `git diff --check`; these checks reported no syntax problems. 
- Ran integration and system test files through Ruby syntax checks (`ruby -c test/...`) which succeeded for the new/modified tests. 
- Could not run the full Rails test suite or containerized verification (`./dev/rails-docker bin/rails test`) in this environment because the repository uses the Docker-only local helper and Docker is not available here. 
- Manual verification of routes and Turbo replacement behavior was exercised where possible via controller/view wiring and the added Turbo stream template; browser screenshot and end-to-end CI validation remain to be run in the project's Docker CI environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8912b675cc832c89ff7b59b498af0d)