### PR TITLE
Phase 7.1 — Purchasing workflow and presentation closeout

### DIFF
--- a/app/controllers/admin/purchasing_controller.rb
+++ b/app/controllers/admin/purchasing_controller.rb
@@ -15,7 +15,7 @@ module Admin
     private
 
     def require_hub_access!
-      return if Purchasing::HubAccess.hub_allowed?(user: current_user, accessible_stores: accessible_stores)
+      return if purchasing_hub_accessible?
 
       Audit::Recorder.record!(
         action: "authorization.denied",

--- a/app/controllers/admin/purchasing_controller.rb
+++ b/app/controllers/admin/purchasing_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Admin
+  class PurchasingController < BaseController
+    before_action :require_hub_access!
+
+    def show
+      @summary = Purchasing::WorkHubSummary.new(
+        user: current_user,
+        store: current_store,
+        accessible_stores: accessible_stores
+      )
+    end
+
+    private
+
+    def require_hub_access!
+      return if Purchasing::HubAccess.hub_allowed?(user: current_user, accessible_stores: accessible_stores)
+
+      Audit::Recorder.record!(
+        action: "authorization.denied",
+        outcome: "denied",
+        actor_user: current_user,
+        actor_label: current_user.display_name,
+        store: current_store,
+        reason_code: "purchasing.hub",
+        metadata: { path: request.fullpath }
+      )
+      redirect_to root_path, alert: "You are not authorized to perform that action."
+    end
+  end
+end

--- a/app/controllers/concerns/authorizes_requests.rb
+++ b/app/controllers/concerns/authorizes_requests.rb
@@ -4,7 +4,7 @@ module AuthorizesRequests
   extend ActiveSupport::Concern
 
   included do
-    helper_method :current_store, :effective_permissions, :accessible_stores
+    helper_method :current_store, :effective_permissions, :accessible_stores, :purchasing_hub_accessible?
   end
 
   private
@@ -27,6 +27,17 @@ module AuthorizesRequests
     @effective_permissions ||= Authorization::PermissionEvaluator.permissions_for(
       user: current_user,
       store: current_store
+    )
+  end
+
+  # Memoized for the request so layout nav and hub controller share one evaluation.
+  def purchasing_hub_accessible?
+    return false unless current_user
+    return @purchasing_hub_accessible if defined?(@purchasing_hub_accessible)
+
+    @purchasing_hub_accessible = Purchasing::HubAccess.nav_visible?(
+      user: current_user,
+      accessible_stores: accessible_stores
     )
   end
 

--- a/app/helpers/purchasing_helper.rb
+++ b/app/helpers/purchasing_helper.rb
@@ -26,9 +26,7 @@ module PurchasingHelper
   end
 
   def purchasing_hub_nav_visible?
-    return false unless current_user
-
-    Purchasing::HubAccess.nav_visible?(user: current_user, accessible_stores: accessible_stores)
+    purchasing_hub_accessible?
   end
 
   def purchasing_link_to(label, url, **options)
@@ -87,53 +85,40 @@ module PurchasingHelper
 
   private
 
-  def purchasing_can_view_order?(order)
-    Authorization::PermissionEvaluator.allowed?(
+  def purchasing_permission_keys_for(store)
+    @purchasing_permission_keys_by_store_id ||= {}
+    cache_key = store&.id || :global
+    @purchasing_permission_keys_by_store_id[cache_key] ||= Authorization::PermissionEvaluator.permissions_for(
       user: current_user,
-      permission_key: "orders.view",
-      store: order.store
+      store: store
     )
+  end
+
+  def purchasing_can_view_order?(order)
+    purchasing_permission_keys_for(order.store).include?("orders.view")
   end
 
   def purchasing_can_view_purchase_order?(purchase_order)
-    Authorization::PermissionEvaluator.allowed?(
-      user: current_user,
-      permission_key: "orders.view",
-      store: purchase_order.store
-    )
+    purchasing_permission_keys_for(purchase_order.store).include?("orders.view")
   end
 
   def purchasing_can_view_purchase_receipt?(receipt)
-    Authorization::PermissionEvaluator.allowed?(
-      user: current_user,
-      permission_key: "purchase_receipts.view",
-      store: receipt.store
-    )
+    purchasing_permission_keys_for(receipt.store).include?("purchase_receipts.view")
   end
 
   def purchasing_can_view_customer_request?(request)
-    Authorization::PermissionEvaluator.allowed?(
-      user: current_user,
-      permission_key: "customers.view",
-      store: request.store
-    )
+    purchasing_permission_keys_for(request.store).include?("customers.view")
   end
 
   def purchasing_can_manage_draft_po?(purchase_order)
     return false unless purchase_order.draft?
 
-    Authorization::PermissionEvaluator.allowed?(
-      user: current_user,
-      permission_key: "orders.manage",
-      store: purchase_order.store
-    ) && current_store&.id == purchase_order.store_id
+    purchasing_permission_keys_for(purchase_order.store).include?("orders.manage") &&
+      current_store&.id == purchase_order.store_id
   end
 
   def purchasing_can_access_receiving?(receipt)
-    Authorization::PermissionEvaluator.allowed?(
-      user: current_user,
-      permission_key: "purchase_receipts.view",
-      store: receipt.store
-    ) && current_store&.id == receipt.store_id
+    purchasing_permission_keys_for(receipt.store).include?("purchase_receipts.view") &&
+      current_store&.id == receipt.store_id
   end
 end

--- a/app/helpers/purchasing_helper.rb
+++ b/app/helpers/purchasing_helper.rb
@@ -1,27 +1,115 @@
 # frozen_string_literal: true
 
 module PurchasingHelper
-  def stock_orderable_variant?(variant)
-    variant.present? &&
-      variant.standard? &&
-      variant.status == "active" &&
-      variant.inventory_mode == "inventory"
+  def purchasing_hub_nav_visible?
+    return false unless current_user
+
+    Purchasing::HubAccess.nav_visible?(user: current_user, accessible_stores: accessible_stores)
   end
 
-  def customer_requestable_variant?(variant, store:)
-    return false if variant.blank? || variant.status != "active" || store.blank?
-    return true if variant.standard?
+  def purchasing_link_to(label, url, **options)
+    return if url.blank?
 
-    return false unless variant.used?
-
-    Inventory::Availability.unreserved_on_hand_units(store, variant).exists?
+    link_to(label, url, **options)
   end
 
-  def order_stock_path_for(variant)
-    new_admin_order_path(product_variant_id: variant.id)
+  def admin_order_link(order, label: nil)
+    return unless order
+    return unless purchasing_can_view_order?(order)
+
+    label ||= order.admin_label
+    link_to(label, admin_order_path(order))
   end
 
-  def create_customer_request_path_for(variant)
-    new_admin_customer_request_path(product_variant_id: variant.id)
+  def admin_purchase_order_link(purchase_order, label: nil)
+    return unless purchase_order
+    return unless purchasing_can_view_purchase_order?(purchase_order)
+
+    label ||= purchase_order.admin_label
+    link_to(label, admin_purchase_order_path(purchase_order))
+  end
+
+  def admin_purchase_receipt_link(receipt, label: nil)
+    return unless receipt
+    return unless purchasing_can_view_purchase_receipt?(receipt)
+
+    label ||= receipt.admin_label
+    link_to(label, admin_purchase_receipt_path(receipt))
+  end
+
+  def admin_customer_request_link(request, label: nil)
+    return unless request
+    return unless purchasing_can_view_customer_request?(request)
+
+    label ||= request.admin_label
+    link_to(label, admin_customer_request_path(request))
+  end
+
+  def ops_draft_purchase_order_link(purchase_order, label: nil)
+    return unless purchase_order
+    return unless purchasing_can_manage_draft_po?(purchase_order)
+
+    label ||= "Open draft workspace"
+    link_to(label, ops_purchase_order_path(purchase_order))
+  end
+
+  def ops_receiving_link(receipt, label: nil)
+    return unless receipt
+    return unless purchasing_can_access_receiving?(receipt)
+
+    label ||= "Ops receiving view"
+    link_to(label, ops_receiving_path(receipt))
+  end
+
+  private
+
+  def purchasing_can_view_order?(order)
+    Authorization::PermissionEvaluator.allowed?(
+      user: current_user,
+      permission_key: "orders.view",
+      store: order.store
+    )
+  end
+
+  def purchasing_can_view_purchase_order?(purchase_order)
+    Authorization::PermissionEvaluator.allowed?(
+      user: current_user,
+      permission_key: "orders.view",
+      store: purchase_order.store
+    )
+  end
+
+  def purchasing_can_view_purchase_receipt?(receipt)
+    Authorization::PermissionEvaluator.allowed?(
+      user: current_user,
+      permission_key: "purchase_receipts.view",
+      store: receipt.store
+    )
+  end
+
+  def purchasing_can_view_customer_request?(request)
+    Authorization::PermissionEvaluator.allowed?(
+      user: current_user,
+      permission_key: "customers.view",
+      store: request.store
+    )
+  end
+
+  def purchasing_can_manage_draft_po?(purchase_order)
+    return false unless purchase_order.draft?
+
+    Authorization::PermissionEvaluator.allowed?(
+      user: current_user,
+      permission_key: "orders.manage",
+      store: purchase_order.store
+    ) && current_store&.id == purchase_order.store_id
+  end
+
+  def purchasing_can_access_receiving?(receipt)
+    Authorization::PermissionEvaluator.allowed?(
+      user: current_user,
+      permission_key: "purchase_receipts.view",
+      store: receipt.store
+    ) && current_store&.id == receipt.store_id
   end
 end

--- a/app/helpers/purchasing_helper.rb
+++ b/app/helpers/purchasing_helper.rb
@@ -1,6 +1,30 @@
 # frozen_string_literal: true
 
 module PurchasingHelper
+  def stock_orderable_variant?(variant)
+    variant.present? &&
+      variant.standard? &&
+      variant.status == "active" &&
+      variant.inventory_mode == "inventory"
+  end
+
+  def customer_requestable_variant?(variant, store:)
+    return false if variant.blank? || variant.status != "active" || store.blank?
+    return true if variant.standard?
+
+    return false unless variant.used?
+
+    Inventory::Availability.unreserved_on_hand_units(store, variant).exists?
+  end
+
+  def order_stock_path_for(variant)
+    new_admin_order_path(product_variant_id: variant.id)
+  end
+
+  def create_customer_request_path_for(variant)
+    new_admin_customer_request_path(product_variant_id: variant.id)
+  end
+
   def purchasing_hub_nav_visible?
     return false unless current_user
 

--- a/app/models/purchase_order.rb
+++ b/app/models/purchase_order.rb
@@ -22,6 +22,9 @@ class PurchaseOrder < ApplicationRecord
   scope :for_store, ->(store) { where(store_id: store.id) }
   scope :with_status, ->(status) { where(status: status) }
   scope :admin_ordered, -> { order(Arel.sql("number DESC NULLS LAST"), :created_at) }
+  scope :with_open_lines, -> {
+    where(id: PurchaseOrderLine.with_positive_open_quantity.select(:purchase_order_id))
+  }
 
   def draft?
     status == "draft"

--- a/app/models/purchase_order_line.rb
+++ b/app/models/purchase_order_line.rb
@@ -15,6 +15,35 @@ class PurchaseOrderLine < ApplicationRecord
   validate :variant_must_match_order
   validate :variant_must_be_standard_inventory_bearing
 
+  scope :with_positive_open_quantity, -> {
+    where(<<~SQL.squish)
+      purchase_order_lines.ordered_quantity
+      - COALESCE((
+          SELECT SUM(polc.quantity)
+          FROM purchase_order_line_cancellations polc
+          WHERE polc.purchase_order_line_id = purchase_order_lines.id
+        ), 0)
+      > COALESCE((
+          SELECT SUM(
+            purchase_receipt_lines.matched_quantity
+            - LEAST(
+                purchase_receipt_lines.matched_quantity,
+                COALESCE((
+                  SELECT SUM(prlc.quantity)
+                  FROM purchase_receipt_line_corrections prlc
+                  WHERE prlc.purchase_receipt_line_id = purchase_receipt_lines.id
+                    AND prlc.correction_type IN ('quantity_reversal', 'compensating_adjustment_reference')
+                ), 0)
+              )
+          )
+          FROM purchase_receipt_lines
+          INNER JOIN purchase_receipts ON purchase_receipts.id = purchase_receipt_lines.purchase_receipt_id
+          WHERE purchase_receipt_lines.purchase_order_line_id = purchase_order_lines.id
+            AND purchase_receipts.status = 'posted'
+        ), 0)
+    SQL
+  }
+
   def expected_extended_cents
     ordered_quantity * expected_unit_cost_cents_snapshot
   end

--- a/app/services/purchasing/hub_access.rb
+++ b/app/services/purchasing/hub_access.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Purchasing
+  module HubAccess
+    HUB_PERMISSIONS = %w[
+      customer_requests.locate
+      orders.view
+      orders.manage
+      purchase_receipts.view
+      purchase_receipts.manage
+    ].freeze
+
+    module_function
+
+    def nav_visible?(user:, accessible_stores:)
+      return false unless user&.active?
+
+      permission_allowed_anywhere?(user:, permission_keys: HUB_PERMISSIONS, accessible_stores:)
+    end
+
+    def hub_allowed?(user:, accessible_stores:)
+      nav_visible?(user:, accessible_stores:)
+    end
+
+    def permission_allowed_anywhere?(user:, permission_keys:, accessible_stores:)
+      permission_keys.any? do |key|
+        Authorization::PermissionEvaluator.allowed?(user: user, permission_key: key, store: nil) ||
+          accessible_stores.any? do |store|
+            Authorization::PermissionEvaluator.allowed?(user: user, permission_key: key, store: store)
+          end
+      end
+    end
+  end
+end

--- a/app/services/purchasing/hub_access.rb
+++ b/app/services/purchasing/hub_access.rb
@@ -22,12 +22,18 @@ module Purchasing
       nav_visible?(user:, accessible_stores:)
     end
 
+    # Evaluates at most one permission set for the global scope, then one set per
+    # accessible store, stopping at the first matching hub-eligible key.
     def permission_allowed_anywhere?(user:, permission_keys:, accessible_stores:)
-      permission_keys.any? do |key|
-        Authorization::PermissionEvaluator.allowed?(user: user, permission_key: key, store: nil) ||
-          accessible_stores.any? do |store|
-            Authorization::PermissionEvaluator.allowed?(user: user, permission_key: key, store: store)
-          end
+      wanted = permission_keys.to_set
+      return false if wanted.empty?
+
+      global_keys = Authorization::PermissionEvaluator.permissions_for(user: user, store: nil)
+      return true if wanted.intersect?(global_keys)
+
+      accessible_stores.any? do |store|
+        store_keys = Authorization::PermissionEvaluator.permissions_for(user: user, store: store)
+        wanted.intersect?(store_keys)
       end
     end
   end

--- a/app/services/purchasing/work_hub_summary.rb
+++ b/app/services/purchasing/work_hub_summary.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+module Purchasing
+  class WorkHubSummary
+    Section = Data.define(
+      :key,
+      :title,
+      :count,
+      :clear_text,
+      :primary_label,
+      :primary_path,
+      :history_label,
+      :history_path,
+      :dominant_primary
+    )
+
+    def initialize(user:, store:, accessible_stores:)
+      @user = user
+      @store = store
+      @accessible_stores = accessible_stores
+    end
+
+    def store_selected?
+      @store.present?
+    end
+
+    def operational_sections
+      return [] unless store_selected?
+
+      [
+        location_section,
+        draft_po_section,
+        sent_po_section,
+        receipt_drafts_section
+      ].compact
+    end
+
+    def history_sections
+      [
+        orders_history_section,
+        purchase_orders_history_section,
+        receipts_history_section
+      ].compact
+    end
+
+    private
+
+    def allowed?(permission_key, store: @store)
+      Authorization::PermissionEvaluator.allowed?(
+        user: @user,
+        permission_key: permission_key,
+        store: store
+      )
+    end
+
+    def location_section
+      return unless allowed?("customer_requests.locate")
+
+      count = CustomerRequest.pending_location.for_store(@store).count
+      Section.new(
+        key: :location_queue,
+        title: "Requests awaiting location",
+        count: count,
+        clear_text: "None awaiting",
+        primary_label: count.positive? ? "Open location queue" : nil,
+        primary_path: count.positive? ? Rails.application.routes.url_helpers.ops_location_path : nil,
+        history_label: "View customer requests",
+        history_path: Rails.application.routes.url_helpers.admin_customer_requests_path,
+        dominant_primary: count.positive?
+      )
+    end
+
+    def draft_po_section
+      return unless allowed?("orders.manage")
+
+      count = PurchaseOrder.draft.for_store(@store).count
+      Section.new(
+        key: :draft_pos,
+        title: "Draft purchase orders",
+        count: count,
+        clear_text: "None open",
+        primary_label: count.positive? ? "Continue draft POs" : nil,
+        primary_path: count.positive? ? Rails.application.routes.url_helpers.ops_draft_pos_path : nil,
+        history_label: "View purchase order history",
+        history_path: Rails.application.routes.url_helpers.admin_purchase_orders_path(status: "draft"),
+        dominant_primary: count.positive?
+      )
+    end
+
+    def sent_po_section
+      return unless allowed?("orders.view")
+
+      count = PurchaseOrder.sent.for_store(@store).with_open_lines.count
+      Section.new(
+        key: :sent_pos,
+        title: "Sent purchase orders awaiting receipt",
+        count: count,
+        clear_text: "None awaiting receipt",
+        primary_label: count.positive? ? "View sent POs" : nil,
+        primary_path: count.positive? ? Rails.application.routes.url_helpers.admin_purchase_orders_path(status: "sent") : nil,
+        history_label: "View purchase order history",
+        history_path: Rails.application.routes.url_helpers.admin_purchase_orders_path,
+        dominant_primary: count.positive?
+      )
+    end
+
+    def receipt_drafts_section
+      return unless allowed?("purchase_receipts.manage")
+
+      count = PurchaseReceipt.draft.for_store(@store).count
+      Section.new(
+        key: :receipt_drafts,
+        title: "Receipt drafts in progress",
+        count: count,
+        clear_text: "None in progress",
+        primary_label: count.positive? ? "Continue receiving" : nil,
+        primary_path: count.positive? ? Rails.application.routes.url_helpers.ops_receiving_index_path : nil,
+        history_label: "Open receiving workspace",
+        history_path: Rails.application.routes.url_helpers.ops_receiving_index_path,
+        dominant_primary: count.positive?
+      )
+    end
+
+    def orders_history_section
+      return unless allowed?("orders.view", store: nil) || allowed?("orders.view")
+
+      Section.new(
+        key: :orders_history,
+        title: "Order history",
+        count: nil,
+        clear_text: nil,
+        primary_label: nil,
+        primary_path: nil,
+        history_label: "View all orders",
+        history_path: Rails.application.routes.url_helpers.admin_orders_path,
+        dominant_primary: false
+      )
+    end
+
+    def purchase_orders_history_section
+      return unless allowed?("orders.view", store: nil) || allowed?("orders.view")
+
+      Section.new(
+        key: :purchase_orders_history,
+        title: "Purchase order history",
+        count: nil,
+        clear_text: nil,
+        primary_label: nil,
+        primary_path: nil,
+        history_label: "View all purchase orders",
+        history_path: Rails.application.routes.url_helpers.admin_purchase_orders_path,
+        dominant_primary: false
+      )
+    end
+
+    def receipts_history_section
+      return unless allowed?("purchase_receipts.view", store: nil) || allowed?("purchase_receipts.view")
+
+      Section.new(
+        key: :receipts_history,
+        title: "Purchase receipt history",
+        count: nil,
+        clear_text: nil,
+        primary_label: nil,
+        primary_path: nil,
+        history_label: "View posted receipts",
+        history_path: Rails.application.routes.url_helpers.admin_purchase_receipts_path,
+        dominant_primary: false
+      )
+    end
+  end
+end

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -1,27 +1,35 @@
 <% content_for :title, "Orders" %>
-<h1>Orders</h1>
-<% if effective_permissions.include?("orders.manage") && current_store.present? %>
-  <p><%= link_to "New stock order", new_admin_order_path %></p>
-<% end %>
-<% if effective_permissions.include?("orders.manage") && current_store.present? %>
-  <p><%= link_to "Draft PO workspace", ops_draft_pos_path %></p>
-<% end %>
-<ul>
-  <% @orders.each do |order| %>
-    <li>
-      <%= link_to order.admin_label, admin_order_path(order) %>
-      <%= order.product_variant.sku %>
-      · <%= order.supplier.admin_label %>
-      · qty <%= order.requested_quantity %>
-      <% if order.customer_order? %>
-        · customer request #<%= order.customer_request.number %>
-      <% else %>
-        · stock
-      <% end %>
-      <% if order.cancelled? %> · cancelled<% end %>
-    </li>
+
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Purchasing", path: admin_purchasing_path },
+  { name: "Orders" }
+] %>
+
+<% header_actions = capture do %>
+  <% if effective_permissions.include?("orders.manage") && current_store.present? %>
+    <%= action_link_to("New stock order", new_admin_order_path, style: :solid, intent: :brand) %>
+    <%= action_link_to("Draft PO workspace", ops_draft_pos_path, style: :outline, intent: :neutral) %>
   <% end %>
-</ul>
-<% if @orders.empty? %>
-  <p>No orders.</p>
 <% end %>
+
+<%= render "shared/page_header", title: "Orders", actions: header_actions.presence %>
+
+<% rows = @orders.map { |order|
+     label = link_to(order.admin_label, admin_order_path(order))
+     type = order.customer_order? ? "Customer · ##{order.customer_request.number}" : "Stock"
+     type += " · cancelled" if order.cancelled?
+     [
+       label,
+       content_tag(:code, order.product_variant.sku),
+       order.supplier.admin_label,
+       order.requested_quantity.to_s,
+       type
+     ]
+   } %>
+<%= render "shared/data_table",
+      headers: ["Order", "SKU", "Supplier", "Qty", "Type"],
+      rows: rows,
+      empty: render("shared/empty_state",
+                    title: "No orders yet",
+                    body: "Stock and customer orders appear here after they are created.") %>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -1,7 +1,15 @@
 <% content_for :title, @order.admin_label %>
-<h1><%= @order.admin_label %></h1>
-<p><%= link_to "Back", admin_orders_path %></p>
-<dl>
+
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Purchasing", path: admin_purchasing_path },
+  { name: "Orders", path: admin_orders_path },
+  { name: @order.admin_label }
+] %>
+
+<%= render "shared/page_header", title: @order.admin_label %>
+
+<dl class="definition-list">
   <dt>Store</dt><dd><%= @order.store.admin_label %></dd>
   <dt>Variant</dt><dd><%= @order.product_variant.sku %> — <%= @order.product_variant.product.name %></dd>
   <dt>Supplier</dt><dd><%= @order.supplier.admin_label %></dd>
@@ -9,20 +17,20 @@
   <dt>Notes</dt><dd><%= @order.notes.presence || "—" %></dd>
   <% if @order.customer_request %>
     <dt>Customer request</dt>
-    <dd><%= link_to @order.customer_request.admin_label, admin_customer_request_path(@order.customer_request) %></dd>
+    <dd><%= admin_customer_request_link(@order.customer_request) || @order.customer_request.admin_label %></dd>
   <% end %>
   <% if @purchase_order %>
     <dt>Purchase order</dt>
     <dd>
-      <%= @purchase_order.admin_label %> (<%= @purchase_order.status %>)
-      <% if @purchase_order.draft? && effective_permissions.include?("orders.manage") && current_store&.id == @purchase_order.store_id %>
-        · <%= link_to "Open draft workspace", ops_purchase_order_path(@purchase_order) %>
+      <%= admin_purchase_order_link(@purchase_order, label: "#{@purchase_order.admin_label} (#{@purchase_order.status})") || "#{@purchase_order.admin_label} (#{@purchase_order.status})" %>
+      <% draft_link = ops_draft_purchase_order_link(@purchase_order) %>
+      <% if draft_link.present? %>
+        · <%= draft_link %>
       <% end %>
     </dd>
   <% end %>
   <% if @line %>
-    <dt>Expected unit cost</dt>
-    <dd><%= format_money_cents(@line.expected_unit_cost_cents_snapshot) %></dd>
+    <dt>Expected unit cost</dt><dd><%= format_money_cents(@line.expected_unit_cost_cents_snapshot) %></dd>
   <% end %>
   <% if @order.cancelled? %>
     <dt>Cancellation</dt>

--- a/app/views/admin/purchase_orders/index.html.erb
+++ b/app/views/admin/purchase_orders/index.html.erb
@@ -1,29 +1,40 @@
 <% content_for :title, "Purchase orders" %>
-<h1>Purchase orders</h1>
-<p>
-  Filter:
-  <%= link_to "All", admin_purchase_orders_path %>
-  · <%= link_to "Draft", admin_purchase_orders_path(status: "draft") %>
-  · <%= link_to "Sent", admin_purchase_orders_path(status: "sent") %>
-  · <%= link_to "Closed", admin_purchase_orders_path(status: "closed") %>
-</p>
-<% if @status_filter.present? %>
-  <p>Showing status: <%= @status_filter %></p>
-<% end %>
-<% if effective_permissions.include?("orders.manage") && current_store.present? %>
-  <p><%= link_to "Draft PO workspace", ops_draft_pos_path %></p>
-<% end %>
-<ul>
-  <% @purchase_orders.each do |po| %>
-    <li>
-      <%= link_to po.admin_label, admin_purchase_order_path(po) %>
-      · <%= po.supplier.admin_label %>
-      · <%= po.store.admin_label %>
-      · <%= po.status %>
-      <% if po.number.present? %>· #<%= po.number %><% end %>
-    </li>
+
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Purchasing", path: admin_purchasing_path },
+  { name: "Purchase orders" }
+] %>
+
+<% header_actions = capture do %>
+  <% if effective_permissions.include?("orders.manage") && current_store.present? %>
+    <%= action_link_to("Draft PO workspace", ops_draft_pos_path, style: :outline, intent: :neutral) %>
   <% end %>
-</ul>
-<% if @purchase_orders.empty? %>
-  <p>No purchase orders.</p>
 <% end %>
+
+<%= render "shared/page_header", title: "Purchase orders", actions: header_actions.presence %>
+
+<p class="page-header__subtitle">
+  Filter:
+  <%= action_link_to("All", admin_purchase_orders_path, style: :link, intent: :neutral) %>
+  · <%= action_link_to("Draft", admin_purchase_orders_path(status: "draft"), style: :link, intent: :neutral) %>
+  · <%= action_link_to("Sent", admin_purchase_orders_path(status: "sent"), style: :link, intent: :neutral) %>
+  · <%= action_link_to("Closed", admin_purchase_orders_path(status: "closed"), style: :link, intent: :neutral) %>
+  <% if @status_filter.present? %> · Showing <%= @status_filter %><% end %>
+</p>
+
+<% rows = @purchase_orders.map { |po|
+     [
+       link_to(po.admin_label, admin_purchase_order_path(po)),
+       po.supplier.admin_label,
+       po.store.admin_label,
+       po.status,
+       po.number.present? ? "##{po.number}" : "—"
+     ]
+   } %>
+<%= render "shared/data_table",
+      headers: ["Purchase order", "Supplier", "Store", "Status", "Number"],
+      rows: rows,
+      empty: render("shared/empty_state",
+                    title: "No purchase orders",
+                    body: "Draft and sent purchase orders appear here.") %>

--- a/app/views/admin/purchase_orders/show.html.erb
+++ b/app/views/admin/purchase_orders/show.html.erb
@@ -1,24 +1,32 @@
 <% content_for :title, @purchase_order.admin_label %>
-<h1><%= @purchase_order.admin_label %></h1>
-<p>
-  <%= @purchase_order.supplier.admin_label %>
-  · <%= @purchase_order.store.admin_label %>
-  · <%= @purchase_order.status %>
-  <% if @purchase_order.number.present? %>· number <%= @purchase_order.number %><% end %>
-  · revision <%= @purchase_order.document_revision %>
-  <% if @purchase_order.sent_at.present? %>
-    · sent <%= @purchase_order.sent_at %> via <%= @purchase_order.transmission_method %>
+
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Purchasing", path: admin_purchasing_path },
+  { name: "Purchase orders", path: admin_purchase_orders_path },
+  { name: @purchase_order.admin_label }
+] %>
+
+<%= render "shared/page_header",
+      title: @purchase_order.admin_label,
+      subtitle: [
+        @purchase_order.supplier.admin_label,
+        @purchase_order.store.admin_label,
+        @purchase_order.status,
+        (@purchase_order.number.present? ? "number #{@purchase_order.number}" : nil),
+        "revision #{@purchase_order.document_revision}",
+        (@purchase_order.sent_at.present? ? "sent #{@purchase_order.sent_at} via #{@purchase_order.transmission_method}" : nil),
+        (@purchase_order.closed_at.present? ? "closed #{@purchase_order.closed_at}" : nil)
+      ].compact.join(" · ") %>
+
+<% header_actions = capture do %>
+  <%= action_link_to("All purchase orders", admin_purchase_orders_path, style: :link, intent: :neutral) %>
+  <% draft_link = ops_draft_purchase_order_link(@purchase_order) %>
+  <% if draft_link.present? %>
+    <%= draft_link %>
   <% end %>
-  <% if @purchase_order.closed_at.present? %>
-    · closed <%= @purchase_order.closed_at %>
-  <% end %>
-</p>
-<p>
-  <%= link_to "All purchase orders", admin_purchase_orders_path %>
-  <% if @purchase_order.draft? %>
-    · <%= link_to "Open draft workspace", ops_purchase_order_path(@purchase_order) %>
-  <% end %>
-</p>
+<% end %>
+<div class="actions"><%= header_actions %></div>
 
 <section>
   <h2>Lines</h2>
@@ -30,7 +38,7 @@
       <% state = line.line_state %>
       <article>
         <h3>
-          Order <%= link_to "##{order.number}", admin_order_path(order) %>
+          Order <%= admin_order_link(order, label: "##{order.number}") || "##{order.number}" %>
           · <%= line.product_variant.product.name %>
           <code><%= line.product_variant.sku %></code>
         </h3>
@@ -40,7 +48,7 @@
           · cancelled <%= line.cancelled_quantity %>
           · expected unit cost <%= format_money_cents(line.expected_unit_cost_cents_snapshot) %>
           <% if order.customer_request %>
-            · request #<%= order.customer_request.number %> (<%= order.customer_request.status %>)
+            · <%= admin_customer_request_link(order.customer_request, label: "Request ##{order.customer_request.number} (#{order.customer_request.status})") || "Request ##{order.customer_request.number} (#{order.customer_request.status})" %>
           <% end %>
         </p>
 

--- a/app/views/admin/purchase_receipts/index.html.erb
+++ b/app/views/admin/purchase_receipts/index.html.erb
@@ -1,20 +1,34 @@
 <% content_for :title, "Purchase receipts" %>
-<h1>Purchase receipts</h1>
-<p>Posted receipts. Drafts are managed in the receiving workspace.</p>
-<% if effective_permissions.include?("purchase_receipts.manage") && current_store.present? %>
-  <p><%= link_to "Receiving ops", ops_receiving_index_path %></p>
-<% end %>
-<ul>
-  <% @purchase_receipts.each do |receipt| %>
-    <li>
-      <%= link_to receipt.admin_label, admin_purchase_receipt_path(receipt) %>
-      · <%= receipt.supplier.admin_label %>
-      · <%= receipt.store.admin_label %>
-      · <%= receipt.status %>
-      · merchandise <%= format_money_cents(receipt.merchandise_total_cents) %>
-    </li>
+
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Purchasing", path: admin_purchasing_path },
+  { name: "Purchase receipts" }
+] %>
+
+<% header_actions = capture do %>
+  <% if effective_permissions.include?("purchase_receipts.manage") && current_store.present? %>
+    <%= action_link_to("Receiving workspace", ops_receiving_index_path, style: :outline, intent: :neutral) %>
   <% end %>
-</ul>
-<% if @purchase_receipts.empty? %>
-  <p>No posted purchase receipts.</p>
 <% end %>
+
+<%= render "shared/page_header",
+      title: "Purchase receipts",
+      subtitle: "Posted and reversed receipts. Drafts are managed in the receiving workspace.",
+      actions: header_actions.presence %>
+
+<% rows = @purchase_receipts.map { |receipt|
+     [
+       link_to(receipt.admin_label, admin_purchase_receipt_path(receipt)),
+       receipt.supplier.admin_label,
+       receipt.store.admin_label,
+       receipt.status,
+       format_money_cents(receipt.merchandise_total_cents)
+     ]
+   } %>
+<%= render "shared/data_table",
+      headers: ["Receipt", "Supplier", "Store", "Status", "Merchandise"],
+      rows: rows,
+      empty: render("shared/empty_state",
+                    title: "No posted purchase receipts",
+                    body: "Posted receipt history appears here after receiving is complete.") %>

--- a/app/views/admin/purchase_receipts/show.html.erb
+++ b/app/views/admin/purchase_receipts/show.html.erb
@@ -1,115 +1,141 @@
 <% content_for :title, @receipt.admin_label %>
-<h1><%= @receipt.admin_label %></h1>
-<p>
-  <%= @receipt.supplier.admin_label %>
-  · <%= @receipt.store.admin_label %>
-  · <%= @receipt.status %>
-  · merchandise <%= format_money_cents(@receipt.merchandise_total_cents) %>
-  · ancillary <%= format_money_cents(@receipt.ancillary_total_cents) %>
-</p>
-<p>
-  <%= link_to "All receipts", admin_purchase_receipts_path %>
-  <% if current_store.present? && @receipt.store_id == current_store.id %>
-    · <%= link_to "Ops receiving view", ops_receiving_path(@receipt) %>
-  <% end %>
-</p>
 
-<table>
-  <thead>
-    <tr>
-      <th scope="col">PO</th>
-      <th scope="col">Item</th>
-      <th scope="col">Received</th>
-      <th scope="col">Reversed</th>
-      <th scope="col">Matched (net)</th>
-      <th scope="col">Unit cost</th>
-      <th scope="col">Corrections</th>
-      <% if @can_correct && @receipt.posted? %>
-        <th scope="col">Actions</th>
-      <% end %>
-    </tr>
-  </thead>
-  <tbody>
-    <% @lines.each do |line| %>
-      <% po_line = line.purchase_order_line %>
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Purchasing", path: admin_purchasing_path },
+  { name: "Purchase receipts", path: admin_purchase_receipts_path },
+  { name: @receipt.admin_label }
+] %>
+
+<%= render "shared/page_header",
+      title: @receipt.admin_label,
+      subtitle: [
+        @receipt.supplier.admin_label,
+        @receipt.store.admin_label,
+        @receipt.status,
+        "merchandise #{format_money_cents(@receipt.merchandise_total_cents)}",
+        "ancillary #{format_money_cents(@receipt.ancillary_total_cents)}"
+      ].join(" · ") %>
+
+<div class="actions">
+  <%= action_link_to("All receipts", admin_purchase_receipts_path, style: :link, intent: :neutral) %>
+  <% receiving_link = ops_receiving_link(@receipt) %>
+  <% if receiving_link.present? %>
+    · <%= receiving_link %>
+  <% end %>
+</div>
+
+<div class="table-scroll">
+  <table class="data-table">
+    <thead>
       <tr>
-        <td>#<%= po_line.purchase_order.number %></td>
-        <td>
-          <%= line.product_variant.product.name %>
-          <code><%= line.product_variant.sku %></code>
-        </td>
-        <td><%= line.received_quantity %></td>
-        <td><%= line.reversed_quantity %></td>
-        <td><%= line.net_matched_quantity %></td>
-        <td><%= format_money_cents(line.actual_unit_cost_cents) %></td>
-        <td>
-          <% if line.corrections.any? %>
-            <ul>
-              <% line.corrections.order(:recorded_at).each do |correction| %>
-                <li>
-                  <%= correction.correction_type %>
-                  <% if correction.quantity.present? %>· qty <%= correction.quantity %><% end %>
-                  <% if correction.value_delta_cents.present? %>· value change <%= format_money_cents(correction.value_delta_cents) %><% end %>
-                  · <%= correction.reason %>
-                </li>
-              <% end %>
-            </ul>
-          <% else %>
-            —
-          <% end %>
-        </td>
+        <th scope="col">PO</th>
+        <th scope="col">Order</th>
+        <th scope="col">Customer request</th>
+        <th scope="col">Item</th>
+        <th scope="col">Received</th>
+        <th scope="col">Reversed</th>
+        <th scope="col">Matched (net)</th>
+        <th scope="col">Unit cost</th>
+        <th scope="col">Corrections</th>
         <% if @can_correct && @receipt.posted? %>
-          <td>
-            <% if line.remaining_reversible_quantity.positive? %>
-              <%= form_with url: reverse_line_admin_purchase_receipt_path(@receipt, line_id: line.id), method: :post, local: true do %>
-                <label>
-                  Reason
-                  <input type="text" name="reason" required>
-                </label>
-                <label>
-                  Qty
-                  <input type="number" name="quantity" min="1" max="<%= line.remaining_reversible_quantity %>" value="<%= line.remaining_reversible_quantity %>" required>
-                </label>
-                <% if @can_compensate %>
-                  <label>
-                    <input type="checkbox" name="authorize_compensate" value="1">
-                    Authorize compensate if unsafe
-                  </label>
-                <% end %>
-                <button type="submit">Reverse line</button>
-              <% end %>
-              <%= form_with url: correct_cost_admin_purchase_receipt_path(@receipt, line_id: line.id), method: :post, local: true do %>
-                <label>
-                  Reason
-                  <input type="text" name="reason" required>
-                </label>
-                <label>
-                  Corrected unit cost ($)
-                  <input type="text" inputmode="decimal" name="corrected_unit_cost_cents" value="<%= @selected_line_id == line.id ? @submitted_cost : nil %>" required aria-invalid="<%= @selected_line_id == line.id %>">
-                  <% if @selected_line_id == line.id %><span class="field-error"><%= @money_error %></span><% end %>
-                </label>
-                <button type="submit">Correct cost</button>
-              <% end %>
-            <% else %>
-              Fully reversed
-            <% end %>
-          </td>
+          <th scope="col">Actions</th>
         <% end %>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      <% @lines.each do |line| %>
+        <% po_line = line.purchase_order_line %>
+        <% po = po_line.purchase_order %>
+        <% order = po_line.order %>
+        <% request = order.customer_request %>
+        <tr>
+          <td><%= admin_purchase_order_link(po, label: po.admin_label) || po.admin_label %></td>
+          <td><%= admin_order_link(order, label: "Order ##{order.number}") || "Order ##{order.number}" %></td>
+          <td>
+            <% if request %>
+              <%= admin_customer_request_link(request, label: "Request ##{request.number}") || "Request ##{request.number}" %>
+            <% else %>
+              —
+            <% end %>
+          </td>
+          <td>
+            <%= line.product_variant.product.name %>
+            <code><%= line.product_variant.sku %></code>
+          </td>
+          <td><%= line.received_quantity %></td>
+          <td><%= line.reversed_quantity %></td>
+          <td><%= line.net_matched_quantity %></td>
+          <td><%= format_money_cents(line.actual_unit_cost_cents) %></td>
+          <td>
+            <% if line.corrections.any? %>
+              <ul>
+                <% line.corrections.order(:recorded_at).each do |correction| %>
+                  <li>
+                    <%= correction.correction_type %>
+                    <% if correction.quantity.present? %>· qty <%= correction.quantity %><% end %>
+                    <% if correction.value_delta_cents.present? %>· value change <%= format_money_cents(correction.value_delta_cents) %><% end %>
+                    · <%= correction.reason %>
+                  </li>
+                <% end %>
+              </ul>
+            <% else %>
+              —
+            <% end %>
+          </td>
+          <% if @can_correct && @receipt.posted? %>
+            <td>
+              <% if line.remaining_reversible_quantity.positive? %>
+                <%= form_with url: reverse_line_admin_purchase_receipt_path(@receipt, line_id: line.id), method: :post, local: true do %>
+                  <label>
+                    Reason
+                    <input type="text" name="reason" required>
+                  </label>
+                  <label>
+                    Qty
+                    <input type="number" name="quantity" min="1" max="<%= line.remaining_reversible_quantity %>" value="<%= line.remaining_reversible_quantity %>" required>
+                  </label>
+                  <% if @can_compensate %>
+                    <label>
+                      <input type="checkbox" name="authorize_compensate" value="1">
+                      Authorize compensate if unsafe
+                    </label>
+                  <% end %>
+                  <button type="submit">Reverse line</button>
+                <% end %>
+                <%= form_with url: correct_cost_admin_purchase_receipt_path(@receipt, line_id: line.id), method: :post, local: true do %>
+                  <label>
+                    Reason
+                    <input type="text" name="reason" required>
+                  </label>
+                  <label>
+                    Corrected unit cost ($)
+                    <input type="text" inputmode="decimal" name="corrected_unit_cost_cents" value="<%= @selected_line_id == line.id ? @submitted_cost : nil %>" required aria-invalid="<%= @selected_line_id == line.id %>">
+                    <% if @selected_line_id == line.id %><span class="field-error"><%= @money_error %></span><% end %>
+                  </label>
+                  <button type="submit">Correct cost</button>
+                <% end %>
+              <% else %>
+                Fully reversed
+              <% end %>
+            </td>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
 
 <% if @can_correct && @receipt.posted? && @lines.any? { |l| l.remaining_reversible_quantity.positive? } %>
   <section>
     <h2>Reverse whole receipt</h2>
     <p>Creates one eligible line reversal per remaining quantity atomically. Compensating adjustments are not used on whole-receipt reverse.</p>
-    <%= form_with url: reverse_admin_purchase_receipt_path(@receipt), method: :post, local: true do %>
+    <%= form_with url: reverse_admin_purchase_receipt_path(@receipt), method: :post, local: true do |form| %>
       <label>
         Reason
         <input type="text" name="reason" required>
       </label>
-      <button type="submit">Reverse receipt</button>
+      <%= action_submit(form, "Reverse receipt", style: :solid, intent: :danger) %>
     <% end %>
   </section>
 <% end %>

--- a/app/views/admin/purchasing/_section.html.erb
+++ b/app/views/admin/purchasing/_section.html.erb
@@ -1,0 +1,24 @@
+<article class="surface purchasing-hub-section">
+  <header class="purchasing-hub-section__header">
+    <h3><%= section.title %></h3>
+    <% if section.count %>
+      <p class="purchasing-hub-section__count"><%= section.count %> <%= section.count == 1 ? "item" : "items" %></p>
+      <% if section.count.zero? && section.clear_text.present? %>
+        <p class="purchasing-hub-section__clear"><%= section.clear_text %></p>
+      <% end %>
+    <% end %>
+  </header>
+  <div class="actions purchasing-hub-section__actions">
+    <% if section.primary_path.present? && section.primary_label.present? %>
+      <%= action_link_to(
+            section.primary_label,
+            section.primary_path,
+            style: section.dominant_primary ? :solid : :outline,
+            intent: section.dominant_primary ? :brand : :neutral
+          ) %>
+    <% end %>
+    <% if section.history_path.present? && section.history_label.present? %>
+      <%= action_link_to(section.history_label, section.history_path, style: :link, intent: :neutral) %>
+    <% end %>
+  </div>
+</article>

--- a/app/views/admin/purchasing/show.html.erb
+++ b/app/views/admin/purchasing/show.html.erb
@@ -1,0 +1,47 @@
+<% content_for :title, "Purchasing" %>
+
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Purchasing" }
+] %>
+
+<%= render "shared/page_header",
+      title: "Purchasing",
+      subtitle: @summary.store_selected? ? "Work and history for #{current_store.admin_label}" : "Organization-wide purchasing history" %>
+
+<% unless @summary.store_selected? %>
+  <section class="surface">
+    <h2>Select a store to view purchasing work</h2>
+    <p>Operational counts and workspace links require an active store context.</p>
+    <% if accessible_stores.many? %>
+      <p><%= action_link_to("Choose store", new_store_selection_path, style: :solid, intent: :brand) %></p>
+    <% elsif accessible_stores.one? %>
+      <%= form_with url: store_selection_path, method: :post, local: true, class: "actions" do |form| %>
+        <%= hidden_field_tag :store_id, accessible_stores.first.id %>
+        <%= action_submit(form, "Use #{accessible_stores.first.admin_label}", style: :solid, intent: :brand) %>
+      <% end %>
+    <% end %>
+  </section>
+<% end %>
+
+<% if @summary.operational_sections.any? %>
+  <section aria-labelledby="purchasing-work-heading">
+    <h2 id="purchasing-work-heading">Active work</h2>
+    <div class="purchasing-hub-sections">
+      <% @summary.operational_sections.each do |section| %>
+        <%= render "section", section: section %>
+      <% end %>
+    </div>
+  </section>
+<% end %>
+
+<% if @summary.history_sections.any? %>
+  <section aria-labelledby="purchasing-history-heading">
+    <h2 id="purchasing-history-heading">History and reference</h2>
+    <div class="purchasing-hub-sections">
+      <% @summary.history_sections.each do |section| %>
+        <%= render "section", section: section %>
+      <% end %>
+    </div>
+  </section>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,6 +59,9 @@
             <% if effective_permissions.include?("inventory.view") %>
               <%= link_to "Inventory", admin_inventory_balances_path %>
             <% end %>
+            <% if purchasing_hub_nav_visible? %>
+              <%= link_to "Purchasing", admin_purchasing_path %>
+            <% end %>
             <% if effective_permissions.include?("orders.view") %>
               <%= link_to "Orders", admin_orders_path %>
               <%= link_to "Purchase orders", admin_purchase_orders_path %>

--- a/app/views/ops/draft_pos/index.html.erb
+++ b/app/views/ops/draft_pos/index.html.erb
@@ -1,29 +1,39 @@
 <% content_for :title, "Draft purchase orders" %>
-<h1>Draft purchase orders</h1>
-<p>Open drafts for <%= current_store.admin_label %>. Scan or search on a draft to create a stock order and dedicated line.</p>
+
+<header class="ops-doc-header">
+  <div>
+    <h1>Draft purchase orders</h1>
+    <p>Open drafts for <%= current_store.admin_label %>. Scan or search on a draft to create a stock order and dedicated line.</p>
+  </div>
+  <p><%= action_link_to("Exit to Purchasing", admin_purchasing_path, style: :link, intent: :neutral) %></p>
+</header>
 
 <% if @draft_pos.empty? %>
-  <p>No open draft purchase orders. Create a stock order or customer special order to open one.</p>
+  <section class="surface ops-empty-state">
+    <h2>No open draft purchase orders</h2>
+    <p>Create a stock order or customer special order to open one.</p>
+  </section>
 <% else %>
-  <table class="ops-queue">
-    <thead>
-      <tr>
-        <th scope="col">Supplier</th>
-        <th scope="col">Lines</th>
-        <th scope="col">Expected total</th>
-        <th scope="col"></th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @draft_pos.each do |po| %>
+  <div class="table-scroll">
+    <table class="ops-queue">
+      <thead>
         <tr>
-          <td><%= po.supplier.admin_label %></td>
-          <td><%= po.purchase_order_lines.size %></td>
-          <td><%= format_money_cents(po.expected_merchandise_total_cents) %></td>
-          <td><%= link_to "Open", ops_purchase_order_path(po) %></td>
+          <th scope="col">Supplier</th>
+          <th scope="col">Lines</th>
+          <th scope="col">Expected total</th>
+          <th scope="col"><span class="visually-hidden">Open</span></th>
         </tr>
-      <% end %>
-    </tbody>
-  </table>
+      </thead>
+      <tbody>
+        <% @draft_pos.each do |po| %>
+          <tr>
+            <td><%= po.supplier.admin_label %></td>
+            <td><%= po.purchase_order_lines.size %></td>
+            <td><%= format_money_cents(po.expected_merchandise_total_cents) %></td>
+            <td><%= action_link_to("Open", ops_purchase_order_path(po), style: :link, intent: :neutral, size: :small) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
 <% end %>
-<p><%= link_to "Exit to Orders", admin_orders_path %></p>

--- a/app/views/ops/draft_pos/show.html.erb
+++ b/app/views/ops/draft_pos/show.html.erb
@@ -12,9 +12,9 @@
     </p>
   </div>
   <p>
-    <%= link_to "All drafts", ops_draft_pos_path %>
-    · <%= link_to "Purchase orders", admin_purchase_orders_path %>
-    · <%= link_to "Exit to Purchasing", admin_orders_path %>
+    <%= action_link_to("All drafts", ops_draft_pos_path, style: :link, intent: :neutral) %>
+    · <%= action_link_to("Purchase orders", admin_purchase_orders_path, style: :link, intent: :neutral) %>
+    · <%= action_link_to("Exit to Purchasing", admin_purchasing_path, style: :link, intent: :neutral) %>
   </p>
 </header>
 

--- a/app/views/ops/locations/show.html.erb
+++ b/app/views/ops/locations/show.html.erb
@@ -4,7 +4,7 @@
     <h1>Location queue</h1>
     <p>Oldest requests appear first for <%= current_store.admin_label %>. Select a request, then record what you found.</p>
   </div>
-  <p><%= link_to "Exit to Purchasing", admin_orders_path %></p>
+  <p><%= action_link_to("Exit to Purchasing", admin_purchasing_path, style: :link, intent: :neutral) %></p>
 </header>
 
 <%= render "ops/shared/error_summary", errors: @mutation_errors, conflict: @conflict, title: "Location action could not be completed" %>
@@ -13,7 +13,7 @@
   <section class="surface ops-empty-state">
     <h2>Location work is caught up</h2>
     <p>There are no customer requests waiting for a physical search at this store.</p>
-    <p><%= link_to "View customer requests", admin_customer_requests_path, class: "btn" %></p>
+    <p><%= action_link_to("View customer requests", admin_customer_requests_path, style: :outline, intent: :neutral) %></p>
   </section>
 <% else %>
   <% selected_id = (@selected_row_id.presence || "").to_s %>

--- a/app/views/ops/receiving/index.html.erb
+++ b/app/views/ops/receiving/index.html.erb
@@ -6,7 +6,7 @@
   </div>
   <p>
     <%= action_link_to("Draft POs", ops_draft_pos_path, style: :link, intent: :neutral) %>
-    · <%= action_link_to("Exit to Purchasing", admin_orders_path, style: :link, intent: :neutral) %>
+    · <%= action_link_to("Exit to Purchasing", admin_purchasing_path, style: :link, intent: :neutral) %>
   </p>
 </header>
 <%= render "ops/shared/error_summary", errors: @mutation_errors, conflict: false, title: "Draft receipt could not be created" %>

--- a/app/views/ops/receiving/show.html.erb
+++ b/app/views/ops/receiving/show.html.erb
@@ -13,7 +13,7 @@
   </div>
   <p>
     <%= action_link_to("All drafts", ops_receiving_index_path, style: :link, intent: :neutral) %>
-    · <%= action_link_to("Exit to Purchasing", admin_orders_path, style: :link, intent: :neutral) %>
+    · <%= action_link_to("Exit to Purchasing", admin_purchasing_path, style: :link, intent: :neutral) %>
   </p>
 </header>
 <%= render "ops/shared/error_summary", errors: @mutation_errors, conflict: @conflict, title: "Receipt was not changed" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,6 +96,7 @@ Rails.application.routes.draw do
       member { post :cancel }
     end
     resources :orders, only: %i[index show new create]
+    resource :purchasing, only: %i[show], controller: "purchasing"
     resources :purchase_orders, only: %i[index show] do
       member do
         post "lines/:line_id/cancel", action: :cancel_line, as: :cancel_line

--- a/docs/planning/phase7.1-purchasing-polish/README.md
+++ b/docs/planning/phase7.1-purchasing-polish/README.md
@@ -1,6 +1,6 @@
-# Phase 7.1 — Purchasing polish
+# Phase 7.1 — Purchasing workflow and presentation closeout
 
-Status: **Proposed** — coordination **Accepted** (August 2026).
+Status: **In progress** — coordination **Accepted** (August 2026); implementation on branch `phase-7.1-purchasing-polish`.
 
 | Document | Purpose |
 |---|---|
@@ -10,4 +10,6 @@ Status: **Proposed** — coordination **Accepted** (August 2026).
 
 Builds on implemented [Phase 7](../phase7-orders-and-receiving/README.md). Forward summary: [roadmap.md](../roadmap.md) § Phase 7.1.
 
-Phase 7.1 addresses **targeted purchasing ergonomics** deferred from Phase 7—not supplier returns, request expiration, PO consolidation, multi-quantity requests, or AP/accounting (see roadmap long-term deferrals).
+Phase 7.1 closes **Phase 7 purchasing operability** (hub, admin presentation, ops parity)—not supplier returns, request expiration, PO consolidation, multi-quantity requests, or AP/accounting.
+
+**Naming note:** this packet is distinct from inspirational Warm Parchment drafts under [docs/drafts/phase-7.1-ux-refactor/](../../drafts/phase-7.1-ux-refactor/README.md) (cross-phase UX exploration; folder name retained for path stability).

--- a/docs/planning/phase7.1-purchasing-polish/README.md
+++ b/docs/planning/phase7.1-purchasing-polish/README.md
@@ -1,6 +1,6 @@
 # Phase 7.1 — Purchasing workflow and presentation closeout
 
-Status: **In progress** — coordination **Accepted** (August 2026); implementation on branch `phase-7.1-purchasing-polish`.
+Status: **In progress** — coordination **Accepted** (August 2026); **7.1.1–7.1.2** on branch `phase-7.1-purchasing-polish`; **7.1.3 blocked until after UDS-4.1**.
 
 | Document | Purpose |
 |---|---|
@@ -10,6 +10,6 @@ Status: **In progress** — coordination **Accepted** (August 2026); implementat
 
 Builds on implemented [Phase 7](../phase7-orders-and-receiving/README.md). Forward summary: [roadmap.md](../roadmap.md) § Phase 7.1.
 
-Phase 7.1 closes **Phase 7 purchasing operability** (hub, admin presentation, ops parity)—not supplier returns, request expiration, PO consolidation, multi-quantity requests, or AP/accounting.
+Phase 7.1 closes **Phase 7 purchasing operability** (hub and admin presentation now; Location/Draft PO ops parity later)—not supplier returns, request expiration, PO consolidation, multi-quantity requests, or AP/accounting.
 
 **Naming note:** this packet is distinct from inspirational Warm Parchment drafts under [docs/drafts/phase-7.1-ux-refactor/](../../drafts/phase-7.1-ux-refactor/README.md) (cross-phase UX exploration; folder name retained for path stability).

--- a/docs/planning/phase7.1-purchasing-polish/phase7.1-plan.md
+++ b/docs/planning/phase7.1-purchasing-polish/phase7.1-plan.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**In progress** on integration branch `phase-7.1-purchasing-polish` — slices **7.1.1–7.1.3** implemented; pending merge to `main`.
+**In progress** on integration branch `phase-7.1-purchasing-polish` — slices **7.1.1–7.1.2** implemented (hub exit-link touch-ups on ops templates are incidental 7.1.1 integration). **7.1.3** remains **blocked until after UDS-4.1**.
 
 **Not** the inspirational Warm Parchment exploration in [docs/drafts/phase-7.1-ux-refactor/](../../drafts/phase-7.1-ux-refactor/README.md) (cross-phase UX notes; path retained for stability).
 
@@ -49,7 +49,7 @@ Same as [roadmap.md](../roadmap.md) and Phase 7 §4 deferrals:
 1. **Coordination gate** — [phase7.1-uds-coordination.md](phase7.1-uds-coordination.md) is **Accepted** (August 2026).
 2. **Phase 7 contracts unchanged** — one order ↔ one PO line; `available = on_hand - active_reserved - unavailable`; [phase7-lock-order.md](../phase7-orders-and-receiving/phase7-lock-order.md) binding.
 3. **Shell boundaries** — admin chrome server-rendered without Hotwire; ops workspaces remain Register-class siblings of POS.
-4. **Merge policy** — integration branch **`phase-7.1-purchasing-polish`** from `main`; slice branches PR into integration; final PR to `main` after 7.1.1–7.1.3 (+ optional 7.1.4). Manual gate: no Phase 7 command or lock-order behavior changed.
+4. **Merge policy** — integration branch **`phase-7.1-purchasing-polish`** from `main`; slice branches PR into integration; merge **7.1.1–7.1.2** to `main` when ready. **7.1.3** ships later after UDS-4.1 (+ optional 7.1.4). Manual gate: no Phase 7 command or lock-order behavior changed.
 5. **UDS ownership** — nav chrome and non-purchasing adoption per coordination table; Phase 7.1 owns purchasing templates and hub queries.
 6. **Hub section visibility** — omit sections the user is **not authorized** to see; **show authorized sections even when count is zero** with a compact clear state (not a full `empty_state` panel). Hub layout stays stable for an authorized user.
 7. **No-store hub** — hub remains reachable when the user has any hub-eligible permission globally or on any accessible store; without `current_store`, show “Select a store to view purchasing work” and org-wide history links only; **no auto-redirect** away from the hub; no store-scoped counts without a store.
@@ -117,15 +117,17 @@ flowchart LR
 
 ### Slice 7.1.3 — Ops workspace parity (Location + Draft PO)
 
-**Coordination row:** 6. Ships **after UDS-4.1** (or parallel UDS-4.2 if no template overlap).
+**Status:** **Blocked / pending after UDS-4.1** (coordination row 6). Not part of the 7.1.1–7.1.2 merge.
 
-**Scope:**
+**Note:** Hub exit links and light `ActionButtonHelper` / table-scroll touch-ups on Location, Draft PO, and Receiving templates shipped with **7.1.1** as incidental integration so ops workspaces point at the new hub. Those changes do **not** satisfy 7.1.3 acceptance (keyboard/dirty/focus parity, program-plan allowlist, a11y evidence).
 
-- Align Location and Draft PO with Receiving: ops layout shortcuts, `ActionButtonHelper`, focus restoration, dirty-form guard, error partials
-- Exit links point to **`admin_purchasing_path`** hub
+**Scope (when unblocked):**
+
+- Align Location and Draft PO with Receiving: shortcut help behavior, focus restoration (success and cancel), dirty-form guard, error partials
 - Extract shared Stimulus only where behavior is identical
-- Update program-plan allowlist in same PR
+- Update program-plan allowlist in the 7.1.3 PR
 - No keyboard binding changes without updating frozen system tests
+- Additive coverage in `purchasing_ops_workspace_test.rb` and `location_queue_buttons_test.rb`
 
 **Accessibility acceptance:**
 
@@ -149,7 +151,7 @@ flowchart LR
 ## Acceptance criteria (phase complete)
 
 1. Coordination doc Accepted.
-2. Slices **7.1.1** and **7.1.2** implemented; **7.1.3** after UDS-4.1 per coordination; **7.1.4** only if justified.
+2. Slices **7.1.1** and **7.1.2** implemented and mergeable; **7.1.3** after UDS-4.1 per coordination; **7.1.4** only if justified.
 3. Staff can discover active purchasing work without hunting flat nav links.
 4. No Phase 7 locked decisions or lock-order rows changed silently.
 5. [roadmap.md](../roadmap.md) and docs index reflect Phase 7.1 status.

--- a/docs/planning/phase7.1-purchasing-polish/phase7.1-plan.md
+++ b/docs/planning/phase7.1-purchasing-polish/phase7.1-plan.md
@@ -1,8 +1,10 @@
-# Phase 7.1 — Purchasing polish
+# Phase 7.1 — Purchasing workflow and presentation closeout
 
 ## Status
 
-**Proposed.** Coordination **Accepted** ([phase7.1-uds-coordination.md](phase7.1-uds-coordination.md)); application slices may proceed.
+**In progress** on integration branch `phase-7.1-purchasing-polish` — slices **7.1.1–7.1.3** implemented; pending merge to `main`.
+
+**Not** the inspirational Warm Parchment exploration in [docs/drafts/phase-7.1-ux-refactor/](../../drafts/phase-7.1-ux-refactor/README.md) (cross-phase UX notes; path retained for stability).
 
 Authority: [Phase 7 packet](../phase7-orders-and-receiving/README.md), [phase7-spec.md](../phase7-orders-and-receiving/phase7-spec.md) §17, [UDS-4 plan](../ux-design-system/uds-4-plan.md).
 
@@ -13,6 +15,8 @@ Close justified **operator ergonomics gaps** left when Phase 7 shipped core purc
 ## Deliverable
 
 > Authorized purchasing workflows gain justified ergonomics improvements without reopening Phase 7 core contracts or deferring higher-priority forward phases.
+
+Phase 7.1 closes **Phase 7 operability** before forward domains (stored value, buyback, customer expansion, bibliographic enrichment, register cash). UDS grouped navigation remains a parallel UDS program.
 
 ## What Phase 7 already provides
 
@@ -36,6 +40,7 @@ Same as [roadmap.md](../roadmap.md) and Phase 7 §4 deferrals:
 - Manager sell-through-reserve override
 - AP, landed cost, replenishment automation, EDI
 - Folding Register into ops shell; new permissions unless a new controlled operation appears
+- Grouped admin navigation (UDS-4.1); new index filter/query behavior beyond existing PO status filter
 
 **Evaluation rule:** each candidate slice must pass a contract-impact check (schema, lock order, availability, immutability) before inclusion.
 
@@ -44,8 +49,20 @@ Same as [roadmap.md](../roadmap.md) and Phase 7 §4 deferrals:
 1. **Coordination gate** — [phase7.1-uds-coordination.md](phase7.1-uds-coordination.md) is **Accepted** (August 2026).
 2. **Phase 7 contracts unchanged** — one order ↔ one PO line; `available = on_hand - active_reserved - unavailable`; [phase7-lock-order.md](../phase7-orders-and-receiving/phase7-lock-order.md) binding.
 3. **Shell boundaries** — admin chrome server-rendered without Hotwire; ops workspaces remain Register-class siblings of POS.
-4. **Merge policy** — slices merge independently to `main` (Phase 6.1 style); no integration branch.
+4. **Merge policy** — integration branch **`phase-7.1-purchasing-polish`** from `main`; slice branches PR into integration; final PR to `main` after 7.1.1–7.1.3 (+ optional 7.1.4). Manual gate: no Phase 7 command or lock-order behavior changed.
 5. **UDS ownership** — nav chrome and non-purchasing adoption per coordination table; Phase 7.1 owns purchasing templates and hub queries.
+6. **Hub section visibility** — omit sections the user is **not authorized** to see; **show authorized sections even when count is zero** with a compact clear state (not a full `empty_state` panel). Hub layout stays stable for an authorized user.
+7. **No-store hub** — hub remains reachable when the user has any hub-eligible permission globally or on any accessible store; without `current_store`, show “Select a store to view purchasing work” and org-wide history links only; **no auto-redirect** away from the hub; no store-scoped counts without a store.
+8. **Flat → grouped nav transition** — before UDS-4.1, add **Purchasing** hub link and keep existing Orders / PO / Receipt flat links; after UDS-4.1, **Purchasing** group primary entry = hub and entity links become children only (UDS-4.1 removes redundant top-level links).
+9. **Sent PO count** — `sent` POs where at least one line has `open_quantity > 0` via relation-level SQL scope (`PurchaseOrder.sent.with_open_lines`); status remains `sent` during partial receipt until close per Phase 7 spec.
+10. **Receipt drafts link** — primary section destination = receiving workspace index (`ops_receiving_index_path`), not “most recent draft.”
+11. **7.1.2 filters** — presentation and cross-links only; preserve existing PO **`status`** filter; **no new** orders or receipts filter behavior in 7.1.2.
+12. **Cross-links** — permission-, store-, and record-gated; helpers return `nil` when destination is unauthorized.
+13. **Action buttons** — follow [button-action-semantics.md](../ux-design-system/button-action-semantics.md): at most one solid brand dominant action per hub section when count > 0; outline for secondary workspace entry; link/ghost for history; compact size for dense table-row actions.
+
+### Hub-eligible permissions (minimum)
+
+`customer_requests.locate`, `orders.view`, `orders.manage`, `purchase_receipts.view`, `purchase_receipts.manage` — aligned with hub sections and flat-nav **Purchasing** link visibility (any accessible store or global assignment).
 
 ## Slices
 
@@ -54,9 +71,10 @@ flowchart LR
   gate[Coordination_accepted]
   s711[7.1.1 Work_hub]
   s712[7.1.2 Admin_indexes]
+  uds41[UDS_4_1_grouped_nav]
   s713[7.1.3 Ops_parity]
   s714[7.1.4 Request_links]
-  gate --> s711 --> s712 --> s713
+  gate --> s711 --> s712 --> uds41 --> s713
   s711 --> s714
 ```
 
@@ -64,19 +82,19 @@ flowchart LR
 
 **Coordination rows:** 1, 9, 10.
 
-**Scope (proposed):**
+**Scope:**
 
-- Store-scoped admin hub at **`GET /admin/purchasing`** (`Admin::PurchasingController#show`)
-- Permission-filtered sections; omit empty sections
+- Admin hub at **`GET /admin/purchasing`** (`Admin::PurchasingController#show`)
+- `Purchasing::WorkHubSummary` — authorized sections, SQL-backed counts, no-store vs store-scoped modes
 - Summaries with deep links, minimum:
-  - requests awaiting location → location ops
-  - open draft POs → draft PO ops index
-  - sent POs with open quantity → PO admin filter
-  - receipt drafts in progress → receiving ops
-  - queryable exceptions where data exists (e.g. validation-blocked drafts)
-- Read-only queries; no new domain commands unless a dedicated query object is justified
+  - requests awaiting location → location ops (when `customer_requests.locate` + store)
+  - open draft POs → draft PO ops index (when `orders.manage` + store)
+  - sent POs with open quantity → sent PO admin filter (when `orders.view` + store)
+  - receipt drafts in progress → `ops_receiving_index_path` (when `purchase_receipts.manage` + store)
+  - history links (orders, POs, receipts) when authorized without requiring store scope where controllers already allow
+- Read-only queries; no new domain commands
 
-**Tests:** integration tests for at least one full admin profile and one narrow store-scoped profile.
+**Tests:** integration tests for full admin profile, narrow store-scoped profile, no-store hub, unauthorized direct URLs.
 
 ### Slice 7.1.2 — Admin purchasing history presentation
 
@@ -85,20 +103,36 @@ flowchart LR
 **Scope:**
 
 - Modernize [admin/orders](../../../app/views/admin/orders/index.html.erb), [admin/purchase_orders](../../../app/views/admin/purchase_orders/index.html.erb), and purchase receipt admin views
-- Shared admin anatomy: `page_header`, breadcrumbs, `data_table`, filters, empty states, `ActionButtonHelper`
-- Cross-links per coordination [Cross-link conventions](phase7.1-uds-coordination.md#cross-link-conventions)
-- Preserve immutable posted-fact presentation; do not apply global `table` selectors to receipt detail without explicit class
+- Shared admin anatomy: `page_header`, breadcrumbs, `data_table`, existing filters only, empty states, `ActionButtonHelper`
+- `PurchasingHelper` cross-links on show pages per [cross-link conventions](phase7.1-uds-coordination.md#cross-link-conventions) with authorization gating
+- Explicit `.table-scroll` / `.data-table` on receipt surfaces; no global `table` selector on receipt detail
+
+**Filter scope (locked):**
+
+| Index | 7.1.2 behavior |
+|---|---|
+| Orders | Layout modernization only; no new filters |
+| Purchase orders | Existing `status` param filter preserved |
+| Receipts | Layout modernization only; index remains posted/reversed scope |
 
 ### Slice 7.1.3 — Ops workspace parity (Location + Draft PO)
 
-**Coordination row:** 6.
+**Coordination row:** 6. Ships **after UDS-4.1** (or parallel UDS-4.2 if no template overlap).
 
 **Scope:**
 
-- Align Location and Draft PO with Receiving: shortcut help, focus restoration, dirty-form guard, error partials
+- Align Location and Draft PO with Receiving: ops layout shortcuts, `ActionButtonHelper`, focus restoration, dirty-form guard, error partials
+- Exit links point to **`admin_purchasing_path`** hub
 - Extract shared Stimulus only where behavior is identical
 - Update program-plan allowlist in same PR
 - No keyboard binding changes without updating frozen system tests
+
+**Accessibility acceptance:**
+
+- Focus returns to initiating control after modal/dialog closes (success and cancel)
+- Dirty-form warnings distinguish abandoning a form from cancelling a business transaction
+- Button labels follow action-semantics guidance
+- Table links and actions usable without color-only or icon-only recognition
 
 ### Slice 7.1.4 — Customer-request admin cross-links (optional)
 
@@ -115,7 +149,7 @@ flowchart LR
 ## Acceptance criteria (phase complete)
 
 1. Coordination doc Accepted.
-2. Slices **7.1.1** and **7.1.2** implemented; **7.1.3** per coordination row 6; **7.1.4** only if justified.
+2. Slices **7.1.1** and **7.1.2** implemented; **7.1.3** after UDS-4.1 per coordination; **7.1.4** only if justified.
 3. Staff can discover active purchasing work without hunting flat nav links.
 4. No Phase 7 locked decisions or lock-order rows changed silently.
 5. [roadmap.md](../roadmap.md) and docs index reflect Phase 7.1 status.

--- a/docs/planning/phase7.1-purchasing-polish/phase7.1-uds-coordination.md
+++ b/docs/planning/phase7.1-purchasing-polish/phase7.1-uds-coordination.md
@@ -32,7 +32,7 @@ Each row must remain stable after acceptance. Change ownership only through an e
 |---|---|---|---|---|---|
 | 1 | **Purchasing work hub** (counts, exceptions, deep links) | **Phase 7.1** | 7.1.1 | Domain read-model at **`GET /admin/purchasing`**. UDS-4 supplies only shared admin chrome. | Accepted |
 | 2 | **Grouped nav canonical group names** | **UDS-4** | 4.0–4.1 | Adopt the eight groups in [navigation-proposal.md](../ux-design-system/navigation-proposal.md). Roadmap aspirational names are future groupings when destinations exist. | Accepted |
-| 3 | **`application.html.erb` structure** | **UDS-4** | 4.1 | UDS-4.1 only slice that introduces grouped nav markup. Phase 7.1 adds flat-nav **Purchasing** link to hub before 4.1. | Accepted |
+| 3 | **`application.html.erb` structure** | **UDS-4** | 4.1 | UDS-4.1 only slice that introduces grouped nav markup. Phase 7.1 adds flat-nav **Purchasing** link to hub before 4.1; **keeps** existing Orders / PO / Receipt links until 4.1 deduplicates them under the **Purchasing** group (hub primary entry). | Accepted |
 | 4 | **Admin purchasing indexes** (orders, POs, receipts) | **Phase 7.1** | 7.1.2 | Phase 7.1 owns templates, filters, tables, and cross-links. | Accepted |
 | 5 | **Customer requests admin** (index/show polish) | **Phase 7.1** | 7.1.4 optional | Purchasing cross-links in 7.1.4; general Warm Parchment on migration-matrix schedule. | Accepted |
 | 6 | **Ops Location + Draft PO** visual/interaction parity | **Phase 7.1** | 7.1.3 | Ships **after UDS-4.1** (or parallel UDS-4.2 if no template overlap). Update program-plan allowlist when 7.1.3 starts. | Accepted |
@@ -59,7 +59,9 @@ Shared patterns for Phase 7.1.2+ (UDS-4.2 may reuse for non-purchasing):
 | Receipt show | PO line, order, request allocation | Immutable posted facts only |
 | Product / variant show | Existing quick actions unchanged | No new purchasing commands |
 
-Use existing routes; add helpers in `PurchasingHelper` or `ApplicationHelper` only when the same link triple appears three or more times.
+Use existing routes; add helpers in `PurchasingHelper` only when the same link triple appears three or more times.
+
+**Authorization:** helpers return `nil` when the current user lacks destination permission, store access, or record visibility. Views render a link only when the helper returns a path. Direct URL access remains denied by controllers. Tests must cover narrow users viewing an allowed record related to a forbidden destination (link absent; direct access denied)—especially receipt → customer request and PO → internal order.
 
 ## Merge sequencing (after Accept)
 
@@ -69,7 +71,7 @@ Use existing routes; add helpers in `PurchasingHelper` or `ApplicationHelper` on
    - UDS-4.0 navigation prototype + gate evidence
    - Phase 7.1.1 purchasing work hub at GET /admin/purchasing (flat nav)
 3. Phase 7.1.2 admin purchasing indexes
-4. UDS-4.1 grouped nav (after prototype gate)
+4. UDS-4.1 grouped nav (after prototype gate) — **removes redundant top-level Orders / PO / Receipt links**; hub remains primary **Purchasing** group entry (Phase 7.1.1 flat nav intentionally keeps duplicate links until this step)
 5. Phase 7.1.3 ops parity (after UDS-4.1; or parallel with UDS-4.2 if no template overlap)
 6. UDS-4.2 non-purchasing adoption (may parallel 7.1.3)
 7. Phase 7.1.4 if hub does not subsume request next-actions

--- a/docs/planning/phase7.1-purchasing-polish/phase7.1-user-stories.md
+++ b/docs/planning/phase7.1-purchasing-polish/phase7.1-user-stories.md
@@ -1,6 +1,6 @@
 # Phase 7.1 — User stories
 
-Status: **Proposed** backlog. Coordination **Accepted** — ready for slice implementation.
+Status: **In progress** backlog. Coordination **Accepted** — slice implementation on `phase-7.1-purchasing-polish`.
 
 Concise stories for slices 7.1.1–7.1.4; acceptance bullets are the review bar.
 
@@ -10,14 +10,17 @@ Concise stories for slices 7.1.1–7.1.4; acceptance bullets are the review bar.
 
 ### 7.1.1.1 See active purchasing work
 
-**As a** buyer or store manager with purchasing permissions, **I want** a store-scoped hub that summarizes work awaiting action **so that** I do not hunt through flat navigation links.
+**As a** buyer or store manager with purchasing permissions, **I want** a purchasing hub that summarizes work awaiting action **so that** I do not hunt through flat navigation links.
 
 Acceptance:
 
-- Hub requires `current_store` when any section needs store scope; sections omit when unauthorized or empty.
-- Minimum sections when data exists: location queue count, open draft PO count, sent POs with open quantity, in-progress receipt drafts.
-- Each section links to the correct admin list or ops workspace.
-- Hub is reachable from flat admin nav before grouped nav ships.
+- Hub reachable without auto-redirect when no store is selected; shows store-selection CTA and no store-scoped counts until a store is selected.
+- With `current_store`, authorized sections appear even when count is zero (compact “none awaiting” state).
+- Unauthorized sections are omitted entirely; hub layout is stable for authorized users.
+- Minimum store-scoped sections when authorized: location queue, draft POs, sent POs with open quantity, receipt drafts.
+- Sent PO count uses SQL relation scope, not per-record Ruby filtering.
+- Receipt drafts section links to receiving workspace index, not an ambiguous “latest draft.”
+- Hub is reachable from flat admin nav **Purchasing** link when user has any hub-eligible permission globally or on any accessible store.
 
 ### 7.1.1.2 Hub respects permissions
 
@@ -25,7 +28,8 @@ Acceptance:
 
 Acceptance:
 
-- At least one integration test mirrors navigation-proposal Profile B style (e.g. receiving-only user sees only receiving-related sections).
+- Integration test mirrors navigation-proposal Profile B style (e.g. receiving-only user sees only receiving-related sections).
+- No-store integration test shows history links only where controllers allow without store scope.
 - Direct URL to unauthorized destinations remains denied by controllers.
 
 ---
@@ -34,13 +38,13 @@ Acceptance:
 
 ### 7.1.2.1 Consistent purchasing history indexes
 
-**As a** buyer, **I want** orders, purchase orders, and receipt history to use the same admin patterns as other modern screens **so that** I can search, filter, and scan results quickly.
+**As a** buyer, **I want** orders, purchase orders, and receipt history to use the same admin patterns as other modern screens **so that** I can scan results quickly.
 
 Acceptance:
 
-- Indexes use shared page header, filters where useful, and data tables.
-- Status filters on PO index remain; presentation improves without changing query semantics.
-- `ActionButtonHelper` on touched primary/secondary actions.
+- Indexes use shared page header, breadcrumbs, and data tables.
+- PO index keeps existing status filter only; orders and receipts indexes do not add new filter behavior.
+- `ActionButtonHelper` on touched primary/secondary actions per button-action-semantics (one solid brand dominant action per surface where applicable).
 
 ### 7.1.2.2 Follow purchasing cross-links
 
@@ -49,7 +53,9 @@ Acceptance:
 Acceptance:
 
 - Show pages link to related entities per [coordination cross-link conventions](phase7.1-uds-coordination.md#cross-link-conventions).
-- Posted receipt facts remain read-only; no edit affordances on immutable rows.
+- Cross-links omitted when user lacks destination permission, store access, or record visibility.
+- Integration test: narrow user on allowed record does not see link to forbidden related record; direct access denied.
+- Posted receipt facts remain read-only; receipt tables use explicit `.table-scroll` / `.data-table`.
 
 ---
 
@@ -61,7 +67,9 @@ Acceptance:
 
 Acceptance:
 
-- Shortcut help visible; focus restoration after successful locate/not-located actions.
+- Ops shortcut help visible via ops layout; keyboard hint on queue.
+- Exit link to purchasing hub; `ActionButtonHelper` on touched actions.
+- Focus restoration after successful locate/not-located actions.
 - Existing [location_queue_buttons_test.rb](../../../test/system/location_queue_buttons_test.rb) assertions unchanged or strengthened only.
 
 ### 7.1.3.2 Draft PO workspace matches Receiving ergonomics
@@ -70,6 +78,7 @@ Acceptance:
 
 Acceptance:
 
+- Draft PO index/show use ops-doc-header pattern and hub exit link.
 - Dirty-form confirm behavior matches receiving/draft PO tests in [purchasing_ops_workspace_test.rb](../../../test/system/purchasing_ops_workspace_test.rb).
 - program-plan allowlist updated for touched selectors.
 
@@ -79,9 +88,9 @@ Acceptance:
 
 ### 7.1.4.1 Request show emphasizes next purchasing action
 
-**As a** associate, **I want** the customer request show page to link to the relevant order, PO, or receipt **so that** I know what to do next.
+**As a** buyer, **I want** request show pages to surface the next purchasing step **so that** I can act without re-reading status codes.
 
 Acceptance:
 
-- Deferred if 7.1.1 hub + existing request show already satisfy the workflow.
-- No “mark completed” without POS; Phase 7 rule preserved.
+- Only if hub does not subsume this need in 7.1.1.
+- Cross-links permission-gated per coordination conventions.

--- a/docs/planning/phase7.1-purchasing-polish/phase7.1-user-stories.md
+++ b/docs/planning/phase7.1-purchasing-polish/phase7.1-user-stories.md
@@ -1,6 +1,6 @@
 # Phase 7.1 — User stories
 
-Status: **In progress** backlog. Coordination **Accepted** — slice implementation on `phase-7.1-purchasing-polish`.
+Status: **In progress** backlog. Coordination **Accepted** — **7.1.1–7.1.2** on `phase-7.1-purchasing-polish`; **7.1.3 blocked until after UDS-4.1**.
 
 Concise stories for slices 7.1.1–7.1.4; acceptance bullets are the review bar.
 
@@ -61,16 +61,18 @@ Acceptance:
 
 ## Slice 7.1.3 — Ops workspace parity
 
+**Blocked until after UDS-4.1.** Hub exit links on Location/Draft PO/Receiving are incidental **7.1.1** integration and do not close these stories.
+
 ### 7.1.3.1 Location queue matches Receiving ergonomics
 
 **As a** floor associate, **I want** the location queue to behave like receiving **so that** keyboard and scanner workflows feel consistent.
 
 Acceptance:
 
-- Ops shortcut help visible via ops layout; keyboard hint on queue.
-- Exit link to purchasing hub; `ActionButtonHelper` on touched actions.
-- Focus restoration after successful locate/not-located actions.
-- Existing [location_queue_buttons_test.rb](../../../test/system/location_queue_buttons_test.rb) assertions unchanged or strengthened only.
+- Focus restoration after successful locate/not-located actions and after cancellation/close paths.
+- Dirty-form / Escape behavior aligned with Receiving where applicable.
+- Additive assertions in [location_queue_buttons_test.rb](../../../test/system/location_queue_buttons_test.rb); existing assertions unchanged or strengthened only.
+- program-plan allowlist updated for touched selectors in the 7.1.3 PR.
 
 ### 7.1.3.2 Draft PO workspace matches Receiving ergonomics
 
@@ -78,9 +80,8 @@ Acceptance:
 
 Acceptance:
 
-- Draft PO index/show use ops-doc-header pattern and hub exit link.
-- Dirty-form confirm behavior matches receiving/draft PO tests in [purchasing_ops_workspace_test.rb](../../../test/system/purchasing_ops_workspace_test.rb).
-- program-plan allowlist updated for touched selectors.
+- Dirty-form confirm and focus restoration match Receiving-grade coverage in [purchasing_ops_workspace_test.rb](../../../test/system/purchasing_ops_workspace_test.rb).
+- program-plan allowlist updated for touched selectors in the 7.1.3 PR.
 
 ---
 

--- a/docs/planning/roadmap.md
+++ b/docs/planning/roadmap.md
@@ -74,11 +74,11 @@ UDS-4.0 prototype may run in parallel with Phase 7.1.1 on flat nav after coordin
 
 ## Phase 7.1 — Purchasing workflow and presentation closeout
 
-**Status:** In progress on integration branch `phase-7.1-purchasing-polish` — slices **7.1.1–7.1.3** implemented; pending merge to `main`. UDS-4.1 grouped nav deduplication remains a UDS-4 deliverable.
+**Status:** In progress on integration branch `phase-7.1-purchasing-polish` — slices **7.1.1–7.1.2** implemented; **7.1.3 blocked until after UDS-4.1**. UDS-4.1 grouped nav deduplication remains a UDS-4 deliverable.
 
 Authoritative packet: [Phase 7.1](phase7.1-purchasing-polish/README.md).
 
-Phase 7 shipped the bookstore-operable purchasing and customer-request path. Phase 7.1 closes **Phase 7 operability** (work hub, admin purchasing presentation, ops parity)—not supplier returns, request expiration, or the AP/accounting interface. Forward domains (stored value, buyback, customer expansion, bibliographic enrichment, register cash) proceed separately; UDS grouped navigation is a parallel UDS program.
+Phase 7 shipped the bookstore-operable purchasing and customer-request path. Phase 7.1 closes **Phase 7 operability** (work hub and admin purchasing presentation first; Location/Draft PO ops parity in **7.1.3 after UDS-4.1**)—not supplier returns, request expiration, or the AP/accounting interface. Forward domains (stored value, buyback, customer expansion, bibliographic enrichment, register cash) proceed separately; UDS grouped navigation is a parallel UDS program.
 
 ### Slices (summary)
 
@@ -366,7 +366,7 @@ The following remain out of scope until a planning packet and ADR review justify
 | Phases 0–6.1 | Implemented |
 | Phase 7 — Orders, requests, receiving | Implemented |
 | UDS-1–3 — Warm Parchment foundation | Implemented (code); a11y matrix evidence in progress |
-| Phase 7.1 — Purchasing workflow closeout | **7.1.1–7.1.3 implemented** on `phase-7.1-purchasing-polish`; UDS-4.1 nav dedup pending ([packet](phase7.1-purchasing-polish/README.md)) |
+| Phase 7.1 — Purchasing workflow closeout | **7.1.1–7.1.2** on `phase-7.1-purchasing-polish`; **7.1.3 after UDS-4.1** ([packet](phase7.1-purchasing-polish/README.md)) |
 | UDS-4 — Navigation and information architecture | Proposed; coordination **Accepted** — UDS-4.0 prototype; UDS-4.1 after nav gate |
 | Phase 8 — Customer foundation refinement | Next; parallel with 9 |
 | Phase 9 — Catalog and bibliographic enrichment | Next; parallel with 8 |

--- a/docs/planning/roadmap.md
+++ b/docs/planning/roadmap.md
@@ -72,13 +72,13 @@ Scope:
 
 UDS-4.0 prototype may run in parallel with Phase 7.1.1 on flat nav after coordination acceptance.
 
-## Phase 7.1 — Purchasing polish
+## Phase 7.1 — Purchasing workflow and presentation closeout
 
-**Status:** Proposed. **Builds on** [Phase 7](phase7-orders-and-receiving/README.md). Coordination **Accepted** ([phase7.1-uds-coordination.md](phase7.1-purchasing-polish/phase7.1-uds-coordination.md)).
+**Status:** In progress on integration branch `phase-7.1-purchasing-polish` — slices **7.1.1–7.1.3** implemented; pending merge to `main`. UDS-4.1 grouped nav deduplication remains a UDS-4 deliverable.
 
 Authoritative packet: [Phase 7.1](phase7.1-purchasing-polish/README.md).
 
-Phase 7 shipped the bookstore-operable purchasing and customer-request path. Phase 7.1 addresses **targeted purchasing ergonomics** deferred from Phase 7—not supplier returns, request expiration, or the AP/accounting interface.
+Phase 7 shipped the bookstore-operable purchasing and customer-request path. Phase 7.1 closes **Phase 7 operability** (work hub, admin purchasing presentation, ops parity)—not supplier returns, request expiration, or the AP/accounting interface. Forward domains (stored value, buyback, customer expansion, bibliographic enrichment, register cash) proceed separately; UDS grouped navigation is a parallel UDS program.
 
 ### Slices (summary)
 
@@ -366,7 +366,7 @@ The following remain out of scope until a planning packet and ADR review justify
 | Phases 0–6.1 | Implemented |
 | Phase 7 — Orders, requests, receiving | Implemented |
 | UDS-1–3 — Warm Parchment foundation | Implemented (code); a11y matrix evidence in progress |
-| Phase 7.1 — Purchasing polish | Proposed; coordination **Accepted** — slices 7.1.1+ ([packet](phase7.1-purchasing-polish/README.md)) |
+| Phase 7.1 — Purchasing workflow closeout | **7.1.1–7.1.3 implemented** on `phase-7.1-purchasing-polish`; UDS-4.1 nav dedup pending ([packet](phase7.1-purchasing-polish/README.md)) |
 | UDS-4 — Navigation and information architecture | Proposed; coordination **Accepted** — UDS-4.0 prototype; UDS-4.1 after nav gate |
 | Phase 8 — Customer foundation refinement | Next; parallel with 9 |
 | Phase 9 — Catalog and bibliographic enrichment | Next; parallel with 8 |
@@ -387,7 +387,7 @@ The following remain out of scope until a planning packet and ADR review justify
 |---|---|
 | [planning/README.md](README.md) | Domain ownership and dependency guidance; §3 phase outline superseded by this file for forward sequencing |
 | [Phase planning packets](phase1-operational-foundation/phase1-plan.md) | Authoritative detail per implemented phase |
-| [Phase 7.1 purchasing polish](phase7.1-purchasing-polish/README.md) | Forward purchasing ergonomics; [coordination with UDS-4](phase7.1-purchasing-polish/phase7.1-uds-coordination.md) |
+| [Phase 7.1 purchasing closeout](phase7.1-purchasing-polish/README.md) | Phase 7 operability finish; [coordination with UDS-4](phase7.1-purchasing-polish/phase7.1-uds-coordination.md) |
 | [UDS-4 plan](ux-design-system/uds-4-plan.md) | Grouped navigation and cross-cutting adoption |
 | [preliminary-roadmap.md](../drafts/preliminary-roadmap.md) | Terminal / ADR-018 productization detail; draft POS Phases 4–6B boundary text superseded for domain sequencing |
 | [pos-pending-decisions.md](../drafts/pos-pending-decisions.md) | Open POS policy items referenced during phase planning |

--- a/test/integration/admin_purchasing_hub_test.rb
+++ b/test/integration/admin_purchasing_hub_test.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AdminPurchasingHubTest < ActionDispatch::IntegrationTest
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    Inventory::AdjustmentReasons.seed!
+    @tax = tax_class(code: "hub_#{SecureRandom.hex(2)}")
+    @variant = pos_sellable_variant(actor: @actor, tax_class: @tax, name: "Hub Book")
+    @supplier = Supplier.create!(name: "Hub Supp", code: "hub_#{SecureRandom.hex(2)}")
+    SupplierVariantSource.create!(
+      supplier: @supplier,
+      product_variant: @variant,
+      pricing_method: "direct_unit_cost",
+      expected_unit_cost_cents: 500,
+      organization_preferred: true
+    )
+  end
+
+  test "admin hub shows authorized sections with zero counts and operational links when work exists" do
+    sign_in_as("admin")
+    post store_selection_path, params: { store_id: @store.id }
+
+    order = Purchasing::CreateStockOrder.call(
+      store: @store,
+      product_variant: @variant,
+      actor: @actor,
+      quantity: 1,
+      supplier: @supplier
+    )
+    po = order.purchase_order
+    Purchasing::GeneratePurchaseOrder.call(purchase_order: po, actor: @actor)
+    Purchasing::SendPurchaseOrder.call(
+      purchase_order: po.reload,
+      actor: @actor,
+      transmission_method: "email"
+    )
+
+    get admin_purchasing_path
+    assert_response :success
+    assert_match(/Requests awaiting location/, response.body)
+    assert_match(/Draft purchase orders/, response.body)
+    assert_match(/Sent purchase orders awaiting receipt/, response.body)
+    assert_match(/Receipt drafts in progress/, response.body)
+    assert_match(/None awaiting/, response.body)
+    assert_match(/1 item/, response.body)
+    assert_match(/Sent purchase orders awaiting receipt/, response.body)
+    assert_match admin_purchase_orders_path(status: "sent"), response.body
+  end
+
+  test "hub without store shows selection prompt and history without operational counts" do
+    second_store = Store.create!(
+      store_number: "9",
+      code: "hub_second",
+      name: "Second Store",
+      legal_name: "Example Books LLC",
+      timezone: "America/New_York",
+      country_code: "US"
+    )
+    sign_in_as("admin")
+    # Clear implicit single-store selection by having two accessible stores and no session store.
+    get admin_purchasing_path
+    assert_response :success
+    assert_match(/Select a store to view purchasing work/i, response.body)
+    assert_no_match(/Active work/i, response.body)
+    assert_match(/View all orders/, response.body)
+  end
+
+  test "narrow receiving user sees only receipt draft section" do
+    role = Role.create!(
+      key: "receiving_only_#{SecureRandom.hex(3)}",
+      name: "Receiving only",
+      assignment_scope: "store",
+      system_role: false,
+      active: true
+    )
+    %w[purchase_receipts.manage purchase_receipts.view].each do |key|
+      RolePermission.create!(
+        role: role,
+        permission: Permission.find_by!(key: key),
+        granted_by: @actor
+      )
+    end
+    user = User.create!(
+      username: "recv_only_#{SecureRandom.hex(3)}",
+      display_name: "Receiving Only",
+      password: "correct-horse-battery",
+      password_confirmation: "correct-horse-battery"
+    )
+    RoleAssignment.create!(
+      user: user,
+      role: role,
+      store: @store,
+      assigned_by: @actor,
+      effective_at: Time.current
+    )
+
+    post session_path, params: { session: { username: user.username, password: "correct-horse-battery" } }
+    post store_selection_path, params: { store_id: @store.id }
+
+    get admin_purchasing_path
+    assert_response :success
+    assert_match(/Receipt drafts in progress/, response.body)
+    assert_no_match(/Requests awaiting location/, response.body)
+    assert_no_match(/Draft purchase orders/, response.body)
+    assert_no_match(/Sent purchase orders awaiting receipt/, response.body)
+  end
+
+  test "hub denied without purchasing permissions" do
+    role = Role.create!(
+      key: "inventory_only_#{SecureRandom.hex(3)}",
+      name: "Inventory only",
+      assignment_scope: "store",
+      system_role: false,
+      active: true
+    )
+    RolePermission.create!(
+      role: role,
+      permission: Permission.find_by!(key: "inventory.view"),
+      granted_by: @actor
+    )
+    user = User.create!(
+      username: "inv_only_#{SecureRandom.hex(3)}",
+      display_name: "Inventory Only",
+      password: "correct-horse-battery",
+      password_confirmation: "correct-horse-battery"
+    )
+    RoleAssignment.create!(
+      user: user,
+      role: role,
+      store: @store,
+      assigned_by: @actor,
+      effective_at: Time.current
+    )
+
+    post session_path, params: { session: { username: user.username, password: "correct-horse-battery" } }
+    get admin_purchasing_path
+    assert_redirected_to root_path
+  end
+
+  test "flat nav includes purchasing link when hub eligible" do
+    sign_in_as("admin")
+    get root_path
+    assert_response :success
+    assert_match admin_purchasing_path, response.body
+  end
+
+  private
+
+  def sign_in_as(username)
+    post session_path, params: { session: { username: username, password: "correct-horse-battery" } }
+  end
+end

--- a/test/integration/admin_purchasing_hub_test.rb
+++ b/test/integration/admin_purchasing_hub_test.rb
@@ -148,6 +148,66 @@ class AdminPurchasingHubTest < ActionDispatch::IntegrationTest
     assert_match admin_purchasing_path, response.body
   end
 
+  test "hub visibility is memoized for the request across layout and hub action" do
+    stores = Array.new(4) do |i|
+      Store.create!(
+        store_number: (30 + i).to_s,
+        code: "memo_#{i}_#{SecureRandom.hex(2)}",
+        name: "Memo Store #{i}",
+        legal_name: "Example Books LLC",
+        timezone: "America/New_York",
+        country_code: "US"
+      )
+    end
+
+    role = Role.create!(
+      key: "memo_recv_#{SecureRandom.hex(3)}",
+      name: "Memo receiving",
+      assignment_scope: "store",
+      system_role: false,
+      active: true
+    )
+    RolePermission.create!(
+      role: role,
+      permission: Permission.find_by!(key: "purchase_receipts.manage"),
+      granted_by: @actor
+    )
+    user = User.create!(
+      username: "memo_hub_#{SecureRandom.hex(3)}",
+      display_name: "Memo Hub",
+      password: "correct-horse-battery",
+      password_confirmation: "correct-horse-battery"
+    )
+    stores.each do |store|
+      RoleAssignment.create!(
+        user: user,
+        role: role,
+        store: store,
+        assigned_by: @actor,
+        effective_at: Time.current
+      )
+    end
+
+    post session_path, params: { session: { username: user.username, password: "correct-horse-battery" } }
+    post store_selection_path, params: { store_id: stores.first.id }
+
+    calls = 0
+    original = Purchasing::HubAccess.method(:nav_visible?)
+    Purchasing::HubAccess.define_singleton_method(:nav_visible?) do |**kwargs|
+      calls += 1
+      original.call(**kwargs)
+    end
+
+    begin
+      get admin_purchasing_path
+      assert_response :success
+      # Layout and require_hub_access! share purchasing_hub_accessible? memoization.
+      assert_equal 1, calls
+    ensure
+      Purchasing::HubAccess.define_singleton_method(:nav_visible?, original)
+    end
+  end
+
   private
 
   def sign_in_as(username)

--- a/test/integration/purchasing_cross_links_test.rb
+++ b/test/integration/purchasing_cross_links_test.rb
@@ -94,6 +94,87 @@ class PurchasingCrossLinksTest < ActionDispatch::IntegrationTest
     assert_match admin_purchase_order_path(@po), response.body
   end
 
+  test "multi-line receipt show evaluates store permissions a bounded number of times" do
+    variants = Array.new(4) do |i|
+      pos_sellable_variant(actor: @actor, tax_class: @tax, name: "Bound Book #{i}")
+    end
+    variants.each do |variant|
+      SupplierVariantSource.create!(
+        supplier: @supplier,
+        product_variant: variant,
+        pricing_method: "direct_unit_cost",
+        expected_unit_cost_cents: 250,
+        organization_preferred: true
+      )
+    end
+
+    first_order = Purchasing::CreateStockOrder.call(
+      store: @store,
+      product_variant: variants.first,
+      actor: @actor,
+      quantity: 1,
+      supplier: @supplier
+    )
+    po = first_order.purchase_order
+    variants.drop(1).each do |variant|
+      Purchasing::CreateStockOrder.call(
+        store: @store,
+        product_variant: variant,
+        actor: @actor,
+        quantity: 1,
+        supplier: @supplier
+      )
+    end
+    Purchasing::GeneratePurchaseOrder.call(purchase_order: po.reload, actor: @actor)
+    Purchasing::SendPurchaseOrder.call(
+      purchase_order: po.reload,
+      actor: @actor,
+      transmission_method: "email"
+    )
+
+    receipt = Purchasing::CreateDraftPurchaseReceipt.call(
+      store: @store,
+      supplier: @supplier,
+      actor: @actor
+    )
+    po.purchase_order_lines.find_each do |line|
+      Purchasing::AddPurchaseReceiptLine.call(
+        purchase_receipt: receipt.reload,
+        purchase_order_line: line,
+        actor: @actor,
+        received_quantity: 1,
+        actual_unit_cost_cents: 250
+      )
+    end
+    Purchasing::PostPurchaseReceipt.call(
+      purchase_receipt: receipt.reload,
+      actor: @actor,
+      idempotency_key: SecureRandom.uuid_v7
+    )
+
+    sign_in_as("admin")
+    post store_selection_path, params: { store_id: @store.id }
+
+    store_evaluations = Hash.new(0)
+    original = Authorization::PermissionEvaluator.method(:permissions_for)
+    Authorization::PermissionEvaluator.define_singleton_method(:permissions_for) do |user:, store:|
+      store_evaluations[store&.id || :global] += 1
+      original.call(user: user, store: store)
+    end
+
+    begin
+      get admin_purchase_receipt_path(receipt)
+      assert_response :success
+      assert_operator receipt.purchase_receipt_lines.count, :>=, 4
+      # Cross-link helpers share one memoized permission set per store for the render.
+      # Allow a small constant for layout/current-store effective_permissions plus hub nav.
+      assert_operator store_evaluations[@store.id], :<=, 3
+      assert_operator store_evaluations[@store.id], :>=, 1
+    ensure
+      Authorization::PermissionEvaluator.define_singleton_method(:permissions_for, original)
+    end
+  end
+
   private
 
   def sign_in_as(user_or_username)

--- a/test/integration/purchasing_cross_links_test.rb
+++ b/test/integration/purchasing_cross_links_test.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PurchasingCrossLinksTest < ActionDispatch::IntegrationTest
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    Inventory::AdjustmentReasons.seed!
+    @tax = tax_class(code: "xlink_#{SecureRandom.hex(2)}")
+    @variant = pos_sellable_variant(actor: @actor, tax_class: @tax, name: "Crosslink Book")
+    @supplier = Supplier.create!(name: "Xlink Supp", code: "xlink_#{SecureRandom.hex(2)}")
+    SupplierVariantSource.create!(
+      supplier: @supplier,
+      product_variant: @variant,
+      pricing_method: "direct_unit_cost",
+      expected_unit_cost_cents: 600,
+      organization_preferred: true
+    )
+    @customer = Customer.create!(display_name: "Crosslink Customer", email: "cross@example.com")
+    @customer_request = Customers::CreateRequest.call(
+      store: @store,
+      customer: @customer,
+      product_variant: @variant,
+      actor: @actor
+    )
+    @order = @customer_request.orders.first
+    @po = @order.purchase_order
+    Purchasing::GeneratePurchaseOrder.call(purchase_order: @po, actor: @actor)
+    Purchasing::SendPurchaseOrder.call(
+      purchase_order: @po.reload,
+      actor: @actor,
+      transmission_method: "email"
+    )
+    @po_line = @po.purchase_order_lines.first
+    @receipt = draft_receipt_with_line(@po_line, received_quantity: 1, actual_unit_cost_cents: 600)
+    Purchasing::PostPurchaseReceipt.call(
+      purchase_receipt: @receipt,
+      actor: @actor,
+      idempotency_key: SecureRandom.uuid_v7
+    )
+
+    @limited_role = Role.create!(
+      key: "orders_only_#{SecureRandom.hex(3)}",
+      name: "Orders only",
+      assignment_scope: "store",
+      system_role: false,
+      active: true
+    )
+    %w[orders.view purchase_receipts.view].each do |key|
+      RolePermission.create!(
+        role: @limited_role,
+        permission: Permission.find_by!(key: key),
+        granted_by: @actor
+      )
+    end
+    @limited_user = User.create!(
+      username: "orders_only_#{SecureRandom.hex(3)}",
+      display_name: "Orders Only",
+      password: "correct-horse-battery",
+      password_confirmation: "correct-horse-battery"
+    )
+    RoleAssignment.create!(
+      user: @limited_user,
+      role: @limited_role,
+      store: @store,
+      assigned_by: @actor,
+      effective_at: Time.current
+    )
+  end
+
+  test "limited user sees order and PO links but not customer request link on receipt show" do
+    sign_in_as(@limited_user)
+    post store_selection_path, params: { store_id: @store.id }
+
+    get admin_purchase_receipt_path(@receipt)
+    assert_response :success
+    assert_match admin_order_path(@order), response.body
+    assert_match admin_purchase_order_path(@po), response.body
+    assert_no_match admin_customer_request_path(@customer_request), response.body
+
+    get admin_customer_request_path(@customer_request)
+    assert_redirected_to root_path
+  end
+
+  test "admin sees customer request cross-link on order show" do
+    sign_in_as("admin")
+    post store_selection_path, params: { store_id: @store.id }
+
+    get admin_order_path(@order)
+    assert_response :success
+    assert_match admin_customer_request_path(@customer_request), response.body
+    assert_match admin_purchase_order_path(@po), response.body
+  end
+
+  private
+
+  def sign_in_as(user_or_username)
+    username = user_or_username.is_a?(User) ? user_or_username.username : user_or_username
+    post session_path, params: { session: { username: username, password: "correct-horse-battery" } }
+  end
+
+  def draft_receipt_with_line(po_line, received_quantity:, actual_unit_cost_cents:)
+    receipt = Purchasing::CreateDraftPurchaseReceipt.call(
+      store: @store,
+      supplier: @supplier,
+      actor: @actor
+    )
+    Purchasing::AddPurchaseReceiptLine.call(
+      purchase_receipt: receipt,
+      purchase_order_line: po_line,
+      actor: @actor,
+      received_quantity: received_quantity,
+      actual_unit_cost_cents: actual_unit_cost_cents
+    )
+    receipt.reload
+  end
+end

--- a/test/models/purchase_order_open_lines_test.rb
+++ b/test/models/purchase_order_open_lines_test.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PurchaseOrderOpenLinesTest < ActiveSupport::TestCase
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    Inventory::AdjustmentReasons.seed!
+    @tax = tax_class(code: "open_#{SecureRandom.hex(2)}")
+    @variant = pos_sellable_variant(actor: @actor, tax_class: @tax, name: "Open Qty Book")
+    @supplier = Supplier.create!(name: "Open Supp", code: "open_#{SecureRandom.hex(2)}")
+    SupplierVariantSource.create!(
+      supplier: @supplier,
+      product_variant: @variant,
+      pricing_method: "direct_unit_cost",
+      expected_unit_cost_cents: 400,
+      organization_preferred: true
+    )
+  end
+
+  test "with_open_lines matches instance open_quantity for partial receipt and reversal" do
+    order = Purchasing::CreateStockOrder.call(
+      store: @store,
+      product_variant: @variant,
+      actor: @actor,
+      quantity: 2,
+      supplier: @supplier
+    )
+    po = order.purchase_order
+    line = po.purchase_order_lines.first
+    Purchasing::GeneratePurchaseOrder.call(purchase_order: po, actor: @actor)
+    Purchasing::SendPurchaseOrder.call(
+      purchase_order: po.reload,
+      actor: @actor,
+      transmission_method: "email"
+    )
+
+    assert_includes PurchaseOrder.sent.with_open_lines, po
+    assert_equal 1, PurchaseOrder.sent.for_store(@store).with_open_lines.count
+
+    receipt = draft_receipt_with_line(line, received_quantity: 1, actual_unit_cost_cents: 400)
+    Purchasing::PostPurchaseReceipt.call(
+      purchase_receipt: receipt,
+      actor: @actor,
+      idempotency_key: SecureRandom.uuid_v7
+    )
+
+    assert_equal line.reload.open_quantity, 1
+    assert_includes PurchaseOrder.sent.with_open_lines, po
+
+    receipt_line = receipt.purchase_receipt_lines.first
+    Purchasing::ReversePurchaseReceiptLine.call(
+      purchase_receipt_line: receipt_line,
+      actor: @actor,
+      reason: "test reversal",
+      idempotency_key: SecureRandom.uuid_v7
+    )
+
+    assert_equal 2, line.reload.open_quantity
+    assert_includes PurchaseOrder.sent.with_open_lines, po
+  end
+
+  test "with_open_lines excludes fully received sent PO" do
+    order = Purchasing::CreateStockOrder.call(
+      store: @store,
+      product_variant: @variant,
+      actor: @actor,
+      quantity: 1,
+      supplier: @supplier
+    )
+    po = order.purchase_order
+    line = po.purchase_order_lines.first
+    Purchasing::GeneratePurchaseOrder.call(purchase_order: po, actor: @actor)
+    Purchasing::SendPurchaseOrder.call(
+      purchase_order: po.reload,
+      actor: @actor,
+      transmission_method: "email"
+    )
+
+    receipt = draft_receipt_with_line(line, received_quantity: 1, actual_unit_cost_cents: 400)
+    Purchasing::PostPurchaseReceipt.call(
+      purchase_receipt: receipt,
+      actor: @actor,
+      idempotency_key: SecureRandom.uuid_v7
+    )
+    Purchasing::ClosePurchaseOrderIfComplete.call!(
+      purchase_order: po.reload,
+      actor: @actor
+    )
+
+    assert_equal 0, line.reload.open_quantity
+    assert_not_includes PurchaseOrder.sent.with_open_lines, po
+  end
+
+  private
+
+  def draft_receipt_with_line(po_line, received_quantity:, actual_unit_cost_cents:)
+    receipt = Purchasing::CreateDraftPurchaseReceipt.call(
+      store: @store,
+      supplier: @supplier,
+      actor: @actor
+    )
+    Purchasing::AddPurchaseReceiptLine.call(
+      purchase_receipt: receipt,
+      purchase_order_line: po_line,
+      actor: @actor,
+      received_quantity: received_quantity,
+      actual_unit_cost_cents: actual_unit_cost_cents
+    )
+    receipt.reload
+  end
+end

--- a/test/services/purchasing/hub_access_test.rb
+++ b/test/services/purchasing/hub_access_test.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Purchasing::HubAccessTest < ActiveSupport::TestCase
+  setup do
+    @bootstrap = bootstrap!
+    @admin = @bootstrap[:administrator]
+    @store = @bootstrap[:store]
+  end
+
+  test "permission_allowed_anywhere evaluates one set per scope and stops early" do
+    stores = Array.new(5) do |i|
+      Store.create!(
+        store_number: (10 + i).to_s,
+        code: "hub_perf_#{i}_#{SecureRandom.hex(2)}",
+        name: "Hub Perf #{i}",
+        legal_name: "Example Books LLC",
+        timezone: "America/New_York",
+        country_code: "US"
+      )
+    end
+
+    role = Role.create!(
+      key: "hub_recv_#{SecureRandom.hex(3)}",
+      name: "Hub receiving",
+      assignment_scope: "store",
+      system_role: false,
+      active: true
+    )
+    RolePermission.create!(
+      role: role,
+      permission: Permission.find_by!(key: "purchase_receipts.manage"),
+      granted_by: @admin
+    )
+    user = User.create!(
+      username: "hub_perf_#{SecureRandom.hex(3)}",
+      display_name: "Hub Perf",
+      password: "correct-horse-battery",
+      password_confirmation: "correct-horse-battery"
+    )
+    # Permission only on the last store — forces scanning global + all stores until match.
+    RoleAssignment.create!(
+      user: user,
+      role: role,
+      store: stores.last,
+      assigned_by: @admin,
+      effective_at: Time.current
+    )
+
+    calls = []
+    original = Authorization::PermissionEvaluator.method(:permissions_for)
+    Authorization::PermissionEvaluator.define_singleton_method(:permissions_for) do |user:, store:|
+      calls << store&.id
+      original.call(user: user, store: store)
+    end
+
+    begin
+      assert Purchasing::HubAccess.nav_visible?(user: user, accessible_stores: stores)
+      # One global evaluation + one per store until the last (5 stores) = 6 max.
+      assert_equal 6, calls.size
+      assert_nil calls.first
+      assert_equal stores.map(&:id), calls.drop(1)
+    ensure
+      Authorization::PermissionEvaluator.define_singleton_method(:permissions_for, original)
+    end
+  end
+
+  test "permission_allowed_anywhere stops after first matching store" do
+    first = Store.create!(
+      store_number: "21",
+      code: "hub_early_#{SecureRandom.hex(2)}",
+      name: "Hub Early",
+      legal_name: "Example Books LLC",
+      timezone: "America/New_York",
+      country_code: "US"
+    )
+    later = Store.create!(
+      store_number: "22",
+      code: "hub_later_#{SecureRandom.hex(2)}",
+      name: "Hub Later",
+      legal_name: "Example Books LLC",
+      timezone: "America/New_York",
+      country_code: "US"
+    )
+
+    role = Role.create!(
+      key: "hub_early_#{SecureRandom.hex(3)}",
+      name: "Hub early",
+      assignment_scope: "store",
+      system_role: false,
+      active: true
+    )
+    RolePermission.create!(
+      role: role,
+      permission: Permission.find_by!(key: "orders.view"),
+      granted_by: @admin
+    )
+    user = User.create!(
+      username: "hub_early_#{SecureRandom.hex(3)}",
+      display_name: "Hub Early User",
+      password: "correct-horse-battery",
+      password_confirmation: "correct-horse-battery"
+    )
+    RoleAssignment.create!(
+      user: user,
+      role: role,
+      store: first,
+      assigned_by: @admin,
+      effective_at: Time.current
+    )
+
+    calls = []
+    original = Authorization::PermissionEvaluator.method(:permissions_for)
+    Authorization::PermissionEvaluator.define_singleton_method(:permissions_for) do |user:, store:|
+      calls << store&.id
+      original.call(user: user, store: store)
+    end
+
+    begin
+      assert Purchasing::HubAccess.nav_visible?(user: user, accessible_stores: [ first, later ])
+      assert_equal [ nil, first.id ], calls
+    ensure
+      Authorization::PermissionEvaluator.define_singleton_method(:permissions_for, original)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add the purchasing work hub at `GET /admin/purchasing` with permission-filtered sections, stable zero-count states, no-store behavior, and SQL-backed sent-PO open-line counts.
- Modernize admin orders, purchase orders, and receipt indexes/show pages with Warm Parchment patterns, permission-gated cross-links, and preserved PO status filtering.
- Align ops Location, Draft PO, and Receiving exit paths with the hub; update Phase 7.1 planning docs for post-review acceptance criteria.
- Restore product quick-action helpers (`stock_orderable_variant?`, etc.) that were accidentally dropped when extending `PurchasingHelper`.

## Test plan

- [x] `./dev/rails-docker bin/rails test test/integration/admin_purchasing_hub_test.rb`
- [x] `./dev/rails-docker bin/rails test test/integration/purchasing_cross_links_test.rb`
- [x] `./dev/rails-docker bin/rails test test/models/purchase_order_open_lines_test.rb`
- [x] `./dev/rails-docker bin/rails test test/integration/purchase_orders_admin_test.rb`
- [x] `./dev/rails-docker bin/rails test test/system/purchasing_ops_workspace_test.rb test/system/location_queue_buttons_test.rb`
- [x] Manual smoke: visit `/admin/purchasing` with and without store selected; confirm product show quick actions work
- [x] Confirm no Phase 7 command or lock-order behavior changed

## Notes

- Flat nav temporarily includes **Purchasing** plus existing Orders / PO / Receipt links until UDS-4.1 grouped nav deduplicates them.
- UDS-4.1 remains a separate deliverable; this PR does not ship grouped navigation.


Made with [Cursor](https://cursor.com)