### PR TITLE
Add accessible customer request lookup and history tools

### DIFF
--- a/app/controllers/admin/customer_requests_controller.rb
+++ b/app/controllers/admin/customer_requests_controller.rb
@@ -3,14 +3,31 @@
 module Admin
   class CustomerRequestsController < BaseController
     before_action -> { require_permission!("customers.view") }, only: %i[index show]
-    before_action -> { require_permission!("customer_requests.manage") }, only: %i[new create cancel]
-    before_action :require_store_for_create!, only: %i[new create]
+    before_action -> { require_permission!("customer_requests.manage") },
+                  only: %i[new create cancel customer_lookup merchandise_lookup]
+    before_action :require_store_for_create!, only: %i[new create customer_lookup merchandise_lookup]
     before_action :set_customer_request, only: %i[show cancel]
 
     def index
-      scope = CustomerRequest.includes(:customer, :product_variant, :store).admin_ordered
-      scope = scope.for_store(current_store) if current_store.present?
-      @customer_requests = scope.limit(200)
+      @stores = accessible_stores.order(:name).select do |store|
+        Authorization::PermissionEvaluator.allowed?(
+          user: current_user,
+          permission_key: "customers.view",
+          store: store
+        )
+      end
+      scope = CustomerRequest.includes(:customer, { product_variant: :product }, :store)
+                             .where(store_id: @stores.map(&:id))
+      selected_store_id = params.key?(:store_id) ? permitted_store_filter : current_store&.id
+      @index = CustomerRequests::AdminIndexQuery.call(
+        scope: scope,
+        q: params[:q],
+        status: params[:status],
+        store_id: selected_store_id,
+        store_filter_applied: params[:store_id].present?,
+        page: params[:page]
+      )
+      @customer_requests = @index.records
     end
 
     def show; end
@@ -21,10 +38,26 @@ module Admin
         @customer_request,
         params[:product_variant_id] || params.dig(:customer_request, :product_variant_id)
       )
-      if params[:customer_id].present?
-        @customer_request.customer = Customer.active.find_by(id: params[:customer_id])
+      customer_id = params[:customer_id] || params.dig(:customer_request, :customer_id)
+      if customer_id.present?
+        @customer_request.customer = Customer.active.find_by(id: customer_id)
       end
       load_request_form_options
+    end
+
+    def customer_lookup
+      prepare_lookup_request
+      @customer_query = params[:customer_q].to_s.strip
+      @customer_results = search_customers(@customer_query) if @customer_query.present?
+      render :new
+    end
+
+    def merchandise_lookup
+      prepare_lookup_request
+      @merchandise_query = params[:merchandise_q].to_s.strip
+      @merchandise_results = search_merchandise(@merchandise_query) if @merchandise_query.present?
+      load_merchandise_availability if @merchandise_results.present?
+      render :new
     end
 
     def create
@@ -85,6 +118,66 @@ module Admin
 
     private
 
+    def permitted_store_filter
+      return if params[:store_id].blank?
+
+      @stores.find { |store| store.id == params[:store_id] }&.id
+    end
+
+    def prepare_lookup_request
+      attributes = request_form_attributes
+      customer_id = attributes.delete("customer_id")
+      @customer_request = CustomerRequest.new(store: current_store, **attributes)
+      @customer_request.customer = Customer.active.find_by(id: customer_id) if customer_id.present?
+      assign_variant_from_params!(@customer_request, @customer_request.product_variant_id)
+      load_request_form_options
+    end
+
+    def request_form_attributes
+      params.fetch(:customer_request, {}).permit(:customer_id, :product_variant_id, :notes).to_h
+    end
+
+    def search_customers(query)
+      pattern = "%#{ActiveRecord::Base.sanitize_sql_like(query)}%"
+      Customer.active
+              .where(
+                "display_name ILIKE :q OR email ILIKE :q OR phone ILIKE :q OR id::text ILIKE :q",
+                q: pattern
+              )
+              .admin_ordered
+              .limit(25)
+    end
+
+    def search_merchandise(query)
+      pattern = "%#{ActiveRecord::Base.sanitize_sql_like(query)}%"
+      identifier = query.gsub(/[\s-]/, "")
+      ProductVariant.active
+                    .joins(:product)
+                    .merge(Product.active)
+                    .where(
+                      <<~SQL.squish,
+                        products.name ILIKE :pattern OR products.lookup_code ILIKE :pattern OR
+                        products.primary_identifier = :identifier OR products.industry_identifier = :identifier OR
+                        product_variants.sku = :identifier OR product_variants.industry_identifier = :identifier
+                      SQL
+                      pattern: pattern,
+                      identifier: identifier
+                    )
+                    .includes(:product)
+                    .order(Product.arel_table[:name], :variant_type, :sku)
+                    .limit(25)
+    end
+
+    def load_merchandise_availability
+      @availability_by_variant_id = @merchandise_results.index_with do |variant|
+        if variant.standard?
+          Inventory::Availability.available(current_store, variant)
+        else
+          Inventory::Availability.unreserved_on_hand_units(current_store, variant).count
+        end
+      end
+    end
+
     def set_customer_request
       @customer_request = CustomerRequest.find(params[:id])
       permission = action_name == "cancel" ? "customer_requests.manage" : "customers.view"
@@ -105,7 +198,6 @@ module Admin
     end
 
     def load_request_form_options
-      @customers = Customer.active.admin_ordered
       @suppliers = Supplier.active.admin_ordered
       return if @product_variant.blank? || current_store.blank?
 

--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -16,6 +16,7 @@ module Admin
 
     def new
       @customer = Customer.new
+      @return_to = valid_customer_request_return_path
     end
 
     def create
@@ -25,8 +26,16 @@ module Admin
         action: "customers.create",
         after_values: { display_name: @customer.display_name, email: @customer.email, phone: @customer.phone }
       )
-        redirect_to admin_customer_path(@customer), notice: "Customer created."
+        if (return_path = valid_customer_request_return_path)
+          uri = URI.parse(return_path)
+          query = Rack::Utils.parse_nested_query(uri.query.to_s)
+          query["customer_id"] = @customer.id
+          redirect_to "#{uri.path}?#{query.to_query}", notice: "Customer created. Continue the customer request."
+        else
+          redirect_to admin_customer_path(@customer), notice: "Customer created."
+        end
       else
+        @return_to = valid_customer_request_return_path
         render :new, status: :unprocessable_entity
       end
     end
@@ -63,6 +72,18 @@ module Admin
     end
 
     private
+
+    def valid_customer_request_return_path
+      value = params[:return_to].to_s
+      return if value.blank?
+
+      uri = URI.parse(value)
+      return unless uri.host.nil? && uri.path == new_admin_customer_request_path
+
+      value
+    rescue URI::InvalidURIError
+      nil
+    end
 
     def set_customer
       @customer = Customer.find(params[:id])

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,6 +10,9 @@ module ApplicationHelper
     configuration: {
       "active" => "active",
       "inactive" => "inactive"
+    }.freeze,
+    customer_request: CustomerRequest::STATUSES.index_with { |status|
+      CustomerRequest::ACTIVE_STATUSES.include?(status) ? "active" : "inactive"
     }.freeze
   }.freeze
 

--- a/app/services/customer_requests/admin_index_query.rb
+++ b/app/services/customer_requests/admin_index_query.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module CustomerRequests
+  class AdminIndexQuery
+    PER_PAGE = 50
+
+    Result = Data.define(
+      :records, :page, :per_page, :total_count, :total_pages,
+      :q, :status, :store_id, :filtered
+    )
+
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(scope:, q: nil, status: nil, store_id: nil, page: 1, store_filter_applied: false)
+      @scope = scope
+      @q = q.to_s.strip
+      @status = status.to_s.presence
+      @store_id = store_id.to_s.presence
+      @requested_page = page
+      @store_filter_applied = store_filter_applied
+    end
+
+    def call
+      relation = apply_search(@scope)
+      relation = relation.where(status: @status) if CustomerRequest::STATUSES.include?(@status)
+      relation = relation.where(store_id: @store_id) if @store_id.present?
+
+      total_count = relation.except(:order, :includes).distinct.count(:id)
+      total_pages = [ (total_count.to_f / PER_PAGE).ceil, 1 ].max
+      page = parse_page(total_pages)
+      records = relation
+        .order(Arel.sql(active_first_sql), created_at: :desc, id: :desc)
+        .offset((page - 1) * PER_PAGE)
+        .limit(PER_PAGE)
+
+      Result.new(
+        records: records,
+        page: page,
+        per_page: PER_PAGE,
+        total_count: total_count,
+        total_pages: total_pages,
+        q: @q.presence,
+        status: CustomerRequest::STATUSES.include?(@status) ? @status : nil,
+        store_id: @store_id,
+        filtered: @q.present? || @status.present? || @store_filter_applied
+      )
+    end
+
+    private
+
+    def apply_search(relation)
+      return relation if @q.blank?
+
+      pattern = "%#{ActiveRecord::Base.sanitize_sql_like(@q)}%"
+      normalized_identifier = @q.gsub(/[\s-]/, "")
+
+      relation
+        .left_joins(:customer, product_variant: :product)
+        .where(
+          <<~SQL.squish,
+            customer_requests.number::text ILIKE :pattern OR
+            customers.display_name ILIKE :pattern OR
+            customers.email ILIKE :pattern OR
+            customers.phone ILIKE :pattern OR
+            customers.id::text ILIKE :pattern OR
+            products.name ILIKE :pattern OR
+            products.primary_identifier = :identifier OR
+            products.industry_identifier = :identifier OR
+            products.lookup_code ILIKE :pattern OR
+            product_variants.sku = :identifier OR
+            product_variants.industry_identifier = :identifier
+          SQL
+          pattern: pattern,
+          identifier: normalized_identifier
+        )
+    end
+
+    def active_first_sql
+      statuses = CustomerRequest::ACTIVE_STATUSES.map { |status| ActiveRecord::Base.connection.quote(status) }.join(", ")
+      "CASE WHEN customer_requests.status IN (#{statuses}) THEN 0 ELSE 1 END"
+    end
+
+    def parse_page(total_pages)
+      page = Integer(@requested_page)
+      page = 1 if page < 1
+      [ page, total_pages ].min
+    rescue ArgumentError, TypeError
+      1
+    end
+  end
+end

--- a/app/views/admin/customer_requests/index.html.erb
+++ b/app/views/admin/customer_requests/index.html.erb
@@ -1,18 +1,57 @@
 <% content_for :title, "Customer requests" %>
-<h1>Customer requests</h1>
-<% if effective_permissions.include?("customer_requests.manage") && current_store.present? %>
-  <p><%= link_to "New request", new_admin_customer_request_path %></p>
+<%= render "shared/page_header", title: "Customer requests", subtitle: "Active customer work and request history",
+      actions: (link_to("New request", new_admin_customer_request_path, class: "btn") if effective_permissions.include?("customer_requests.manage") && current_store.present?) %>
+
+<%= form_with url: admin_customer_requests_path, method: :get, local: true, class: "filters" do %>
+  <div class="form-field form-field--grow">
+    <%= label_tag :q, "Search" %>
+    <%= search_field_tag :q, @index.q, placeholder: "Request number, customer, contact, title, or identifier" %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :store_id, "Store" %>
+    <%= select_tag :store_id, options_for_select([["All authorized stores", ""]] + @stores.map { |store| [store.name, store.id] }, @index.store_id) %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :status, "Status" %>
+    <%= select_tag :status, options_for_select([["Any status", ""]] + CustomerRequest::STATUSES.map { |status| [status.humanize, status] }, @index.status) %>
+  </div>
+  <div class="form-field"><%= submit_tag "Apply", class: "btn" %></div>
+  <% if @index.filtered %><div class="form-field"><%= link_to "Clear filters", admin_customer_requests_path, class: "btn btn--ghost" %></div><% end %>
 <% end %>
+
 <% if current_store.present? && effective_permissions.include?("customer_requests.locate") %>
-  <p><%= link_to "Open location queue", ops_location_path %></p>
+  <p><%= link_to "Open location queue", ops_location_path, class: "btn btn--ghost" %></p>
 <% end %>
-<ul>
-  <% @customer_requests.each do |request| %>
-    <li>
-      <%= link_to "Request ##{request.number}", admin_customer_request_path(request) %>
-      — <%= request.customer.display_name %>
-      — <%= request.status %>
-      — <%= request.product_variant.sku %>
-    </li>
-  <% end %>
-</ul>
+
+<% if @customer_requests.empty? && !@index.filtered %>
+  <%= render "shared/empty_state", title: "No customer requests yet", body: "Create a request to begin customer location or special-order work.",
+        action: (link_to("New request", new_admin_customer_request_path, class: "btn") if effective_permissions.include?("customer_requests.manage") && current_store.present?) %>
+<% elsif @customer_requests.empty? %>
+  <%= render "shared/empty_state", title: "No matching customer requests", body: "Try a different search or clear the store and status filters.",
+        action: link_to("Clear filters", admin_customer_requests_path, class: "btn btn--ghost") %>
+<% else %>
+  <% rows = @customer_requests.map { |request|
+       next_action = case request.status
+       when "pending_location"
+         effective_permissions.include?("customer_requests.locate") && request.store == current_store ? link_to("Locate merchandise", ops_location_path, class: "btn btn--ghost") : link_to("View request", admin_customer_request_path(request))
+       when "available"
+         link_to("View pickup details", admin_customer_request_path(request))
+       when "special_order_pending", "ordered"
+         link_to("Review order", admin_customer_request_path(request))
+       else
+         link_to("View history", admin_customer_request_path(request))
+       end
+       contact = [request.customer.phone.presence, request.customer.email.presence].compact.join(" · ").presence || missing_value("No contact")
+       [link_to("##{request.number}", admin_customer_request_path(request)), request.store.name,
+        safe_join([request.customer.display_name, tag.br, content_tag(:span, contact, class: "muted")]),
+        safe_join([request.product_variant.product.name, tag.br, content_tag(:span, request.product_variant.sku, class: "muted")]),
+        status_badge(request.status, scheme: :customer_request), next_action]
+     } %>
+  <%= render "shared/data_table", headers: ["Request", "Store", "Customer", "Merchandise", "Status", "Next action"], rows: rows %>
+  <nav class="pagination" aria-label="Customer request pages">
+    <span class="muted">Page <%= @index.page %> of <%= @index.total_pages %> · <%= @index.total_count %> total</span>
+    <% query = { q: @index.q, status: @index.status, store_id: @index.store_id }.compact %>
+    <% if @index.page > 1 %><%= link_to "Previous", admin_customer_requests_path(query.merge(page: @index.page - 1)), class: "btn btn--ghost" %><% end %>
+    <% if @index.page < @index.total_pages %><%= link_to "Next", admin_customer_requests_path(query.merge(page: @index.page + 1)), class: "btn btn--ghost" %><% end %>
+  </nav>
+<% end %>

--- a/app/views/admin/customer_requests/new.html.erb
+++ b/app/views/admin/customer_requests/new.html.erb
@@ -7,59 +7,129 @@
 
 <%= render "shared/page_header",
       title: "New customer request",
-      subtitle: "In-stock Standard or Used enters the location queue. Out-of-stock Standard becomes a special order." %>
+      subtitle: "Find a customer and exact merchandise variant. In-stock Standard or Used enters the location queue; out-of-stock Standard becomes a special order." %>
 
-<% if @product_variant %>
-  <section class="section surface">
+<% request_state = {
+     customer_id: @customer_request.customer_id,
+     product_variant_id: @customer_request.product_variant_id,
+     supplier_id: params.dig(:customer_request, :supplier_id),
+     expected_unit_cost_cents: params.dig(:customer_request, :expected_unit_cost_cents),
+     estimated_price_cents: params.dig(:customer_request, :estimated_price_cents),
+     notes: params.dig(:customer_request, :notes)
+   }.compact %>
+
+<section class="section surface" aria-labelledby="customer-lookup-heading">
+  <h2 id="customer-lookup-heading">1. Customer</h2>
+  <% if @customer_request.customer %>
+    <p>
+      <strong><%= @customer_request.customer.display_name %></strong><br>
+      <span class="muted">
+        <%= @customer_request.customer.phone.presence || "No phone" %> ·
+        <%= @customer_request.customer.email.presence || "No email" %> ·
+        ID <%= @customer_request.customer.id %>
+      </span>
+    </p>
+  <% end %>
+  <%= form_with url: customer_lookup_admin_customer_requests_path, method: :get, local: true, class: "filters" do %>
+    <% request_state.each do |key, value| %>
+      <%= hidden_field_tag "customer_request[#{key}]", value %>
+    <% end %>
+    <div class="form-field form-field--grow">
+      <%= label_tag :customer_q, "Find customer by name, phone, email, or customer ID" %>
+      <%= search_field_tag :customer_q, @customer_query, required: true, autocomplete: "off" %>
+    </div>
+    <div class="form-field"><%= submit_tag "Find customer", class: "btn btn--ghost" %></div>
+  <% end %>
+
+  <% if defined?(@customer_results) %>
+    <% if @customer_results.empty? %>
+      <p role="status">No active customers matched. Try another name, contact detail, or identifier.</p>
+    <% else %>
+      <% rows = @customer_results.map { |customer| [
+           customer.display_name,
+           customer.phone.presence || missing_value("No phone"),
+           customer.email.presence || missing_value("No email"),
+           customer.id,
+           link_to("Select", new_admin_customer_request_path(customer_request: request_state.merge(customer_id: customer.id)), class: "btn btn--ghost", aria: { label: "Select #{customer.display_name}, #{customer.email.presence || customer.phone.presence || customer.id}" })
+         ] } %>
+      <%= render "shared/data_table", headers: ["Name", "Phone", "Email", "Customer ID", "Action"], rows: rows %>
+    <% end %>
+  <% end %>
+
+  <% if effective_permissions.include?("customers.manage") %>
+    <% return_path = new_admin_customer_request_path(customer_request: request_state) %>
+    <p><%= link_to "Create customer", new_admin_customer_path(return_to: return_path), class: "btn btn--ghost" %>
+      <span class="muted">Your merchandise selection and entered request details will be kept.</span></p>
+  <% end %>
+</section>
+
+<section class="section surface" aria-labelledby="merchandise-lookup-heading">
+  <h2 id="merchandise-lookup-heading">2. Merchandise</h2>
+  <% if @product_variant %>
     <%= render "shared/definition_list", rows: [
-          ["Product", link_to(@product_variant.product.name, admin_product_path(@product_variant.product))],
+          ["Title", link_to(@product_variant.product.name, admin_product_path(@product_variant.product))],
           ["Variant", link_to(@product_variant.name.presence || @product_variant.sku, admin_product_variant_path(@product_variant))],
           ["SKU", @product_variant.sku],
-          ["Type", @product_variant.variant_type.humanize],
+          ["Identity", @product_variant.variant_type.humanize],
           ["Apparent available", (@available_quantity.nil? ? "—" : @available_quantity)]
         ] %>
-  </section>
-<% end %>
-
-<section class="section surface">
-  <%= form_with url: admin_customer_requests_path, scope: :customer_request do |form| %>
-    <p>
-      <%= form.label :customer_id, "Customer" %>
-      <%= form.collection_select :customer_id, @customers, :id, :admin_label,
-            { selected: params[:customer_id] || @customer_request.customer_id, include_blank: "Select…" },
-            { required: true } %>
-      <% if effective_permissions.include?("customers.manage") %>
-        <span class="muted"><%= link_to "New customer", new_admin_customer_path %></span>
+  <% else %>
+    <%= form_with url: merchandise_lookup_admin_customer_requests_path, method: :get, local: true, class: "filters" do %>
+      <% request_state.each do |key, value| %>
+        <%= hidden_field_tag "customer_request[#{key}]", value %>
       <% end %>
-    </p>
-    <% if @product_variant %>
-      <%= form.hidden_field :product_variant_id, value: @product_variant.id %>
-    <% else %>
-      <p>
-        <%= form.label :product_variant_id, "Product variant ID" %>
-        <%= form.text_field :product_variant_id, value: @customer_request.product_variant_id, required: true %>
-        <span class="muted">Prefer starting from a product or variant page.</span>
-      </p>
+      <div class="form-field form-field--grow">
+        <%= label_tag :merchandise_q, "Find merchandise by ISBN, UPC, identifier, SKU, or title" %>
+        <%= search_field_tag :merchandise_q, @merchandise_query, required: true, autocomplete: "off" %>
+      </div>
+      <div class="form-field"><%= submit_tag "Find merchandise", class: "btn btn--ghost" %></div>
     <% end %>
+  <% end %>
+
+  <% if defined?(@merchandise_results) %>
+    <% if @merchandise_results.empty? %>
+      <p role="status">No active merchandise matched. Try another title or identifier.</p>
+    <% else %>
+      <% rows = @merchandise_results.map { |variant|
+           available = @availability_by_variant_id.fetch(variant.id)
+           selectable = variant.standard? || available.positive?
+           action = if selectable
+             link_to("Select", new_admin_customer_request_path(customer_request: request_state.merge(product_variant_id: variant.id)), class: "btn btn--ghost", aria: { label: "Select #{variant.product.name}, #{variant.variant_type.humanize}, SKU #{variant.sku}" })
+           else
+             content_tag(:span, "Unavailable", class: "muted")
+           end
+           [variant.product.name, variant.name.presence || "Default", variant.sku,
+            content_tag(:span, variant.variant_type.humanize, class: "status-badge"), available, action]
+         } %>
+      <%= render "shared/data_table", headers: ["Title", "Variant", "SKU", "Identity", { text: "Available", class: "numeric" }, "Action"], rows: rows %>
+      <p class="muted">Out-of-stock Standard merchandise remains selectable for special ordering. Out-of-stock Used merchandise cannot be requested.</p>
+    <% end %>
+  <% end %>
+</section>
+
+<section class="section surface" aria-labelledby="request-details-heading">
+  <h2 id="request-details-heading">3. Request details</h2>
+  <%= form_with url: admin_customer_requests_path, scope: :customer_request do |form| %>
+    <%= form.hidden_field :customer_id, value: @customer_request.customer_id %>
+    <%= form.hidden_field :product_variant_id, value: @customer_request.product_variant_id %>
     <% if @product_variant.nil? || @product_variant.standard? %>
       <p>
-        <%= form.label :supplier_id, "Supplier (OOS Standard)" %>
+        <%= form.label :supplier_id, "Supplier (out-of-stock Standard)" %>
         <%= form.collection_select :supplier_id, @suppliers, :id, :admin_label,
-              { selected: @preferred_source&.supplier_id, include_blank: "Preferred source (if any)" } %>
+              { selected: params.dig(:customer_request, :supplier_id).presence || @preferred_source&.supplier_id, include_blank: "Preferred source (if any)" } %>
       </p>
       <%= render "shared/currency_field",
             name: "customer_request[expected_unit_cost_cents]", id: "customer_request_expected_unit_cost_cents",
-            label: "Expected unit cost ($, OOS Standard)",
+            label: "Expected unit cost ($, out-of-stock Standard)",
             value: params.dig(:customer_request, :expected_unit_cost_cents).presence || money_field_value(@preferred_source&.derived_expected_unit_cost_cents) %>
     <% end %>
     <%= render "shared/currency_field",
           name: "customer_request[estimated_price_cents]", id: "customer_request_estimated_price_cents",
           label: "Estimated customer price ($)", value: params.dig(:customer_request, :estimated_price_cents) %>
-    <p>
-      <%= form.label :notes %>
-      <%= form.text_area :notes %>
-    </p>
-    <p><%= form.submit "Create request", class: "btn" %></p>
+    <p><%= form.label :notes %><%= form.text_area :notes, value: params.dig(:customer_request, :notes) || @customer_request.notes %></p>
+    <% ready = @customer_request.customer_id.present? && @customer_request.product_variant_id.present? %>
+    <p><%= form.submit "Create request", class: "btn", disabled: !ready %></p>
+    <% unless ready %><p class="muted" role="status">Select both a customer and merchandise before creating the request.</p><% end %>
   <% end %>
 </section>
 

--- a/app/views/admin/customers/_form.html.erb
+++ b/app/views/admin/customers/_form.html.erb
@@ -1,4 +1,5 @@
 <%= form_with model: [:admin, customer] do |form| %>
+  <%= hidden_field_tag :return_to, @return_to if @return_to.present? %>
   <% if customer.errors.any? %><ul><% customer.errors.full_messages.each do |m| %><li><%= m %></li><% end %></ul><% end %>
   <%= form.hidden_field :lock_version %>
   <p><%= form.label :display_name %><%= form.text_field :display_name, autofocus: true %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,6 +89,10 @@ Rails.application.routes.draw do
       member { post :reactivate }
     end
     resources :customer_requests, only: %i[index show new create] do
+      collection do
+        get :customer_lookup
+        get :merchandise_lookup
+      end
       member { post :cancel }
     end
     resources :orders, only: %i[index show new create]

--- a/docs/planning/phase7-orders-and-receiving/phase7-workflows.md
+++ b/docs/planning/phase7-orders-and-receiving/phase7-workflows.md
@@ -102,6 +102,15 @@ ShelfSense assigns a store-scoped **request number** at creation and checks appa
 
 Creating a location request does not reserve inventory. Staff must physically confirm the merchandise first.
 
+The admin creation flow uses explicit, keyboard-accessible lookups rather than exposing database IDs. Customer
+lookup matches name, phone, email, or customer identifier and shows contact details before selection. Merchandise
+lookup matches title, ISBN/UPC/product identifier, lookup code, or SKU and shows the exact Standard/Used identity
+and current store availability. Creating a customer inline returns to the preserved request draft. Product and
+variant pages remain the fastest route because their quick action preselects the merchandise.
+
+The request-history view searches request, customer/contact, and merchandise identity, supports store and status
+filters, orders active work ahead of completed or cancelled history, and paginates results.
+
 ## 4. Locate in-stock merchandise
 
 The request appears in the store’s location ops workspace.

--- a/test/integration/customer_requests_admin_test.rb
+++ b/test/integration/customer_requests_admin_test.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CustomerRequestsAdminTest < ActionDispatch::IntegrationTest
+  setup do
+    @bootstrap = bootstrap!
+    @admin = @bootstrap[:administrator]
+    @store = @bootstrap[:store]
+    @tax = tax_class(code: "request_admin_#{SecureRandom.hex(2)}")
+    @variant = pos_sellable_variant(actor: @admin, tax_class: @tax, name: "Accessible Lookup Book")
+    supplier = Supplier.create!(name: "Lookup Supplier", code: "lookup_#{SecureRandom.hex(2)}")
+    SupplierVariantSource.create!(
+      supplier: supplier,
+      product_variant: @variant,
+      pricing_method: "direct_unit_cost",
+      expected_unit_cost_cents: 500,
+      organization_preferred: true
+    )
+    @customer = Customer.create!(
+      display_name: "Alex Similar",
+      phone: "555-0199",
+      email: "alex.lookup@example.com"
+    )
+    @request = Customers::CreateRequest.call(
+      store: @store,
+      customer: @customer,
+      product_variant: @variant,
+      actor: @admin
+    )
+  end
+
+  test "new request looks up customers and merchandise without raw ids" do
+    sign_in_as("admin")
+    select_store
+
+    get customer_lookup_admin_customer_requests_path, params: { customer_q: "555-0199" }
+    assert_response :success
+    assert_includes response.body, "Alex Similar"
+    assert_includes response.body, "alex.lookup@example.com"
+    assert_includes response.body, @customer.id
+
+    get merchandise_lookup_admin_customer_requests_path, params: { merchandise_q: @variant.sku }
+    assert_response :success
+    assert_includes response.body, "Accessible Lookup Book"
+    assert_includes response.body, "Standard"
+    assert_includes response.body, "Available"
+
+    get new_admin_customer_request_path
+    assert_response :success
+    assert_no_match(/Product variant ID/, response.body)
+  end
+
+  test "creating a customer returns to preserved request state" do
+    sign_in_as("admin")
+    select_store
+    return_to = new_admin_customer_request_path(
+      product_variant_id: @variant.id,
+      customer_request: { notes: "Keep these notes", estimated_price_cents: "12.34" }
+    )
+
+    post admin_customers_path, params: {
+      return_to: return_to,
+      customer: { display_name: "Inline Customer", phone: "555-0101" }
+    }
+
+    customer = Customer.find_by!(display_name: "Inline Customer")
+    assert response.redirect?
+    assert_equal new_admin_customer_request_path, URI.parse(response.location).path
+    assert_includes response.location, "customer_id=#{customer.id}"
+    assert_includes response.location, "Keep+these+notes"
+  end
+
+  test "index searches filters sorts active first and paginates" do
+    @request.update_columns(status: "completed", updated_at: Time.current) # historical fixture setup
+    active_customer = Customer.create!(display_name: "Current Reader", phone: "555-0110")
+    active_request = Customers::CreateRequest.call(
+      store: @store,
+      customer: active_customer,
+      product_variant: @variant,
+      actor: @admin
+    )
+    sign_in_as("admin")
+    select_store
+
+    get admin_customer_requests_path, params: { q: "Current Reader", status: active_request.status }
+    assert_response :success
+    assert_includes response.body, "Current Reader"
+    assert_not_includes response.body, "Alex Similar"
+    assert_includes response.body, "Page 1 of 1"
+
+    get admin_customer_requests_path
+    assert_operator response.body.index("##{active_request.number}"), :<, response.body.index("##{@request.number}")
+  end
+
+  test "lookup endpoints deny direct requests without management permission" do
+    viewer = User.create!(
+      username: "request_viewer",
+      display_name: "Request Viewer",
+      password: "correct-horse-battery",
+      password_confirmation: "correct-horse-battery"
+    )
+    role = Role.create!(key: "request_viewer", name: "Request Viewer", assignment_scope: "store")
+    permission = Permission.find_by!(key: "customers.view")
+    RolePermission.create!(role: role, permission: permission, granted_by: @admin)
+    RoleAssignment.create!(user: viewer, role: role, store: @store, assigned_by: @admin, effective_at: Time.current)
+    sign_in_as("request_viewer")
+    select_store
+
+    get customer_lookup_admin_customer_requests_path, params: { customer_q: @customer.email }
+    assert_redirected_to root_path
+    get merchandise_lookup_admin_customer_requests_path, params: { merchandise_q: @variant.sku }
+    assert_redirected_to root_path
+    assert_equal 2, AuditEvent.where(action: "authorization.denied", actor_user: viewer).count
+  end
+
+  private
+
+  def sign_in_as(username)
+    post session_path, params: { session: { username: username, password: "correct-horse-battery" } }
+  end
+
+  def select_store
+    post store_selection_path, params: { store_id: @store.id }
+  end
+end


### PR DESCRIPTION
### Motivation

- Replace the legacy customer dropdown and raw product-variant ID fallback with keyboard-accessible lookup flows so staff can reliably find customers and merchandise without needing database IDs.
- Preserve partially-entered request state across inline customer creation and keep quick product/variant actions as the fastest preselected route.
- Improve the customer-requests index to support real search, useful defaults, store/status filtering, and paginated active-first results for operational clarity.

### Description

- Added new lookup endpoints and routes: `customer_lookup` and `merchandise_lookup` on `customer_requests` and guarded them with the existing permission checks. (routes and controller updates.)
- Replaced `app/views/admin/customer_requests/new.html.erb` with an accessible 3-step flow (Customer lookup → Merchandise lookup → Request details) that shows contact details, identifier info, Standard/Used identity, and store availability; preserves request draft state across selection and inline customer creation. (views + controller: `customer_lookup`, `merchandise_lookup`, `prepare_lookup_request`.)
- Implemented `CustomerRequests::AdminIndexQuery` service to provide search by request number / customer name / contact / merchandise identifier/title, store and status filters, active-work-first ordering, and pagination (50/page). (new service file.)
- Updated index view `app/views/admin/customer_requests/index.html.erb` to show distinct empty/filtered states, status badges, contextual next-action links, store selector scoped to authorized stores, and pagination controls. (view changes.)
- Made `Admin::CustomersController#create` return to a preserved `new` customer-request draft via a guarded `return_to` parameter, and added a hidden `return_to` field on the customer form. (controller + partial.)
- Used `Inventory::Availability` to show apparent availability per variant in the lookup flow and preserved product/variant quick-action behavior when a variant is already preselected. (controller integrations.)
- Extended `status_badge` mapping to include `:customer_request` scheme and added an integration test file `test/integration/customer_requests_admin_test.rb` covering lookup display, state-preserving customer creation redirect, index search/filter/sort presentation, and authorization denial behavior. (tests added.)

### Testing

- `git diff --check` was run and reported no whitespace/file errors.
- Integration test suite for the new behavior was added at `test/integration/customer_requests_admin_test.rb`, but running the test harness could not be completed locally because the project uses the Docker helper and Docker is not available in this environment; therefore the new integration tests were not executed here (CI should run them). 
- The change set was committed as "Add accessible customer request lookups" and is ready for CI verification (including `./dev/rails-docker bin/rails test` in the project Docker environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a89236056ec832ca08b6e5e8b1c8776)