### PR TITLE
Refactor customer requests into fulfillment timelines

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -478,6 +478,53 @@ input[type="submit"]:hover {
   color: var(--color-text);
 }
 
+.request-summary__heading,
+.fulfillment-timeline__heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.request-summary__heading p,
+.request-summary__heading h2,
+.fulfillment-timeline__heading h3 {
+  margin-top: 0;
+}
+
+.request-next-action {
+  margin-top: var(--space-5);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--color-border);
+}
+
+.fulfillment-timeline {
+  list-style: none;
+  margin: var(--space-4) 0 0;
+  padding: 0 0 0 var(--space-5);
+  border-left: 2px solid var(--color-border);
+}
+
+.fulfillment-timeline__event {
+  position: relative;
+  margin-bottom: var(--space-4);
+}
+
+.fulfillment-timeline__marker {
+  position: absolute;
+  top: var(--space-4);
+  left: calc(-1 * var(--space-5) - 0.45rem);
+  width: 0.75rem;
+  height: 0.75rem;
+  border: 2px solid var(--color-action);
+  border-radius: 50%;
+  background: var(--color-surface);
+}
+
+.fulfillment-timeline__content p:last-child {
+  margin-bottom: 0;
+}
+
 .pagination {
   display: flex;
   flex-wrap: wrap;

--- a/app/controllers/admin/customer_requests_controller.rb
+++ b/app/controllers/admin/customer_requests_controller.rb
@@ -179,7 +179,34 @@ module Admin
     end
 
     def set_customer_request
-      @customer_request = CustomerRequest.find(params[:id])
+      @customer_request = CustomerRequest.includes(
+        :store,
+        :customer,
+        :location_failed_by,
+        :cancelled_by,
+        { product_variant: [ :product, :merchandise_condition ] },
+        { customer_request_allocations: [
+          :inventory_unit,
+          :released_by,
+          { purchase_receipt_line: :purchase_receipt },
+          { fulfilled_pos_transaction_line: :pos_transaction }
+        ] },
+        { orders: [
+          :supplier,
+          :replaces_order,
+          :cancelled_by,
+          { purchase_order_line: [
+            :line_state,
+            :cancellations,
+            { purchase_receipt_lines: :purchase_receipt },
+            :purchase_order
+          ] }
+        ] }
+      ).find(params[:id])
+      @allocations = @customer_request.customer_request_allocations.sort_by(&:created_at)
+      @related_orders = @customer_request.orders.sort_by(&:created_at)
+      @active_allocation = @allocations.find(&:reserved?)
+      @unsent_special_orders = @related_orders.select { |order| !order.cancelled? && order.unsent? }
       permission = action_name == "cancel" ? "customer_requests.manage" : "customers.view"
       nil unless authorize!(permission, store: @customer_request.store)
     end

--- a/app/views/admin/customer_requests/show.html.erb
+++ b/app/views/admin/customer_requests/show.html.erb
@@ -1,69 +1,182 @@
 <% content_for :title, @customer_request.admin_label %>
-<h1><%= @customer_request.admin_label %></h1>
-<p><%= link_to "Back", admin_customer_requests_path %></p>
-<dl>
-  <dt>Store</dt><dd><%= @customer_request.store.admin_label %></dd>
-  <dt>Customer</dt><dd><%= link_to @customer_request.customer.admin_label, admin_customer_path(@customer_request.customer) %></dd>
-  <dt>Variant</dt><dd><%= @customer_request.product_variant.sku %> (<%= @customer_request.product_variant.variant_type %>)</dd>
-  <dt>Status</dt><dd><%= @customer_request.status %></dd>
-  <dt>Estimated customer price</dt><dd><%= @customer_request.estimated_price_cents.nil? ? "—" : format_money_cents(@customer_request.estimated_price_cents) %></dd>
-  <dt>Notes</dt><dd><%= @customer_request.notes.presence || "—" %></dd>
-  <% if @customer_request.cancelled? %>
-    <dt>Cancellation</dt>
-    <dd><%= @customer_request.cancellation_reason %> at <%= @customer_request.cancelled_at %></dd>
-  <% end %>
-</dl>
 
-<% if @customer_request.active_allocation %>
-  <p>Active allocation: <%= @customer_request.active_allocation.allocation_type %> (reserved)</p>
+<% promise_label = {
+     "pending_location" => "Needs locating",
+     "special_order_pending" => "Ordered",
+     "ordered" => "Ordered",
+     "available" => "Available for pickup",
+     "completed" => "Completed",
+     "cancelled" => "Cancelled"
+   }.fetch(@customer_request.status) %>
+<% contact = [@customer_request.customer.phone.presence, @customer_request.customer.email.presence].compact.join(" · ").presence %>
+<% merchandise = safe_join([
+     @customer_request.product_variant.product.name,
+     tag.br,
+     content_tag(:span, "#{@customer_request.product_variant.variant_type.humanize} · SKU #{@customer_request.product_variant.sku}", class: "muted")
+   ]) %>
+
+<%= render "shared/page_header", title: @customer_request.admin_label,
+      subtitle: "Customer fulfillment at #{@customer_request.store.admin_label}",
+      actions: link_to("Back to requests", admin_customer_requests_path, class: "btn btn--ghost") %>
+
+<section class="section surface request-summary" aria-labelledby="current-state-heading">
+  <div class="request-summary__heading">
+    <div>
+      <p class="muted">Current promise</p>
+      <h2 id="current-state-heading"><%= promise_label %></h2>
+    </div>
+    <%= status_badge(@customer_request.status, scheme: :customer_request) %>
+  </div>
+
+  <%= render "shared/definition_list", rows: [
+    ["Customer", link_to(@customer_request.customer.admin_label, admin_customer_path(@customer_request.customer))],
+    ["Contact method", contact || missing_value("No phone or email")],
+    ["Merchandise", merchandise],
+    ["Store", @customer_request.store.admin_label],
+    ["Request number", "##{@customer_request.number}"],
+    ["Status", @customer_request.status.humanize],
+    ["Estimated customer price", @customer_request.estimated_price_cents.nil? ? missing_value : format_money_cents(@customer_request.estimated_price_cents)],
+    ["Request notes", @customer_request.notes.presence || missing_value]
+  ] %>
+
+  <div class="request-next-action">
+    <h3>Next step</h3>
+    <% if @customer_request.pending_location? %>
+      <% if effective_permissions.include?("customer_requests.locate") && current_store&.id == @customer_request.store_id %>
+        <%= link_to "Open location queue", ops_location_path, class: "btn" %>
+      <% else %>
+        <p>Merchandise must be physically located by an authorized team member at this store.</p>
+      <% end %>
+    <% elsif @customer_request.available? %>
+      <p><strong>Bring this request to the Register for customer pickup.</strong> The cashier must select the request allocation; do not add the merchandise as an ordinary sale.</p>
+    <% elsif @customer_request.completed? %>
+      <% transaction = @allocations.filter_map { |allocation| allocation.fulfilled_pos_transaction_line&.pos_transaction }.first %>
+      <% if transaction && effective_permissions.include?("pos.transact") && current_store&.id == transaction.store_id %>
+        <%= link_to "Open pickup receipt #{transaction.transaction_reference}", pos_transaction_path(transaction), class: "btn" %>
+      <% else %>
+        <p>No action needed. Pickup was completed at the Register.</p>
+      <% end %>
+    <% elsif @customer_request.cancelled? %>
+      <p>No action needed. This request is cancelled.</p>
+    <% else %>
+      <% current_order = @related_orders.reject(&:cancelled?).last || @related_orders.last %>
+      <% purchase_order = current_order&.purchase_order %>
+      <% if purchase_order&.draft? && effective_permissions.include?("orders.manage") && current_store&.id == @customer_request.store_id %>
+        <%= link_to "Open draft PO", ops_purchase_order_path(purchase_order), class: "btn" %>
+      <% elsif purchase_order && effective_permissions.include?("orders.view") %>
+        <%= link_to "Open #{purchase_order.admin_label}", admin_purchase_order_path(purchase_order), class: "btn" %>
+      <% elsif current_order && effective_permissions.include?("orders.view") %>
+        <%= link_to "Open #{current_order.admin_label}", admin_order_path(current_order), class: "btn" %>
+      <% else %>
+        <p>An authorized buyer is responsible for the supplier order.</p>
+      <% end %>
+    <% end %>
+  </div>
+</section>
+
+<% events = [] %>
+<% events << { at: @customer_request.created_at, title: "Request created", badge: "Created", body: "Routed to #{promise_label == "Needs locating" ? "the location queue" : "supplier ordering"}." } %>
+<% if @customer_request.location_failed_at %>
+  <% events << { at: @customer_request.location_failed_at, title: "Not located", badge: "Not located", body: @customer_request.location_failure_notes.presence || "No location notes recorded." } %>
+<% elsif @allocations.any? { |allocation| allocation.purchase_receipt_line.nil? } %>
+  <% allocation = @allocations.find { |candidate| candidate.purchase_receipt_line.nil? } %>
+  <% events << { at: allocation.created_at, title: "Located in store", badge: "Located", body: "Physical merchandise was confirmed and reserved." } %>
+<% end %>
+<% @related_orders.each do |order| %>
+  <% lineage = order.replaces_order ? " Re-sourced from #{order.replaces_order.admin_label}." : " Original supplier order." %>
+  <% order_label = effective_permissions.include?("orders.view") ? link_to(order.admin_label, admin_order_path(order)) : order.admin_label %>
+  <% events << { at: order.created_at, title: order.replaces_order ? "Replacement order created" : "Supplier order created", badge: order.cancelled? ? "Cancelled" : "Order", body: safe_join([order_label, " with #{order.supplier.admin_label}.#{lineage}"]) } %>
+  <% if order.purchase_order_line %>
+    <% po = order.purchase_order %>
+    <% if po&.generated_at %>
+      <% po_label = effective_permissions.include?("orders.view") ? link_to(po.admin_label, admin_purchase_order_path(po)) : po.admin_label %>
+      <% events << { at: po.generated_at, title: "Purchase order generated", badge: po.status.humanize, body: po_label } %>
+    <% end %>
+    <% if po&.sent_at %>
+      <% events << { at: po.sent_at, title: "Purchase order sent", badge: "Sent", body: "#{po.admin_label} sent#{po.transmission_method.present? ? " by #{po.transmission_method.humanize.downcase}" : ""}." } %>
+    <% end %>
+    <% state = order.purchase_order_line.line_state %>
+    <% if state && (state.confirmed_quantity.present? || state.backordered_quantity.positive? || state.supplier_reference.present? || state.expected_on.present? || state.notes.present?) %>
+      <% acknowledgment = [state.confirmed_quantity.present? ? "#{state.confirmed_quantity} confirmed" : nil, state.backordered_quantity.positive? ? "#{state.backordered_quantity} backordered" : nil, state.expected_on ? "expected #{format_date(state.expected_on)}" : nil, state.supplier_reference.presence, state.notes.presence].compact.join(" · ") %>
+      <% events << { at: state.updated_at, title: "Supplier acknowledgment", badge: "Acknowledged", body: acknowledgment } %>
+    <% end %>
+    <% order.purchase_order_line.cancellations.each do |cancellation| %>
+      <% events << { at: cancellation.occurred_at, title: "Order quantity cancelled", badge: "#{cancellation.source.humanize} cancellation", body: cancellation.reason } %>
+    <% end %>
+    <% order.purchase_order_line.purchase_receipt_lines.each do |line| %>
+      <% receipt = line.purchase_receipt %>
+      <% next unless receipt.posted? %>
+      <% made_available = @allocations.any? { |allocation| allocation.purchase_receipt_line_id == line.id } %>
+      <% receipt_label = effective_permissions.include?("purchase_receipts.view") ? link_to(receipt.admin_label, admin_purchase_receipt_path(receipt)) : receipt.admin_label %>
+      <% events << { at: receipt.posted_at, title: "Receipt posted", badge: "Received", body: safe_join([receipt_label, " · line received #{line.received_quantity} at #{format_money_cents(line.actual_unit_cost_cents)} each#{made_available ? " · made this request available" : ""}"]) } %>
+    <% end %>
+  <% end %>
+  <% if order.cancelled_at %>
+    <% events << { at: order.cancelled_at, title: "Order cancelled", badge: "Cancelled", body: order.cancellation_reason.presence || "No reason recorded." } %>
+  <% end %>
+<% end %>
+<% @allocations.each do |allocation| %>
+  <% allocation_description = if allocation.standard_quantity?
+       "Standard quantity (1)"
+     else
+       "Exact Used unit #{allocation.inventory_unit&.unit_identifier || "identifier unavailable"}"
+     end %>
+  <% events << { at: allocation.created_at, title: allocation.reserved? ? "Allocation reserved" : "Allocation created", badge: allocation.status.humanize, body: allocation_description } unless allocation.purchase_receipt_line.nil? && events.any? { |event| event[:at] == allocation.created_at && event[:title] == "Located in store" } %>
+  <% if allocation.released? %>
+    <% events << { at: allocation.released_at, title: "Allocation released", badge: "Released", body: "#{allocation_description} · #{allocation.release_reason}" } %>
+  <% elsif allocation.fulfilled? %>
+    <% line = allocation.fulfilled_pos_transaction_line %>
+    <% transaction = line&.pos_transaction %>
+    <% receipt_link = transaction && effective_permissions.include?("pos.transact") && current_store&.id == transaction.store_id ? link_to(transaction.transaction_reference, pos_transaction_path(transaction)) : transaction&.transaction_reference %>
+    <% events << { at: transaction&.completed_at || @customer_request.completed_at || allocation.updated_at, title: "Pickup completed", badge: "Completed", body: safe_join(["Fulfilled through POS receipt ", receipt_link || "not available", " · ", format_money_cents(line&.line_total_cents)]) } %>
+  <% end %>
+<% end %>
+<% if @customer_request.cancelled? %>
+  <% events << { at: @customer_request.cancelled_at, title: "Request cancelled", badge: "Cancelled", body: @customer_request.cancellation_reason } %>
 <% end %>
 
-<% related_orders = @customer_request.orders.includes(:supplier, purchase_order_line: :purchase_order) %>
-<% if related_orders.any? %>
-  <h2>Related orders</h2>
-  <ul>
-    <% related_orders.each do |order| %>
-      <li>
-        <%= link_to order.admin_label, admin_order_path(order) %>
-        · <%= order.supplier.admin_label %>
-        <% if order.purchase_order %>
-          · <%= order.purchase_order.admin_label %> (<%= order.purchase_order.status %>)
-          <% if order.purchase_order.draft? && effective_permissions.include?("orders.manage") && current_store&.id == order.store_id %>
-            · <%= link_to "Draft workspace", ops_purchase_order_path(order.purchase_order) %>
-          <% end %>
-        <% end %>
-        <% if order.cancelled? %> · cancelled<% end %>
+<section class="section" aria-labelledby="timeline-heading">
+  <h2 id="timeline-heading">Fulfillment timeline</h2>
+  <ol class="fulfillment-timeline">
+    <% events.compact.sort_by { |event| [event[:at] || Time.at(0), event[:title]] }.each do |event| %>
+      <li class="fulfillment-timeline__event">
+        <div class="fulfillment-timeline__marker" aria-hidden="true"></div>
+        <div class="fulfillment-timeline__content surface">
+          <div class="fulfillment-timeline__heading">
+            <h3><%= event[:title] %></h3>
+            <span class="status-badge"><%= event[:badge] %></span>
+          </div>
+          <p class="muted"><%= format_timestamp(event[:at]) %></p>
+          <p><%= event[:body] %></p>
+        </div>
       </li>
     <% end %>
-  </ul>
-<% end %>
-
-<% if @customer_request.pending_location? && effective_permissions.include?("customer_requests.locate") && current_store&.id == @customer_request.store_id %>
-  <p><%= link_to "Locate in ops workspace", ops_location_path %></p>
-<% end %>
+  </ol>
+</section>
 
 <% if !@customer_request.cancelled? && !@customer_request.completed? && effective_permissions.include?("customer_requests.manage") %>
-  <% unsent = @customer_request.unsent_special_orders %>
-  <%= form_with url: cancel_admin_customer_request_path(@customer_request), method: :post do %>
-    <%= hidden_field_tag :lock_version, @customer_request.lock_version %>
-    <p>
-      <label for="cancellation_reason">Cancel reason</label>
-      <input type="text" name="cancellation_reason" id="cancellation_reason" required>
-    </p>
-    <% if unsent.any? %>
-      <fieldset>
-        <legend>Unsent special order</legend>
-        <p>This request has an unsent order. Choose whether to cancel the draft order too.</p>
-        <label>
-          <input type="radio" name="cancel_draft_order" value="true" required>
-          Cancel the draft order
-        </label>
-        <label>
-          <input type="radio" name="cancel_draft_order" value="false" required>
-          Keep the draft order on the PO
-        </label>
-      </fieldset>
+  <section class="section surface" aria-labelledby="cancel-request-heading">
+    <h2 id="cancel-request-heading">Cancel request</h2>
+    <%= form_with url: cancel_admin_customer_request_path(@customer_request), method: :post do %>
+      <%= hidden_field_tag :lock_version, @customer_request.lock_version %>
+      <p><%= label_tag :cancellation_reason, "Cancellation reason" %><%= text_field_tag :cancellation_reason, nil, required: true %></p>
+      <% if @unsent_special_orders.any? %>
+        <fieldset>
+          <legend>Unsent special order</legend>
+          <p>This request has an unsent order. Choose whether to cancel the draft order too.</p>
+          <label><%= radio_button_tag :cancel_draft_order, true, false, required: true %> Cancel the draft order</label>
+          <label><%= radio_button_tag :cancel_draft_order, false, false, required: true %> Keep the draft order on the PO</label>
+        </fieldset>
+      <% end %>
+      <p><%= submit_tag "Cancel request", class: "btn btn--danger" %></p>
     <% end %>
-    <p><button type="submit">Cancel request</button></p>
-  <% end %>
+  </section>
 <% end %>
+
+<%= render "shared/technical_details", rows: [
+  ["Request ID", @customer_request.id],
+  ["Customer ID", @customer_request.customer_id],
+  ["Product variant ID", @customer_request.product_variant_id],
+  ["Lock version", @customer_request.lock_version],
+  ["Last updated", format_timestamp(@customer_request.updated_at)]
+] %>

--- a/test/integration/customer_requests_admin_test.rb
+++ b/test/integration/customer_requests_admin_test.rb
@@ -93,6 +93,24 @@ class CustomerRequestsAdminTest < ActionDispatch::IntegrationTest
     assert_operator response.body.index("##{active_request.number}"), :<, response.body.index("##{@request.number}")
   end
 
+  test "show presents current promise and chronological fulfillment summary" do
+    sign_in_as("admin")
+    select_store
+
+    get admin_customer_request_path(@request)
+
+    assert_response :success
+    assert_select "h2", text: "Needs locating"
+    assert_select "h2", text: "Fulfillment timeline"
+    assert_select ".request-summary", text: /Alex Similar/
+    assert_select ".request-summary", text: /555-0199/
+    assert_select ".request-summary", text: /Accessible Lookup Book/
+    assert_select ".request-summary", text: /Pending location/
+    assert_select ".request-next-action a", text: "Open location queue"
+    assert_select ".fulfillment-timeline__event", minimum: 1, text: /Request created/
+    assert_select "details.technical-details", text: /Request ID/
+  end
+
   test "lookup endpoints deny direct requests without management permission" do
     viewer = User.create!(
       username: "request_viewer",


### PR DESCRIPTION
### Motivation

- Present the customer-request detail as an operator-friendly current-state summary followed by a chronological fulfillment timeline to make the single next action and history obvious.  
- Avoid view-level association queries and N+1s by eager-loading the fulfillment graph so the show page can render a complete current-state summary without additional DB hits.  

### Description

- Replace the old detail dump with a current-state summary that shows customer, contact method, merchandise, store, request number, humanized status, estimated price, notes, and one permission-aware next action in `app/views/admin/customer_requests/show.html.erb`.  
- Render a chronological fulfillment timeline that links creation/routing, locate outcomes, allocations (standard vs exact used unit), order/re-source lineage, PO generation/send state and acknowledgments, posted receipts and matched receipt lines, allocation releases/cancellations, and completed POS pickup receipts in `app/views/admin/customer_requests/show.html.erb`.  
- Eager-load the complete fulfillment association graph in `Admin::CustomerRequestsController#set_customer_request` (allocations, receipt lines, purchase orders/lines, orders and lineage, suppliers, and POS transaction line relations) and prepare ordered in-memory collections for the view in `app/controllers/admin/customer_requests_controller.rb`.  
- Move UUIDs and lock metadata into collapsible technical details and add responsive timeline styling in `app/assets/stylesheets/application.css`.  
- Add an integration-level assertion that the new summary, next action, timeline, and technical-details are present in `test/integration/customer_requests_admin_test.rb`.

### Testing

- Ran `ruby -c app/controllers/admin/customer_requests_controller.rb` which returned `Syntax OK`.  
- Ran `ruby -c test/integration/customer_requests_admin_test.rb` which returned `Syntax OK` for the added assertions.  
- Ran `git diff --check` which reported no whitespace or diff-check issues.  
- Attempted the Rails integration test run (`./dev/rails-docker bin/rails test`) and full RuboCop in this environment but they could not be executed because the Docker/bundled gems environment is not available here; the test added is present and was syntax-checked locally in the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a89259ab6e0832cb0c282748d271e3d)