### PR TITLE
Location ops: add workspace UI, keyboard-driven Stimulus controller, and controller/view rework

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -186,6 +186,64 @@ summary:focus-visible {
   outline-offset: -3px;
 }
 
+.location-workspace {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.location-queue td {
+  vertical-align: top;
+}
+
+.location-queue__secondary {
+  display: block;
+  margin-top: var(--space-1);
+  color: var(--color-text-muted);
+  font-size: 0.875rem;
+}
+
+.location-action-panel {
+  position: sticky;
+  bottom: var(--space-3);
+  box-shadow: 0 -0.5rem 1.5rem rgb(15 23 42 / 12%);
+}
+
+.location-action-panel__header,
+.location-action-panel__choices,
+.location-action-form {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: end;
+  gap: var(--space-3);
+}
+
+.location-action-panel__header {
+  justify-content: space-between;
+}
+
+.location-action-panel__header h2,
+.location-action-panel__header p {
+  margin-block: 0 var(--space-1);
+}
+
+.location-action-panel__choices {
+  margin-block: var(--space-3);
+}
+
+.location-action-form > p,
+.location-action-form > fieldset,
+.location-action-form > .ops-row-error {
+  flex-basis: 100%;
+}
+
+.location-confirmation {
+  flex-basis: 100%;
+}
+
+.ops-empty-state {
+  text-align: center;
+}
+
 form[data-dirty="true"] {
   border-inline-start: 3px solid var(--color-warning);
   padding-inline-start: var(--space-2);

--- a/app/controllers/ops/locations_controller.rb
+++ b/app/controllers/ops/locations_controller.rb
@@ -6,13 +6,11 @@ module Ops
     before_action :set_customer_request, only: %i[confirm not_located]
 
     def show
-      @pending_requests = CustomerRequest.pending_location
-        .for_store(current_store)
-        .includes(:customer, :product_variant)
-        .order(:number)
+      load_location_queue
     end
 
     def confirm
+      require_physical_confirmation! if @customer_request.product_variant.standard?
       unit = resolve_unit_param
       Customers::ConfirmLocation.call(
         customer_request: @customer_request,
@@ -53,6 +51,28 @@ module Ops
 
     private
 
+    def load_location_queue
+      @pending_requests = CustomerRequest.pending_location
+        .for_store(current_store)
+        .includes(:customer, product_variant: { product: :merchandise_category })
+        .order(:created_at, :id)
+      @availability_by_request = @pending_requests.index_with do |customer_request|
+        variant = customer_request.product_variant
+        if variant.standard?
+          Inventory::Availability.available(current_store, variant)
+        else
+          Inventory::Availability.unreserved_on_hand_units(current_store, variant).count
+        end
+      end
+      @units_by_request = @pending_requests.index_with do |customer_request|
+        next [] if customer_request.product_variant.standard?
+
+        Inventory::Availability.unreserved_on_hand_units(current_store, customer_request.product_variant)
+          .order(:unit_identifier).to_a
+      end
+      @suppliers = Supplier.active.admin_ordered.to_a
+    end
+
     def render_mutation_failure(action, exception, field:, stale: false)
       @submitted = params.to_unsafe_h.slice("inventory_unit_id", "unit_identifier", "notes", "supplier_id", "expected_unit_cost_cents")
       @error_action = action
@@ -61,7 +81,7 @@ module Ops
       @conflict = stale
       @mutation_errors = [ stale ? "This request was changed by someone else." : exception.message ]
       @customer_request.reload
-      @pending_requests = CustomerRequest.pending_location.for_store(current_store).includes(:customer, :product_variant).order(:number)
+      load_location_queue
       render :show, status: :unprocessable_entity
     end
 
@@ -81,6 +101,12 @@ module Ops
       end
     rescue Identifiers::NormalizationError, ActiveRecord::RecordNotFound => e
       raise Customers::Error, e.message
+    end
+
+    def require_physical_confirmation!
+      return if ActiveModel::Type::Boolean.new.cast(params[:physical_copy_confirmed])
+
+      raise Customers::Error, "Confirm that you physically located a copy before reserving it."
     end
 
     def optional_cents(value)

--- a/app/javascript/controllers/location_queue_controller.js
+++ b/app/javascript/controllers/location_queue_controller.js
@@ -1,0 +1,134 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "row", "panel", "initialFocus", "locateSection", "notLocatedSection", "specialOrderFields", "convertField" ]
+  static values = { selectedId: String }
+
+  connect() {
+    this.selectedIndex = Math.max(0, this.rowTargets.findIndex((row) => row.dataset.requestId === this.selectedIdValue))
+    this.select(this.selectedIndex, { focus: false })
+    this.restoreFailureState()
+  }
+
+  keydown(event) {
+    if (event.defaultPrevented || event.altKey || event.ctrlKey || event.metaKey) return
+
+    if (event.key === "Escape" && this.activePanel) {
+      event.preventDefault()
+      this.closePanel()
+      return
+    }
+    if (event.target.closest("[data-location-queue-target='panel']")) return
+    if (this.editable(event.target) || ![ "ArrowUp", "ArrowDown", "Enter" ].includes(event.key)) return
+    event.preventDefault()
+    if (event.key === "Enter") return this.openSelectedPanel()
+
+    const step = event.key === "ArrowDown" ? 1 : -1
+    this.select((this.selectedIndex + step + this.rowTargets.length) % this.rowTargets.length)
+  }
+
+  selectRow(event) {
+    if (event.target.closest("button, a, input, select")) return
+    this.select(this.rowTargets.indexOf(event.currentTarget))
+  }
+
+  openPanel(event) {
+    const row = event.currentTarget.closest("tr")
+    this.select(this.rowTargets.indexOf(row), { focus: false })
+    this.openSelectedPanel()
+  }
+
+  openSelectedPanel() {
+    const panel = this.panelForSelection
+    if (!panel) return
+    this.panelTargets.forEach((item) => { item.hidden = item !== panel })
+    this.activePanel = panel
+    this.showLocate()
+    this.focusLocate(panel)
+  }
+
+  closePanel() {
+    if (!this.activePanel) return
+    this.activePanel.hidden = true
+    this.activePanel = null
+    this.rowTargets[this.selectedIndex]?.focus()
+  }
+
+  showLocate() {
+    const panel = this.panelForSelection
+    this.sectionIn(panel, "locate")?.removeAttribute("hidden")
+    this.sectionIn(panel, "not-located")?.setAttribute("hidden", "")
+    this.focusLocate(panel)
+  }
+
+  showNotLocated() {
+    const panel = this.panelForSelection
+    this.sectionIn(panel, "locate")?.setAttribute("hidden", "")
+    const section = this.sectionIn(panel, "not-located")
+    section?.removeAttribute("hidden")
+    section?.querySelector("input[name='notes']")?.focus()
+  }
+
+  toggleResolution(event) {
+    const panel = event.currentTarget.closest("[data-location-queue-target='panel']")
+    const special = event.currentTarget.value === "special_order"
+    const fields = panel.querySelector("[data-location-queue-target='specialOrderFields']")
+    const convert = panel.querySelector("[data-location-queue-target='convertField']")
+    const submit = panel.querySelector("[data-location-resolution-submit]")
+    fields.hidden = !special
+    convert.value = special ? "1" : "0"
+    submit.textContent = special ? "Convert to special order" : "Cancel request"
+    if (special) fields.querySelector("select, input")?.focus()
+  }
+
+  select(index, { focus = true } = {}) {
+    if (index < 0) return
+    this.selectedIndex = index
+    this.rowTargets.forEach((row, rowIndex) => {
+      const selected = rowIndex === index
+      row.classList.toggle("is-selected", selected)
+      row.setAttribute("aria-selected", selected.toString())
+      row.tabIndex = selected ? 0 : -1
+    })
+    if (focus) this.rowTargets[index].focus()
+  }
+
+  restoreFailureState() {
+    const summary = this.element.previousElementSibling
+    if (!summary?.matches("[data-ops-error-summary]")) return
+    this.openSelectedPanel()
+    const error = this.panelForSelection?.querySelector(".ops-row-error")
+    if (!error) return
+    if (error.id.includes("confirm")) this.showLocate()
+    else {
+      this.showNotLocated()
+      if (error.id.includes("special")) {
+        const special = this.panelForSelection.querySelector("input[name='resolution'][value='special_order']")
+        if (special) {
+          special.checked = true
+          this.toggleResolution({ currentTarget: special })
+        }
+      }
+    }
+    const described = this.panelForSelection.querySelector(`[aria-describedby='${error.id}']`)
+    ;(described || error.closest("form")?.querySelector("input:not([type='hidden']), select, button"))?.focus()
+  }
+
+  focusLocate(panel) {
+    const scan = panel?.querySelector("[data-location-scan]")
+    ;(scan || panel?.querySelector("[data-location-submit]"))?.focus()
+  }
+
+  sectionIn(panel, name) {
+    return panel?.querySelector(`[data-location-queue-target='${name === "locate" ? "locateSection" : "notLocatedSection"}']`)
+  }
+
+  get panelForSelection() {
+    const id = this.rowTargets[this.selectedIndex]?.dataset.requestId
+    return this.panelTargets.find((panel) => panel.dataset.requestId === id)
+  }
+
+  editable(target) {
+    return target.matches("input, textarea, select, [contenteditable='true']")
+  }
+}

--- a/app/views/ops/locations/show.html.erb
+++ b/app/views/ops/locations/show.html.erb
@@ -1,95 +1,166 @@
 <% content_for :title, "Location queue" %>
-<h1>Location queue</h1>
-<p>Pending in-store customer requests for <%= current_store.admin_label %>. Confirm location to reserve, or mark not located.</p>
+<header class="ops-doc-header">
+  <div>
+    <h1>Location queue</h1>
+    <p>Oldest requests appear first for <%= current_store.admin_label %>. Select a request, then record what you found.</p>
+  </div>
+  <p><%= link_to "Exit to Purchasing", admin_orders_path %></p>
+</header>
+
 <%= render "ops/shared/error_summary", errors: @mutation_errors, conflict: @conflict, title: "Location action could not be completed" %>
 
 <% if @pending_requests.empty? %>
-  <p>No pending location requests.</p>
+  <section class="surface ops-empty-state">
+    <h2>Location work is caught up</h2>
+    <p>There are no customer requests waiting for a physical search at this store.</p>
+    <p><%= link_to "View customer requests", admin_customer_requests_path, class: "btn" %></p>
+  </section>
 <% else %>
-  <table class="ops-queue" data-controller="<%= @mutation_errors.present? ? 'row-selection' : 'focus-restore row-selection' %>" data-action="keydown->row-selection#keydown">
-    <thead>
-      <tr>
-        <th scope="col">#</th>
-        <th scope="col">Customer</th>
-        <th scope="col">Merchandise</th>
-        <th scope="col">Type</th>
-        <th scope="col">Actions</th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @pending_requests.each do |request| %>
-        <% variant = request.product_variant %>
-        <tr tabindex="-1" aria-selected="<%= (@selected_row_id.to_s == request.id.to_s).to_s %>" class="<%= "is-selected" if @selected_row_id.to_s == request.id.to_s %>" data-row-selection-target="row">
-          <td><%= request.number %></td>
-          <td><%= request.customer.display_name %></td>
-          <td>
-            <%= variant.product.name %>
-            <code><%= variant.sku %></code>
-          </td>
-          <td><%= variant.variant_type.capitalize %></td>
-          <td>
-            <%= form_with url: ops_location_confirm_path(request), method: :post, local: true, html: { class: "ops-inline-form" } do %>
-              <%= hidden_field_tag :lock_version, request.lock_version %>
-              <% if variant.used? %>
-                <% units = Inventory::Availability.unreserved_on_hand_units(current_store, variant).order(:unit_identifier) %>
-                <label>
-                  Unit
-                  <select name="inventory_unit_id" required <%= "autofocus aria-describedby=location_confirm_#{request.id}_error" if @selected_row_id.to_s == request.id.to_s && @error_action == :confirm %>>
-                    <option value="">Select unit…</option>
-                    <% units.each do |unit| %>
-                      <option value="<%= unit.id %>" <%= "selected" if @selected_row_id.to_s == request.id.to_s && @submitted&.fetch("inventory_unit_id", nil) == unit.id %>><%= unit.unit_identifier %></option>
-                    <% end %>
-                  </select>
-                </label>
-                <label>
-                  or scan
-                  <input type="text" name="unit_identifier" value="<%= @selected_row_id.to_s == request.id.to_s ? @submitted&.fetch("unit_identifier", nil) : nil %>" autocomplete="off" inputmode="numeric"<%= " data-focus-restore-target=lookup" if request == @pending_requests.first %>>
-                </label>
-              <% end %>
-              <button type="submit" data-row-primary<%= " data-focus-restore-target=lookup" if request == @pending_requests.first && variant.standard? %>>Located</button>
-              <%= render "ops/shared/inline_row_error", action: :confirm, row_id: request.id, id: "location_confirm_#{request.id}_error" %>
+  <div class="location-workspace"
+       data-controller="location-queue"
+       data-location-queue-selected-id-value="<%= @selected_row_id.presence || @pending_requests.first.id %>"
+       data-action="keydown@window->location-queue#keydown">
+    <section aria-labelledby="location-queue-heading">
+      <h2 id="location-queue-heading" class="visually-hidden">Requests awaiting location</h2>
+      <div class="table-scroll">
+        <table class="ops-queue location-queue">
+          <thead>
+            <tr>
+              <th scope="col">Request</th>
+              <th scope="col">Customer</th>
+              <th scope="col">Merchandise</th>
+              <th scope="col">Shelving</th>
+              <th scope="col">Available</th>
+              <th scope="col"><span class="visually-hidden">Select</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @pending_requests.each do |request| %>
+              <% variant = request.product_variant %>
+              <% product = variant.product %>
+              <% selected = (@selected_row_id.presence || @pending_requests.first.id).to_s == request.id.to_s %>
+              <tr tabindex="<%= selected ? 0 : -1 %>"
+                  aria-selected="<%= selected %>"
+                  class="<%= "is-selected" if selected %>"
+                  data-location-queue-target="row"
+                  data-request-id="<%= request.id %>"
+                  data-action="click->location-queue#selectRow">
+                <td>
+                  <strong>#<%= request.number %></strong>
+                  <span class="location-queue__secondary"><%= time_ago_in_words(request.created_at) %> ago</span>
+                </td>
+                <td>
+                  <strong><%= request.customer.display_name %></strong>
+                  <span class="location-queue__secondary"><%= request.customer.phone.presence || request.customer.email.presence || "No contact on file" %></span>
+                </td>
+                <td>
+                  <strong><%= product.name %></strong>
+                  <span class="location-queue__secondary">
+                    <span class="status-badge status-badge--<%= variant.used? ? "warning" : "active" %>"><%= variant.variant_type.capitalize %></span>
+                    SKU <%= variant.sku %> · <%= variant.industry_identifier.presence || product.industry_identifier.presence || product.primary_identifier %>
+                  </span>
+                </td>
+                <td><%= product.merchandise_category&.path_label.presence || "Not categorized" %></td>
+                <td><strong><%= @availability_by_request.fetch(request.id) %></strong></td>
+                <td><button type="button" class="btn btn--ghost" data-action="location-queue#openPanel">Select</button></td>
+              </tr>
             <% end %>
-            <%= form_with url: ops_location_not_located_path(request), method: :post, local: true, html: { class: "ops-inline-form" } do %>
-              <%= hidden_field_tag :lock_version, request.lock_version %>
-              <label>
-                Notes
-                <input type="text" name="notes" value="<%= @selected_row_id.to_s == request.id.to_s && @error_action == :not_located ? @submitted&.fetch("notes", nil) : nil %>" autocomplete="off" <%= "autofocus aria-describedby=location_cancel_#{request.id}_error" if @selected_row_id.to_s == request.id.to_s && @error_action == :not_located %>>
-              </label>
-              <button type="submit">Not located — cancel</button>
-              <%= render "ops/shared/inline_row_error", action: :not_located, row_id: request.id, id: "location_cancel_#{request.id}_error" %>
-            <% end %>
+          </tbody>
+        </table>
+      </div>
+      <p class="ops-hint">Use ↑/↓ to move, Enter to open the selected request, or choose Select. Escape closes the action panel without changing the request.</p>
+    </section>
+
+    <% @pending_requests.each do |request| %>
+      <% variant = request.product_variant %>
+      <% selected = (@selected_row_id.presence || @pending_requests.first.id).to_s == request.id.to_s %>
+      <section class="location-action-panel surface"
+               aria-labelledby="location-panel-title-<%= request.id %>"
+               <%= "hidden" unless selected %>
+               data-location-queue-target="panel"
+               data-request-id="<%= request.id %>">
+        <header class="location-action-panel__header">
+          <div>
+            <p class="eyebrow">Request #<%= request.number %></p>
+            <h2 id="location-panel-title-<%= request.id %>"><%= variant.product.name %></h2>
+            <p><%= request.customer.display_name %> · apparent availability <strong><%= @availability_by_request.fetch(request.id) %></strong></p>
+          </div>
+          <button type="button" class="btn btn--ghost" data-action="location-queue#closePanel">Close <kbd>Esc</kbd></button>
+        </header>
+
+        <div class="location-action-panel__choices" role="group" aria-label="Location outcome">
+          <button type="button" class="btn" data-location-queue-target="initialFocus" data-action="location-queue#showLocate">Located</button>
+          <button type="button" class="btn btn--ghost" data-action="location-queue#showNotLocated">Not located</button>
+        </div>
+
+        <div data-location-queue-target="locateSection">
+          <%= form_with url: ops_location_confirm_path(request), method: :post, local: true, html: { class: "location-action-form" } do %>
+            <%= hidden_field_tag :lock_version, request.lock_version %>
             <% if variant.standard? %>
-              <%= form_with url: ops_location_not_located_path(request), method: :post, local: true, html: { class: "ops-inline-form" } do %>
-                <%= hidden_field_tag :lock_version, request.lock_version %>
-                <%= hidden_field_tag :convert_to_special_order, "1" %>
-                <label>
-                  Notes
-                  <input type="text" name="notes" value="<%= @selected_row_id.to_s == request.id.to_s && @error_action == :special_order ? @submitted&.fetch("notes", nil) : nil %>" autocomplete="off">
-                </label>
+              <p><strong>Physical confirmation required.</strong> Confirm that you have this copy in hand before reserving it for the customer.</p>
+              <label class="location-confirmation">
+                <input type="checkbox" name="physical_copy_confirmed" value="1" required<%= " aria-describedby=location_confirm_#{request.id}_error" if selected && @error_action == :confirm %>>
+                I physically located one copy of this title.
+              </label>
+            <% else %>
+              <p>Scan the exact Used inventory unit. Selection is available as a fallback.</p>
+              <label>
+                Unit scan
+                <input type="text" name="unit_identifier" value="<%= selected ? @submitted&.fetch("unit_identifier", nil) : nil %>" autocomplete="off" inputmode="numeric" data-location-scan>
+              </label>
+              <label>
+                Select unit instead
+                <select name="inventory_unit_id">
+                  <option value="">Select unit…</option>
+                  <% @units_by_request.fetch(request.id).each do |unit| %>
+                    <option value="<%= unit.id %>" <%= "selected" if selected && @submitted&.fetch("inventory_unit_id", nil) == unit.id %>><%= unit.unit_identifier %></option>
+                  <% end %>
+                </select>
+              </label>
+            <% end %>
+            <button type="submit" class="btn" data-location-submit>Reserve for <%= request.customer.display_name %></button>
+            <%= render "ops/shared/inline_row_error", action: :confirm, row_id: request.id, id: "location_confirm_#{request.id}_error" %>
+          <% end %>
+        </div>
+
+        <div hidden data-location-queue-target="notLocatedSection">
+          <%= form_with url: ops_location_not_located_path(request), method: :post, local: true, html: { class: "location-action-form" } do %>
+            <%= hidden_field_tag :lock_version, request.lock_version %>
+            <label>
+              Notes (optional)
+              <input type="text" name="notes" value="<%= selected ? @submitted&.fetch("notes", nil) : nil %>" autocomplete="off">
+            </label>
+            <% if variant.standard? %>
+              <fieldset>
+                <legend>Resolution</legend>
+                <label><input type="radio" name="resolution" value="cancel" checked data-action="location-queue#toggleResolution"> Cancel request</label>
+                <label><input type="radio" name="resolution" value="special_order" data-action="location-queue#toggleResolution"> Convert to special order</label>
+              </fieldset>
+              <div hidden data-location-queue-target="specialOrderFields">
+                <input type="hidden" name="convert_to_special_order" value="0" data-location-queue-target="convertField">
                 <label>
                   Supplier (optional if preferred)
                   <select name="supplier_id">
                     <option value="">Preferred source…</option>
-                    <% submitted_supplier = @selected_row_id.to_s == request.id.to_s ? @submitted&.fetch("supplier_id", nil) : nil %>
-                    <% if submitted_supplier.present? && Supplier.active.none? { |supplier| supplier.id == submitted_supplier } %>
-                      <option value="<%= submitted_supplier %>" selected>Unavailable submitted supplier (<%= submitted_supplier %>)</option>
-                    <% end %>
-                    <% Supplier.active.admin_ordered.each do |supplier| %>
-                      <option value="<%= supplier.id %>" <%= "selected" if @selected_row_id.to_s == request.id.to_s && @submitted&.fetch("supplier_id", nil) == supplier.id %>><%= supplier.admin_label %></option>
+                    <% @suppliers.each do |supplier| %>
+                      <option value="<%= supplier.id %>" <%= "selected" if selected && @submitted&.fetch("supplier_id", nil) == supplier.id %>><%= supplier.admin_label %></option>
                     <% end %>
                   </select>
                 </label>
                 <label>
                   Expected cost (cents)
-                  <input type="number" name="expected_unit_cost_cents" value="<%= @selected_row_id.to_s == request.id.to_s ? @submitted&.fetch("expected_unit_cost_cents", nil) : nil %>" min="0" <%= "autofocus aria-describedby=location_special_#{request.id}_error" if @selected_row_id.to_s == request.id.to_s && @error_action == :special_order %>>
+                  <input type="number" name="expected_unit_cost_cents" value="<%= selected ? @submitted&.fetch("expected_unit_cost_cents", nil) : nil %>" min="0">
                 </label>
-                <button type="submit">Not located — special order</button>
-                <%= render "ops/shared/inline_row_error", action: :special_order, row_id: request.id, id: "location_special_#{request.id}_error" %>
-              <% end %>
+              </div>
+            <% else %>
+              <p>This Used request cannot become a supplier order. Not located will cancel it.</p>
             <% end %>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
+            <button type="submit" class="btn btn--danger" data-location-resolution-submit><%= variant.standard? ? "Cancel request" : "Cancel Used request" %></button>
+            <%= render "ops/shared/inline_row_error", action: :not_located, row_id: request.id, id: "location_cancel_#{request.id}_error" %>
+            <%= render "ops/shared/inline_row_error", action: :special_order, row_id: request.id, id: "location_special_#{request.id}_error" %>
+          <% end %>
+        </div>
+      </section>
+    <% end %>
+  </div>
 <% end %>

--- a/test/integration/location_ops_workspace_test.rb
+++ b/test/integration/location_ops_workspace_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class LocationOpsWorkspaceTest < ActionDispatch::IntegrationTest
+  setup do
+    bootstrap = bootstrap!
+    @store = bootstrap[:store]
+    @actor = bootstrap[:administrator]
+    tax = tax_class(code: "location_ops_#{SecureRandom.hex(3)}")
+    @variant = pos_sellable_variant(actor: @actor, tax_class: tax, name: "Find This Book")
+    open_quantity_stock(store: @store, variant: @variant, actor: @actor, quantity: 1, unit_cost_cents: 500)
+    @older_customer = Customer.create!(display_name: "Older Reader", phone: "555-0100")
+    @newer_customer = Customer.create!(display_name: "Newer Reader", email: "newer@example.com")
+    @older_request = create_request(@older_customer)
+    @newer_request = create_request(@newer_customer)
+    @older_request.update_columns(created_at: 2.days.ago)
+    @newer_request.update_columns(created_at: 1.hour.ago)
+    post session_path, params: { session: { username: @actor.username, password: "correct-horse-battery" } }
+  end
+
+  test "queue is oldest first and presents concise search context with focused actions" do
+    get ops_location_path
+
+    assert_response :success
+    rows = css_select(".location-queue tbody tr")
+    assert_equal [ @older_request.id, @newer_request.id ], rows.map { |row| row["data-request-id"] }
+    assert_select rows.first, text: /Older Reader/
+    assert_select rows.first, text: /555-0100/
+    assert_select rows.first, text: /Find This Book/
+    assert_select rows.first, text: /Standard/
+    assert_select rows.first, text: /SKU/
+    assert_select rows.first, text: /Not categorized/
+    assert_select rows.first, text: /1/
+    assert_select ".location-action-panel:not([hidden])", count: 1 do
+      assert_select "input[name='physical_copy_confirmed'][required]"
+      assert_select "button", text: /Reserve for Older Reader/
+      assert_select "input[name='resolution'][value='special_order']"
+      assert_select "[data-location-queue-target='specialOrderFields'][hidden]"
+    end
+  end
+
+  test "standard locate requires server-side physical confirmation" do
+    post ops_location_confirm_path(@older_request), params: { lock_version: @older_request.lock_version }
+
+    assert_response :unprocessable_entity
+    assert_select "[data-ops-error-summary]", text: /physically located/i
+    assert_equal "pending_location", @older_request.reload.status
+
+    post ops_location_confirm_path(@older_request), params: {
+      lock_version: @older_request.lock_version,
+      physical_copy_confirmed: "1"
+    }
+    assert_redirected_to ops_location_path
+    assert_equal "available", @older_request.reload.status
+  end
+
+  test "competing locate failure stays inline on the selected request" do
+    Customers::ConfirmLocation.call(customer_request: @older_request, actor: @actor)
+
+    post ops_location_confirm_path(@newer_request), params: {
+      lock_version: @newer_request.lock_version,
+      physical_copy_confirmed: "1"
+    }
+
+    assert_response :unprocessable_entity
+    assert_select "[data-ops-error-summary]", text: /no available/i
+    assert_select ".location-action-panel:not([hidden])[data-request-id='#{@newer_request.id}'] .ops-row-error",
+                  text: /no available/i
+    assert_equal "pending_location", @newer_request.reload.status
+  end
+
+  private
+
+  def create_request(customer)
+    Customers::CreateRequest.call(
+      store: @store,
+      customer: customer,
+      product_variant: @variant,
+      actor: @actor
+    )
+  end
+end

--- a/test/integration/purchasing_ops_mutation_failures_test.rb
+++ b/test/integration/purchasing_ops_mutation_failures_test.rb
@@ -85,8 +85,10 @@ class PurchasingOpsMutationFailuresTest < ActionDispatch::IntegrationTest
 
     assert_response :unprocessable_entity
     assert_select "tr.is-selected[aria-selected='true']"
-    assert_select "tr.is-selected input[name='notes'][value='retain location note']"
-    assert_select "tr.is-selected input[name='expected_unit_cost_cents'][value='00123'][autofocus]"
-    assert_select "tr.is-selected .ops-row-error"
+    assert_select ".location-action-panel:not([hidden])[data-request-id='#{customer_request.id}']" do
+      assert_select "input[name='notes'][value='retain location note']"
+      assert_select "input[name='expected_unit_cost_cents'][value='00123']"
+      assert_select ".ops-row-error"
+    end
   end
 end


### PR DESCRIPTION
### Motivation

- Improve the in-store "location queue" workflow by providing a focused workspace that surfaces the oldest requests first and lets staff record outcomes without leaving the page. 
- Make keyboard navigation and inline error recovery smooth so operators can move through requests quickly and restore form state after server-side validation failures.

### Description

- Reworked the location queue view by replacing the old inline table with a grid-based workspace and per-request sticky action panels in `app/views/ops/locations/show.html.erb`, and added new layout styles in `app/assets/stylesheets/application.css` for the workspace and panels. 
- Added a Stimulus controller `app/javascript/controllers/location_queue_controller.js` that implements keyboard navigation (↑/↓/Enter/Escape), panel open/close behavior, section toggles for "Located" vs "Not located", and client-side restoration of failed mutation state. 
- Refactored `Ops::LocationsController` by extracting `load_location_queue`, computing `@availability_by_request`, `@units_by_request`, and loading `@suppliers`, enforcing server-side confirmation for standard variants with `require_physical_confirmation!`, and reusing `load_location_queue` in `render_mutation_failure`. 
- Updated view forms to support the new workspace: unit scanning and selection, physical copy confirmation checkbox for standard variants, resolution choices for not-located requests, and consolidated inline error rendering. 
- Added `test/integration/location_ops_workspace_test.rb` to cover ordering, UI elements, and server-side confirmation behavior, and adjusted `test/integration/purchasing_ops_mutation_failures_test.rb` assertions to match the new DOM structure.

### Testing

- Ran the updated integration tests for the location workspace with `bin/rails test test/integration/location_ops_workspace_test.rb`, and they passed. 
- Re-ran the affected mutation failure integration test with `bin/rails test test/integration/purchasing_ops_mutation_failures_test.rb`, and the updated assertions passed. 
- The touched integration tests were executed successfully against the change set covering UI behavior, server-side validation, and error retention.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a890b5aa9e0832cb7b6059cb93b27cb)