### PR TITLE
Render recoverable ops mutation failures inline (422 / Turbo)

### DIFF
--- a/app/controllers/ops/draft_pos_controller.rb
+++ b/app/controllers/ops/draft_pos_controller.rb
@@ -38,10 +38,9 @@ module Ops
       redirect_to ops_purchase_order_path(@purchase_order),
                   notice: "Added stock order ##{order.number}."
     rescue Purchasing::Error, ActiveRecord::RecordInvalid => e
-      redirect_to ops_purchase_order_path(@purchase_order), alert: e.message
-    rescue ActiveRecord::StaleObjectError
-      redirect_to ops_purchase_order_path(@purchase_order),
-                  alert: "This draft PO was changed by someone else. Reload and try again."
+      render_mutation_failure(:add_line, e, field: :identifier)
+    rescue ActiveRecord::StaleObjectError => e
+      render_mutation_failure(:add_line, e, field: :identifier, stale: true)
     end
 
     def update_line
@@ -56,10 +55,9 @@ module Ops
       )
       redirect_to ops_purchase_order_path(@purchase_order), notice: "Line updated."
     rescue Purchasing::Error, ActiveRecord::RecordInvalid => e
-      redirect_to ops_purchase_order_path(@purchase_order), alert: e.message
-    rescue ActiveRecord::StaleObjectError
-      redirect_to ops_purchase_order_path(@purchase_order),
-                  alert: "This order was changed by someone else. Reload and try again."
+      render_mutation_failure(:update_line, e, field: :quantity, row_id: params[:line_id])
+    rescue ActiveRecord::StaleObjectError => e
+      render_mutation_failure(:update_line, e, field: :quantity, row_id: params[:line_id], stale: true)
     end
 
     def generate
@@ -70,10 +68,9 @@ module Ops
       )
       redirect_to ops_purchase_order_path(@purchase_order), notice: "Purchase order generated."
     rescue Purchasing::Error, ActiveRecord::RecordInvalid => e
-      redirect_to ops_purchase_order_path(@purchase_order), alert: e.message
-    rescue ActiveRecord::StaleObjectError
-      redirect_to ops_purchase_order_path(@purchase_order),
-                  alert: "This draft PO was changed by someone else. Reload and try again."
+      render_mutation_failure(:generate, e)
+    rescue ActiveRecord::StaleObjectError => e
+      render_mutation_failure(:generate, e, stale: true)
     end
 
     def send_po
@@ -85,10 +82,9 @@ module Ops
       )
       redirect_to admin_purchase_order_path(@purchase_order), notice: "Purchase order sent."
     rescue Purchasing::Error, ActiveRecord::RecordInvalid => e
-      redirect_to ops_purchase_order_path(@purchase_order), alert: e.message
-    rescue ActiveRecord::StaleObjectError
-      redirect_to ops_purchase_order_path(@purchase_order),
-                  alert: "This draft PO was changed by someone else. Reload and try again."
+      render_mutation_failure(:send_po, e, field: :transmission_method)
+    rescue ActiveRecord::StaleObjectError => e
+      render_mutation_failure(:send_po, e, field: :transmission_method, stale: true)
     end
 
     def return_to_draft
@@ -99,13 +95,24 @@ module Ops
       )
       redirect_to ops_purchase_order_path(@purchase_order), notice: "Returned to draft for further edits."
     rescue Purchasing::Error, ActiveRecord::RecordInvalid => e
-      redirect_to ops_purchase_order_path(@purchase_order), alert: e.message
-    rescue ActiveRecord::StaleObjectError
-      redirect_to ops_purchase_order_path(@purchase_order),
-                  alert: "This draft PO was changed by someone else. Reload and try again."
+      render_mutation_failure(:return_to_draft, e)
+    rescue ActiveRecord::StaleObjectError => e
+      render_mutation_failure(:return_to_draft, e, stale: true)
     end
 
     private
+
+    def render_mutation_failure(action, exception, field: nil, row_id: nil, stale: false)
+      @submitted = params.to_unsafe_h.slice("identifier", "product_variant_id", "quantity", "expected_unit_cost_cents", "notes", "transmission_method")
+      @error_action = action
+      @error_field = field
+      @selected_row_id = row_id
+      @conflict = stale
+      @mutation_errors = [stale ? "This purchase order was changed by someone else." : exception.message]
+      @purchase_order.reload
+      @lines = @purchase_order.purchase_order_lines.includes(order: :customer_request, product_variant: :product).order(:created_at)
+      render :show, status: :unprocessable_entity
+    end
 
     def set_purchase_order
       @purchase_order = PurchaseOrder.for_store(current_store).find(params[:id])

--- a/app/controllers/ops/locations_controller.rb
+++ b/app/controllers/ops/locations_controller.rb
@@ -22,9 +22,9 @@ module Ops
       )
       redirect_to ops_location_path, notice: "Request ##{@customer_request.number} located and reserved."
     rescue Customers::Error, ActiveRecord::RecordInvalid => e
-      redirect_to ops_location_path, alert: e.message
-    rescue ActiveRecord::StaleObjectError
-      redirect_to ops_location_path, alert: "This request was changed by someone else. Reload and try again."
+      render_mutation_failure(:confirm, e, field: @customer_request.product_variant.used? ? :inventory_unit_id : :confirm)
+    rescue ActiveRecord::StaleObjectError => e
+      render_mutation_failure(:confirm, e, field: @customer_request.product_variant.used? ? :inventory_unit_id : :confirm, stale: true)
     end
 
     def not_located
@@ -46,12 +46,24 @@ module Ops
       end
       redirect_to ops_location_path, notice: notice
     rescue Customers::Error, ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
-      redirect_to ops_location_path, alert: e.message
-    rescue ActiveRecord::StaleObjectError
-      redirect_to ops_location_path, alert: "This request was changed by someone else. Reload and try again."
+      render_mutation_failure(convert ? :special_order : :not_located, e, field: convert ? :expected_unit_cost_cents : :notes)
+    rescue ActiveRecord::StaleObjectError => e
+      render_mutation_failure(convert ? :special_order : :not_located, e, field: convert ? :expected_unit_cost_cents : :notes, stale: true)
     end
 
     private
+
+    def render_mutation_failure(action, exception, field:, stale: false)
+      @submitted = params.to_unsafe_h.slice("inventory_unit_id", "unit_identifier", "notes", "supplier_id", "expected_unit_cost_cents")
+      @error_action = action
+      @error_field = field
+      @selected_row_id = @customer_request.id
+      @conflict = stale
+      @mutation_errors = [stale ? "This request was changed by someone else." : exception.message]
+      @customer_request.reload
+      @pending_requests = CustomerRequest.pending_location.for_store(current_store).includes(:customer, :product_variant).order(:number)
+      render :show, status: :unprocessable_entity
+    end
 
     def set_customer_request
       @customer_request = CustomerRequest.for_store(current_store).find(params[:id])

--- a/app/controllers/ops/receiving_controller.rb
+++ b/app/controllers/ops/receiving_controller.rb
@@ -74,8 +74,14 @@ module Ops
         notes: params[:notes]
       )
       redirect_to ops_receiving_path(receipt), notice: "Draft receipt created."
-    rescue Purchasing::Error, ActiveRecord::RecordInvalid => e
-      redirect_to ops_receiving_index_path, alert: e.message
+    rescue Purchasing::Error, ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
+      @submitted = params.to_unsafe_h.slice("supplier_id", "received_at", "supplier_document_number")
+      @error_action = :create
+      @error_field = :supplier_id
+      @mutation_errors = [e.message]
+      @draft_receipts = PurchaseReceipt.draft.for_store(current_store).includes(:supplier, :purchase_receipt_lines).order(created_at: :desc)
+      @suppliers = Supplier.active.admin_ordered
+      render :index, status: :unprocessable_entity
     end
 
     def update
@@ -95,10 +101,9 @@ module Ops
       )
       redirect_to ops_receiving_path(@receipt), notice: "Receipt updated."
     rescue Purchasing::Error, ActiveRecord::RecordInvalid => e
-      redirect_to ops_receiving_path(@receipt), alert: e.message
-    rescue ActiveRecord::StaleObjectError
-      redirect_to ops_receiving_path(@receipt),
-                  alert: "This receipt was changed by someone else. Reload and try again."
+      render_mutation_failure(:update, e, field: :received_at)
+    rescue ActiveRecord::StaleObjectError => e
+      render_mutation_failure(:update, e, field: :received_at, stale: true)
     end
 
     def add_line
@@ -125,10 +130,9 @@ module Ops
         end
       end
     rescue Purchasing::Error, ActiveRecord::RecordInvalid => e
-      redirect_to ops_receiving_path(@receipt), alert: e.message
-    rescue ActiveRecord::StaleObjectError
-      redirect_to ops_receiving_path(@receipt),
-                  alert: "This receipt was changed by someone else. Reload and try again."
+      render_mutation_failure(:add_line, e, field: :received_quantity, row_id: params[:purchase_order_line_id])
+    rescue ActiveRecord::StaleObjectError => e
+      render_mutation_failure(:add_line, e, field: :received_quantity, row_id: params[:purchase_order_line_id], stale: true)
     end
 
     def update_line
@@ -144,10 +148,9 @@ module Ops
       )
       redirect_to ops_receiving_path(@receipt), notice: "Line updated."
     rescue Purchasing::Error, ActiveRecord::RecordInvalid => e
-      redirect_to ops_receiving_path(@receipt), alert: e.message
-    rescue ActiveRecord::StaleObjectError
-      redirect_to ops_receiving_path(@receipt),
-                  alert: "This receipt was changed by someone else. Reload and try again."
+      render_mutation_failure(:update_line, e, field: :received_quantity, row_id: params[:line_id])
+    rescue ActiveRecord::StaleObjectError => e
+      render_mutation_failure(:update_line, e, field: :received_quantity, row_id: params[:line_id], stale: true)
     end
 
     def review
@@ -174,10 +177,9 @@ module Ops
       )
       redirect_to ops_receiving_path(receipt), notice: "Receipt ##{receipt.number} posted."
     rescue Purchasing::Error, ActiveRecord::RecordInvalid => e
-      redirect_to ops_receiving_review_path(@receipt), alert: e.message
-    rescue ActiveRecord::StaleObjectError
-      redirect_to ops_receiving_path(@receipt),
-                  alert: "This receipt was changed by someone else. Reload and try again."
+      render_review_failure(e)
+    rescue ActiveRecord::StaleObjectError => e
+      render_review_failure(e, stale: true)
     end
 
     def reverse
@@ -223,6 +225,33 @@ module Ops
     end
 
     private
+
+    def render_mutation_failure(action, exception, field:, row_id: nil, stale: false)
+      @submitted = params.to_unsafe_h.slice(
+        "received_at", "supplier_document_number", "supplier_document_date", "freight_cents", "handling_cents",
+        "supplier_tax_cents", "miscellaneous_charges_cents", "charge_notes", "notes", "purchase_order_line_id",
+        "received_quantity", "actual_unit_cost_cents"
+      )
+      @error_action = action
+      @error_field = field
+      @selected_row_id = row_id
+      @conflict = stale
+      @mutation_errors = [stale ? "This receipt was changed by someone else." : exception.message]
+      load_receipt_lines
+      respond_to do |format|
+        format.html { render :show, status: :unprocessable_entity }
+        format.turbo_stream { render :mutation_failure, status: :unprocessable_entity }
+      end
+    end
+
+    def render_review_failure(exception, stale: false)
+      @error_action = :post
+      @conflict = stale
+      @mutation_errors = [stale ? "This receipt was changed by someone else." : exception.message]
+      load_receipt_lines
+      @preview_lines = @lines.map { |line| preview_line(line) }
+      render :review, status: :unprocessable_entity
+    end
 
     def load_receipt_lines
       @receipt.reload

--- a/app/views/ops/draft_pos/show.html.erb
+++ b/app/views/ops/draft_pos/show.html.erb
@@ -18,31 +18,37 @@
   </p>
 </header>
 
+<%= render "ops/shared/error_summary", errors: @mutation_errors, conflict: @conflict,
+      title: @error_action.in?([:generate, :send_po]) ? "Cannot #{@error_action == :send_po ? 'send' : 'generate'} purchase order" : "Purchase order was not changed" %>
+
 <% if effective_permissions.include?("purchase_orders.send") %>
   <section class="ops-actions">
     <h2>Generate / send</h2>
     <% unless @purchase_order.generated? %>
       <%= form_with url: ops_purchase_order_generate_path(@purchase_order), method: :post, local: true do %>
         <%= hidden_field_tag :lock_version, @purchase_order.lock_version %>
-        <button type="submit" data-ops-primary>Generate PO number</button>
+        <button type="submit" data-ops-primary <%= "autofocus aria-describedby=po_generate_error" if @error_action == :generate %>>Generate PO number</button>
+        <%= render "ops/shared/inline_row_error", action: :generate, id: "po_generate_error" %>
       <% end %>
     <% else %>
       <p>Generated #<%= @purchase_order.number %> (revision <%= @purchase_order.document_revision %>).</p>
       <%= form_with url: ops_purchase_order_return_to_draft_path(@purchase_order), method: :post, local: true do %>
         <%= hidden_field_tag :lock_version, @purchase_order.lock_version %>
-        <button type="submit">Return to draft</button>
+        <button type="submit" <%= "autofocus aria-describedby=po_return_error" if @error_action == :return_to_draft %>>Return to draft</button>
+        <%= render "ops/shared/inline_row_error", action: :return_to_draft, id: "po_return_error" %>
       <% end %>
       <%= form_with url: ops_purchase_order_send_path(@purchase_order), method: :post, local: true do %>
         <%= hidden_field_tag :lock_version, @purchase_order.lock_version %>
         <label>
           Transmission method
-          <select name="transmission_method" required>
+          <select name="transmission_method" required <%= "autofocus aria-describedby=po_action_error" if @error_action == :send_po %>>
             <option value="">Select…</option>
             <% PurchaseOrder::TRANSMISSION_METHODS.each do |method| %>
-              <option value="<%= method %>"><%= method %></option>
+              <option value="<%= method %>" <%= "selected" if @submitted&.fetch("transmission_method", nil) == method %>><%= method %></option>
             <% end %>
           </select>
         </label>
+        <%= render "ops/shared/inline_row_error", action: :send_po, id: "po_action_error" %>
         <button type="submit">Record send</button>
       <% end %>
     <% end %>
@@ -56,21 +62,22 @@
       <%= hidden_field_tag :lock_version, @purchase_order.lock_version %>
       <label>
         Scan / identifier
-        <input type="text" name="identifier" autocomplete="off" inputmode="text" data-focus-restore-target="lookup">
+        <input type="text" name="identifier" value="<%= @submitted&.fetch("identifier", nil) %>" autocomplete="off" inputmode="text" data-focus-restore-target="lookup" <%= "autofocus aria-describedby=po_add_error" if @error_action == :add_line %>>
       </label>
       <label>
         or variant ID
-        <input type="text" name="product_variant_id" autocomplete="off">
+        <input type="text" name="product_variant_id" value="<%= @submitted&.fetch("product_variant_id", nil) %>" autocomplete="off">
       </label>
       <label>
         Qty
-        <input type="number" name="quantity" value="1" min="1" required>
+        <input type="number" name="quantity" value="<%= @submitted&.fetch("quantity", nil) || 1 %>" min="1" required>
       </label>
       <label>
         Expected cost (cents)
-        <input type="number" name="expected_unit_cost_cents" min="0">
+        <input type="number" name="expected_unit_cost_cents" value="<%= @submitted&.fetch("expected_unit_cost_cents", nil) %>" min="0">
       </label>
       <button type="submit">Add</button>
+      <%= render "ops/shared/inline_row_error", action: :add_line, id: "po_add_error" %>
     <% end %>
     <p class="ops-hint">Creates a stock order and dedicated PO line. Used merchandise is rejected.</p>
   </section>
@@ -96,7 +103,7 @@
       <tbody>
         <% @lines.each do |line| %>
           <% order = line.order %>
-          <tr tabindex="-1" aria-selected="false" data-row-selection-target="row">
+          <tr tabindex="-1" aria-selected="<%= (@selected_row_id.to_s == line.id.to_s).to_s %>" class="<%= "is-selected" if @selected_row_id.to_s == line.id.to_s %>" data-row-selection-target="row">
             <td><%= link_to "##{order.number}", admin_order_path(order) %></td>
             <td>
               <%= line.product_variant.product.name %>
@@ -118,17 +125,19 @@
                   <%= hidden_field_tag :lock_version, order.lock_version %>
                   <label>
                     Qty
-                    <input type="number" name="quantity" value="<%= line.ordered_quantity %>" min="1" <%= "readonly" if order.customer_order? %>>
+                    <input type="number" name="quantity" value="<%= @selected_row_id.to_s == line.id.to_s ? @submitted&.fetch("quantity", line.ordered_quantity) : line.ordered_quantity %>" min="1" <%= "readonly" if order.customer_order? %> <%= "autofocus aria-describedby=po_line_#{line.id}_error" if @selected_row_id.to_s == line.id.to_s %>>
                   </label>
                   <label>
                     Cost
-                    <input type="number" name="expected_unit_cost_cents" value="<%= line.expected_unit_cost_cents_snapshot %>" min="0">
+                    <input type="number" name="expected_unit_cost_cents" value="<%= @selected_row_id.to_s == line.id.to_s ? @submitted&.fetch("expected_unit_cost_cents", line.expected_unit_cost_cents_snapshot) : line.expected_unit_cost_cents_snapshot %>" min="0">
                   </label>
                   <label>
                     Notes
-                    <input type="text" name="notes" value="<%= order.notes %>">
+                    <input type="text" name="notes" value="<%= @selected_row_id.to_s == line.id.to_s ? @submitted&.fetch("notes", order.notes) : order.notes %>">
                   </label>
                   <button type="submit" data-ops-save data-row-primary>Save</button>
+                  <%= render "ops/shared/inline_row_error", action: :update_line, row_id: line.id, id: "po_line_#{line.id}_error" %>
+                  <% if @conflict && @selected_row_id.to_s == line.id.to_s %><small>Current: qty <%= line.ordered_quantity %>, cost <%= line.expected_unit_cost_cents_snapshot %>, notes <%= line.order.notes.presence || "blank" %>.</small><% end %>
                 <% end %>
               </td>
             <% end %>

--- a/app/views/ops/locations/show.html.erb
+++ b/app/views/ops/locations/show.html.erb
@@ -1,11 +1,12 @@
 <% content_for :title, "Location queue" %>
 <h1>Location queue</h1>
 <p>Pending in-store customer requests for <%= current_store.admin_label %>. Confirm location to reserve, or mark not located.</p>
+<%= render "ops/shared/error_summary", errors: @mutation_errors, conflict: @conflict, title: "Location action could not be completed" %>
 
 <% if @pending_requests.empty? %>
   <p>No pending location requests.</p>
 <% else %>
-  <table class="ops-queue" data-controller="focus-restore row-selection" data-action="keydown->row-selection#keydown">
+  <table class="ops-queue" data-controller="<%= @mutation_errors.present? ? 'row-selection' : 'focus-restore row-selection' %>" data-action="keydown->row-selection#keydown">
     <thead>
       <tr>
         <th scope="col">#</th>
@@ -18,7 +19,7 @@
     <tbody>
       <% @pending_requests.each do |request| %>
         <% variant = request.product_variant %>
-        <tr tabindex="-1" aria-selected="false" data-row-selection-target="row">
+        <tr tabindex="-1" aria-selected="<%= (@selected_row_id.to_s == request.id.to_s).to_s %>" class="<%= "is-selected" if @selected_row_id.to_s == request.id.to_s %>" data-row-selection-target="row">
           <td><%= request.number %></td>
           <td><%= request.customer.display_name %></td>
           <td>
@@ -33,27 +34,29 @@
                 <% units = Inventory::Availability.unreserved_on_hand_units(current_store, variant).order(:unit_identifier) %>
                 <label>
                   Unit
-                  <select name="inventory_unit_id" required>
+                  <select name="inventory_unit_id" required <%= "autofocus aria-describedby=location_confirm_#{request.id}_error" if @selected_row_id.to_s == request.id.to_s && @error_action == :confirm %>>
                     <option value="">Select unit…</option>
                     <% units.each do |unit| %>
-                      <option value="<%= unit.id %>"><%= unit.unit_identifier %></option>
+                      <option value="<%= unit.id %>" <%= "selected" if @selected_row_id.to_s == request.id.to_s && @submitted&.fetch("inventory_unit_id", nil) == unit.id %>><%= unit.unit_identifier %></option>
                     <% end %>
                   </select>
                 </label>
                 <label>
                   or scan
-                  <input type="text" name="unit_identifier" autocomplete="off" inputmode="numeric"<%= " data-focus-restore-target=lookup" if request == @pending_requests.first %>>
+                  <input type="text" name="unit_identifier" value="<%= @selected_row_id.to_s == request.id.to_s ? @submitted&.fetch("unit_identifier", nil) : nil %>" autocomplete="off" inputmode="numeric"<%= " data-focus-restore-target=lookup" if request == @pending_requests.first %>>
                 </label>
               <% end %>
               <button type="submit" data-row-primary<%= " data-focus-restore-target=lookup" if request == @pending_requests.first && variant.standard? %>>Located</button>
+              <%= render "ops/shared/inline_row_error", action: :confirm, row_id: request.id, id: "location_confirm_#{request.id}_error" %>
             <% end %>
             <%= form_with url: ops_location_not_located_path(request), method: :post, local: true, html: { class: "ops-inline-form" } do %>
               <%= hidden_field_tag :lock_version, request.lock_version %>
               <label>
                 Notes
-                <input type="text" name="notes" autocomplete="off">
+                <input type="text" name="notes" value="<%= @selected_row_id.to_s == request.id.to_s && @error_action == :not_located ? @submitted&.fetch("notes", nil) : nil %>" autocomplete="off" <%= "autofocus aria-describedby=location_cancel_#{request.id}_error" if @selected_row_id.to_s == request.id.to_s && @error_action == :not_located %>>
               </label>
               <button type="submit">Not located — cancel</button>
+              <%= render "ops/shared/inline_row_error", action: :not_located, row_id: request.id, id: "location_cancel_#{request.id}_error" %>
             <% end %>
             <% if variant.standard? %>
               <%= form_with url: ops_location_not_located_path(request), method: :post, local: true, html: { class: "ops-inline-form" } do %>
@@ -61,22 +64,27 @@
                 <%= hidden_field_tag :convert_to_special_order, "1" %>
                 <label>
                   Notes
-                  <input type="text" name="notes" autocomplete="off">
+                  <input type="text" name="notes" value="<%= @selected_row_id.to_s == request.id.to_s && @error_action == :special_order ? @submitted&.fetch("notes", nil) : nil %>" autocomplete="off">
                 </label>
                 <label>
                   Supplier (optional if preferred)
                   <select name="supplier_id">
                     <option value="">Preferred source…</option>
+                    <% submitted_supplier = @selected_row_id.to_s == request.id.to_s ? @submitted&.fetch("supplier_id", nil) : nil %>
+                    <% if submitted_supplier.present? && Supplier.active.none? { |supplier| supplier.id == submitted_supplier } %>
+                      <option value="<%= submitted_supplier %>" selected>Unavailable submitted supplier (<%= submitted_supplier %>)</option>
+                    <% end %>
                     <% Supplier.active.admin_ordered.each do |supplier| %>
-                      <option value="<%= supplier.id %>"><%= supplier.admin_label %></option>
+                      <option value="<%= supplier.id %>" <%= "selected" if @selected_row_id.to_s == request.id.to_s && @submitted&.fetch("supplier_id", nil) == supplier.id %>><%= supplier.admin_label %></option>
                     <% end %>
                   </select>
                 </label>
                 <label>
                   Expected cost (cents)
-                  <input type="number" name="expected_unit_cost_cents" min="0">
+                  <input type="number" name="expected_unit_cost_cents" value="<%= @selected_row_id.to_s == request.id.to_s ? @submitted&.fetch("expected_unit_cost_cents", nil) : nil %>" min="0" <%= "autofocus aria-describedby=location_special_#{request.id}_error" if @selected_row_id.to_s == request.id.to_s && @error_action == :special_order %>>
                 </label>
                 <button type="submit">Not located — special order</button>
+                <%= render "ops/shared/inline_row_error", action: :special_order, row_id: request.id, id: "location_special_#{request.id}_error" %>
               <% end %>
             <% end %>
           </td>

--- a/app/views/ops/receiving/_line_grid.html.erb
+++ b/app/views/ops/receiving/_line_grid.html.erb
@@ -15,7 +15,7 @@
           <% po_line = line.purchase_order_line %>
           <% open_quantity = po_line.open_quantity %>
           <% over_shipment = [line.received_quantity - open_quantity, 0].max %>
-          <tr tabindex="-1" aria-selected="false" data-row-selection-target="row">
+          <tr tabindex="-1" aria-selected="<%= (@selected_row_id.to_s == line.id.to_s).to_s %>" class="<%= "is-selected" if @selected_row_id.to_s == line.id.to_s %>" data-row-selection-target="row">
             <td>#<%= po_line.purchase_order.number %></td>
             <td><%= line.product_variant.product.name %> <code><%= line.product_variant.sku %></code></td>
             <td><%= open_quantity %></td><td><%= line.received_quantity %></td>
@@ -26,9 +26,12 @@
             <% if @receipt.draft? && effective_permissions.include?("purchase_receipts.manage") %>
               <td><%= form_with url: ops_receiving_update_line_path(@receipt, line), method: :patch, local: true, html: { class: "ops-inline-form", data: { dirty_track: true } } do %>
                 <%= hidden_field_tag :lock_version, @receipt.lock_version %>
-                <label>Qty <input type="number" name="received_quantity" value="<%= line.received_quantity %>" min="1" required></label>
-                <label>Cost <input type="number" name="actual_unit_cost_cents" value="<%= line.actual_unit_cost_cents %>" min="0" required></label>
+                <label>Qty <input type="number" name="received_quantity" value="<%= @selected_row_id.to_s == line.id.to_s ? @submitted&.fetch("received_quantity", line.received_quantity) : line.received_quantity %>" min="1" required <%= "autofocus aria-describedby=receipt_line_#{line.id}_error" if @selected_row_id.to_s == line.id.to_s %>></label>
+                <label>Cost <input type="number" name="actual_unit_cost_cents" value="<%= @selected_row_id.to_s == line.id.to_s ? @submitted&.fetch("actual_unit_cost_cents", line.actual_unit_cost_cents) : line.actual_unit_cost_cents %>" min="0" required></label>
+                <label>Notes <input type="text" name="notes" value="<%= @selected_row_id.to_s == line.id.to_s ? @submitted&.fetch("notes", line.notes) : line.notes %>"></label>
                 <button type="submit" data-ops-save data-row-primary>Save</button>
+                <%= render "ops/shared/inline_row_error", action: :update_line, row_id: line.id, id: "receipt_line_#{line.id}_error" %>
+                <% if @conflict && @selected_row_id.to_s == line.id.to_s %><small>Current: qty <%= line.received_quantity %>, cost <%= line.actual_unit_cost_cents %>, notes <%= line.notes.presence || "blank" %>.</small><% end %>
               <% end %></td>
             <% end %>
           </tr>

--- a/app/views/ops/receiving/_line_scanner.html.erb
+++ b/app/views/ops/receiving/_line_scanner.html.erb
@@ -1,4 +1,4 @@
-<section id="receiving_line_scanner" class="ops-scan" data-controller="receiving-lookup focus-restore" data-receiving-lookup-url-value="<%= ops_receiving_line_lookup_path(@receipt) %>" data-action="turbo:submit-end->focus-restore#focus">
+<section id="receiving_line_scanner" class="ops-scan" data-controller="receiving-lookup<%= ' focus-restore' unless @error_action == :add_line %>" data-receiving-lookup-url-value="<%= ops_receiving_line_lookup_path(@receipt) %>" data-action="turbo:submit-end->focus-restore#focus">
   <h2>Scan or search open PO lines</h2>
   <label>
     Product identifier, name, lookup code, or customer request #
@@ -14,20 +14,22 @@
 
   <div data-receiving-lookup-target="editor">
     <h3>Current line</h3>
-    <p data-receiving-lookup-target="selection">Scan or search to select an eligible PO line.</p>
+    <p data-receiving-lookup-target="selection"><%= @error_action == :add_line ? "Selected purchase-order line retained; correct the values and retry." : "Scan or search to select an eligible PO line." %></p>
     <%= form_with url: ops_receiving_add_line_path(@receipt), method: :post,
           data: { receiving_lookup_target: "form" } do %>
       <%= hidden_field_tag :lock_version, @receipt.lock_version %>
-      <input type="hidden" name="purchase_order_line_id" data-receiving-lookup-target="lineId">
+      <input type="hidden" name="purchase_order_line_id" value="<%= @error_action == :add_line ? @submitted&.fetch("purchase_order_line_id", nil) : nil %>" data-receiving-lookup-target="lineId">
       <label>
         Qty received
-        <input type="number" name="received_quantity" min="1" required disabled data-receiving-lookup-target="quantity">
+        <input type="number" name="received_quantity" value="<%= @error_action == :add_line ? @submitted&.fetch("received_quantity", nil) : nil %>" min="1" required <%= "disabled" unless @error_action == :add_line %> <%= "autofocus aria-describedby=receipt_add_error" if @error_action == :add_line %> data-receiving-lookup-target="quantity">
       </label>
       <label>
         Actual unit cost (cents)
-        <input type="number" name="actual_unit_cost_cents" min="0" required disabled data-receiving-lookup-target="cost">
+        <input type="number" name="actual_unit_cost_cents" value="<%= @error_action == :add_line ? @submitted&.fetch("actual_unit_cost_cents", nil) : nil %>" min="0" required <%= "disabled" unless @error_action == :add_line %> data-receiving-lookup-target="cost">
       </label>
-      <button type="submit" disabled data-receiving-lookup-target="confirm">Confirm and add line</button>
+      <label>Notes <input type="text" name="notes" value="<%= @error_action == :add_line ? @submitted&.fetch("notes", nil) : nil %>"></label>
+      <button type="submit" <%= "disabled" unless @error_action == :add_line %> data-receiving-lookup-target="confirm">Confirm and add line</button>
+      <%= render "ops/shared/inline_row_error", action: :add_line, id: "receipt_add_error" %>
     <% end %>
   </div>
 </section>

--- a/app/views/ops/receiving/index.html.erb
+++ b/app/views/ops/receiving/index.html.erb
@@ -9,6 +9,7 @@
     · <%= link_to "Exit to Purchasing", admin_orders_path %>
   </p>
 </header>
+<%= render "ops/shared/error_summary", errors: @mutation_errors, conflict: false, title: "Draft receipt could not be created" %>
 
 <% if effective_permissions.include?("purchase_receipts.manage") %>
   <section class="ops-actions">
@@ -16,22 +17,23 @@
     <%= form_with url: ops_receiving_create_path, method: :post, local: true do %>
       <label>
         Supplier
-        <select name="supplier_id" required>
+        <select name="supplier_id" required <%= "autofocus aria-describedby=receipt_create_error" if @error_action == :create %>>
           <option value="">Select…</option>
           <% @suppliers.each do |supplier| %>
-            <option value="<%= supplier.id %>"><%= supplier.admin_label %></option>
+            <option value="<%= supplier.id %>" <%= "selected" if @submitted&.fetch("supplier_id", nil) == supplier.id %>><%= supplier.admin_label %></option>
           <% end %>
         </select>
       </label>
       <label>
         Received at
-        <input type="datetime-local" name="received_at">
+        <input type="datetime-local" name="received_at" value="<%= @submitted&.fetch("received_at", nil) %>">
       </label>
       <label>
         Supplier document #
-        <input type="text" name="supplier_document_number" autocomplete="off">
+        <input type="text" name="supplier_document_number" value="<%= @submitted&.fetch("supplier_document_number", nil) %>" autocomplete="off">
       </label>
       <button type="submit">Create draft</button>
+      <%= render "ops/shared/inline_row_error", action: :create, id: "receipt_create_error" %>
     <% end %>
   </section>
 <% end %>

--- a/app/views/ops/receiving/mutation_failure.turbo_stream.erb
+++ b/app/views/ops/receiving/mutation_failure.turbo_stream.erb
@@ -1,0 +1,9 @@
+<%= turbo_stream.replace "ops_mutation_errors" do %>
+  <%= render "ops/shared/error_summary", errors: @mutation_errors, conflict: @conflict, title: "Receipt was not changed" %>
+<% end %>
+<%= turbo_stream.replace "receiving_line_scanner" do %>
+  <%= render "line_scanner" %>
+<% end %>
+<%= turbo_stream.replace "receiving_line_grid" do %>
+  <%= render "line_grid" %>
+<% end %>

--- a/app/views/ops/receiving/review.html.erb
+++ b/app/views/ops/receiving/review.html.erb
@@ -10,6 +10,7 @@
   </div>
   <p><%= link_to "Back to draft", ops_receiving_path(@receipt) %></p>
 </header>
+<%= render "ops/shared/error_summary", errors: @mutation_errors, conflict: @conflict, title: "Receipt cannot be posted" %>
 
 <section>
   <h2>Summary</h2>
@@ -72,6 +73,7 @@
   <%= form_with url: ops_receiving_post_path(@receipt), method: :post, local: true do %>
     <%= hidden_field_tag :lock_version, @receipt.lock_version %>
     <%= hidden_field_tag :idempotency_key, SecureRandom.uuid_v7 %>
-    <button type="submit">Post receipt</button>
+    <button type="submit" <%= "autofocus aria-describedby=receipt_post_error" if @error_action == :post %>>Post receipt</button>
+    <%= render "ops/shared/inline_row_error", action: :post, id: "receipt_post_error" %>
   <% end %>
 </section>

--- a/app/views/ops/receiving/show.html.erb
+++ b/app/views/ops/receiving/show.html.erb
@@ -16,6 +16,7 @@
     · <%= link_to "Exit to Purchasing", admin_orders_path %>
   </p>
 </header>
+<%= render "ops/shared/error_summary", errors: @mutation_errors, conflict: @conflict, title: "Receipt was not changed" %>
 
 <% if @receipt.draft? && effective_permissions.include?("purchase_receipts.manage") %>
   <section class="ops-actions">
@@ -24,41 +25,43 @@
       <%= hidden_field_tag :lock_version, @receipt.lock_version %>
       <label>
         Received at
-        <input type="datetime-local" name="received_at" value="<%= @receipt.received_at&.strftime("%Y-%m-%dT%H:%M") %>">
+        <input type="datetime-local" name="received_at" value="<%= @error_action == :update ? @submitted&.fetch("received_at", nil) : @receipt.received_at&.strftime("%Y-%m-%dT%H:%M") %>" <%= "autofocus aria-describedby=receipt_header_error" if @error_action == :update %>>
       </label>
       <label>
         Supplier document #
-        <input type="text" name="supplier_document_number" value="<%= @receipt.supplier_document_number %>">
+        <input type="text" name="supplier_document_number" value="<%= @error_action == :update ? @submitted&.fetch("supplier_document_number", nil) : @receipt.supplier_document_number %>">
       </label>
       <label>
         Supplier document date
-        <input type="date" name="supplier_document_date" value="<%= @receipt.supplier_document_date %>">
+        <input type="date" name="supplier_document_date" value="<%= @error_action == :update ? @submitted&.fetch("supplier_document_date", nil) : @receipt.supplier_document_date %>">
       </label>
       <label>
         Freight (cents)
-        <input type="number" name="freight_cents" min="0" value="<%= @receipt.freight_cents %>">
+        <input type="number" name="freight_cents" min="0" value="<%= @error_action == :update ? @submitted&.fetch("freight_cents", nil) : @receipt.freight_cents %>">
       </label>
       <label>
         Handling (cents)
-        <input type="number" name="handling_cents" min="0" value="<%= @receipt.handling_cents %>">
+        <input type="number" name="handling_cents" min="0" value="<%= @error_action == :update ? @submitted&.fetch("handling_cents", nil) : @receipt.handling_cents %>">
       </label>
       <label>
         Supplier tax (cents)
-        <input type="number" name="supplier_tax_cents" min="0" value="<%= @receipt.supplier_tax_cents %>">
+        <input type="number" name="supplier_tax_cents" min="0" value="<%= @error_action == :update ? @submitted&.fetch("supplier_tax_cents", nil) : @receipt.supplier_tax_cents %>">
       </label>
       <label>
         Misc charges (cents)
-        <input type="number" name="miscellaneous_charges_cents" min="0" value="<%= @receipt.miscellaneous_charges_cents %>">
+        <input type="number" name="miscellaneous_charges_cents" min="0" value="<%= @error_action == :update ? @submitted&.fetch("miscellaneous_charges_cents", nil) : @receipt.miscellaneous_charges_cents %>">
       </label>
       <label>
         Charge notes
-        <input type="text" name="charge_notes" value="<%= @receipt.charge_notes %>">
+        <input type="text" name="charge_notes" value="<%= @error_action == :update ? @submitted&.fetch("charge_notes", nil) : @receipt.charge_notes %>">
       </label>
       <label>
         Notes
-        <input type="text" name="notes" value="<%= @receipt.notes %>">
+        <input type="text" name="notes" value="<%= @error_action == :update ? @submitted&.fetch("notes", nil) : @receipt.notes %>">
       </label>
       <button type="submit" data-ops-save>Save header</button>
+      <%= render "ops/shared/inline_row_error", action: :update, id: "receipt_header_error" %>
+      <% if @conflict && @error_action == :update %><small>Current saved notes: <%= @receipt.notes.presence || "blank" %>; freight: <%= @receipt.freight_cents %> cents.</small><% end %>
     <% end %>
     <p class="ops-hint">Ancillary charges are recorded but never enter inventory valuation.</p>
   </section>

--- a/app/views/ops/shared/_error_summary.html.erb
+++ b/app/views/ops/shared/_error_summary.html.erb
@@ -1,0 +1,14 @@
+<div id="ops_mutation_errors">
+<% if local_assigns[:errors].present? %>
+  <div class="form-errors ops-error-summary" role="alert" tabindex="-1" data-ops-error-summary>
+    <h2><%= local_assigns.fetch(:title, "Please correct the following") %></h2>
+    <ul>
+      <% Array(errors).each do |error| %><li><%= error %></li><% end %>
+    </ul>
+    <% if local_assigns[:conflict] %>
+      <p><strong>Current values are shown alongside your submitted values.</strong></p>
+      <p><%= link_to "Reload current values", request.path %>, then review your retained entries and retry.</p>
+    <% end %>
+  </div>
+<% end %>
+</div>

--- a/app/views/ops/shared/_inline_row_error.html.erb
+++ b/app/views/ops/shared/_inline_row_error.html.erb
@@ -1,0 +1,3 @@
+<% if @error_action == local_assigns[:action] && (!local_assigns.key?(:row_id) || @selected_row_id.to_s == row_id.to_s) %>
+  <span class="field-error ops-row-error" id="<%= local_assigns.fetch(:id, "ops_row_error") %>" role="alert"><%= Array(@mutation_errors).to_sentence %></span>
+<% end %>

--- a/docs/planning/phase7-orders-and-receiving/phase7-workflows.md
+++ b/docs/planning/phase7-orders-and-receiving/phase7-workflows.md
@@ -358,3 +358,9 @@ open quantity =
 Backordered quantity remains open.
 
 When every line reaches zero open quantity, ShelfSense closes the PO automatically. Unplanned overage does not affect PO fulfillment.
+
+## Recoverable mutation failures
+
+Ops location, draft-PO, and receiving forms render recoverable validation and command failures with HTTP `422 Unprocessable Entity`; receiving line submissions may replace the error, scanner, and line-grid regions with Turbo Streams. The response retains the operator's submitted strings independently of reloaded current records, marks the affected row, places an inline error at the invalid control, and presents an aggregate summary before generate, send, review, or post actions. Focus returns to the invalid control (or to the primary scan input when there is no field error).
+
+An optimistic-lock conflict reloads and displays current aggregate values without discarding submitted strings. The operator must explicitly reload/reconcile or retry; stale input never silently overwrites current state. Every successful receiving Turbo replacement refreshes both scanner and grid forms so all `lock_version` fields for the receipt advance together.

--- a/test/integration/purchasing_ops_mutation_failures_test.rb
+++ b/test/integration/purchasing_ops_mutation_failures_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PurchasingOpsMutationFailuresTest < ActionDispatch::IntegrationTest
+  setup do
+    bootstrap = bootstrap!
+    @store = bootstrap[:store]
+    @actor = bootstrap[:administrator]
+    tax = tax_class(code: "ops_failure_#{SecureRandom.hex(3)}")
+    @variant = pos_sellable_variant(actor: @actor, tax_class: tax, name: "Failure Retention Book")
+    @supplier = Supplier.create!(name: "Failure Supplier", code: "fail_#{SecureRandom.hex(3)}")
+    SupplierVariantSource.create!(
+      supplier: @supplier,
+      product_variant: @variant,
+      pricing_method: "direct_unit_cost",
+      expected_unit_cost_cents: 725,
+      organization_preferred: true
+    )
+    @purchase_order = Purchasing::CreateStockOrder.call(
+      store: @store, product_variant: @variant, actor: @actor, quantity: 1
+    ).purchase_order
+    post session_path, params: { session: { username: @actor.username, password: "correct-horse-battery" } }
+  end
+
+  test "draft PO stale row response retains strings, row selection, focus, and current values" do
+    line = @purchase_order.purchase_order_lines.first
+    order = line.order
+    submitted_version = order.lock_version
+    order.update!(notes: "current buyer note")
+
+    patch ops_purchase_order_update_line_path(@purchase_order, line), params: {
+      lock_version: submitted_version,
+      quantity: "07",
+      expected_unit_cost_cents: "00999",
+      notes: "submitted buyer note"
+    }
+
+    assert_response :unprocessable_entity
+    assert_select "[data-ops-error-summary]", text: /changed by someone else/i
+    assert_select "tr.is-selected[aria-selected='true'] input[name='quantity'][value='07'][autofocus]"
+    assert_select "tr.is-selected input[name='expected_unit_cost_cents'][value='00999']"
+    assert_select "tr.is-selected input[name='notes'][value='submitted buyer note']"
+    assert_select "tr.is-selected", text: /Current:.*current buyer note/
+    assert_select "a", text: "Reload current values"
+  end
+
+  test "receipt validation retains quantity, cost, notes, selected row, and invalid-control focus" do
+    Purchasing::GeneratePurchaseOrder.call(purchase_order: @purchase_order, actor: @actor)
+    Purchasing::SendPurchaseOrder.call(purchase_order: @purchase_order.reload, actor: @actor, transmission_method: "email")
+    receipt = Purchasing::CreateDraftPurchaseReceipt.call(store: @store, supplier: @supplier, actor: @actor)
+    po_line = @purchase_order.purchase_order_lines.first
+
+    post ops_receiving_add_line_path(receipt), params: {
+      lock_version: receipt.lock_version,
+      purchase_order_line_id: po_line.id,
+      received_quantity: "0",
+      actual_unit_cost_cents: "00888",
+      notes: "keep receiving note"
+    }
+
+    assert_response :unprocessable_entity
+    assert_select "[data-ops-error-summary]"
+    assert_select "input[name='purchase_order_line_id'][value='#{po_line.id}']"
+    assert_select "input[name='received_quantity'][value='0'][autofocus]"
+    assert_select "input[name='actual_unit_cost_cents'][value='00888']"
+    assert_select "input[name='notes'][value='keep receiving note']"
+    assert_select ".ops-row-error"
+  end
+
+  test "location exception retains row notes, cost, supplier choice, and focus" do
+    open_quantity_stock(store: @store, variant: @variant, actor: @actor, quantity: 1, unit_cost_cents: 100)
+    customer = Customer.create!(display_name: "Failure Customer")
+    customer_request = Customers::CreateRequest.call(
+      store: @store, customer: customer, product_variant: @variant, actor: @actor
+    )
+
+    post ops_location_not_located_path(customer_request), params: {
+      lock_version: customer_request.lock_version,
+      convert_to_special_order: "1",
+      supplier_id: SecureRandom.uuid_v7,
+      expected_unit_cost_cents: "00123",
+      notes: "retain location note"
+    }
+
+    assert_response :unprocessable_entity
+    assert_select "tr.is-selected[aria-selected='true']"
+    assert_select "tr.is-selected input[name='notes'][value='retain location note']"
+    assert_select "tr.is-selected input[name='expected_unit_cost_cents'][value='00123'][autofocus]"
+    assert_select "tr.is-selected .ops-row-error"
+  end
+end

--- a/test/system/purchasing_ops_workspace_test.rb
+++ b/test/system/purchasing_ops_workspace_test.rb
@@ -38,8 +38,28 @@ class PurchasingOpsWorkspaceTest < ApplicationSystemTestCase
 
     find("input[name='identifier']").fill_in with: "not-a-real-identifier"
     find("input[name='identifier']").send_keys :enter
-    assert_selector ".flash--alert"
+    assert_selector ".ops-row-error"
+    assert_field "identifier", with: "not-a-real-identifier"
     assert_equal "identifier", page.evaluate_script("document.activeElement && document.activeElement.name")
+  end
+
+  test "stale line edit keeps row strings selected and focuses quantity" do
+    visit ops_purchase_order_path(@purchase_order)
+    line = @purchase_order.purchase_order_lines.first
+    line.order.update!(notes: "current note")
+
+    row = find("tr", text: "Keyboard Purchasing Book")
+    row.find("input[name='quantity']").fill_in with: "7"
+    row.find("input[name='expected_unit_cost_cents']").fill_in with: "999"
+    row.find("input[name='notes']").fill_in with: "submitted note"
+    row.click_button "Save"
+
+    assert_selector "[data-ops-error-summary]", text: /changed by someone else/i
+    assert_selector "tr.is-selected", text: /current note/
+    assert_field "quantity", with: "7"
+    assert_field "expected_unit_cost_cents", with: "999"
+    assert_field "notes", with: "submitted note"
+    assert_equal "quantity", page.evaluate_script("document.activeElement && document.activeElement.name")
   end
 
   test "visible shortcuts focus lookup, save the active row, and invoke the primary action" do


### PR DESCRIPTION
### Motivation

- Convert redirect-only error handling in ops forms to structured recoverable responses so operators can correct mistakes without losing typed input or row/context selection.
- Preserve submitted field strings, show inline control-level errors, and surface an aggregate validation/conflict summary for clearer reconciliation and retry paths.
- Present optimistic-lock conflicts with current values side-by-side and an explicit reload/retry affordance, and ensure Turbo replacements refresh all receipt lock versions together.

### Description

- Replace redirect-on-error flows in `Ops::DraftPosController`, `Ops::LocationsController`, and `Ops::ReceivingController` with `render`/`render :mutation_failure` responses and a shared `render_mutation_failure` helper that prepares `@submitted`, `@error_action`, `@selected_row_id`, `@mutation_errors`, and `@conflict` state.
- Add ops-specific view partials `app/views/ops/shared/_error_summary.html.erb` and `app/views/ops/shared/_inline_row_error.html.erb` for aggregate summaries and per-row/control inline errors, and use them across the affected ops views to show errors and conflict guidance.
- Introduce `app/views/ops/receiving/mutation_failure.turbo_stream.erb` to replace the scanner, grid, and error-summary regions on receiving line failures so successful Turbo responses refresh `lock_version` fields for the same aggregate.
- Update ops forms and grids (`draft_pos/show`, `locations/show`, `receiving/*`) to retain submitted strings (`@submitted`), mark and persist the selected row (`@selected_row_id` / `is-selected`), add `autofocus aria-describedby` on the invalid control, and render current values alongside submitted values when a conflict occurs.
- Add automated coverage: `test/integration/purchasing_ops_mutation_failures_test.rb` (request-level flows for stale-row, receiving validation, and location exceptions) and extend `test/system/purchasing_ops_workspace_test.rb` to assert focus/field retention and inline error presence on recoverable failure scenarios.
- Document the recoverable-failure contract in `docs/planning/phase7-orders-and-receiving/phase7-workflows.md` and wire the new views into existing ops UI patterns.

### Testing

- Ran syntax and static checks: `ruby -c` on updated controllers and new tests all returned `Syntax OK` and `git diff --check` reported no problems.
- Loaded and type-checked new ERB partials and Turbo stream template; view templates validated without parse errors via ERB/Ruby checks.
- Added and ran controller/test-level Ruby checks for `test/integration/purchasing_ops_mutation_failures_test.rb` and `test/system/purchasing_ops_workspace_test.rb` with `ruby -c` which succeeded, and updated system test assertions to expect inline errors and focused fields.
- Could not run the full Rails test suite in this environment because the locked gems and Docker helper are not available (`./dev/rails-docker` / `bin/rails test` failed due to missing Docker or gems), so end-to-end execution and browser screenshots were not performed here. Please run the full test matrix in CI or locally via the project's Docker helper (`./dev/rails-docker bin/rails test`) to validate runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a89163e19b8832c8fc8e2e0d14dc2cb)