### PR TITLE
Present Phase 7 money as currency

### DIFF
--- a/app/controllers/admin/customer_requests_controller.rb
+++ b/app/controllers/admin/customer_requests_controller.rb
@@ -51,7 +51,7 @@ module Admin
           "Customer request ##{request.number} created."
         end
       redirect_to admin_customer_request_path(request), notice: notice
-    rescue Customers::Error, ActiveRecord::RecordNotFound => e
+    rescue Customers::Error, Money::ParseCents::Error, ActiveRecord::RecordNotFound => e
       @customer_request = CustomerRequest.new(
         store: current_store,
         customer_id: params.dig(:customer_request, :customer_id),
@@ -124,9 +124,7 @@ module Admin
     def optional_cents(value)
       return if value.blank?
 
-      Integer(value)
-    rescue ArgumentError, TypeError
-      nil
+      Money::ParseCents.call(value)
     end
   end
 end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -40,7 +40,7 @@ module Admin
       po = order.purchase_order
       redirect_to ops_purchase_order_path(po),
                   notice: "Stock order ##{order.number} created and added to draft PO."
-    rescue Purchasing::Error, ActiveRecord::RecordNotFound, ActiveRecord::RecordInvalid => e
+    rescue Purchasing::Error, Money::ParseCents::Error, ActiveRecord::RecordNotFound, ActiveRecord::RecordInvalid => e
       @order = Order.new(
         store: current_store,
         product_variant_id: params.dig(:order, :product_variant_id),
@@ -89,9 +89,7 @@ module Admin
     def optional_cents(value)
       return if value.blank?
 
-      Integer(value)
-    rescue ArgumentError, TypeError
-      nil
+      Money::ParseCents.call(value)
     end
   end
 end

--- a/app/controllers/admin/purchase_orders_controller.rb
+++ b/app/controllers/admin/purchase_orders_controller.rb
@@ -46,7 +46,7 @@ module Admin
         notice += " Replacement order ##{result[:replacement_order].number} created."
       end
       redirect_to admin_purchase_order_path(@purchase_order), notice: notice
-    rescue Purchasing::Error, ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
+    rescue Purchasing::Error, Money::ParseCents::Error, ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
       redirect_to admin_purchase_order_path(@purchase_order), alert: e.message
     end
 
@@ -89,9 +89,7 @@ module Admin
     def optional_cents(value)
       return if value.blank?
 
-      Integer(value)
-    rescue ArgumentError, TypeError
-      nil
+      Money::ParseCents.call(value)
     end
   end
 end

--- a/app/controllers/admin/purchase_receipts_controller.rb
+++ b/app/controllers/admin/purchase_receipts_controller.rb
@@ -58,16 +58,26 @@ module Admin
         purchase_receipt_line: @line,
         actor: current_user,
         reason: params.require(:reason),
-        corrected_unit_cost_cents: params[:corrected_unit_cost_cents],
+        corrected_unit_cost_cents: Money::ParseCents.call(params[:corrected_unit_cost_cents]),
         value_delta_cents: params[:value_delta_cents],
         idempotency_key: params[:idempotency_key].presence || SecureRandom.uuid_v7
       )
       redirect_to admin_purchase_receipt_path(@receipt), notice: "Cost correction posted."
+    rescue Money::ParseCents::Error => e
+      load_show
+      @money_error = e.message
+      @submitted_cost = params[:corrected_unit_cost_cents]
+      @selected_line_id = @line.id
+      render :show, status: :unprocessable_entity
     rescue Purchasing::Error, ActiveRecord::RecordInvalid => e
       redirect_to admin_purchase_receipt_path(@receipt), alert: e.message
     end
 
     private
+
+    def load_show
+      show
+    end
 
     def set_receipt
       @receipt = PurchaseReceipt.find(params[:id])

--- a/app/controllers/admin/supplier_variant_sources_controller.rb
+++ b/app/controllers/admin/supplier_variant_sources_controller.rb
@@ -2,6 +2,7 @@
 
 module Admin
   class SupplierVariantSourcesController < BaseController
+    rescue_from Money::ParseCents::Error, with: :render_money_error
     before_action -> { require_permission!("suppliers.view") }, only: %i[show]
     before_action -> { require_permission!("suppliers.manage") }, only: %i[new create edit update destroy reactivate]
     before_action :set_supplier, only: %i[new create], if: -> { params[:supplier_id].present? }
@@ -126,6 +127,13 @@ module Admin
 
     private
 
+    def render_money_error(exception)
+      @supplier_variant_source ||= SupplierVariantSource.new
+      @supplier_variant_source.errors.add(:base, exception.message)
+      prepare_form_rerender
+      render(action_name == "update" ? :edit : :new, status: :unprocessable_entity)
+    end
+
     def set_supplier
       @supplier = Supplier.find(params[:supplier_id])
     end
@@ -206,6 +214,9 @@ module Admin
       )
       %i[supplier_list_price_cents discount_basis_points expected_unit_cost_cents].each do |key|
         permitted[key] = nil if permitted[key].blank?
+      end
+      %i[supplier_list_price_cents expected_unit_cost_cents].each do |key|
+        permitted[key] = Money::ParseCents.call(permitted[key]) if permitted[key].present?
       end
       permitted[:organization_preferred] = ActiveModel::Type::Boolean.new.cast(permitted[:organization_preferred])
       permitted

--- a/app/controllers/ops/draft_pos_controller.rb
+++ b/app/controllers/ops/draft_pos_controller.rb
@@ -37,6 +37,8 @@ module Ops
       )
       redirect_to ops_purchase_order_path(@purchase_order),
                   notice: "Added stock order ##{order.number}."
+    rescue Money::ParseCents::Error => e
+      render_mutation_failure(:add_line, e, field: :expected_unit_cost_cents)
     rescue Purchasing::Error, ActiveRecord::RecordInvalid => e
       render_mutation_failure(:add_line, e, field: :identifier)
     rescue ActiveRecord::StaleObjectError => e
@@ -54,6 +56,8 @@ module Ops
         expected_lock_version: params[:lock_version]
       )
       redirect_to ops_purchase_order_path(@purchase_order), notice: "Line updated."
+    rescue Money::ParseCents::Error => e
+      render_mutation_failure(:update_line, e, field: :expected_unit_cost_cents, row_id: params[:line_id])
     rescue Purchasing::Error, ActiveRecord::RecordInvalid => e
       render_mutation_failure(:update_line, e, field: :quantity, row_id: params[:line_id])
     rescue ActiveRecord::StaleObjectError => e
@@ -148,9 +152,7 @@ module Ops
     def optional_cents(value)
       return if value.blank?
 
-      Integer(value)
-    rescue ArgumentError, TypeError
-      nil
+      Money::ParseCents.call(value)
     end
   end
 end

--- a/app/controllers/ops/receiving_controller.rb
+++ b/app/controllers/ops/receiving_controller.rb
@@ -66,15 +66,15 @@ module Ops
         received_at: parse_time(params[:received_at]),
         supplier_document_number: params[:supplier_document_number],
         supplier_document_date: params[:supplier_document_date].presence,
-        freight_cents: params[:freight_cents].presence || 0,
-        handling_cents: params[:handling_cents].presence || 0,
-        supplier_tax_cents: params[:supplier_tax_cents].presence || 0,
-        miscellaneous_charges_cents: params[:miscellaneous_charges_cents].presence || 0,
+        freight_cents: optional_charge_cents(params[:freight_cents]),
+        handling_cents: optional_charge_cents(params[:handling_cents]),
+        supplier_tax_cents: optional_charge_cents(params[:supplier_tax_cents]),
+        miscellaneous_charges_cents: optional_charge_cents(params[:miscellaneous_charges_cents]),
         charge_notes: params[:charge_notes],
         notes: params[:notes]
       )
       redirect_to ops_receiving_path(receipt), notice: "Draft receipt created."
-    rescue Purchasing::Error, ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
+    rescue Purchasing::Error, Money::ParseCents::Error, ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
       @submitted = params.to_unsafe_h.slice("supplier_id", "received_at", "supplier_document_number")
       @error_action = :create
       @error_field = :supplier_id
@@ -92,14 +92,16 @@ module Ops
         received_at: parse_time(params[:received_at]) || :__omit__,
         supplier_document_number: params.key?(:supplier_document_number) ? params[:supplier_document_number] : :__omit__,
         supplier_document_date: params.key?(:supplier_document_date) ? params[:supplier_document_date] : :__omit__,
-        freight_cents: params.key?(:freight_cents) ? params[:freight_cents] : :__omit__,
-        handling_cents: params.key?(:handling_cents) ? params[:handling_cents] : :__omit__,
-        supplier_tax_cents: params.key?(:supplier_tax_cents) ? params[:supplier_tax_cents] : :__omit__,
-        miscellaneous_charges_cents: params.key?(:miscellaneous_charges_cents) ? params[:miscellaneous_charges_cents] : :__omit__,
+        freight_cents: parsed_if_present(:freight_cents),
+        handling_cents: parsed_if_present(:handling_cents),
+        supplier_tax_cents: parsed_if_present(:supplier_tax_cents),
+        miscellaneous_charges_cents: parsed_if_present(:miscellaneous_charges_cents),
         charge_notes: params.key?(:charge_notes) ? params[:charge_notes] : :__omit__,
         notes: params.key?(:notes) ? params[:notes] : :__omit__
       )
       redirect_to ops_receiving_path(@receipt), notice: "Receipt updated."
+    rescue Money::ParseCents::Error => e
+      render_mutation_failure(:update, e, field: e.field)
     rescue Purchasing::Error, ActiveRecord::RecordInvalid => e
       render_mutation_failure(:update, e, field: :received_at)
     rescue ActiveRecord::StaleObjectError => e
@@ -117,7 +119,7 @@ module Ops
         purchase_order_line: po_line,
         actor: current_user,
         received_quantity: params.require(:received_quantity),
-        actual_unit_cost_cents: params.require(:actual_unit_cost_cents),
+        actual_unit_cost_cents: required_money_cents(params.require(:actual_unit_cost_cents), :actual_unit_cost_cents),
         notes: params[:notes],
         expected_lock_version: params[:lock_version]
       )
@@ -129,6 +131,8 @@ module Ops
           render :add_line
         end
       end
+    rescue Money::ParseCents::Error => e
+      render_mutation_failure(:add_line, e, field: :actual_unit_cost_cents, row_id: params[:purchase_order_line_id])
     rescue Purchasing::Error, ActiveRecord::RecordInvalid => e
       render_mutation_failure(:add_line, e, field: :received_quantity, row_id: params[:purchase_order_line_id])
     rescue ActiveRecord::StaleObjectError => e
@@ -142,11 +146,13 @@ module Ops
         purchase_order_line: line.purchase_order_line,
         actor: current_user,
         received_quantity: params.require(:received_quantity),
-        actual_unit_cost_cents: params.require(:actual_unit_cost_cents),
+        actual_unit_cost_cents: required_money_cents(params.require(:actual_unit_cost_cents), :actual_unit_cost_cents),
         notes: params.key?(:notes) ? params[:notes] : line.notes,
         expected_lock_version: params[:lock_version]
       )
       redirect_to ops_receiving_path(@receipt), notice: "Line updated."
+    rescue Money::ParseCents::Error => e
+      render_mutation_failure(:update_line, e, field: :actual_unit_cost_cents, row_id: params[:line_id])
     rescue Purchasing::Error, ActiveRecord::RecordInvalid => e
       render_mutation_failure(:update_line, e, field: :received_quantity, row_id: params[:line_id])
     rescue ActiveRecord::StaleObjectError => e
@@ -215,22 +221,55 @@ module Ops
         purchase_receipt_line: line,
         actor: current_user,
         reason: params.require(:reason),
-        corrected_unit_cost_cents: params[:corrected_unit_cost_cents],
+        corrected_unit_cost_cents: required_money_cents(params[:corrected_unit_cost_cents], :corrected_unit_cost_cents),
         value_delta_cents: params[:value_delta_cents],
         idempotency_key: params[:idempotency_key].presence || SecureRandom.uuid_v7
       )
       redirect_to ops_receiving_path(@receipt), notice: "Cost correction posted."
+    rescue Money::ParseCents::Error => e
+      render_mutation_failure(:correct_cost, e, field: :corrected_unit_cost_cents, row_id: params[:line_id])
     rescue Purchasing::Error, ActiveRecord::RecordInvalid => e
       redirect_to ops_receiving_path(@receipt), alert: e.message
     end
 
     private
 
+    MoneyFieldError = Class.new(Money::ParseCents::Error) do
+      attr_reader :field
+
+      def initialize(message, field)
+        @field = field
+        super(message)
+      end
+    end
+
+    def parsed_if_present(field)
+      return :__omit__ unless params.key?(field)
+
+      optional_charge_cents(params[field], field)
+    end
+
+    def optional_charge_cents(value, field = nil)
+      Money::ParseCents.call(value) || 0
+    rescue Money::ParseCents::Error => e
+      raise MoneyFieldError.new(e.message, field) if field
+
+      raise
+    end
+
+    def required_money_cents(value, field)
+      Money::ParseCents.call(value).tap { |cents| raise MoneyFieldError.new("is required", field) if cents.nil? }
+    rescue Money::ParseCents::Error => e
+      raise e if e.is_a?(MoneyFieldError)
+
+      raise MoneyFieldError.new(e.message, field)
+    end
+
     def render_mutation_failure(action, exception, field:, row_id: nil, stale: false)
       @submitted = params.to_unsafe_h.slice(
         "received_at", "supplier_document_number", "supplier_document_date", "freight_cents", "handling_cents",
         "supplier_tax_cents", "miscellaneous_charges_cents", "charge_notes", "notes", "purchase_order_line_id",
-        "received_quantity", "actual_unit_cost_cents"
+        "received_quantity", "actual_unit_cost_cents", "corrected_unit_cost_cents", "reason"
       )
       @error_action = action
       @error_field = field
@@ -314,7 +353,8 @@ module Ops
         customer_request: request&.number,
         order_date: line.purchase_order.sent_at&.to_date || line.purchase_order.created_at.to_date,
         open_quantity: line.open_quantity,
-        expected_unit_cost_cents: line.expected_unit_cost_cents_snapshot
+        expected_unit_cost: helpers.money_field_value(line.expected_unit_cost_cents_snapshot),
+        expected_unit_cost_formatted: helpers.format_money_cents(line.expected_unit_cost_cents_snapshot)
       }
     end
 

--- a/app/javascript/controllers/receiving_lookup_controller.js
+++ b/app/javascript/controllers/receiving_lookup_controller.js
@@ -93,7 +93,7 @@ export default class extends Controller {
     this.pickerTarget.hidden = true
     this.lineIdTarget.value = match.id
     this.quantityTarget.value = match.open_quantity
-    this.costTarget.value = match.expected_unit_cost_cents
+    this.costTarget.value = match.expected_unit_cost
     this.quantityTarget.disabled = false
     this.costTarget.disabled = false
     this.confirmTarget.disabled = false
@@ -116,7 +116,7 @@ export default class extends Controller {
 
   description(match) {
     const request = match.customer_request ? ` · customer request #${match.customer_request}` : " · stock order"
-    return `PO #${match.po_number} · ${match.product} · SKU ${match.sku}${request} · ordered ${match.order_date} · open ${match.open_quantity} · expected ${match.expected_unit_cost_cents}¢`
+    return `PO #${match.po_number} · ${match.product} · SKU ${match.sku}${request} · ordered ${match.order_date} · open ${match.open_quantity} · expected ${match.expected_unit_cost_formatted}`
   }
 
   showMessage(message) {

--- a/app/views/admin/customer_requests/new.html.erb
+++ b/app/views/admin/customer_requests/new.html.erb
@@ -47,15 +47,14 @@
         <%= form.collection_select :supplier_id, @suppliers, :id, :admin_label,
               { selected: @preferred_source&.supplier_id, include_blank: "Preferred source (if any)" } %>
       </p>
-      <p>
-        <%= form.label :expected_unit_cost_cents, "Expected unit cost (cents, OOS Standard)" %>
-        <%= form.number_field :expected_unit_cost_cents, min: 0, value: @preferred_source&.derived_expected_unit_cost_cents %>
-      </p>
+      <%= render "shared/currency_field",
+            name: "customer_request[expected_unit_cost_cents]", id: "customer_request_expected_unit_cost_cents",
+            label: "Expected unit cost ($, OOS Standard)",
+            value: params.dig(:customer_request, :expected_unit_cost_cents).presence || money_field_value(@preferred_source&.derived_expected_unit_cost_cents) %>
     <% end %>
-    <p>
-      <%= form.label :estimated_price_cents, "Estimated price (cents)" %>
-      <%= form.number_field :estimated_price_cents, min: 0 %>
-    </p>
+    <%= render "shared/currency_field",
+          name: "customer_request[estimated_price_cents]", id: "customer_request_estimated_price_cents",
+          label: "Estimated customer price ($)", value: params.dig(:customer_request, :estimated_price_cents) %>
     <p>
       <%= form.label :notes %>
       <%= form.text_area :notes %>

--- a/app/views/admin/customer_requests/show.html.erb
+++ b/app/views/admin/customer_requests/show.html.erb
@@ -6,6 +6,7 @@
   <dt>Customer</dt><dd><%= link_to @customer_request.customer.admin_label, admin_customer_path(@customer_request.customer) %></dd>
   <dt>Variant</dt><dd><%= @customer_request.product_variant.sku %> (<%= @customer_request.product_variant.variant_type %>)</dd>
   <dt>Status</dt><dd><%= @customer_request.status %></dd>
+  <dt>Estimated customer price</dt><dd><%= @customer_request.estimated_price_cents.nil? ? "—" : format_money_cents(@customer_request.estimated_price_cents) %></dd>
   <dt>Notes</dt><dd><%= @customer_request.notes.presence || "—" %></dd>
   <% if @customer_request.cancelled? %>
     <dt>Cancellation</dt>

--- a/app/views/admin/orders/new.html.erb
+++ b/app/views/admin/orders/new.html.erb
@@ -40,11 +40,11 @@
       <%= form.label :requested_quantity, "Quantity" %>
       <%= form.number_field :requested_quantity, value: @order.requested_quantity || 1, min: 1, required: true %>
     </p>
-    <p>
-      <%= form.label :expected_unit_cost_cents, "Expected unit cost (cents)" %>
-      <%= form.number_field :expected_unit_cost_cents, min: 0, value: @preferred_expected_cost_cents %>
-      <span class="muted">Required when no preferred source supplies cost.</span>
-    </p>
+    <%= render "shared/currency_field",
+          name: "order[expected_unit_cost_cents]", id: "order_expected_unit_cost_cents",
+          label: "Expected unit cost ($)",
+          value: params.dig(:order, :expected_unit_cost_cents).presence || money_field_value(@preferred_expected_cost_cents),
+          help: "Required when no preferred source supplies cost." %>
     <p>
       <%= form.label :notes %>
       <%= form.text_area :notes, value: @order.notes %>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -22,7 +22,7 @@
   <% end %>
   <% if @line %>
     <dt>Expected unit cost</dt>
-    <dd><%= @line.expected_unit_cost_cents_snapshot %> cents</dd>
+    <dd><%= format_money_cents(@line.expected_unit_cost_cents_snapshot) %></dd>
   <% end %>
   <% if @order.cancelled? %>
     <dt>Cancellation</dt>

--- a/app/views/admin/purchase_orders/show.html.erb
+++ b/app/views/admin/purchase_orders/show.html.erb
@@ -38,7 +38,7 @@
           Ordered <%= line.ordered_quantity %>
           · open <%= line.open_quantity %>
           · cancelled <%= line.cancelled_quantity %>
-          · expected cost <%= line.expected_unit_cost_cents_snapshot %> cents
+          · expected unit cost <%= format_money_cents(line.expected_unit_cost_cents_snapshot) %>
           <% if order.customer_request %>
             · request #<%= order.customer_request.number %> (<%= order.customer_request.status %>)
           <% end %>
@@ -113,8 +113,8 @@
               </select>
             </label>
             <label>
-              Expected cost (cents, if no source)
-              <input type="number" name="expected_unit_cost_cents" min="0">
+              Expected unit cost ($, if no source)
+              <input type="text" inputmode="decimal" name="expected_unit_cost_cents">
             </label>
             <button type="submit">Cancel quantity</button>
           <% end %>

--- a/app/views/admin/purchase_receipts/index.html.erb
+++ b/app/views/admin/purchase_receipts/index.html.erb
@@ -11,7 +11,7 @@
       · <%= receipt.supplier.admin_label %>
       · <%= receipt.store.admin_label %>
       · <%= receipt.status %>
-      · merchandise <%= receipt.merchandise_total_cents %> cents
+      · merchandise <%= format_money_cents(receipt.merchandise_total_cents) %>
     </li>
   <% end %>
 </ul>

--- a/app/views/admin/purchase_receipts/show.html.erb
+++ b/app/views/admin/purchase_receipts/show.html.erb
@@ -4,8 +4,8 @@
   <%= @receipt.supplier.admin_label %>
   · <%= @receipt.store.admin_label %>
   · <%= @receipt.status %>
-  · merchandise <%= @receipt.merchandise_total_cents %> cents
-  · ancillary <%= @receipt.ancillary_total_cents %> cents
+  · merchandise <%= format_money_cents(@receipt.merchandise_total_cents) %>
+  · ancillary <%= format_money_cents(@receipt.ancillary_total_cents) %>
 </p>
 <p>
   <%= link_to "All receipts", admin_purchase_receipts_path %>
@@ -41,7 +41,7 @@
         <td><%= line.received_quantity %></td>
         <td><%= line.reversed_quantity %></td>
         <td><%= line.net_matched_quantity %></td>
-        <td><%= line.actual_unit_cost_cents %></td>
+        <td><%= format_money_cents(line.actual_unit_cost_cents) %></td>
         <td>
           <% if line.corrections.any? %>
             <ul>
@@ -49,7 +49,7 @@
                 <li>
                   <%= correction.correction_type %>
                   <% if correction.quantity.present? %>· qty <%= correction.quantity %><% end %>
-                  <% if correction.value_delta_cents.present? %>· Δ<%= correction.value_delta_cents %>¢<% end %>
+                  <% if correction.value_delta_cents.present? %>· value change <%= format_money_cents(correction.value_delta_cents) %><% end %>
                   · <%= correction.reason %>
                 </li>
               <% end %>
@@ -84,8 +84,9 @@
                   <input type="text" name="reason" required>
                 </label>
                 <label>
-                  Corrected unit cost (cents)
-                  <input type="number" name="corrected_unit_cost_cents" min="0" required>
+                  Corrected unit cost ($)
+                  <input type="text" inputmode="decimal" name="corrected_unit_cost_cents" value="<%= @selected_line_id == line.id ? @submitted_cost : nil %>" required aria-invalid="<%= @selected_line_id == line.id %>">
+                  <% if @selected_line_id == line.id %><span class="field-error"><%= @money_error %></span><% end %>
                 </label>
                 <button type="submit">Correct cost</button>
               <% end %>

--- a/app/views/admin/supplier_variant_sources/_form.html.erb
+++ b/app/views/admin/supplier_variant_sources/_form.html.erb
@@ -41,9 +41,15 @@
       ["Discount from list", "discount_from_list"]
     ] %>
   </p>
-  <p><%= form.label :supplier_list_price_cents, "Supplier list price (cents)" %><%= form.number_field :supplier_list_price_cents %></p>
+  <%= render "shared/currency_field",
+        name: "supplier_variant_source[supplier_list_price_cents]", id: "supplier_variant_source_supplier_list_price_cents",
+        label: "Supplier list price ($)",
+        value: params.dig(:supplier_variant_source, :supplier_list_price_cents).presence || money_field_value(supplier_variant_source.supplier_list_price_cents) %>
   <p><%= form.label :discount_basis_points, "Discount (basis points)" %><%= form.number_field :discount_basis_points %></p>
-  <p><%= form.label :expected_unit_cost_cents, "Expected unit cost (cents)" %><%= form.number_field :expected_unit_cost_cents %></p>
+  <%= render "shared/currency_field",
+        name: "supplier_variant_source[expected_unit_cost_cents]", id: "supplier_variant_source_expected_unit_cost_cents",
+        label: "Expected unit cost ($)",
+        value: params.dig(:supplier_variant_source, :expected_unit_cost_cents).presence || money_field_value(supplier_variant_source.expected_unit_cost_cents) %>
   <p><%= form.check_box :organization_preferred %><%= form.label :organization_preferred, "Organization preferred" %></p>
   <p><%= form.submit class: "btn" %></p>
 <% end %>

--- a/app/views/admin/supplier_variant_sources/show.html.erb
+++ b/app/views/admin/supplier_variant_sources/show.html.erb
@@ -8,11 +8,11 @@
 <p>
   Pricing: <%= @supplier_variant_source.pricing_method.humanize %>
   <% if @supplier_variant_source.pricing_method == "direct_unit_cost" %>
-    · expected <%= @supplier_variant_source.expected_unit_cost_cents %>¢
+    · expected unit cost <%= format_money_cents(@supplier_variant_source.expected_unit_cost_cents) %>
   <% else %>
-    · list <%= @supplier_variant_source.supplier_list_price_cents %>¢
+    · supplier list price <%= format_money_cents(@supplier_variant_source.supplier_list_price_cents) %>
     · discount <%= @supplier_variant_source.discount_basis_points %> bps
-    · derived <%= @supplier_variant_source.derived_expected_unit_cost_cents %>¢
+    · derived expected unit cost <%= format_money_cents(@supplier_variant_source.derived_expected_unit_cost_cents) %>
   <% end %>
 </p>
 <% if @supplier_variant_source.organization_preferred? %><p>Organization preferred source for this variant.</p><% end %>

--- a/app/views/ops/draft_pos/index.html.erb
+++ b/app/views/ops/draft_pos/index.html.erb
@@ -19,7 +19,7 @@
         <tr>
           <td><%= po.supplier.admin_label %></td>
           <td><%= po.purchase_order_lines.size %></td>
-          <td><%= po.expected_merchandise_total_cents %> cents</td>
+          <td><%= format_money_cents(po.expected_merchandise_total_cents) %></td>
           <td><%= link_to "Open", ops_purchase_order_path(po) %></td>
         </tr>
       <% end %>

--- a/app/views/ops/draft_pos/show.html.erb
+++ b/app/views/ops/draft_pos/show.html.erb
@@ -8,7 +8,7 @@
       · <%= @purchase_order.status %>
       <% if @purchase_order.generated? %>· generated rev <%= @purchase_order.document_revision %><% end %>
       · <%= @lines.size %> lines
-      · <%= @purchase_order.expected_merchandise_total_cents %> cents expected
+      · <%= format_money_cents(@purchase_order.expected_merchandise_total_cents) %> expected
     </p>
   </div>
   <p>
@@ -73,8 +73,8 @@
         <input type="number" name="quantity" value="<%= @submitted&.fetch("quantity", nil) || 1 %>" min="1" required>
       </label>
       <label>
-        Expected cost (cents)
-        <input type="number" name="expected_unit_cost_cents" value="<%= @submitted&.fetch("expected_unit_cost_cents", nil) %>" min="0">
+        Expected unit cost ($)
+        <input type="text" inputmode="decimal" name="expected_unit_cost_cents" value="<%= @submitted&.fetch("expected_unit_cost_cents", nil) %>" aria-invalid="<%= @error_field == :expected_unit_cost_cents %>">
       </label>
       <button type="submit">Add</button>
       <%= render "ops/shared/inline_row_error", action: :add_line, id: "po_add_error" %>
@@ -110,7 +110,7 @@
               <code><%= line.product_variant.sku %></code>
             </td>
             <td><%= line.ordered_quantity %></td>
-            <td><%= line.expected_unit_cost_cents_snapshot %></td>
+            <td><%= format_money_cents(line.expected_unit_cost_cents_snapshot) %></td>
             <td>
               <% if order.customer_request %>
                 Req #<%= order.customer_request.number %>
@@ -129,7 +129,7 @@
                   </label>
                   <label>
                     Cost
-                    <input type="number" name="expected_unit_cost_cents" value="<%= @selected_row_id.to_s == line.id.to_s ? @submitted&.fetch("expected_unit_cost_cents", line.expected_unit_cost_cents_snapshot) : line.expected_unit_cost_cents_snapshot %>" min="0">
+                    <input type="text" inputmode="decimal" name="expected_unit_cost_cents" value="<%= @selected_row_id.to_s == line.id.to_s ? @submitted&.fetch("expected_unit_cost_cents", money_field_value(line.expected_unit_cost_cents_snapshot)) : money_field_value(line.expected_unit_cost_cents_snapshot) %>" aria-invalid="<%= @error_field == :expected_unit_cost_cents && @selected_row_id.to_s == line.id.to_s %>">
                   </label>
                   <label>
                     Notes
@@ -137,7 +137,7 @@
                   </label>
                   <button type="submit" data-ops-save data-row-primary>Save</button>
                   <%= render "ops/shared/inline_row_error", action: :update_line, row_id: line.id, id: "po_line_#{line.id}_error" %>
-                  <% if @conflict && @selected_row_id.to_s == line.id.to_s %><small>Current: qty <%= line.ordered_quantity %>, cost <%= line.expected_unit_cost_cents_snapshot %>, notes <%= line.order.notes.presence || "blank" %>.</small><% end %>
+                  <% if @conflict && @selected_row_id.to_s == line.id.to_s %><small>Current: qty <%= line.ordered_quantity %>, expected cost <%= format_money_cents(line.expected_unit_cost_cents_snapshot) %>, notes <%= line.order.notes.presence || "blank" %>.</small><% end %>
                 <% end %>
               </td>
             <% end %>

--- a/app/views/ops/receiving/_line_grid.html.erb
+++ b/app/views/ops/receiving/_line_grid.html.erb
@@ -7,7 +7,7 @@
       <thead><tr>
         <th scope="col">PO</th><th scope="col">Item</th><th scope="col">Open</th><th scope="col">Received</th>
         <th scope="col">Matched*</th><th scope="col">Unplanned*</th><th scope="col">Over-shipment</th>
-        <th scope="col">Unit cost</th><th scope="col">Customer</th>
+        <th scope="col">Expected unit cost</th><th scope="col">Actual unit cost</th><th scope="col">Customer</th>
         <% if @receipt.draft? && effective_permissions.include?("purchase_receipts.manage") %><th scope="col">Edit</th><% end %>
       </tr></thead>
       <tbody>
@@ -21,17 +21,18 @@
             <td><%= open_quantity %></td><td><%= line.received_quantity %></td>
             <td><%= line.matched_quantity %></td><td><%= line.unplanned_quantity %></td>
             <td><% if over_shipment.positive? %><strong>Yes — <%= over_shipment %> over open quantity</strong><% else %>No<% end %></td>
-            <td><%= line.actual_unit_cost_cents %></td>
+            <td><%= format_money_cents(po_line.expected_unit_cost_cents_snapshot) %></td>
+            <td><%= format_money_cents(line.actual_unit_cost_cents) %></td>
             <td><%= po_line.order.customer_request.present? ? "Req ##{po_line.order.customer_request.number}" : "—" %></td>
             <% if @receipt.draft? && effective_permissions.include?("purchase_receipts.manage") %>
               <td><%= form_with url: ops_receiving_update_line_path(@receipt, line), method: :patch, local: true, html: { class: "ops-inline-form", data: { dirty_track: true } } do %>
                 <%= hidden_field_tag :lock_version, @receipt.lock_version %>
                 <label>Qty <input type="number" name="received_quantity" value="<%= @selected_row_id.to_s == line.id.to_s ? @submitted&.fetch("received_quantity", line.received_quantity) : line.received_quantity %>" min="1" required <%= "autofocus aria-describedby=receipt_line_#{line.id}_error" if @selected_row_id.to_s == line.id.to_s %>></label>
-                <label>Cost <input type="number" name="actual_unit_cost_cents" value="<%= @selected_row_id.to_s == line.id.to_s ? @submitted&.fetch("actual_unit_cost_cents", line.actual_unit_cost_cents) : line.actual_unit_cost_cents %>" min="0" required></label>
+                <label>Actual unit cost ($) <input type="text" inputmode="decimal" name="actual_unit_cost_cents" value="<%= @selected_row_id.to_s == line.id.to_s ? @submitted&.fetch("actual_unit_cost_cents", money_field_value(line.actual_unit_cost_cents)) : money_field_value(line.actual_unit_cost_cents) %>" required></label>
                 <label>Notes <input type="text" name="notes" value="<%= @selected_row_id.to_s == line.id.to_s ? @submitted&.fetch("notes", line.notes) : line.notes %>"></label>
                 <button type="submit" data-ops-save data-row-primary>Save</button>
                 <%= render "ops/shared/inline_row_error", action: :update_line, row_id: line.id, id: "receipt_line_#{line.id}_error" %>
-                <% if @conflict && @selected_row_id.to_s == line.id.to_s %><small>Current: qty <%= line.received_quantity %>, cost <%= line.actual_unit_cost_cents %>, notes <%= line.notes.presence || "blank" %>.</small><% end %>
+                <% if @conflict && @selected_row_id.to_s == line.id.to_s %><small>Current: qty <%= line.received_quantity %>, actual cost <%= format_money_cents(line.actual_unit_cost_cents) %>, notes <%= line.notes.presence || "blank" %>.</small><% end %>
               <% end %></td>
             <% end %>
           </tr>

--- a/app/views/ops/receiving/_line_scanner.html.erb
+++ b/app/views/ops/receiving/_line_scanner.html.erb
@@ -24,8 +24,8 @@
         <input type="number" name="received_quantity" value="<%= @error_action == :add_line ? @submitted&.fetch("received_quantity", nil) : nil %>" min="1" required <%= "disabled" unless @error_action == :add_line %> <%= "autofocus aria-describedby=receipt_add_error" if @error_action == :add_line %> data-receiving-lookup-target="quantity">
       </label>
       <label>
-        Actual unit cost (cents)
-        <input type="number" name="actual_unit_cost_cents" value="<%= @error_action == :add_line ? @submitted&.fetch("actual_unit_cost_cents", nil) : nil %>" min="0" required <%= "disabled" unless @error_action == :add_line %> data-receiving-lookup-target="cost">
+        Actual unit cost ($)
+        <input type="text" inputmode="decimal" name="actual_unit_cost_cents" value="<%= @error_action == :add_line ? @submitted&.fetch("actual_unit_cost_cents", nil) : nil %>" required <%= "disabled" unless @error_action == :add_line %> aria-invalid="<%= @error_field == :actual_unit_cost_cents %>" data-receiving-lookup-target="cost">
       </label>
       <label>Notes <input type="text" name="notes" value="<%= @error_action == :add_line ? @submitted&.fetch("notes", nil) : nil %>"></label>
       <button type="submit" <%= "disabled" unless @error_action == :add_line %> data-receiving-lookup-target="confirm">Confirm and add line</button>

--- a/app/views/ops/receiving/review.html.erb
+++ b/app/views/ops/receiving/review.html.erb
@@ -20,15 +20,15 @@
     <li>Matched units: <%= @preview_lines.sum { |row| row[:matched_quantity] } %></li>
     <li>Unplanned units: <%= @preview_lines.sum { |row| row[:unplanned_quantity] } %></li>
     <li>Customer allocations to create: <%= @preview_lines.count { |row| row[:allocates] } %></li>
-    <li>Merchandise value: <%= @receipt.merchandise_total_cents %> cents</li>
+    <li>Merchandise value: <%= format_money_cents(@receipt.merchandise_total_cents) %></li>
     <li>
-      Freight: <%= @receipt.freight_cents %>
-      · Handling: <%= @receipt.handling_cents %>
-      · Tax: <%= @receipt.supplier_tax_cents %>
-      · Misc: <%= @receipt.miscellaneous_charges_cents %>
+      Freight: <%= format_money_cents(@receipt.freight_cents) %>
+      · Handling: <%= format_money_cents(@receipt.handling_cents) %>
+      · Tax: <%= format_money_cents(@receipt.supplier_tax_cents) %>
+      · Misc: <%= format_money_cents(@receipt.miscellaneous_charges_cents) %>
     </li>
-    <li>Ancillary total (not inventoried): <%= @receipt.ancillary_total_cents %> cents</li>
-    <li>Operational acquisition total: <%= @receipt.operational_acquisition_total_cents %> cents</li>
+    <li>Ancillary total (not inventoried): <%= format_money_cents(@receipt.ancillary_total_cents) %></li>
+    <li>Operational acquisition total: <%= format_money_cents(@receipt.operational_acquisition_total_cents) %></li>
   </ul>
 </section>
 
@@ -42,7 +42,8 @@
         <th scope="col">Received</th>
         <th scope="col">Matched</th>
         <th scope="col">Unplanned</th>
-        <th scope="col">Unit cost</th>
+        <th scope="col">Expected unit cost</th>
+        <th scope="col">Actual unit cost</th>
         <th scope="col">Allocation</th>
       </tr>
     </thead>
@@ -55,7 +56,8 @@
           <td><%= line.received_quantity %></td>
           <td><%= row[:matched_quantity] %></td>
           <td><%= row[:unplanned_quantity] %></td>
-          <td><%= line.actual_unit_cost_cents %></td>
+          <td><%= format_money_cents(line.purchase_order_line.expected_unit_cost_cents_snapshot) %></td>
+          <td><%= format_money_cents(line.actual_unit_cost_cents) %></td>
           <td>
             <% if row[:allocates] %>
               Reserve request #<%= row[:request].number %>

--- a/app/views/ops/receiving/show.html.erb
+++ b/app/views/ops/receiving/show.html.erb
@@ -7,8 +7,8 @@
       · <%= current_store.admin_label %>
       · <%= @receipt.status %>
       · <%= @lines.size %> lines
-      · merchandise <%= @receipt.merchandise_total_cents %> cents
-      · ancillary <%= @receipt.ancillary_total_cents %> cents
+      · merchandise <%= format_money_cents(@receipt.merchandise_total_cents) %>
+      · ancillary <%= format_money_cents(@receipt.ancillary_total_cents) %>
     </p>
   </div>
   <p>
@@ -36,20 +36,20 @@
         <input type="date" name="supplier_document_date" value="<%= @error_action == :update ? @submitted&.fetch("supplier_document_date", nil) : @receipt.supplier_document_date %>">
       </label>
       <label>
-        Freight (cents)
-        <input type="number" name="freight_cents" min="0" value="<%= @error_action == :update ? @submitted&.fetch("freight_cents", nil) : @receipt.freight_cents %>">
+        Freight ($)
+        <input type="text" inputmode="decimal" name="freight_cents" value="<%= @error_action == :update ? @submitted&.fetch("freight_cents", nil) : money_field_value(@receipt.freight_cents) %>" aria-invalid="<%= @error_field == :freight_cents %>">
       </label>
       <label>
-        Handling (cents)
-        <input type="number" name="handling_cents" min="0" value="<%= @error_action == :update ? @submitted&.fetch("handling_cents", nil) : @receipt.handling_cents %>">
+        Handling ($)
+        <input type="text" inputmode="decimal" name="handling_cents" value="<%= @error_action == :update ? @submitted&.fetch("handling_cents", nil) : money_field_value(@receipt.handling_cents) %>" aria-invalid="<%= @error_field == :handling_cents %>">
       </label>
       <label>
-        Supplier tax (cents)
-        <input type="number" name="supplier_tax_cents" min="0" value="<%= @error_action == :update ? @submitted&.fetch("supplier_tax_cents", nil) : @receipt.supplier_tax_cents %>">
+        Supplier tax ($)
+        <input type="text" inputmode="decimal" name="supplier_tax_cents" value="<%= @error_action == :update ? @submitted&.fetch("supplier_tax_cents", nil) : money_field_value(@receipt.supplier_tax_cents) %>" aria-invalid="<%= @error_field == :supplier_tax_cents %>">
       </label>
       <label>
-        Misc charges (cents)
-        <input type="number" name="miscellaneous_charges_cents" min="0" value="<%= @error_action == :update ? @submitted&.fetch("miscellaneous_charges_cents", nil) : @receipt.miscellaneous_charges_cents %>">
+        Miscellaneous charges ($)
+        <input type="text" inputmode="decimal" name="miscellaneous_charges_cents" value="<%= @error_action == :update ? @submitted&.fetch("miscellaneous_charges_cents", nil) : money_field_value(@receipt.miscellaneous_charges_cents) %>" aria-invalid="<%= @error_field == :miscellaneous_charges_cents %>">
       </label>
       <label>
         Charge notes
@@ -61,7 +61,7 @@
       </label>
       <button type="submit" data-ops-save>Save header</button>
       <%= render "ops/shared/inline_row_error", action: :update, id: "receipt_header_error" %>
-      <% if @conflict && @error_action == :update %><small>Current saved notes: <%= @receipt.notes.presence || "blank" %>; freight: <%= @receipt.freight_cents %> cents.</small><% end %>
+      <% if @conflict && @error_action == :update %><small>Current saved notes: <%= @receipt.notes.presence || "blank" %>; freight: <%= format_money_cents(@receipt.freight_cents) %>.</small><% end %>
     <% end %>
     <p class="ops-hint">Ancillary charges are recorded but never enter inventory valuation.</p>
   </section>
@@ -107,7 +107,7 @@
                 <code><%= line.product_variant.sku %></code>
               </td>
               <td><%= line.remaining_reversible_quantity %> / <%= line.received_quantity %></td>
-              <td><%= line.actual_unit_cost_cents %></td>
+              <td><%= format_money_cents(line.actual_unit_cost_cents) %></td>
               <td>
                 <% if line.remaining_reversible_quantity.positive? %>
                   <%= form_with url: ops_receiving_reverse_line_path(@receipt, line), method: :post, local: true, html: { class: "ops-inline-form" } do %>
@@ -139,8 +139,8 @@
                       <input type="text" name="reason" required>
                     </label>
                     <label>
-                      Corrected unit cost
-                      <input type="number" name="corrected_unit_cost_cents" min="0" required>
+                      Corrected unit cost ($)
+                      <input type="text" inputmode="decimal" name="corrected_unit_cost_cents" value="<%= @selected_row_id.to_s == line.id.to_s ? @submitted&.fetch("corrected_unit_cost_cents", nil) : nil %>" required aria-invalid="<%= @error_field == :corrected_unit_cost_cents && @selected_row_id.to_s == line.id.to_s %>">
                     </label>
                     <button type="submit">Correct cost</button>
                   <% end %>
@@ -173,7 +173,7 @@
           <li>
             <%= correction.correction_type %>
             <% if correction.quantity.present? %>· qty <%= correction.quantity %><% end %>
-            <% if correction.value_delta_cents.present? %>· Δ<%= correction.value_delta_cents %>¢<% end %>
+            <% if correction.value_delta_cents.present? %>· value change <%= format_money_cents(correction.value_delta_cents) %><% end %>
             · <%= correction.reason %>
           </li>
         <% end %>

--- a/test/integration/orders_admin_test.rb
+++ b/test/integration/orders_admin_test.rb
@@ -48,6 +48,34 @@ class OrdersAdminTest < ActionDispatch::IntegrationTest
     assert_match(/Add stock line/, response.body)
   end
 
+  test "stock order parses dollar input and preserves malformed input" do
+    sign_in_as("admin")
+    post store_selection_path, params: { store_id: @store.id }
+
+    post admin_orders_path, params: {
+      order: {
+        product_variant_id: @variant.id,
+        requested_quantity: 1,
+        supplier_id: @supplier.id,
+        expected_unit_cost_cents: "$12.50"
+      }
+    }
+    assert_equal 1_250, Order.order(:created_at).last.purchase_order_line.expected_unit_cost_cents_snapshot
+
+    assert_no_difference -> { Order.count } do
+      post admin_orders_path, params: {
+        order: {
+          product_variant_id: @variant.id,
+          requested_quantity: 1,
+          supplier_id: @supplier.id,
+          expected_unit_cost_cents: "twelve dollars"
+        }
+      }
+    end
+    assert_response :unprocessable_entity
+    assert_select "input[name='order[expected_unit_cost_cents]'][value='twelve dollars']"
+  end
+
   test "product and variant pages expose order stock and request actions" do
     sign_in_as("admin")
     post store_selection_path, params: { store_id: @store.id }

--- a/test/integration/suppliers_admin_test.rb
+++ b/test/integration/suppliers_admin_test.rb
@@ -73,7 +73,7 @@ class SuppliersAdminTest < ActionDispatch::IntegrationTest
         supplier_variant_source: {
           supplier_id: supplier.id,
           pricing_method: "direct_unit_cost",
-          expected_unit_cost_cents: 525,
+          expected_unit_cost_cents: "5.25",
           organization_preferred: true,
           supplier_item_number: "VS-1"
         }
@@ -91,7 +91,7 @@ class SuppliersAdminTest < ActionDispatch::IntegrationTest
     patch admin_supplier_variant_source_path(source, return_to: "variant"), params: {
       supplier_variant_source: {
         pricing_method: "direct_unit_cost",
-        expected_unit_cost_cents: 600,
+        expected_unit_cost_cents: "6.00",
         organization_preferred: true,
         lock_version: source.lock_version
       }

--- a/test/services/money/parse_cents_test.rb
+++ b/test/services/money/parse_cents_test.rb
@@ -7,6 +7,8 @@ class Money::ParseCentsTest < ActiveSupport::TestCase
     assert_equal 1250, Money::ParseCents.call("12.50")
     assert_equal 1250, Money::ParseCents.call("$12.50")
     assert_equal 120_000, Money::ParseCents.call("1,200.00")
+    assert_equal 0, Money::ParseCents.call("0")
+    assert_equal 0, Money::ParseCents.call("0.00")
     assert_nil Money::ParseCents.call("")
     assert_nil Money::ParseCents.call(nil)
   end


### PR DESCRIPTION
### Motivation

- Phase 7 admin and ops surfaces were displaying and accepting raw integer cents in human-facing fields, which is error-prone and unfriendly for users expecting dollar-formatted amounts.
- The change converts presentation to dollar/currency formatting while preserving integer-cent storage and service contracts and retaining submitted raw input on parse errors.

### Description

- Convert Phase 7 purchase-order, order, receipt, supplier-source, and customer-request views to show formatted dollars using `format_money_cents` and to accept dollar-style input via `shared/currency_field` / `money_field_value` rather than raw numeric `_cents` inputs.  Key view updates include `app/views/ops/draft_pos/*`, `app/views/ops/receiving/*`, `app/views/admin/customer_requests/*`, `app/views/admin/purchase_receipts/*`, `app/views/admin/purchase_orders/*`, and supplier-source forms.  
- Parse dollar-oriented form inputs into authoritative integer cents with `Money::ParseCents` at controller boundaries and preserve the original submitted string and associate field errors when parsing fails, including new rescue handling in `ops/*` and `admin/*` controllers.  
- Distinguish expected versus actual receiving costs explicitly in receiving grids and review pages and surface formatted expected/actual unit costs side-by-side rather than unlabeled integers.  
- Update the receiving JS picker to receive and display formatted expected cost and populate ops forms with money-field strings for consistent UX.  
- Add a small Money parsing boundary test expansion and a new integration test that verifies dollar input is parsed into cents and malformed input is preserved in the form for user correction.

### Testing

- Ran `git diff --check` and fixed issues (passed).  
- Performed Ruby syntax checks for modified controllers (`ruby -c`) and ERB template parsing (ERB -> Ruby) and resolved initial template issues; final controller and ERB syntax checks succeeded.  
- Attempted to run the Rails test suite slices (`./dev/rails-docker bin/rails test` / `bundle exec rails test`) but the environment lacks Docker and the project gem executables, so CI-style Rails tests could not be executed here; the added `Money::ParseCents` expectations are covered by updated tests in `test/services/money/parse_cents_test.rb` and integration assertions were added to `test/integration/orders_admin_test.rb` but those integration runs were not executed due to missing runtime dependencies.  

If you want, I can split remaining follow-ups (full test runs in CI, small UX polish, or add additional parse error translations) into separate PRs or prepare a CI job note for reviewers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a89189dee68832cbc7311a9908b60af)