### PR TITLE
Add review-dialog modals for consequential Phase 7 actions

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1227,3 +1227,25 @@ input[type="submit"]:hover {
     gap: 0;
   }
 }
+
+/* Consequential-action reviews use native modal dialogs for focus containment. */
+.review-dialog {
+  width: min(42rem, calc(100vw - 2rem));
+  max-height: calc(100vh - 2rem);
+  padding: 0;
+  border: 2px solid var(--color-border, #334155);
+  border-radius: 0.65rem;
+  box-shadow: 0 1.5rem 4rem rgb(15 23 42 / 45%);
+}
+
+.review-dialog::backdrop { background: rgb(15 23 42 / 68%); }
+.review-dialog--warning { background: #fff7d6; border-color: #a16207; }
+.review-dialog--danger { background: #fff0f0; border-color: #b91c1c; }
+.review-dialog--information { background: #eaf6ff; border-color: #0369a1; }
+.review-dialog__body { padding: var(--space-5, 1.5rem); }
+.review-dialog__body > :first-child { margin-top: 0; }
+.review-dialog__facts { display: grid; grid-template-columns: max-content 1fr; gap: 0.35rem 1rem; }
+.review-dialog__facts dt { font-weight: 700; }
+.review-dialog__facts dd { margin: 0; }
+.review-dialog__consequences { padding: 0.8rem 1rem; background: rgb(255 255 255 / 65%); border-left: 0.3rem solid currentColor; }
+.review-dialog__actions { display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: center; margin-top: 1rem; }

--- a/app/javascript/controllers/review_dialog_controller.js
+++ b/app/javascript/controllers/review_dialog_controller.js
@@ -1,0 +1,32 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Presents consequential server-backed forms in a native modal dialog. The browser
+// supplies modal focus trapping; this controller owns initial focus and restores
+// focus to the visible trigger after Escape or Cancel.
+export default class extends Controller {
+  static targets = [ "dialog", "initialFocus", "trigger" ]
+  static values = { open: Boolean }
+
+  connect() {
+    if (this.openValue) this.show()
+  }
+
+  open(event) {
+    event.preventDefault()
+    this.show()
+  }
+
+  show() {
+    this.dialogTarget.showModal()
+    requestAnimationFrame(() => this.initialFocusTarget.focus())
+  }
+
+  close(event) {
+    event.preventDefault()
+    this.dialogTarget.close()
+  }
+
+  restoreFocus() {
+    this.triggerTarget.focus()
+  }
+}

--- a/app/views/admin/customer_requests/show.html.erb
+++ b/app/views/admin/customer_requests/show.html.erb
@@ -157,19 +157,36 @@
 <% if !@customer_request.cancelled? && !@customer_request.completed? && effective_permissions.include?("customer_requests.manage") %>
   <section class="section surface" aria-labelledby="cancel-request-heading">
     <h2 id="cancel-request-heading">Cancel request</h2>
-    <%= form_with url: cancel_admin_customer_request_path(@customer_request), method: :post do %>
-      <%= hidden_field_tag :lock_version, @customer_request.lock_version %>
-      <p><%= label_tag :cancellation_reason, "Cancellation reason" %><%= text_field_tag :cancellation_reason, nil, required: true %></p>
-      <% if @unsent_special_orders.any? %>
-        <fieldset>
-          <legend>Unsent special order</legend>
-          <p>This request has an unsent order. Choose whether to cancel the draft order too.</p>
-          <label><%= radio_button_tag :cancel_draft_order, true, false, required: true %> Cancel the draft order</label>
-          <label><%= radio_button_tag :cancel_draft_order, false, false, required: true %> Keep the draft order on the PO</label>
-        </fieldset>
-      <% end %>
-      <p><%= submit_tag "Cancel request", class: "btn btn--danger" %></p>
-    <% end %>
+    <div data-controller="review-dialog">
+      <button type="button" class="btn btn--danger" data-review-dialog-target="trigger" data-action="review-dialog#open">Review cancellation</button>
+      <dialog class="review-dialog review-dialog--danger" data-review-dialog-target="dialog" data-action="close->review-dialog#restoreFocus">
+        <div class="review-dialog__body">
+          <h3>Review cancelling request #<%= @customer_request.number %></h3>
+          <dl class="review-dialog__facts">
+            <dt>Customer</dt><dd><%= @customer_request.customer.admin_label %></dd>
+            <dt>Merchandise</dt><dd><%= @customer_request.product_variant.product.name %></dd>
+            <dt>Allocation release</dt><dd><%= @active_allocation ? "The active allocation will be released for other sales." : "No active allocation will be released." %></dd>
+            <dt>Related unsent order</dt><dd><%= @unsent_special_orders.any? ? "An explicit keep-or-cancel decision is required below." : "No unsent related order requires a decision." %></dd>
+          </dl>
+          <p class="review-dialog__consequences">Sent supplier quantity is not cancelled. Any later receipt for this cancelled request becomes ordinary stock.</p>
+          <%= form_with url: cancel_admin_customer_request_path(@customer_request), method: :post do %>
+            <%= hidden_field_tag :lock_version, @customer_request.lock_version %>
+            <p><%= label_tag :cancellation_reason, "Cancellation reason" %><%= text_field_tag :cancellation_reason, nil, required: true, data: { review_dialog_target: "initialFocus" } %></p>
+            <% if @unsent_special_orders.any? %>
+              <fieldset>
+                <legend>Explicit unsent-order decision</legend>
+                <label><%= radio_button_tag :cancel_draft_order, true, false, required: true %> Cancel the unsent draft order</label>
+                <label><%= radio_button_tag :cancel_draft_order, false, false, required: true %> Keep the unsent draft order on the PO</label>
+              </fieldset>
+            <% end %>
+            <div class="review-dialog__actions">
+              <%= submit_tag "Cancel request and release allocation", class: "btn btn--danger" %>
+              <button type="button" data-action="review-dialog#close">Keep request active</button>
+            </div>
+          <% end %>
+        </div>
+      </dialog>
+    </div>
   </section>
 <% end %>
 

--- a/app/views/admin/purchase_orders/show.html.erb
+++ b/app/views/admin/purchase_orders/show.html.erb
@@ -83,41 +83,36 @@
 
         <% if effective_permissions.include?("purchase_orders.cancel") && @purchase_order.sent? && line.open_quantity.positive? %>
           <h4>Cancel / re-source</h4>
-          <%= form_with url: cancel_line_admin_purchase_order_path(@purchase_order, line_id: line.id), method: :post, local: true do %>
-            <label>
-              Quantity
-              <input type="number" name="quantity" value="<%= line.open_quantity %>" min="1" max="<%= line.open_quantity %>" required>
-            </label>
-            <label>
-              Source
-              <select name="source">
-                <option value="buyer">buyer</option>
-                <option value="supplier">supplier</option>
-              </select>
-            </label>
-            <label>
-              Reason
-              <input type="text" name="reason" required>
-            </label>
-            <label>
-              <input type="checkbox" name="re_source" value="1">
-              Re-source to replacement supplier
-            </label>
-            <label>
-              Replacement supplier
-              <select name="replacement_supplier_id">
-                <option value="">Select…</option>
-                <% @suppliers.each do |supplier| %>
-                  <option value="<%= supplier.id %>"><%= supplier.admin_label %></option>
+          <div data-controller="review-dialog">
+            <button type="button" data-review-dialog-target="trigger" data-action="review-dialog#open">Review cancellation</button>
+            <dialog class="review-dialog review-dialog--danger" data-review-dialog-target="dialog" data-action="close->review-dialog#restoreFocus">
+              <div class="review-dialog__body">
+                <h3>Review cancellation for <%= line.product_variant.product.name %></h3>
+                <dl class="review-dialog__facts">
+                  <dt>Open quantity</dt><dd><%= line.open_quantity %></dd>
+                  <dt>Customer impact</dt><dd><%= line.order.customer_request ? "Customer request ##{line.order.customer_request.number} remains linked to any replacement; without one, later receipt will not fulfill it." : "Stock order; no customer request is linked." %></dd>
+                  <dt>Original supplier</dt><dd><%= @purchase_order.supplier.admin_label %></dd>
+                  <dt>Replacement supplier</dt><dd>Select below when re-sourcing.</dd>
+                  <dt>Expected cost</dt><dd><%= format_money_cents(line.expected_unit_cost_cents) %> current; enter the replacement cost below.</dd>
+                </dl>
+                <p class="review-dialog__consequences">The cancelled quantity immediately stops being open on the original PO. Re-sourcing atomically creates a linked replacement order and draft PO line; history is not rewritten.</p>
+                <%= form_with url: cancel_line_admin_purchase_order_path(@purchase_order, line_id: line.id), method: :post, local: true do %>
+                  <label>Quantity <input type="number" name="quantity" value="<%= line.open_quantity %>" min="1" max="<%= line.open_quantity %>" required data-review-dialog-target="initialFocus"></label>
+                  <label>Source <select name="source"><option value="buyer">buyer</option><option value="supplier">supplier</option></select></label>
+                  <label>Reason <input type="text" name="reason" required></label>
+                  <label><input type="checkbox" name="re_source" value="1"> Re-source to replacement supplier</label>
+                  <label>Replacement supplier
+                    <select name="replacement_supplier_id"><option value="">Select…</option><% @suppliers.each do |supplier| %><option value="<%= supplier.id %>"><%= supplier.admin_label %></option><% end %></select>
+                  </label>
+                  <label>Expected replacement unit cost ($) <input type="text" inputmode="decimal" name="expected_unit_cost_cents"></label>
+                  <div class="review-dialog__actions">
+                    <button type="submit">Cancel quantity and apply re-source choice</button>
+                    <button type="button" data-action="review-dialog#close">Keep original open quantity</button>
+                  </div>
                 <% end %>
-              </select>
-            </label>
-            <label>
-              Expected unit cost ($, if no source)
-              <input type="text" inputmode="decimal" name="expected_unit_cost_cents">
-            </label>
-            <button type="submit">Cancel quantity</button>
-          <% end %>
+              </div>
+            </dialog>
+          </div>
         <% end %>
 
         <% if line.cancellations.any? %>

--- a/app/views/ops/draft_pos/show.html.erb
+++ b/app/views/ops/draft_pos/show.html.erb
@@ -37,20 +37,37 @@
         <button type="submit" <%= "autofocus aria-describedby=po_return_error" if @error_action == :return_to_draft %>>Return to draft</button>
         <%= render "ops/shared/inline_row_error", action: :return_to_draft, id: "po_return_error" %>
       <% end %>
-      <%= form_with url: ops_purchase_order_send_path(@purchase_order), method: :post, local: true do %>
-        <%= hidden_field_tag :lock_version, @purchase_order.lock_version %>
-        <label>
-          Transmission method
-          <select name="transmission_method" required <%= "autofocus aria-describedby=po_action_error" if @error_action == :send_po %>>
-            <option value="">Select…</option>
-            <% PurchaseOrder::TRANSMISSION_METHODS.each do |method| %>
-              <option value="<%= method %>" <%= "selected" if @submitted&.fetch("transmission_method", nil) == method %>><%= method %></option>
+      <div data-controller="review-dialog" <%= 'data-review-dialog-open-value="true"' if @error_action == :send_po %>>
+        <button type="button" data-review-dialog-target="trigger" data-action="review-dialog#open">Review send</button>
+        <dialog class="review-dialog review-dialog--warning" data-review-dialog-target="dialog" data-action="close->review-dialog#restoreFocus">
+          <div class="review-dialog__body">
+            <h3>Review sending <%= @purchase_order.admin_label %></h3>
+            <dl class="review-dialog__facts">
+              <dt>Supplier</dt><dd><%= @purchase_order.supplier.admin_label %></dd>
+              <dt>Destination</dt><dd><%= current_store.admin_label %></dd>
+              <dt>Line count</dt><dd><%= @lines.size %></dd>
+              <dt>Expected total</dt><dd><%= format_money_cents(@purchase_order.expected_merchandise_total_cents) %></dd>
+            </dl>
+            <p class="review-dialog__consequences"><strong>After send:</strong> supplier-facing PO and line snapshots become immutable. Corrections require cancellation or re-sourcing rather than editing the snapshots.</p>
+            <%= form_with url: ops_purchase_order_send_path(@purchase_order), method: :post, local: true do %>
+              <%= hidden_field_tag :lock_version, @purchase_order.lock_version %>
+              <label>Transmission method
+                <select name="transmission_method" required data-review-dialog-target="initialFocus" <%= "aria-describedby=po_action_error" if @error_action == :send_po %>>
+                  <option value="">Select…</option>
+                  <% PurchaseOrder::TRANSMISSION_METHODS.each do |method| %>
+                    <option value="<%= method %>" <%= "selected" if @submitted&.fetch("transmission_method", nil) == method %>><%= method %></option>
+                  <% end %>
+                </select>
+              </label>
+              <%= render "ops/shared/inline_row_error", action: :send_po, id: "po_action_error" %>
+              <div class="review-dialog__actions">
+                <button type="submit">Send PO and freeze snapshots</button>
+                <button type="button" data-action="review-dialog#close">Keep PO generated</button>
+              </div>
             <% end %>
-          </select>
-        </label>
-        <%= render "ops/shared/inline_row_error", action: :send_po, id: "po_action_error" %>
-        <button type="submit">Record send</button>
-      <% end %>
+          </div>
+        </dialog>
+      </div>
     <% end %>
   </section>
 <% end %>

--- a/app/views/ops/receiving/show.html.erb
+++ b/app/views/ops/receiving/show.html.erb
@@ -110,40 +110,48 @@
               <td><%= format_money_cents(line.actual_unit_cost_cents) %></td>
               <td>
                 <% if line.remaining_reversible_quantity.positive? %>
-                  <%= form_with url: ops_receiving_reverse_line_path(@receipt, line), method: :post, local: true, html: { class: "ops-inline-form" } do %>
-                    <label>
-                      Reason
-                      <input type="text" name="reason" required>
-                    </label>
-                    <label>
-                      Qty
-                      <input type="number" name="quantity" min="1" max="<%= line.remaining_reversible_quantity %>" value="<%= line.remaining_reversible_quantity %>" required>
-                    </label>
-                    <% if @can_compensate %>
-                      <label>
-                        <input type="checkbox" name="authorize_compensate" value="1">
-                        Compensate if unsafe
-                      </label>
-                    <% end %>
-                    <button type="submit">Reverse</button>
-                  <% end %>
+                  <div data-controller="review-dialog">
+                    <button type="button" data-review-dialog-target="trigger" data-action="review-dialog#open">Review line reversal</button>
+                    <dialog class="review-dialog review-dialog--danger" data-review-dialog-target="dialog" data-action="close->review-dialog#restoreFocus">
+                      <div class="review-dialog__body">
+                        <h3>Review receipt-line reversal</h3>
+                        <dl class="review-dialog__facts">
+                          <dt>Item</dt><dd><%= line.product_variant.product.name %></dd>
+                          <dt>Inventory</dt><dd>Reduce physical on-hand by the quantity entered below.</dd>
+                          <dt>Valuation</dt><dd>Reverse the exact linked receipt value when safe.</dd>
+                          <dt>Customer allocation</dt><dd><%= line.customer_request_allocation&.reserved? ? "The active receipt allocation will be released/reconciled." : "No active receipt allocation will be released." %></dd>
+                          <dt>Downstream sale</dt><dd>A completed pickup or sale blocks exact reversal; compensation requires separate authorization.</dd>
+                        </dl>
+                        <%= form_with url: ops_receiving_reverse_line_path(@receipt, line), method: :post, local: true do %>
+                          <label>Reason <input type="text" name="reason" required data-review-dialog-target="initialFocus"></label>
+                          <label>Quantity <input type="number" name="quantity" min="1" max="<%= line.remaining_reversible_quantity %>" value="<%= line.remaining_reversible_quantity %>" required></label>
+                          <% if @can_compensate %><label><input type="checkbox" name="authorize_compensate" value="1"> Authorize compensation if exact reversal is unsafe</label><% end %>
+                          <div class="review-dialog__actions"><button type="submit">Reverse receipt line quantity and value</button><button type="button" data-action="review-dialog#close">Keep receipt line</button></div>
+                        <% end %>
+                      </div>
+                    </dialog>
+                  </div>
                 <% else %>
                   —
                 <% end %>
               </td>
               <td>
                 <% if line.remaining_reversible_quantity.positive? %>
-                  <%= form_with url: ops_receiving_correct_cost_path(@receipt, line), method: :post, local: true, html: { class: "ops-inline-form" } do %>
-                    <label>
-                      Reason
-                      <input type="text" name="reason" required>
-                    </label>
-                    <label>
-                      Corrected unit cost ($)
-                      <input type="text" inputmode="decimal" name="corrected_unit_cost_cents" value="<%= @selected_row_id.to_s == line.id.to_s ? @submitted&.fetch("corrected_unit_cost_cents", nil) : nil %>" required aria-invalid="<%= @error_field == :corrected_unit_cost_cents && @selected_row_id.to_s == line.id.to_s %>">
-                    </label>
-                    <button type="submit">Correct cost</button>
-                  <% end %>
+                  <div data-controller="review-dialog">
+                    <button type="button" data-review-dialog-target="trigger" data-action="review-dialog#open">Review cost correction</button>
+                    <dialog class="review-dialog review-dialog--information" data-review-dialog-target="dialog" data-action="close->review-dialog#restoreFocus">
+                      <div class="review-dialog__body">
+                        <h3>Review cost-only correction</h3>
+                        <p class="review-dialog__consequences"><strong>Physical quantity will not change.</strong> This posts only a valuation delta; the posted receipt remains immutable.</p>
+                        <dl class="review-dialog__facts"><dt>Item</dt><dd><%= line.product_variant.product.name %></dd><dt>Current unit cost</dt><dd><%= format_money_cents(line.actual_unit_cost_cents) %></dd><dt>Inventory effect</dt><dd>No on-hand or customer-allocation change.</dd></dl>
+                        <%= form_with url: ops_receiving_correct_cost_path(@receipt, line), method: :post, local: true do %>
+                          <label>Reason <input type="text" name="reason" required data-review-dialog-target="initialFocus"></label>
+                          <label>Corrected unit cost ($) <input type="text" inputmode="decimal" name="corrected_unit_cost_cents" value="<%= @selected_row_id.to_s == line.id.to_s ? @submitted&.fetch("corrected_unit_cost_cents", nil) : nil %>" required aria-invalid="<%= @error_field == :corrected_unit_cost_cents && @selected_row_id.to_s == line.id.to_s %>"></label>
+                          <div class="review-dialog__actions"><button type="submit">Post cost-only valuation correction</button><button type="button" data-action="review-dialog#close">Keep current cost</button></div>
+                        <% end %>
+                      </div>
+                    </dialog>
+                  </div>
                 <% else %>
                   —
                 <% end %>
@@ -155,13 +163,19 @@
 
       <% if @lines.any? { |l| l.remaining_reversible_quantity.positive? } %>
         <h3>Reverse whole receipt</h3>
-        <%= form_with url: ops_receiving_reverse_path(@receipt), method: :post, local: true do %>
-          <label>
-            Reason
-            <input type="text" name="reason" required>
-          </label>
-          <button type="submit">Reverse all lines</button>
-        <% end %>
+        <div data-controller="review-dialog">
+          <button type="button" data-review-dialog-target="trigger" data-action="review-dialog#open">Review whole-receipt reversal</button>
+          <dialog class="review-dialog review-dialog--danger" data-review-dialog-target="dialog" data-action="close->review-dialog#restoreFocus">
+            <div class="review-dialog__body">
+              <h3>Review whole-receipt reversal</h3>
+              <dl class="review-dialog__facts"><dt>Inventory</dt><dd>Reverse all remaining eligible physical quantities atomically.</dd><dt>Valuation</dt><dd>Reverse their exact linked receipt values.</dd><dt>Customer allocations</dt><dd>Active receipt allocations are released/reconciled.</dd><dt>Downstream sales</dt><dd>Any unsafe line, including completed pickup/sale consequences, blocks the entire reversal.</dd></dl>
+              <%= form_with url: ops_receiving_reverse_path(@receipt), method: :post, local: true do %>
+                <label>Reason <input type="text" name="reason" required data-review-dialog-target="initialFocus"></label>
+                <div class="review-dialog__actions"><button type="submit">Reverse entire eligible receipt atomically</button><button type="button" data-action="review-dialog#close">Keep posted receipt</button></div>
+              <% end %>
+            </div>
+          </dialog>
+        </div>
       <% end %>
     <% end %>
 

--- a/docs/ux-conventions.md
+++ b/docs/ux-conventions.md
@@ -84,3 +84,7 @@ Admin screens remain Propshaft CSS + ERB (Phase 2.2). The admin layout loads `ap
 ## Phase 3 and later
 
 Reuse this shell, partials, helpers, and money/status conventions for inventory screens. Add domain-specific presentation (ledger language, denser operational tables) without inventing a second design system. Search/filter/pagination may expand beyond products when a phase explicitly requires it; keep `per_page` fixed in application code unless a later decision changes that contract.
+
+## Consequential Phase 7 actions
+
+Sending purchase orders, cancelling or re-sourcing quantity, cancelling customer requests, and correcting posted receipts use native modal review dialogs rather than browser confirmation prompts. The server-rendered dialog content summarizes the affected records and domain consequences; the submitted form continues to invoke the existing command/service and idempotency boundary. Each review uses a consequence-specific background, receives initial focus, relies on native modal focus containment, supports Escape, restores focus to its visible trigger, and provides an explicit visible cancel button. Final action labels state the exact business effect rather than using generic “Confirm” wording.

--- a/test/system/purchasing_ops_workspace_test.rb
+++ b/test/system/purchasing_ops_workspace_test.rb
@@ -114,6 +114,26 @@ class PurchasingOpsWorkspaceTest < ApplicationSystemTestCase
     assert_nil @purchase_order.purchase_order_lines.first.order.reload.notes
   end
 
+  test "send review dialog describes immutable effects and Escape returns focus without sending" do
+    Purchasing::GeneratePurchaseOrder.call(purchase_order: @purchase_order, actor: @actor)
+
+    visit ops_purchase_order_path(@purchase_order.reload)
+    click_on "Review send"
+
+    assert_selector "dialog[open]", text: "supplier-facing PO and line snapshots become immutable"
+    assert_equal "transmission_method", page.evaluate_script("document.activeElement && document.activeElement.name")
+    send_keys :escape
+    assert_no_selector "dialog[open]"
+    assert_equal "Review send", page.evaluate_script("document.activeElement && document.activeElement.textContent.trim")
+    assert_equal "generated", @purchase_order.reload.status
+
+    click_on "Review send"
+    select "email", from: "Transmission method"
+    click_on "Send PO and freeze snapshots"
+    assert_text "Purchase order sent"
+    assert_equal "sent", @purchase_order.reload.status
+  end
+
   test "receiving scan selects defaults, updates through Turbo, and restores scanner focus" do
     Purchasing::GeneratePurchaseOrder.call(purchase_order: @purchase_order, actor: @actor)
     Purchasing::SendPurchaseOrder.call(purchase_order: @purchase_order.reload, actor: @actor, transmission_method: "email")


### PR DESCRIPTION
### Motivation

- Replace brittle browser confirmations with server-backed, focused review panels for consequential Phase 7 operations so operators clearly understand effects before invoking immutable or multi-record commands.
- Cover the Phase 7 flows that have irreversible or cross-record consequences: sending a purchase order, cancel / re-source PO quantity, cancelling a customer request with unsent related orders, receipt-line and whole-receipt reversal, and cost-only corrections.

### Description

- Add a reusable Stimulus controller `review_dialog_controller.js` that opens native modal `<dialog>` review panels, sets initial focus, restores trigger focus on close, and exposes an `open` value for server-driven re-opening.  
- Introduce dialog styles and distinct backgrounds (`--warning`, `--danger`, `--information`) and structured fact/action layouts in `application.css` for visually distinct review panels.  
- Replace inline form/confirmation flows with server-rendered review dialogs in these views: PO send (`app/views/ops/draft_pos/show.html.erb`), PO line cancel/re-source (`app/views/admin/purchase_orders/show.html.erb`), customer-request cancel (`app/views/admin/customer_requests/show.html.erb`), and receipt-line / whole-receipt reversal and cost-only correction (`app/views/ops/receiving/show.html.erb`), preserving existing form targets and server-side services/commands and idempotency boundaries.  
- Document the convention in `docs/ux-conventions.md` and add a system test exercising the PO send review dialog's content, initial focus, Escape behavior, focus restoration, and successful submission in `test/system/purchasing_ops_workspace_test.rb`.

### Testing

- Ran JavaScript syntax check `node --check app/javascript/controllers/review_dialog_controller.js`, which passed.  
- Ran repository static checks `git diff --check` and Ruby controller syntax checks (where applicable) during development and fixed template issues until syntax checks reported OK.  
- Attempted to run the Rails test subset via the project helper (`./dev/rails-docker bin/rails test ...`) but the execution environment lacks Docker so the command failed with `docker: command not found`, therefore integration and system tests could not be executed here.  
- The new system test was added but not run in this environment due to the Docker limitation mentioned above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8927193868832caf065f0f6abc9dc5)