### PR TITLE
10.0 — Land Phase 10 packet corrections

### DIFF
--- a/docs/adr/ADR-026-gift-card-number-protection.md
+++ b/docs/adr/ADR-026-gift-card-number-protection.md
@@ -6,28 +6,30 @@
 
 ## Context
 
-A gift-card number is a bearer credential. Anyone who knows it can redeem the remaining balance online. Phase 10 generates numbers at successful POS completion for system-generated programs and accepts manual/external numbers at activation.
+A gift-card number is a bearer credential. Anyone who knows it can redeem the remaining balance online. Phase 10 generates numbers at successful POS completion for system-generated programs and accepts manual/external numbers at activation and new-refund-card creation.
 
 [ADR-009](ADR-009-concurrency-and-idempotency.md) requires completion retries to return the stored outcome, including enough data for the controlled first print. Ordinary receipt reprints must not reproduce the full number. [AGENTS.md](../../AGENTS.md) and [ADR-008](ADR-008-audit-events.md) forbid placing secrets in audit payloads, logs, fixtures, and indiscriminate event dumps.
 
-Digest-only storage cannot satisfy complete-retry print. Leaving encryption as an optional implementation detail postpones key management until the first printer failure.
+Digest-only storage cannot satisfy complete-retry print. Custom ciphertext envelopes and per-row key identifiers would invent key management ShelfSense does not operate.
 
 ## Decision
 
-1. **The full normalized number is a secret.** ShelfSense stores it as non-deterministic Active Record encryption ciphertext plus a keyed HMAC digest for uniqueness and exact lookup. Display fields are prefix and last four only.
-2. **Keys live outside the repository.** Encryption keys come from credentials or environment configuration (Docker/CI test keys are documented and distinct from production). Support `key_id` / previous-keys rotation. Do not commit production keys, plaintext numbers, or decryptable fixtures.
+1. **ShelfSense stores the normalized gift-card number through Rails Active Record Encryption using nondeterministic encryption.** A separate keyed HMAC digest provides exact lookup and uniqueness. Prefix and last four digits are stored for ordinary display.
+2. **Active Record Encryption keys are configured through the standard Rails credentials/environment mechanism.** ShelfSense does not implement custom ciphertext envelopes, IV handling, per-row key identifiers, or application-specific key-rotation metadata. Future rotation uses Rails-supported encryption schemes. HMAC secret is separate from Active Record Encryption keys. Do not commit production keys, plaintext numbers, or decryptable fixtures. Docker/CI test keys are documented and distinct from production.
 3. **Lookup is exact-match on the digest.** No prefix search, autocomplete, or unmasked lists. Failed lookup uses a generic error. Repeated failures are throttled and audited without recording the submitted number.
-4. **The completed POS envelope never contains the full number.** Command payload for system-generated cards expresses “generate a number from program X.” The envelope snapshots masked identity and Core foreign keys. Decrypt for the controlled activation print channel and for idempotent complete-retry of that first print.
-5. **Ordinary reprints stay masked.** Revealing or reprinting the full credential requires `gift_cards.reveal_number` (or the equivalent keyed in the Phase 10 authorization contract), a reason, and an audit event whose payload records outcome and last four—not the number.
+4. **The completed POS envelope never contains the full number.** Command payload for system-generated cards expresses “generate a number from program X.” The envelope snapshots masked identity and Core foreign keys. Decrypt for the controlled activation/refund-card print channel and for idempotent complete-retry of that first print.
+5. **Full-number decryption is limited to controlled first-print, idempotent completion retry, and narrowly authorized print-recovery or replacement services.** Phase 10 does not provide a general administrative reveal screen. Audit records card identity by ID and last four only.
 6. **Outbox, URLs, logs, exceptions, screenshots, and support dumps never include the full number or ciphertext that tests could treat as a credential.** Tests use the documented test key and synthetic numbers.
+
+Working manual activation and new refund cards may persist `pending_card_number` with `encrypts :pending_card_number` on the working POS row. No gift-card row exists until completion.
 
 PIN/access codes remain out of Phase 10. Offline number pools remain a future ADR-005 design; they do not change this protection model.
 
 ## Consequences
 
-- Gift-card rows carry `number_digest`, encrypted `number_ciphertext` (or Rails `encrypts`), `number_prefix`, `number_last_four`, and encryption key metadata as specified in [phase10-gift-card-numbering.md](../planning/phase10-stored-value/phase10-gift-card-numbering.md).
-- First-print after commit and complete-retry can recover the number; abandoned working transactions never persist a number or liability.
-- Operators who lack reveal permission cannot recover a lost printed card except through the replacement workflow.
+- Gift-card rows carry `number` (`encrypts :number`), `number_digest`, `number_prefix`, and `number_last_four` as specified in [phase10-gift-card-numbering.md](../planning/phase10-stored-value/phase10-gift-card-numbering.md). There is no `number_ciphertext`, `encryption_key_id`, or `gift_cards.reveal_number` permission.
+- First-print after commit and complete-retry can recover the number; abandoned working transactions never persist a gift-card liability.
+- Lost physical cards are recovered through print-recovery or replacement, not a general reveal UI.
 - CI and local Docker must configure Active Record encryption keys; document them in development guidance when implementation lands.
 
 ## Related documentation

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -26,17 +26,22 @@ This file starts with stored-value vocabulary for [Phase 10](planning/phase10-st
 | **Stored-value account** | Authoritative balance container. `balance_cents` is a locked projection over entries. |
 | **Stored-value operation** | One completed stored-value business action (issue, activate, reload, redeem, refund, cash-out, transfer, adjust, reverse). Immutable. |
 | **Stored-value entry** | One signed balance change on one account inside an operation. Append-only. |
-| **Store credit** | Customer-owned retail-credit liability. Organization-wide balance; activity attributed to a store. Ordinary refund-to-credit destination. |
-| **Trade credit** | Customer-owned buyback-related liability, distinct from store credit. Manual issue in Phase 10; buyback issue in Phase 12. Not created by retail refunds. Cash-out prohibited. |
+| **Store credit** | Customer-owned retail-credit liability. Organization-wide balance; activity attributed to a store. Ordinary account-bound refund destination. |
+| **Trade credit** | Customer-owned buyback-related liability, distinct from store credit. Manual issue in Phase 10; buyback issue in Phase 12. Not created by retail refunds as a generic destination. Cash-out prohibited. |
 | **Gift card** | Bearer stored-value **instrument** with its own account. Optional customer association is not ownership. |
 | **Gift-card program** | Number namespace and operating policy (prefix, length, reload, cash-out). |
 | **Gift-card instrument** | The `gift_cards` row: digest, encrypted number, status, program, 1:1 account. |
 | **Gift-card activation** | POS **issuance** that creates the instrument and liability when the customer pays. Not a tender and not a merchandise line. |
 | **Reload** | POS issuance that adds value to an existing active gift card. |
 | **Redemption** | POS **tender** that spends stored value against amount due. |
+| **Original-instrument refund** | Refund of gift-card-funded value onto the presented matching original (or verified replacement) card. |
+| **Refund gift card** | New bearer instrument created only for value originally paid by gift card when the original instrument is unavailable. Receives the current refund amount only; does not replace or drain the original card. |
 | **Cash-out** | Controlled Register payout of a gift card’s full eligible remaining balance. Not a generic paid-out; not a tender. |
-| **Transfer** | Ledger move of a balance (customer merge, or gift-card replacement). Not discretionary customer-to-customer transfer. |
-| **Tender versus issuance** | A tender settles what the customer owes or is owed. An issuance is customer-paid sale of gift-card liability and increases amount due. Refund-to-credit is a tender, not an issuance. |
-| **Unused-instrument return** | Reverse an unused gift-card issuance and refund tenders. Not a merchandise return. |
+| **Transfer** | Atomic, net-zero movement between same-type stored-value accounts. Includes customer merge, administrative transfer, and account consolidation. Cross-type movement is conversion, not transfer. |
+| **Account consolidation** | Full-balance same-type transfer that closes the source account. |
+| **Manual adjustment** | Controlled credit or debit of an eligible account through a reason catalog. Never a balance-field edit, POS refund, or transfer. |
+| **Stored-value conversion** | Moving value from one account type to another (store credit ↔ trade credit ↔ gift card). Explicitly prohibited in Phase 10. |
+| **Credential print recovery** | Narrowly authorized service that decrypts a stored number for a reasoned reprint. Not a general reveal screen. |
+| **Tender versus issuance** | A tender settles what the customer owes or is owed. An issuance is customer-paid sale of gift-card liability and increases amount due. Refunds (including new refund cards) are tenders, not issuance. |
 
-Phase 10 contracts: [phase10-plan.md](planning/phase10-stored-value/phase10-plan.md).
+Phase 10 contracts: [phase10-plan.md](planning/phase10-stored-value/phase10-plan.md). Unused-instrument return is deferred and is not a Phase 10 glossary term.

--- a/docs/planning/phase10-stored-value/README.md
+++ b/docs/planning/phase10-stored-value/README.md
@@ -1,19 +1,20 @@
 # Phase 10 — Stored value
 
-Status: **Proposed**. After Phase 8 customer identity. Authority: this packet plus [ADR-025](../../adr/ADR-025-domain-owned-operational-ledgers.md) and [ADR-026](../../adr/ADR-026-gift-card-number-protection.md).
+Status: **Proposed**. After Phase 8 customer identity. Authority: this packet plus [ADR-025](../../adr/ADR-025-domain-owned-operational-ledgers.md) and [ADR-026](../../adr/ADR-026-gift-card-number-protection.md). GitHub tracker: [milestone 5](https://github.com/BankEncore/ShelfSense-v1/milestone/5).
 
 The draft [phase-10-stored-value-spec.md](../../drafts/phase-10-stored-value-spec.md) is **superseded**. Do not implement from it.
 
 | Document | Purpose |
 |---|---|
 | [phase10-plan.md](phase10-plan.md) | Goal, slices 10.1–10.5, deferrals, acceptance |
-| [phase10-schema.md](phase10-schema.md) | Tables, checks, uniqueness, one-source FKs |
+| [phase10-schema.md](phase10-schema.md) | Tables, checks, uniqueness, source-row operation FKs |
 | [phase10-authorization.md](phase10-authorization.md) | Permission keys, scope, role grants |
 | [phase10-user-stories.md](phase10-user-stories.md) | GitHub-issue-ready stories |
 | [phase10-implementation-plan.md](phase10-implementation-plan.md) | Locked decisions and living slice status |
 | [phase10-pos-issuance-and-tenders.md](phase10-pos-issuance-and-tenders.md) | Signed-net, issuance vs tender, customer on POS, envelope |
-| [phase10-gift-card-numbering.md](phase10-gift-card-numbering.md) | Format, scan routing, encryption, reveal |
-| [phase10-refund-post-void.md](phase10-refund-post-void.md) | Refund-to-credit, unused-card return, post-void |
+| [phase10-gift-card-numbering.md](phase10-gift-card-numbering.md) | Format, scan routing, Rails encryption, print recovery |
+| [phase10-refund-post-void.md](phase10-refund-post-void.md) | Gift-card refund destinations and post-void |
+| [phase10-account-transfers-and-adjustments.md](phase10-account-transfers-and-adjustments.md) | Same-type transfer, consolidation, manual adjust |
 | [phase10-reporting-closeout.md](phase10-reporting-closeout.md) | Expected cash, X/Z, reporting-period snapshots |
 | [phase10-manual-test-plan.md](phase10-manual-test-plan.md) | Manual Register, admin, merge, print, closeout checks |
 

--- a/docs/planning/phase10-stored-value/phase10-account-transfers-and-adjustments.md
+++ b/docs/planning/phase10-stored-value/phase10-account-transfers-and-adjustments.md
@@ -1,0 +1,77 @@
+# Phase 10 — Account transfers and adjustments
+
+Status: **Proposed**. Administrative same-type movement and manual ledger corrections. POS refund destinations remain [phase10-refund-post-void.md](phase10-refund-post-void.md). Schema: [phase10-schema.md](phase10-schema.md). Authorization: [phase10-authorization.md](phase10-authorization.md).
+
+### Actually locked
+
+```text
+transfer is never debit-plus-credit adjustments
+refund is never a manual adjustment
+erroneous operations are reversed, not offset
+same type and currency only
+cross-type conversion prohibited
+merge and consolidation move the full balance and close source
+partial administrative transfer leaves source active
+all manual debits require second user
+credits at/above organization threshold require second user
+performer cannot self-approve
+merge uses merge authority, not stored_value.transfer
+```
+
+## 1. Transfer
+
+`stored_value_transfers` plus one `transfer` operation with paired entries that net to zero.
+
+| `transfer_type` | Amount | Source after post | Authority |
+|---|---|---|---|
+| `customer_merge` | Full remaining | Closed | `Customers::MergeCustomers` |
+| `account_consolidation` | Full remaining | Closed | `stored_value.transfer` + second user |
+| `administrative` | Full or partial | Closed only if amount equals remaining; otherwise active | `stored_value.transfer` + second user |
+
+Rules:
+
+- Source and destination differ.
+- Same `account_type` and `currency_code`.
+- Amount > 0 and ≤ source `balance_cents`.
+- Inter-customer and administrative transfers (including consolidation) require second-user approval. Performer ≠ approver.
+- Customer-merge transfer follows merge authority, not `stored_value.transfer`.
+- Reversal of a transfer is blocked after the destination has downstream spend that would overdraw.
+
+**Zero-balance merge:** close the merged source customer’s zero-balance store/trade accounts. Do not create a survivor account for a zero balance. No transfer operation when amount is 0.
+
+Ordinary uniqueness remains one non-closed store-credit and one non-closed trade-credit account per customer. Consolidation typically moves a source customer’s full balance into the destination customer’s existing same-type account (or creates that account when the transferred amount is positive).
+
+Gift-card replacement is **not** this table; it is `gift_card_replacements`.
+
+## 2. Manual adjustment
+
+`stored_value_adjustments` plus one `adjust` operation. Signed entry amount is derived from `adjustment_direction` and positive `amount_cents`. Never expose a balance-edit field.
+
+Eligible accounts: store credit, trade credit, and gift-card accounts that pass lifecycle checks.
+
+| Instrument / account | Adjustment |
+|---|---|
+| Active gift card | Allowed |
+| Suspended gift card | Elevated administrative adjustment only |
+| Replaced gift card | Block; use the replacement account |
+| Closed gift card | Block ordinary adjustment |
+| Positive adjustment | Must respect program `maximum_balance_cents` |
+| Negative adjustment | Cannot overdraw |
+
+Reasons come from `stored_value_adjustment_reasons`. Do not seed `opening_balance` as an ordinary reason. Snapshot `reason_code` / `reason_name_snapshot` on the posted adjustment.
+
+## 3. Separation from other workflows
+
+| Workflow | Mechanism |
+|---|---|
+| POS refund | `refund` operation via tenders and tender details |
+| Paid gift-card sale | `activate` / `reload` issuance |
+| Accommodation not tied to a POS refund | `adjust` with a catalog reason |
+| Known bad posted operation | `reverse` |
+| Move value between same-type accounts | `transfer` |
+
+## 4. Outbox
+
+- `stored_value.transferred`
+- `stored_value.adjusted`
+- `stored_value.reversed` when an adjust or transfer is reversed

--- a/docs/planning/phase10-stored-value/phase10-authorization.md
+++ b/docs/planning/phase10-stored-value/phase10-authorization.md
@@ -9,16 +9,17 @@ Phase 1–9 keys are unchanged except where this document adds grants to seeded 
 | Permission | scope_type | group_key | Meaning |
 |---|---|---|---|
 | `stored_value.view_activity` | either | stored_value | View account balances and activity (customer show, admin inquiry) |
-| `stored_value.adjust` | either | stored_value | Manual issue/debit of store or trade credit |
+| `stored_value.adjust` | either | stored_value | Manual credit/debit of eligible accounts |
+| `stored_value.transfer` | either | stored_value | Same-type administrative transfer and consolidation |
+| `stored_value.manage_adjustment_reasons` | global | stored_value | Catalog of adjustment reasons |
 | `gift_cards.manage_programs` | global | gift_cards | Create/update gift-card programs |
-| `gift_cards.view` | either | gift_cards | Inquiry (masked); not full-number reveal |
+| `gift_cards.view` | either | gift_cards | Inquiry (masked) |
 | `gift_cards.suspend` | either | gift_cards | Suspend / reinstate instrument |
 | `gift_cards.replace` | either | gift_cards | Replacement / controlled transfer of remaining balance |
 | `gift_cards.associate_customer` | either | gift_cards | Set or clear optional customer association |
 | `gift_cards.cash_out` | either | gift_cards | Register cash-out of eligible gift-card balance |
-| `gift_cards.reveal_number` | global | gift_cards | Elevated reveal or full-number reprint of encrypted credential |
 
-Do **not** add `gift_cards.activate`, `gift_cards.reload`, `gift_cards.redeem`, or `stored_value.redeem_customer_credit`. Those are ordinary Register actions.
+Do **not** add `gift_cards.activate`, `gift_cards.reload`, `gift_cards.redeem`, `stored_value.redeem_customer_credit`, or `gift_cards.reveal_number`. Ordinary Register actions use `pos.transact`. Full-number decryption is a controlled print/recovery service, not a general plaintext-view permission.
 
 ## Register vs administrative
 
@@ -26,32 +27,44 @@ Do **not** add `gift_cards.activate`, `gift_cards.reload`, `gift_cards.redeem`, 
 |---|---|
 | Activate / reload gift card | `pos.transact` (open session) |
 | Redeem gift card, store credit, or trade credit | `pos.transact` |
-| Unused-instrument return | `pos.transact` (same session rules as returns) |
-| Refund-to-store-credit | `pos.transact` |
+| Refund destinations (original card, new refund card, store credit) | `pos.transact` |
 | Gift-card cash-out | `gift_cards.cash_out` **and** open session |
 | Balance inquiry at Register (masked) | `pos.transact` |
+| Immediate first print after complete | `pos.transact` (same completion) |
+| Controlled print-recovery / replacement print | Narrow service authorization (not a general reveal key); store managers may be permitted narrowly |
 | Admin/customer activity | `stored_value.view_activity` |
 | Manual adjust | `stored_value.adjust` |
-| Reveal full number | `gift_cards.reveal_number` (global assignment) |
+| Administrative transfer / consolidation | `stored_value.transfer` |
+| Adjustment reason catalog | `stored_value.manage_adjustment_reasons` |
+| Customer-merge transfer | Merge authority (`customers.manage`), not `stored_value.transfer` |
 
 Store-scoped `pos.transact` authorizes using an organization-wide customer credit **at that store**. It does not grant organization-wide administration of the account.
 
+| Permission | System administrator | Store manager | Associate |
+|---|---:|---:|---:|
+| `stored_value.transfer` | Yes | Yes, store-scoped | No |
+| `stored_value.adjust` | Yes | Yes, store-scoped | No |
+| `stored_value.manage_adjustment_reasons` | Yes | No | No |
+| Controlled credential reprint | Through POS recovery/replacement service | Narrowly permitted | Immediate first print only |
+
 ## Second-user and Register controlled actions
 
-- Manual debit adjustments always require a second user with `stored_value.adjust` (or a dedicated approve key if implementation splits perform/approve). Performer ≠ approver.
-- Manual credits at or above the organization threshold require second-user approval.
-- Register cash-out approval, when program policy requires it, should reuse `PosControlledAction` (extend `ACTION_TYPES`) rather than a parallel protocol. Performer ≠ approver.
-- Ordinary activate/reload/redeem do not use `PosControlledAction`.
+- All manual debits require a second user. Performer ≠ approver.
+- Credits at or above the organization threshold require second-user approval.
+- Administrative and inter-customer transfers require second-user approval. Performer ≠ approver.
+- Customer-merge transfer follows merge authority, not `stored_value.transfer`.
+- Gift-card cash-out requires `gift_cards.cash_out`. When the program’s `cash_out_approval_required` is true, reuse `PosControlledAction` (extend `ACTION_TYPES`) rather than a parallel protocol.
+- Ordinary activate/reload/redeem/refund destinations do not use `PosControlledAction`.
 
 ## Role grants
 
 | Role | Phase 10 additions |
 |---|---|
 | `system_administrator` | Entire Phase 10 catalog |
-| `store_manager` | `stored_value.view_activity`, `stored_value.adjust`, `gift_cards.view`, `gift_cards.suspend`, `gift_cards.replace`, `gift_cards.associate_customer`, `gift_cards.cash_out` (not `gift_cards.manage_programs`, not `gift_cards.reveal_number`) |
-| `associate` | No new keys. Existing `pos.transact` covers ordinary SV at the Register. No cash-out, adjust, reveal, or program manage. |
+| `store_manager` | `stored_value.view_activity`, `stored_value.adjust`, `stored_value.transfer`, `gift_cards.view`, `gift_cards.suspend`, `gift_cards.replace`, `gift_cards.associate_customer`, `gift_cards.cash_out` (not `gift_cards.manage_programs`, not `stored_value.manage_adjustment_reasons`) |
+| `associate` | No new keys. Existing `pos.transact` covers ordinary SV at the Register including first print. No cash-out, adjust, transfer, or program manage. |
 
-`gift_cards.manage_programs` and `gift_cards.reveal_number` require a **global** assignment (`system_administrator` or a custom global role). Store-scoped managers cannot rotate programs or recover bearer numbers.
+`gift_cards.manage_programs` and `stored_value.manage_adjustment_reasons` require a **global** assignment.
 
 Customer show: displaying balances requires `stored_value.view_activity` in addition to `customers.view`. Do not imply credit balances from customer view alone.
 
@@ -61,8 +74,8 @@ Deactivate-with-balance: `customers.manage` remains the lifecycle permission; th
 
 | Kind | Contents |
 |---|---|
-| Production baseline | Permission keys; system-protected tender types `store_credit`, `trade_credit`, `gift_card`; at least two gift-card programs |
+| Production baseline | Permission keys; system-protected tender types `store_credit`, `trade_credit`, `gift_card`; at least two gift-card programs; adjustment-reason seed without `opening_balance` |
 | Bootstrap / demo | Example program names/prefixes only if needed for operability |
-| Test fixtures | Synthetic encrypted numbers with the documented test encryption key |
+| Test fixtures | Synthetic numbers encrypted with the documented Rails test encryption keys |
 
 Already-initialized databases will need `shelfsense:seed_permissions` when implementation lands.

--- a/docs/planning/phase10-stored-value/phase10-gift-card-numbering.md
+++ b/docs/planning/phase10-stored-value/phase10-gift-card-numbering.md
@@ -9,10 +9,13 @@ Status: **Proposed**. Policy: [ADR-026](../../adr/ADR-026-gift-card-number-prote
 PPP + body + Luhn check digit
 system_generated vs manual_external programs
 exact digest lookup; throttle; generic failure
-AR encryption + HMAC digest; prefix + last four display
+GiftCard encrypts :number using default nondeterministic Active Record Encryption
+PosStoredValueIssuance encrypts :pending_card_number
+PosStoredValueTenderDetail encrypts :pending_card_number
+HMAC digest remains the exact lookup and uniqueness key
 generate at completion; no reservation table
-ordinary reprint masked; reveal is elevated + audited without the number in the payload
-scan: gift-card shape before merchandise lookup
+ordinary reprint masked; no general reveal permission
+scan: gift-card shape before merchandise lookup (Register integration is 10.4; 10.3 uses the resolver for admin inquiry only)
 ```
 
 ## 1. Format
@@ -31,43 +34,50 @@ Strip presentation separators before validation. Do not insert values into `iden
 
 ## 2. Scan routing (Register)
 
+10.3 ships the validator/resolver and uses it for administrative inquiry. **Do not insert gift-card routing into the Register scan path until 10.4.** 10.4 wires sale, activation, reload, redemption, and refund. 10.5 wires cash-out.
+
 1. Normalize scan.
-2. If the value matches an active program’s prefix, length, and check digit, route to the current gift-card context (activate, reload, redeem, inquiry, cash-out, unused return)—not merchandise add.
+2. If the value matches an active program’s prefix, length, and check digit, route to the current gift-card context (activate, reload, redeem, inquiry, cash-out, original-instrument refund)—not merchandise add.
 3. Otherwise use existing merchandise lookup (GTIN / `222` / unit / variant / lookup code).
 
 Program save must reject a prefix+length that is ambiguous with another scanned-identifier namespace. Merchandise **lookup codes** must be rejected (or warned and blocked) when they match an active gift-card shape.
 
-Unknown numbers cannot be redeemed, reloaded, inquired, replaced, or cashed out. They may enter only through permitted activation (manual/external program).
+Unknown numbers cannot be redeemed, reloaded, inquired, replaced, or cashed out. They may enter only through permitted activation or new-refund-card creation (manual/external program).
 
 ## 3. Storage
 
 | Persist | Do not persist / leak |
 |---|---|
 | HMAC digest (keyed, unique) | Plaintext in logs, URLs, audit JSON, outbox, envelope |
-| Encrypted ciphertext (Rails `encrypts`, non-deterministic) | Unmasked lists or autocomplete |
+| `number` via `encrypts :number` (nondeterministic) | Unmasked lists or autocomplete |
 | Prefix, last four | Fixtures with production keys or plaintext production-like numbers |
-| `encryption_key_id` / previous keys as Rails provides | Ciphertext in exception messages |
+| Pending working numbers via `encrypts :pending_card_number` | Ciphertext in exception messages; custom `encryption_key_id` columns |
 
-Lookup: compute digest of normalized input; equality on `number_digest`. Keys from credentials/ENV. Docker/CI uses a documented test key.
+Lookup: compute digest of normalized input; equality on `number_digest`. Repeated encrypted writes must not rely on ciphertext equality. Active Record Encryption keys use the standard Rails credentials/environment mechanism. HMAC secret is separate. Docker/CI uses documented test keys.
 
-## 4. Generation timing
+Number identity on `gift_cards` is immutable after insert.
 
-System-generated: create the number inside authoritative POS completion after uniqueness claim. Working state stores only `gift_card_program_id`. Abandoned baskets leave no card, account, or liability.
+## 4. Generation timing and pending identity
 
-Manual/external: number comes from the card at activation; uniqueness at complete.
+System-generated: create the number inside authoritative POS completion after uniqueness claim. Working activation stores only `gift_card_program_id` until complete. Abandoned baskets leave no card, account, or liability.
+
+Manual activation and new refund-card working state persist **encrypted pending identity** on the issuance or tender detail without creating a gift-card row before completion. `gift_card_id` stays null while working.
 
 If the number must be printed **before** payment, that is out of Phase 10 (would require a reservation table).
 
-## 5. Print and reveal
+## 5. Print and recovery
 
 | Channel | Full number |
 |---|---|
-| Controlled first print after successful activation complete (and complete-retry of that command) | Yes, decrypt to the print surface only |
-| Ordinary receipt reprint / history / envelope | Masked (prefix + last four) |
-| `gift_cards.reveal_number` exception | Yes; reason required; audit outcome + last four only |
-| Replacement workflow | New number; old number remains stored encrypted, not printed |
+| Controlled first print | Yes |
+| Idempotent retry of same completion | Yes |
+| Ordinary reprint / history / envelope | No |
+| Controlled print-recovery service | Only with reason and appropriate authority |
+| Replacement | Print new credential; do not reveal old |
 
-Print failure after commit does not reopen the transaction ([receipt-presentation.md](../phase4-6-point-of-sale/phase6-pos-mvp/receipt-presentation.md)). Recovery is reprint-via-reveal, replacement of an unused card, or unused-instrument return—not a second unauthenticated print.
+Print failure after commit does not reopen the transaction ([receipt-presentation.md](../phase4-6-point-of-sale/phase6-pos-mvp/receipt-presentation.md)). Recovery is the print-recovery service or replacement—not a general reveal screen and not unused-instrument return (deferred).
+
+Audit records card identity by ID and last four only.
 
 ## 6. Inquiry and abuse
 

--- a/docs/planning/phase10-stored-value/phase10-implementation-plan.md
+++ b/docs/planning/phase10-stored-value/phase10-implementation-plan.md
@@ -2,27 +2,48 @@
 
 Status: **Proposed** (not started). Living file: update slice status when work lands.
 
+GitHub tracker: [milestone Phase 10](https://github.com/BankEncore/ShelfSense-v1/milestone/5) — [#58](https://github.com/BankEncore/ShelfSense-v1/issues/58) packet, [#59](https://github.com/BankEncore/ShelfSense-v1/issues/59) 10.1, [#60](https://github.com/BankEncore/ShelfSense-v1/issues/60) 10.2, [#61](https://github.com/BankEncore/ShelfSense-v1/issues/61) 10.3, [#62](https://github.com/BankEncore/ShelfSense-v1/issues/62) 10.4, [#63](https://github.com/BankEncore/ShelfSense-v1/issues/63) 10.5.
+
 Authority: [phase10-plan.md](phase10-plan.md), [phase10-schema.md](phase10-schema.md), [ADR-025](../../adr/ADR-025-domain-owned-operational-ledgers.md), [ADR-026](../../adr/ADR-026-gift-card-number-protection.md).
+
+## Merge policy
+
+Issue branches PR **directly to `main`**. There is no `phase-10-stored-value` integration branch.
+
+- Branch naming: `<issue-number>-<short-description>` ([github-workflow.md](../../github-workflow.md)).
+- Merge order: optional 10.0 packet docs → 10.1 → 10.2 → 10.3 → 10.4 → 10.5.
+- 10.1–10.3 are additive. Ordinary Register scan, completion, and amount-due do not change until 10.4.
+- 10.4 is **one** complete PR (reviewable commits, not independently mergeable). Signed-net, issuance, tenders, refund destinations, Register scan routing, controlled first print, and post-void land together.
+- Do not insert gift-card routing into the Register scan path before 10.4. 10.3 builds the validator/resolver for administrative inquiry only.
+- Navigation destinations land in the slice that introduces the screens. 10.5 adds only cash-out/reporting destinations and the final nav audit.
 
 ## Locked decisions
 
 1. No universal `financial_events` table. Accounting unification is Phase 14 ([ADR-025](../../adr/ADR-025-domain-owned-operational-ledgers.md)).
 2. Gift-card activation/reload is `pos_stored_value_issuances`, not a merchandise SKU and not a tender.
-3. Refund-to-credit is a `stored_value` refund tender, not an issuance row.
-4. Three system-protected SV tender types: `store_credit`, `trade_credit`, `gift_card`.
-5. Ordinary Register SV uses `pos.transact`. Cash-out, adjust, reveal, and program manage are separate keys.
-6. `Customers::MergeStoredValueAccounts` is an explicit call from `Customers::MergeCustomers`.
-7. Inactive: no new credit; redeem after reactivation; deactivate warns/blocks on nonzero balance.
-8. Generate numbers at completion; Active Record encryption + HMAC digest; ordinary reprints masked ([ADR-026](../../adr/ADR-026-gift-card-number-protection.md)).
-9. Unused-instrument return is in Phase 10.
-10. Same-transaction activate+redeem and reload+redeem (any cards) forbidden in Phase 10.
-11. Store `reversal_of_id` only.
-12. `register_id` on `gift_card_cash_outs`, not on every operation.
-13. Currency snapshot from `system_settings.base_currency_code` only; one customer account per type.
-14. Expected cash: float + cash payments − cash refunds − completed gift-card cash-outs + cash-out reversals.
-15. Opening-balance migration out. Store/trade cash-out out. Trade-credit cash-out prohibited. Seed trade-credit tender in 10.4.
-16. Cash-out policy values: `prohibited`, `permitted_when_eligible`, `required_on_request_when_eligible`.
-17. No working-transaction number reservation table.
+3. POS refunds of stored value are `refund` operations via tenders and `pos_stored_value_tender_details`, not issuance rows.
+4. Gift-card-funded refund destinations: original matching card, new refund gift card, or store credit. Never trade credit as a generic destination.
+5. Three system-protected SV tender types: `store_credit`, `trade_credit`, `gift_card`.
+6. Ordinary Register SV uses `pos.transact`. Cash-out, adjust, transfer, and program manage are separate keys. No `gift_cards.reveal_number`.
+7. `Customers::MergeStoredValueAccounts` is an explicit call from `Customers::MergeCustomers`. Zero-balance source accounts close; no survivor account for zero.
+8. Inactive: no new credit; redeem after reactivation; deactivate warns/blocks on nonzero balance.
+9. Rails `encrypts :number` and `encrypts :pending_card_number`; HMAC digest for lookup; no custom `encryption_key_id`.
+10. Same-type administrative transfers and consolidation are in Phase 10. Cross-type conversion is prohibited.
+11. Manual adjustments cover store credit, trade credit, and eligible gift cards.
+12. Unused-instrument return is **deferred**.
+13. Same-transaction activate+redeem and reload+redeem (any cards) forbidden in Phase 10.
+14. Store `reversal_of_id` only. Source rows hold `stored_value_operation_id`; operations do not hold source FKs.
+15. `register_id` on `gift_card_cash_outs`, not on every operation.
+16. Currency snapshot from `system_settings.base_currency_code` only; one customer account per type.
+17. Expected cash: float + cash payments − cash refunds − completed gift-card cash-outs + cash-out reversals.
+18. Opening-balance migration out. Store/trade cash-out out. Trade-credit cash-out prohibited. Seed trade-credit tender in 10.4.
+19. Cash-out policy values: `prohibited`, `permitted_when_eligible`, `required_on_request_when_eligible`, plus `cash_out_approval_required`.
+20. No working-transaction number reservation table; pending encrypted identity on working issuance/tender detail.
+21. Stored-value tender `stored_value_operation_id` lives on `pos_stored_value_tender_details`, not on `pos_tenders`.
+22. Controlled first print of generated activation and generated refund cards ships in 10.4. Exceptional recovery, cash-out receipts, and X/Z print polish wait for 10.5.
+23. Every newly started POS transaction snapshots `system_settings.base_currency_code`. Stored value does not introduce a conditional currency path.
+24. Value originally paid from trade credit returns to that same trade-credit account. Trade credit is never a generic refund destination.
+25. Cash-out reversal requires confirmation that cash physically returned to an open Register session. Bookkeeping-only reversal is prohibited.
 
 ## Slice status
 
@@ -31,11 +52,12 @@ Authority: [phase10-plan.md](phase10-plan.md), [phase10-schema.md](phase10-schem
 | 10.1 Stored-value core | Not started |
 | 10.2 Customer store/trade credit | Not started |
 | 10.3 Gift-card programs and instruments | Not started |
-| 10.4 POS issuance, tenders, unused return, post-void | Not started |
+| 10.4 POS issuance, tenders, refund destinations, post-void | Not started |
 | 10.5 Cash-out, closeout, print, nav | Not started |
 
 ## Integration notes
 
-- Prefer one issue/PR per user-story cluster; keep signed-net + issuance + envelope together.
+- Prefer one issue/PR per slice; keep signed-net + issuance + envelope + first print together in 10.4.
 - Frozen POS closeout, receipt, and print suites must be extended, not rewritten.
 - Local commands remain Docker-only (`./dev/rails-docker`).
+- Successful mutation audit and outbox facts commit with the business transaction. Failed or denied attempts that must survive rollback are recorded outside the rolled-back mutation. Outbox events exist only for committed business facts.

--- a/docs/planning/phase10-stored-value/phase10-manual-test-plan.md
+++ b/docs/planning/phase10-stored-value/phase10-manual-test-plan.md
@@ -17,14 +17,18 @@ Do not treat this as a substitute for CI.
 9. Attempt reload + redeem in one ticket — blocked.
 10. Two Registers race the last cent on one card — one succeeds.
 
-## 2. Refunds, unused return, post-void
+## 2. Refunds and post-void
 
-1. Return merchandise; allocate remainder to store credit; customer required; trade credit not offered.
-2. Unused-instrument return of a never-spent activation; cash refund; card cannot redeem afterward.
-3. Attempt unused return after a redeem — blocked.
-4. Post-void a pure cash sale (existing) — still works.
-5. Post-void a ticket that activated a card later redeemed — blocked; no partial void; lineage visible.
-6. Post-void a ticket whose only SV effect is unused-return — follow fail-closed rules if already returned.
+1. Original gift card present and matching — refund original; remaining on that card increases.
+2. Wrong gift card presented — blocked; masked history is not sufficient.
+3. Original gift card unavailable → new generated refund card; first print shows full number; not an issuance; `stored_value_issuance_cents` unchanged.
+4. Original unavailable → manually numbered refund card.
+5. Original unavailable → customer store credit (customer required).
+6. New refund card complete retry creates only one instrument/liability.
+7. Trade credit is not offered as a generic destination.
+8. Trade-credit original-tender portion may return to the original trade account.
+9. Post-void a pure cash sale (existing) — still works.
+10. Post-void a ticket that activated a card later redeemed — blocked; no partial void; lineage visible; card need not be presented.
 
 ## 3. Cash-out and closeout
 
@@ -33,19 +37,48 @@ Do not treat this as a substitute for CI.
 3. Close session; reopen view; expected cash frozen.
 4. Reverse/post-void eligible cash-out; expected cash restores.
 5. `required_on_request_when_eligible` does not auto-payout without cashier confirmation.
+6. `cash_out_approval_required` requires second user.
 
-## 4. Admin, merge, security
+## 4. Transfers
+
+1. Partial same-type transfer.
+2. Full transfer.
+3. Account consolidation closes source.
+4. Customer merge transfer; zero-balance source accounts close without creating a survivor account.
+5. Cross-type transfer blocked.
+6. Reversal after destination spend blocked.
+7. Concurrent destination redemption/transfer serialized.
+
+## 5. Adjustments
+
+1. Customer-service credit.
+2. Debit with second user.
+3. Threshold credit approval.
+4. Self-approval blocked.
+5. Active gift-card adjustment.
+6. Suspended gift-card elevated adjustment.
+7. Replaced/closed gift-card adjustment blocked.
+8. Adjustment reversal after spend blocked.
+
+## 6. Encryption and print
+
+1. Database stores ciphertext, not the normalized number.
+2. Digest lookup succeeds.
+3. Repeated encrypted writes do not rely on ciphertext equality.
+4. Logs/audit/outbox/envelope omit full number.
+5. Ordinary reprint masked.
+6. Controlled retry prints original credential.
+7. Print recovery requires reason and authority; no general reveal screen.
+
+## 7. Admin, merge, security
 
 1. Customer show balances require `stored_value.view_activity`.
-2. Manual debit requires second user; self-approve fails.
-3. Deactivate customer with nonzero store credit — warn/block.
-4. Merge two customers with store credit — one survivor balance; source closed; activity lineage; concurrent redeem does not skip the transfer.
-5. Gift-card association follows merge; balance stays on the instrument.
-6. Failed inquiry throttle; lists never show full numbers.
-7. Reveal requires global permission; audit has last four only.
-8. Lookup code colliding with program prefix cannot be saved.
+2. Deactivate customer with nonzero store credit — warn/block.
+3. Gift-card association follows merge; balance stays on the instrument.
+4. Failed inquiry throttle; lists never show full numbers.
+5. Lookup code colliding with program prefix cannot be saved.
 
-## 5. Navigation and UDS
+## 8. Navigation and UDS
 
 1. Gift-card programs appear in `Admin::NavigationCatalog` for authorized users only.
 2. New admin screens use current composition primitives.

--- a/docs/planning/phase10-stored-value/phase10-plan.md
+++ b/docs/planning/phase10-stored-value/phase10-plan.md
@@ -8,7 +8,7 @@ Implement authoritative store credit, trade credit, and gift cards without treat
 
 ## Exit outcome
 
-> ShelfSense can issue, activate, reload, redeem, refund, reverse, cash out eligible gift cards, and reconcile those facts on the Register without treating balances as editable fields, without a gift-card merchandise SKU, and without a cross-domain financial-event subledger.
+> ShelfSense can issue, activate, reload, redeem, refund, transfer, consolidate, manually adjust, reverse, cash out, and reconcile store credit, trade credit, and gift cards without editable balances or a cross-domain financial-event subledger.
 
 ## Scope boundary
 
@@ -16,14 +16,17 @@ Implement authoritative store credit, trade credit, and gift cards without treat
 |---|---|
 | Shared accounts, operations, entries, `StoredValue::Post` | Universal `financial_events` table; GL IDs; journal direction; export status ([ADR-025](../../adr/ADR-025-domain-owned-operational-ledgers.md)) |
 | Store credit and trade credit as distinct customer-owned liabilities | Opening-balance migration |
-| Gift-card programs, bearer instruments, encrypted numbers | Gift-card PIN; ecommerce inquiry; external processor |
+| Gift-card programs, bearer instruments, Rails-encrypted numbers | Gift-card PIN; ecommerce inquiry; external processor |
 | POS issuance table (activation/reload); `stored_value` tenders | Gift-card merchandise SKU / tax class / department |
-| Unused-instrument return (deactivate unused card + refund tenders) | Store-credit or trade-credit cash-out |
-| Gift-card cash-out vs expected cash | Phase 11 paid-in/out, drops, safe transfers |
-| Merge transfer command | Customer-to-customer discretionary transfer |
-| Online-only SV | Offline activation/redeem (ADR-005) |
-| Trade-credit tender seeded; manual issue | Phase 12 buyback intake and payout workflow |
-| Print/reveal of generated numbers ([ADR-026](../../adr/ADR-026-gift-card-number-protection.md)) | Multi-currency; expiration; escheatment; loyalty |
+| Gift-card refund destinations (original card, new refund card, store credit) | Unused-instrument return (later POS policy slice) |
+| Gift-card cash-out vs expected cash | Store-credit or trade-credit cash-out |
+| Same-type transfers, consolidation, merge transfer | Cross-type conversion between store credit, trade credit, and gift-card value |
+| Online-only SV | Customer-initiated self-service transfer |
+| Trade-credit tender seeded; manual issue | Phase 11 paid-in/out, drops, safe transfers |
+| Controlled first print and print recovery ([ADR-026](../../adr/ADR-026-gift-card-number-protection.md)) | Offline activation/redeem (ADR-005) |
+| | Phase 12 buyback intake and payout workflow |
+| | Multi-currency; expiration; escheatment; loyalty |
+| | General administrative plaintext reveal of gift-card numbers |
 
 ## Slices
 
@@ -33,19 +36,27 @@ Accounts, operations, entries, posting and reversal, projection verification, ou
 
 ### 10.2 — Customer store credit and trade credit
 
-Customer-owned accounts; `Customers::MergeStoredValueAccounts`; admin adjust with second-user rule; deactivate-with-balance warning/block; customer show activity; refund-to-credit policy (implemented with POS in 10.4). Seed system-protected `store_credit` and `trade_credit` tender types when tenders land in 10.4; account types exist here.
+Customer-owned store-credit and trade-credit accounts; full and partial same-type transfers; account consolidation; `Customers::MergeStoredValueAccounts`; controlled manual credit/debit adjustments; adjustment reasons and approvals; deactivate-with-balance; customer activity. Refund destination rules are implemented with POS in 10.4. Seed system-protected `store_credit` and `trade_credit` tender types when tenders land in 10.4; account types exist here. Policy: [phase10-account-transfers-and-adjustments.md](phase10-account-transfers-and-adjustments.md).
 
 ### 10.3 — Gift-card programs and instruments
 
-Programs, instruments, numbering, encryption, scan routing, inquiry, suspend/reinstate, replacement, optional customer association. Activation/reload/redeem wait for 10.4. Cash-out waits for 10.5.
+Programs, instruments, numbering, Rails Active Record Encryption, administrative inquiry resolver, inquiry, suspend/reinstate, replacement, optional customer association, gift-card nav destinations. Do **not** insert gift-card routing into the Register scan path. Activation/reload/redeem and Register scan integration wait for 10.4. Cash-out waits for 10.5.
 
-### 10.4 — POS issuance, tenders, unused return, post-void
+### 10.4 — POS issuance, tenders, refund destinations, first print, post-void
 
-`pos_stored_value_issuances`; `stored_value` tender category; `pos_transactions.customer_id`; signed-net rewrite; envelope/core links; nested idempotency; unused-instrument return; post-void fail-closed on downstream spend. Same-transaction activate+redeem and reload+redeem (any cards) forbidden.
+`pos_stored_value_issuances`; `stored_value` tender category and `pos_stored_value_tender_details`; `pos_transactions.customer_id`; signed-net rewrite; envelope/core links; nested idempotency; Register gift-card scan routing; controlled first print of generated activation and generated refund cards (plus complete-retry of that outcome); masked ordinary receipts; post-void fail-closed on downstream spend. Same-transaction activate+redeem and reload+redeem (any cards) forbidden.
 
-### 10.5 — Cash-out, closeout, print, admin nav
+Refund destinations:
 
-Gift-card cash-out; expected-cash formula; X/Z and reporting-period snapshots; receipt/print contracts; UDS admin screens; `Admin::NavigationCatalog` destinations.
+- Refund to original gift card when the customer presents the matching instrument.
+- Refund to a newly created refund gift card when the original instrument is unavailable.
+- Refund to customer store credit.
+- Explicit prohibition on retail-refund creation of trade credit.
+- Stored-value tender destination details in Core.
+
+### 10.5 — Cash-out, closeout, recovery print, reporting nav
+
+Gift-card cash-out (physical-cash confirmation on reversal); expected-cash formula; X/Z and reporting-period snapshots; exceptional print recovery; cash-out receipts; cash-out/reporting `Admin::NavigationCatalog` destinations and final nav audit. Administrative destinations for 10.2/10.3 screens land in those slices.
 
 ## Architectural position
 
@@ -55,13 +66,15 @@ StoredValueOperation       completed business action
         └── Account.balance_cents  locked projection
 ```
 
-POS links:
+POS and administrative sources hold `stored_value_operation_id`. Operations do not store inverse source FKs.
 
 ```text
 activation / reload     -> pos_stored_value_issuances -> operation
-redemption / refund-to-credit -> pos_tenders -> operation
-unused-card return      -> reverse issuance + refund tenders -> reverse operation
+redemption / refund     -> pos_tenders + tender details -> operation
 cash-out                -> gift_card_cash_outs -> operation
+adjust                  -> stored_value_adjustments -> operation
+transfer / consolidation / merge -> stored_value_transfers -> operation
+replacement             -> gift_card_replacements -> operation
 ```
 
 No generic `source_type` / `source_id` on operations.
@@ -75,20 +88,58 @@ No generic `source_type` / `source_id` on operations.
 | Uniqueness | One non-closed store-credit and one non-closed trade-credit account per customer (not per currency) |
 | Negative balances | Prohibited |
 | Authorization | Online only |
-| Register ordinary SV | `pos.transact` covers activate, reload, redeem store/trade/gift |
-| Exceptional Register | `gift_cards.cash_out`; reveal is never ordinary reprint |
-| Merge | Transfer operation; no `customer_id` rewrite on ledger rows |
+| Register ordinary SV | `pos.transact` covers activate, reload, redeem store/trade/gift, and refund destinations |
+| Exceptional Register | `gift_cards.cash_out`; full number only on controlled print/recovery |
+| Merge | Transfer operation; no `customer_id` rewrite on ledger rows; close zero-balance source accounts without creating a survivor account |
 | Inactive customer | No new credit; redeem only after reactivation; reversals of historic ops allowed; deactivate warns/blocks on nonzero balance |
 | Cash-out | Gift cards only; full remaining eligible balance; policy values `prohibited`, `permitted_when_eligible`, `required_on_request_when_eligible` |
 | Trade-credit cash-out | Prohibited |
-| Approval thresholds | Organization/system setting for manual adjust; gift-card program for cash-out threshold |
-| `issue` vs `activate` | Customer credit is issued; gift cards are activated |
+| Approval thresholds | Organization/system setting for manual adjust; gift-card program for cash-out threshold and `cash_out_approval_required` |
+| `issue` vs `activate` vs `refund` | `issue` is non-refund value creation; gift cards are `activate`d; all POS refund destinations use `refund` |
+
+### Gift-card-funded refund
+
+```text
+Gift-card-funded refund:
+- Original matching card when presented and usable
+- New refund gift card when original instrument is unavailable
+- Customer store credit when customer is identified and chooses account-bound value
+- Never trade credit
+```
+
+A new gift card is not a generic destination for arbitrary refund value. It is permitted as a substitute bearer instrument for value originally paid by gift card.
+
+### Same-type store-credit and trade-credit transfer
+
+```text
+Same-type store-credit and trade-credit transfer:
+- Full or partial
+- Same customer or different customers
+- Elevated permission
+- Second-user approval
+- Paired entries net to zero
+- Cross-type conversion prohibited
+```
+
+Detail: [phase10-account-transfers-and-adjustments.md](phase10-account-transfers-and-adjustments.md).
+
+### Manual adjustments
+
+```text
+Manual adjustments:
+- Store credit, trade credit, and eligible gift-card accounts
+- Explicit credit/debit direction
+- Required reason
+- All debits require second user
+- Credits at or above organization threshold require second user
+- Never direct balance editing
+```
 
 ## Sequencing
 
 ```text
 10.1 core
-  → 10.2 customer credit (merge, adjust, lifecycle)
+  → 10.2 customer credit (merge, transfer, adjust, lifecycle)
   → 10.3 gift-card identity (can overlap late 10.2)
   → 10.4 POS commercial (depends on 10.1–10.3)
   → 10.5 cash-out, closeout, print, nav (depends on 10.4)
@@ -114,12 +165,13 @@ Do not ship Register redemption before Core posting, tenders, and signed-net che
 
 1. Store credit, trade credit, and gift-card liabilities are distinct; balances reconstruct from entries.
 2. Gift-card activation/reload is not merchandise and not a tender; amount due includes issuance; issuance is not taxable merchandise.
-3. Completed Core holds FKs to stored-value operations; envelope snapshots masked facts only.
-4. Merge transfers via `Customers::MergeStoredValueAccounts`; ledger `customer_id` unchanged.
-5. Unused-instrument return and ordinary post-void-when-spent behave as [phase10-refund-post-void.md](phase10-refund-post-void.md).
-6. Expected cash includes gift-card cash-outs; closed-session snapshots stay immutable.
-7. Full gift-card numbers never appear in logs, audit payloads, envelopes, or ordinary reprints.
-8. No `financial_events` table, GL mapping columns, or Phase 11 cash-movement ledger.
+3. Completed Core holds FKs from source rows to stored-value operations; envelope snapshots masked facts only.
+4. Merge transfers via `Customers::MergeStoredValueAccounts`; ledger `customer_id` unchanged; zero-balance source accounts close without creating a survivor account.
+5. Gift-card refund destinations and ordinary post-void-when-spent behave as [phase10-refund-post-void.md](phase10-refund-post-void.md).
+6. Same-type transfers and eligible-account adjustments behave as [phase10-account-transfers-and-adjustments.md](phase10-account-transfers-and-adjustments.md).
+7. Expected cash includes gift-card cash-outs; closed-session snapshots stay immutable.
+8. Full gift-card numbers never appear in logs, audit payloads, envelopes, or ordinary reprints.
+9. No `financial_events` table, GL mapping columns, or Phase 11 cash-movement ledger.
 
 ## Parallel work
 

--- a/docs/planning/phase10-stored-value/phase10-pos-issuance-and-tenders.md
+++ b/docs/planning/phase10-stored-value/phase10-pos-issuance-and-tenders.md
@@ -2,7 +2,7 @@
 
 Status: **Proposed**. Implementation authority for how stored value joins completed POS facts.
 
-Companions: [phase10-schema.md](phase10-schema.md), [mvp-contract.md](../phase4-6-point-of-sale/phase6-pos-mvp/mvp-contract.md), [operation-and-core-facts.md](../phase4-6-point-of-sale/phase4-point-of-sale/operation-and-core-facts.md), [ADR-020](../../adr/ADR-020-pos-operation-envelope-and-core-facts.md).
+Companions: [phase10-schema.md](phase10-schema.md), [phase10-refund-post-void.md](phase10-refund-post-void.md), [mvp-contract.md](../phase4-6-point-of-sale/phase6-pos-mvp/mvp-contract.md), [operation-and-core-facts.md](../phase4-6-point-of-sale/phase4-point-of-sale/operation-and-core-facts.md), [ADR-020](../../adr/ADR-020-pos-operation-envelope-and-core-facts.md).
 
 ### Actually locked
 
@@ -10,15 +10,20 @@ Companions: [phase10-schema.md](phase10-schema.md), [mvp-contract.md](../phase4-
 issuance is not a line and not a tender
 signed_net includes stored_value_issuance_cents
 issuance is not taxable merchandise revenue
-refund-to-credit is a stored_value refund tender
+refund destinations are stored_value refund tenders + tender details
+new refund gift card does not increase stored_value_issuance_cents
 three protected SV tender types
-customer_id on pos_transactions required at complete for store/trade tenders
-Core FKs required; envelope snapshots masked facts
+customer_id on pos_transactions required at complete for store/trade tenders and store-credit refund
+source rows hold stored_value_operation_id; operations do not hold source FKs
+envelope snapshots masked facts
 command hash must not include generated secrets
 nested SV idempotency keyed by POS operation + issuance/tender id
 same-tx activate/reload + redeem forbidden (any cards)
 multiple SV payment tenders allowed
 one cash payment constraint unchanged
+transfer is never debit plus credit adjustments
+refund is never a manual adjustment
+known erroneous operations are reversed rather than offset
 ```
 
 ## 1. Amount due
@@ -39,28 +44,33 @@ total = abs(signed_net)
 
 `Pos::Support.refresh_totals!`, `sale_total_cents` (merchandise+tax only — do not silently fold issuance into “sales”), `CompleteTransaction` expected totals, `CompletedTransactionFacts`, customer receipt, operator/X/Z, and reporting-period `finalized_*` must all agree. Issuance-only and mixed merchandise+issuance examples are required tests.
 
-Tender coverage still uses `signed_net` / remaining-due rules from Phase 6, now including issuance in the amount the customer pays.
+Tender coverage still uses `signed_net` / remaining-due rules from Phase 6, now including issuance in the amount the customer pays. Refund gift cards are tenders, not issuance.
 
 ## 2. What belongs where
 
 | Flow | POS fact | Stored-value operation |
 |---|---|---|
 | Customer pays to activate or reload a gift card | `pos_stored_value_issuances` (`activation` / `reload`) | `activate` / `reload` |
-| Customer spends store credit, trade credit, or gift card | `pos_tenders` payment `stored_value` | `redeem` |
-| Retail refund remaining to store credit | `pos_tenders` refund `stored_value` (`store_credit`) | `issue` or `refund` as specified in [phase10-refund-post-void.md](phase10-refund-post-void.md) |
-| Original gift-card tender portion returned to the same card | `pos_tenders` refund `stored_value` (`gift_card`) | `refund` |
-| Unused gift-card return | reverse issuance + refund tenders | `reverse` of the original activate/reload |
+| Customer spends store credit, trade credit, or gift card | Stored-value payment tender + detail targeting existing account | `redeem` |
+| Refund to presented original gift card | Stored-value refund tender + detail targeting original account | `refund` |
+| Refund to customer store credit | Stored-value refund tender + detail targeting customer account | `refund` |
+| Refund to new gift card | Stored-value refund tender + pending new-card detail | `refund` |
+| Trade-credit-funded portion returned to original account | Stored-value refund tender targeting original trade account | `refund` |
 | Gift-card cash-out | `gift_card_cash_outs` (not a tender) | `cash_out` |
 
 Do not model gift-card sale of liability as a `non_inventory` product variant.
 
+**Possession:** refund to an original gift card requires scanning or keying a valid card whose resolved account matches the original gift-card tender. Transaction history’s masked identity is insufficient proof of possession.
+
 ## 3. Working transaction
 
-Commands (names illustrative): add/remove issuance; set generate-from-program or manual number; add/remove SV tenders. Each mutates `lock_version`.
+Commands (names illustrative): add/remove issuance; set generate-from-program or manual pending number; add/remove SV tenders and destination details. Each mutates `lock_version`.
 
 Working generate-at-complete activation: `gift_card_id` null; command carries `gift_card_program_id`. No reservation row; no liability.
 
-Working manual activation: advisory digest uniqueness; completion revalidates.
+Working manual activation: persist encrypted `pending_card_number` and digest on the issuance; `gift_card_id` stays null until completion.
+
+Working new refund card: encrypted pending identity on `pos_stored_value_tender_details`; no gift-card row until completion.
 
 Register basket: distinct issuance section (UDS-3 hierarchy), not a merchandise line. Scan routing: [phase10-gift-card-numbering.md](phase10-gift-card-numbering.md).
 
@@ -68,32 +78,33 @@ Register basket: distinct issuance section (UDS-3 hierarchy), not a merchandise 
 
 `pos_transactions.customer_id` is new and optional.
 
-At completion, if any tender has `stored_value_account_type` in (`store_credit`, `trade_credit`):
+At completion, if any tender is store/trade credit or destination mode is `customer_store_credit`:
 
 - Customer present, not merged, satisfies active policy
 - Each such tender’s account belongs to that customer
 - Revalidate customer and accounts under lock
 
-Gift-card tenders do not require a transaction customer.
+Gift-card payment tenders and new-refund-card destinations do not require a transaction customer.
 
 ## 5. Tender types
 
-See [phase10-schema.md](phase10-schema.md) §10.3. Affected contracts: `TenderType::CATEGORIES`, DB checks on `tender_types` and `pos_tenders`, cashier ordering, envelope validation, session totals, X/Z, post-void, seeds/fixtures.
+See [phase10-schema.md](phase10-schema.md) §11.3. Affected contracts: `TenderType::CATEGORIES`, DB checks on `tender_types` and `pos_tenders`, cashier ordering, envelope validation, session totals, X/Z, post-void, seeds/fixtures.
 
 ## 6. Completion sequence
 
 Inside the existing complete transaction (inventory, tax, envelope, outbox):
 
 1. Lock stored-value accounts in deterministic UUID order (and gift-card instrument rows that control access).
-2. Revalidate programs, cards, customers, issuance rows, tenders, and totals.
-3. Reject same-transaction activate/reload of a card (or newly generated identity) together with any redemption of that or another stored-value instrument as specified in locked decisions (Phase 10: **any** activate/reload plus **any** SV redeem in one ticket is forbidden).
-4. Generate system numbers only now; encrypt; digest; persist instrument + account.
-5. Persist Core issuance/tender FKs to new operations.
-6. `StoredValue::Post` nested idempotency keys: `pos.complete_transaction` outcome id + issuance id or tender id.
-7. Build envelope from persisted Core (masked numbers only).
-8. Commit atomically. Failure rolls back POS and SV.
+2. Revalidate programs, cards, customers, issuance rows, tenders, tender details, and totals.
+3. Reject same-transaction activate/reload together with any stored-value redeem in one ticket.
+4. For activations: generate system numbers or consume pending manual identity; `encrypts :number`; digest; persist instrument + account.
+5. For new-gift-card refunds: generate or consume pending identity; create gift card and account; post positive `refund` entry; link tender detail, card, account, and operation. **Do not** add the amount to `stored_value_issuance_cents`.
+6. Persist `stored_value_operation_id` on issuance, tender, cash-out, and related source rows.
+7. `StoredValue::Post` nested idempotency keys: `pos.complete_transaction` outcome id + issuance id or tender id.
+8. Build envelope from persisted Core (masked numbers only).
+9. Commit atomically. Failure rolls back POS and SV.
 
-Command payload includes expected signed_net, issuance cents, tender plan, and “generate from program X” — not the resulting number.
+Command payload includes expected signed_net, issuance cents, tender plan, destination modes, and “generate from program X” — not the resulting number.
 
 Complete-retry (ADR-009): same command hash returns stored envelope **and** may decrypt for the controlled first-print channel. The public envelope still has last four only.
 
@@ -101,12 +112,12 @@ Complete-retry (ADR-009): same command hash returns stored envelope **and** may 
 
 Core (required):
 
-- `PosTender.stored_value_operation_id`
+- `PosTender.stored_value_operation_id` and `PosStoredValueTenderDetail`
 - `PosStoredValueIssuance.stored_value_operation_id`
-- `GiftCardCashOut` → operation (10.5)
+- `GiftCardCashOut.stored_value_operation_id` (10.5)
 - Post-void source tender/issuance FKs
 
-Envelope snapshots those ids, account types, masked identity, amounts, balance-after when appropriate. Bump completed-operation schema version; keep verify accepting prior versions for historical rows.
+Envelope snapshots those ids, destination modes, account types, masked identity, amounts, balance-after when appropriate. Bump completed-operation schema version; keep verify accepting prior versions for historical rows.
 
 ## 8. Split tender
 

--- a/docs/planning/phase10-stored-value/phase10-refund-post-void.md
+++ b/docs/planning/phase10-stored-value/phase10-refund-post-void.md
@@ -1,100 +1,96 @@
-# Phase 10 — Refund, unused-instrument return, and post-void
+# Phase 10 — Refund and post-void
 
-Status: **Proposed**. Builds on [returns.md](../phase4-6-point-of-sale/phase6-pos-mvp/returns.md) and [post-void.md](../phase4-6-point-of-sale/phase6-pos-mvp/post-void.md).
+Status: **Proposed**. Builds on [returns.md](../phase4-6-point-of-sale/phase6-pos-mvp/returns.md) and [post-void.md](../phase4-6-point-of-sale/phase6-pos-mvp/post-void.md). Gift-card refund destinations: [phase10-pos-issuance-and-tenders.md](phase10-pos-issuance-and-tenders.md). Unused-instrument return is **deferred**.
 
 ### Actually locked
 
 ```text
-return to original tenders where supported
-store credit is the ordinary stored-value refund alternative
-no trade credit from retail returns
-no new gift card as generic refund destination
-unused gift-card return is in Phase 10 and is not a merchandise return
-unused = no redeem/reload/cash-out/replacement after the target issuance; remaining equals issued residual
+for gift-card-funded amounts: original card, else new refund card, or store credit
+never trade credit from retail refund as a generic destination
+new gift card is not a generic dump for arbitrary refund value
+refund gift card receives only the current refund amount
+replacement is a separate controlled transfer
 ordinary post-void blocked when downstream SV cannot be fully reversed
+post-void does not require presenting the bearer card
 no partial post-void
 elevated correction may be a later story
 ```
 
-## 1. Refund-to-credit
+## 1. Refund destinations
 
-The cashier (or policy) builds an explicit allocation before complete:
+The cashier (or policy) builds an explicit allocation before complete. Cash / card / check refunds keep Phase 6 behavior (cash refunds affect expected cash).
 
-- Cash / card / check refunds keep Phase 6 behavior (cash refunds affect expected cash).
-- Portion originally paid with a gift card ordinarily returns to **that** card (`refund` operation, refund tender `gift_card`) when the instrument is still active.
-- Remaining refundable amount may go to **store credit** (refund tender `store_credit` → issue/refund operation on the customer’s store-credit account). Transaction `customer_id` required.
-- Retail refunds never create trade credit.
-- A brand-new gift card is not an ordinary refund destination.
+For an amount originally paid by gift card:
 
-Refund tenders, POS facts, stored-value posts, and projections commit atomically.
+1. Refund to the matching original card when the customer presents it and it is usable.
+2. Otherwise issue a new refund gift card.
+3. Alternatively refund to customer store credit when a canonical active customer is attached.
+4. Never create trade credit.
+5. Do not convert the amount directly to cash except through a separately eligible gift-card cash-out after refund completion.
 
-Do **not** use `pos_stored_value_issuances` for refund-to-credit (that would change amount due). Issuance is customer-paid liability sale only.
+A new gift card is not a generic destination for arbitrary refund value. It is permitted as a substitute bearer instrument for value originally paid by gift card.
 
-## 2. Unused-instrument return
+Trade-credit-funded portions may return to the **original** trade-credit account (`allows_original_tender_refund`). Trade credit is not a generic leftover destination.
 
-Customer wants money back for a gift card that was activated (or a reload increment) and **not subsequently used**.
+Store credit may receive leftover refund value (`allows_generic_refund_destination`) when a customer is attached.
 
-This is not:
+Refund tenders, tender details, POS facts, stored-value `refund` operations, and projections commit atomically. Do **not** use `pos_stored_value_issuances` for refunds (that would change amount due). Issuance is customer-paid liability sale only.
 
-- a `pos_transaction_lines` linked return
-- a gift-card **tender** refund of a merchandise sale
-- a post-void of a mixed basket (unless the original ticket is wholly unused and post-void is still eligible)
+### 1.1 Original gift-card status
 
-### 2.1 Unused definition
+| Original status | Action |
+|---|---|
+| Active and presented | Refund original |
+| Suspended | New refund card or store credit |
+| Replaced | Refund verified replacement when presented; otherwise new card/store credit |
+| Closed | New card or store credit |
+| Cashed out | New card or store credit |
+| Unavailable | New card or store credit |
 
-An issuance is unused when **all** of:
+Refund to an original gift card requires scanning or keying a valid card whose resolved account matches the original gift-card tender. Masked history is not proof of possession.
 
-1. No later `redeem`, `reload`, `cash_out`, or `transfer`/replacement operations on that account after this issuance (except reversals of this issuance).
-2. Current `balance_cents` equals the residual of this issuance (activation: remaining equals activated amount; reload: remaining equals that reload increment when no later activity—if later reloads exist, only the latest unused reload increment may return, or block until policy is explicit: **Phase 10 allows unused return of the entire remaining balance only when the instrument has had no redeem/cash-out/replacement and remaining equals sum of unreverted issuances**).
+### 1.2 Refund gift card vs replacement
 
-Spell residual cents: `balance_after` of the last effective entry equals the sum of unreverted issue/activate/reload amounts minus unreverted redeems (here, redeems must be zero).
+A refund gift card:
 
-Reloaded-then-partially-spent cards are **not** unused; cashier uses ordinary post-void (if eligible) or exceptional correction (later).
+- Receives only the current refund amount.
+- Does not transfer the original card’s remaining balance.
+- Does not mark the original card replaced.
 
-### 2.2 Mechanics
+Replacement remains a separate controlled transfer of remaining balance onto a new instrument.
 
-New completed POS transaction (or mixed ticket that includes this workflow):
+Missing original card is handled without requiring customer creation (new refund card). Store credit still requires a canonical active customer.
 
-1. Lock card and account.
-2. Confirm unused.
-3. Add `pos_stored_value_issuances` row `issuance_type = unused_return` with `unused_return_of_issuance_id` pointing at the original activation/reload issuance.
-4. `StoredValue::Post` `reverse` of the original operation (or a dedicated reverse covering remaining = issued).
-5. Instrument: close or leave zero-balance closed/unusable per lifecycle (cannot redeem afterward).
-6. Customer receives refund via existing refund tenders (cash/card/check) for `amount_cents`. Signed-net is negative (or netted in a mixed ticket) using issuance reverse **not** as positive `stored_value_issuance_cents`. Unused return **decreases** liability; it must not increase amount due.
-
-Signed-net: unused-return amount is **not** added to `stored_value_issuance_cents`. Treat it as reducing net like a return total component **or** as a dedicated nonnegative `stored_value_unused_return_cents` subtracted in the identity. Prefer a dedicated column if mixing unused return with merchandise sales in one ticket is required; if unused return is always its own ticket, `signed_net = -(refundable cents)` with zero merchandise and zero issuance, settled by refund tenders.
-
-**Phase 10 default:** unused-instrument return is its **own** completed transaction (no merchandise lines). Simpler signed-net: `signed_net = -amount`, refund tenders cover it. Document that mixed unused-return+sale is out of Phase 10.
-
-### 2.3 Presentation
-
-Receipt and history: distinct “Gift card unused return” with masked identity. Not a merchandise title.
-
-## 3. Post-void
+## 2. Post-void
 
 Post-void still appends a reversing POS transaction ([post-void.md](../phase4-6-point-of-sale/phase6-pos-mvp/post-void.md)).
 
 Additionally reverse stored-value operations from the source ticket:
 
 - Redeem reverse restores value
-- Refund-to-credit reverse removes issued credit
+- Refund reverse removes refunded value (including new refund-card liability)
 - Activation/reload reverse removes issued value
 - Cash-out reverse restores value and expected cash (10.5)
 
-**Block** ordinary post-void when issued value was later redeemed, reloaded, transferred, cashed out, or unused-returned, such that reverse would overdraw or break lineage. UX: state that no partial post-void occurred; list downstream operation ids (masked cards).
+Post-void does **not** require the bearer card to be presented. It corrects the original transaction through stored-value operation lineage.
 
-Tests: activation, reload, refund-to-credit, merge transfer, cash-out, unused return as blockers.
+**Block** ordinary post-void when issued or refunded value was later redeemed, reloaded, transferred, cashed out, or replaced, such that reverse would overdraw or break lineage. UX: state that no partial post-void occurred; list downstream operation ids (masked cards).
+
+Tests: activation, reload, refund to original/new card/store credit, merge transfer, cash-out as blockers.
 
 Elevated correction (force reverse + compensating ops) is **not** required in Phase 10; fail closed.
 
 Register post-void continues to use `PosControlledAction` perform/approve keys.
 
-## 4. Same-transaction prohibitions
+## 3. Same-transaction prohibitions
 
 Forbidden in one working/completed ticket:
 
 - Activate a card and redeem any stored value
 - Reload any card and redeem any stored value
-- Unused-return and redeem of the same instrument
 
 Allow merchandise + activation (customer pays both). Allow merchandise + redeem. Allow split SV tenders without issuance.
+
+## 4. Deferred: unused-instrument return
+
+Returning an unused activated gift card for cash/card (not a merchandise return, not post-void) is a later POS policy slice. Do not add `unused_return` issuance types or signed-net special cases in Phase 10.

--- a/docs/planning/phase10-stored-value/phase10-reporting-closeout.md
+++ b/docs/planning/phase10-stored-value/phase10-reporting-closeout.md
@@ -14,6 +14,8 @@ X/Z and reporting-period finalized_* extended, not replaced
 issuance is not merchandise subtotal
 SV tenders report under stored_value category
 cash-out is not a tender and not a refund
+transfers net to zero organization-wide but remain visible as activity
+manual adjustments change liability and must not be grouped with refunds or paid issuance
 ```
 
 ## 1. Expected cash
@@ -30,31 +32,41 @@ opening_float_cents
 
 Closed session: return `closing_expected_cash_cents` as today. Never rewrite closed snapshots.
 
+Reversing a gift-card cash-out requires confirmation that the original cash has physically returned to an open Register session. The reversing session receives the positive expected-cash effect. A bookkeeping-only reversal cannot pretend cash was recovered.
+
 ## 2. Surfaces that must regress
 
 | Surface | Change |
 |---|---|
 | Open-session totals / Home | New formula; show cash-out total |
 | Session close / blind count | Expected includes cash-outs |
-| X report | Issuance, SV tenders by type, cash-outs |
+| X report | Issuance, SV tenders by type, cash-outs, refund destinations |
 | Z report | Same; finalized period columns |
 | Reporting-period finalization | New `finalized_*` cents as needed (issuance, SV payments/refunds, cash-outs); existing merchandise/tax columns unchanged in meaning |
 | Reopened page / complete retry | Totals stable |
 | Post-void of cash sale | Unchanged cash tender math |
-| Post-void or reverse of cash-out | Restores expected cash |
+| Post-void or reverse of cash-out | Restores expected cash after physical-cash confirmation on an open Register session |
 | Closed-session immutability | No live recompute |
 
 Add tests beside existing Z/close suites; do not rewrite those suites to drop old assertions.
 
-## 3. X/Z content
+## 3. X/Z and operational reporting
 
 Distinct rows or sections:
 
 - Merchandise subtotal, discounts, tax, returns (existing)
 - Stored-value issuance (activation/reload) — **not** sales revenue
-- Store-credit / trade-credit / gift-card payments and refunds
+- Store-credit / trade-credit / gift-card payments
+- Refund to original gift card
+- Refund to new gift card
+- Refund to store credit
 - Gift-card cash-outs (count and cents)
-- Unused-instrument return refunds (cash effect via refund tenders)
+- Manual credits
+- Manual debits
+- Same-type transfers
+- Account consolidation
+
+Transfers net to zero organization-wide but remain visible as activity. Manual adjustments change liability and must not be grouped with refunds or paid issuance.
 
 Do not dump issuance into `other` or merchandise subtotal.
 
@@ -66,4 +78,4 @@ No GL export status.
 
 ## 5. Print
 
-See [phase10-gift-card-numbering.md](phase10-gift-card-numbering.md) and [receipt-presentation.md](../phase4-6-point-of-sale/phase6-pos-mvp/receipt-presentation.md). Customer paper: issuance, redemption, remaining balance (masked), cash-out, unused return. Full number only on controlled activation print / reveal.
+See [phase10-gift-card-numbering.md](phase10-gift-card-numbering.md) and [receipt-presentation.md](../phase4-6-point-of-sale/phase6-pos-mvp/receipt-presentation.md). Customer paper: issuance, redemption, remaining balance (masked), refund destinations, cash-out. Full number only on controlled first print, complete-retry, or print recovery.

--- a/docs/planning/phase10-stored-value/phase10-schema.md
+++ b/docs/planning/phase10-stored-value/phase10-schema.md
@@ -2,13 +2,14 @@
 
 Status: **Proposed**. PostgreSQL is authoritative. Do not edit `db/schema.rb` until migrations land. UUIDv7 via `create_uuid_table` / application-assigned ids ([AGENTS.md](../../../AGENTS.md) §10).
 
-Companions: [phase10-plan.md](phase10-plan.md), [phase10-pos-issuance-and-tenders.md](phase10-pos-issuance-and-tenders.md), [phase10-gift-card-numbering.md](phase10-gift-card-numbering.md).
+Companions: [phase10-plan.md](phase10-plan.md), [phase10-pos-issuance-and-tenders.md](phase10-pos-issuance-and-tenders.md), [phase10-gift-card-numbering.md](phase10-gift-card-numbering.md), [phase10-account-transfers-and-adjustments.md](phase10-account-transfers-and-adjustments.md).
 
 ## Naming
 
 - User FKs: `performed_by_id`, `approved_by_id` (not `actor_id`).
 - Compensating: `reversal_of_id` only; inverse association `reversed_by` ([ADR-011](../../adr/ADR-011-naming-conventions.md)).
 - No polymorphic `source_type` / `source_id` on stored-value operations.
+- Source rows hold `stored_value_operation_id`. Operations do **not** store inverse source FKs.
 
 ## 1. `stored_value_accounts`
 
@@ -55,29 +56,15 @@ Gift-card accounts are 1:1 with `gift_cards.stored_value_account_id`.
 | `reason_code` | string, nullable | Required for policy-controlled actions |
 | `reason_name_snapshot` | string, nullable | Historic label |
 | `notes` | text, nullable | Controlled |
-| One source FK | uuid, nullable | See §2.1 |
 | timestamps | timestamptz | Required |
 
 No `lock_version` (immutable after insert). No `register_id` on this table; cash-out Register identity lives on `gift_card_cash_outs`.
 
-### 2.1 One-source constraint
+Do **not** persist `pos_tender_id`, `pos_stored_value_issuance_id`, `gift_card_cash_out_id`, `stored_value_adjustment_id`, `gift_card_replacement_id`, or `stored_value_transfer_id` on this table.
 
-Exactly one of the following is non-null:
+Inverse `has_one` from the operation to the unique source row. Exactly one source table references a given operation (application invariant + tests). Unique `reversal_of_id` where not null. Reversals use `operation_type = reverse`.
 
-| Column | Use |
-|---|---|
-| `pos_tender_id` | Redeem or refund-to-credit (and original-tender stored-value refund) |
-| `pos_stored_value_issuance_id` | Activate, reload, or unused-instrument reverse issuance |
-| `gift_card_cash_out_id` | Cash-out |
-| `stored_value_adjustment_id` | Manual adjust |
-| `gift_card_replacement_id` | Replacement transfer |
-| `stored_value_transfer_id` | Customer-merge transfer |
-
-Check: count of non-null source FKs = 1. All are FKs with `ON DELETE RESTRICT`.
-
-Do not also store `pos_transaction_id` as a peer source; reach the transaction through the tender or issuance.
-
-Unique `reversal_of_id` where not null. Reversals use `operation_type = reverse` and point `reversal_of_id` at the original.
+`refund` is used for refund to original gift card, refund to store credit, and refund to a new gift card. `issue` is non-refund value creation (manual accommodation or a later domain source such as buyback). Do not use “issue or refund” as alternatives for the same POS refund.
 
 ## 3. `stored_value_entries`
 
@@ -94,7 +81,26 @@ Unique `reversal_of_id` where not null. Reversals use `operation_type = reverse`
 
 Append-only. Transfer operations have at least two entries that net to zero. All accounts in one operation share `currency_code`.
 
-## 4. `stored_value_adjustments`
+## 4. `stored_value_adjustment_reasons`
+
+| Column | Type | Contract |
+|---|---|---|
+| `id` | uuid | UUIDv7 PK |
+| `code` | string | Immutable machine code |
+| `name` | string | Display |
+| `description` | text, nullable | |
+| `allowed_direction` | string | `credit`, `debit`, or `either` |
+| `allowed_account_types` | string[] or equivalent | Subset of `store_credit`, `trade_credit`, `gift_card` |
+| `notes_required` | boolean | |
+| `approval_required` | boolean | Additional to the global debit/threshold rules |
+| `active` | boolean | |
+| `display_order` | integer | |
+| `lock_version` | integer | Required |
+| timestamps | timestamptz | Required |
+
+Do not add `opening_balance` as an ordinary reason.
+
+## 5. `stored_value_adjustments`
 
 Posted manual credit or debit. Immutable after post.
 
@@ -102,41 +108,56 @@ Posted manual credit or debit. Immutable after post.
 |---|---|---|
 | `id` | uuid | UUIDv7 PK |
 | `stored_value_account_id` | uuid | Required |
-| `amount_cents` | bigint | Signed, nonzero (command magnitude > 0 with explicit direction) |
-| `reason_code` / `reason_name_snapshot` | string | Required |
-| `notes` | text, nullable | Required when policy says so |
+| `adjustment_direction` | string | `credit` or `debit` |
+| `amount_cents` | bigint | Positive magnitude |
+| `reason_id` | uuid | FK → `stored_value_adjustment_reasons` |
+| `reason_code` / `reason_name_snapshot` | string | Historic snapshots |
+| `customer_explanation` | text, nullable | |
+| `internal_notes` | text, nullable | Required when the reason says so |
 | `store_id` | uuid | Required |
 | `performed_by_id` | uuid | Required |
 | `approved_by_id` | uuid, nullable | Required when second-user rule applies; ≠ `performed_by_id` |
+| `stored_value_operation_id` | uuid, nullable | Unique when present; set at post |
+| `idempotency_operation_id` | uuid | Required |
+| `reversal_of_id` | uuid, nullable | Unique when present |
 | `posted_at` | timestamptz | Required when posted |
 | timestamps | timestamptz | Required |
 
-## 5. `stored_value_transfers`
+Signed ledger entry = `+amount_cents` for credit, `-amount_cents` for debit. Gift-card eligibility: [phase10-account-transfers-and-adjustments.md](phase10-account-transfers-and-adjustments.md).
 
-Merge (and only merge in Phase 10, besides gift-card replacement which uses `gift_card_replacements`).
+## 6. `stored_value_transfers`
 
 | Column | Type | Contract |
 |---|---|---|
 | `id` | uuid | UUIDv7 PK |
-| `from_account_id` | uuid | Source account (closed after transfer) |
-| `to_account_id` | uuid | Survivor account (same `account_type`) |
-| `amount_cents` | bigint | > 0; entire source balance |
-| `source_customer_id` / `survivor_customer_id` | uuid | Merge pair snapshots |
+| `transfer_type` | string | `customer_merge`, `administrative`, `account_consolidation` |
+| `from_account_id` | uuid | Source |
+| `to_account_id` | uuid | Destination; ≠ source |
+| `amount_cents` | bigint | > 0 |
+| `source_customer_id` / `survivor_customer_id` | uuid, nullable | Merge snapshots when `customer_merge` |
+| `reason_code` / `reason_name_snapshot` | string, nullable | Required for administrative/consolidation |
+| `notes` | text, nullable | |
+| `performed_by_id` | uuid | Required |
+| `approved_by_id` | uuid, nullable | Required for administrative/consolidation; ≠ performer |
+| `stored_value_operation_id` | uuid, nullable | Unique when present |
+| `posted_at` | timestamptz | Required when posted |
+| `reversal_of_id` | uuid, nullable | Unique when present |
 | `merge_idempotency_operation_id` | uuid, nullable | Correlation with `Customers::MergeCustomers` |
-| `performed_by_id` | uuid | Merge actor |
 | timestamps | timestamptz | Required |
 
-Zero source balance: close or retain per lifecycle policy in the merge command; no transfer operation if amount is 0.
+Same account type and currency. Source has enough value. Entries net to zero. Merge and consolidation transfer the full remaining balance and close source. Ordinary partial administrative transfer leaves source active. Cross-type conversion prohibited.
+
+Zero-balance merge: close source customer-owned accounts; do not create a survivor account for a zero balance; no transfer row when amount is 0.
 
 | Source | Survivor | Behavior |
 |---|---|---|
-| No account | No account | Nothing |
-| Balance/account only on source | No survivor account | Create/resolve survivor account, transfer, close source |
+| No account | No account | Close nothing of stored value; nothing to transfer |
+| Positive balance only on source | No survivor account | Create survivor account, transfer full amount, close source |
 | Accounts on both | Existing survivor account | Transfer source balance into survivor, close source |
-| Zero source balance | Any | Close or retain per lifecycle; no transfer operation |
+| Zero source balance | Any | Close source accounts; do not create a survivor account for zero |
 | Concurrent redemption | Any | Lock and serialize; merge cannot rewrite ownership |
 
-## 6. `gift_card_programs`
+## 7. `gift_card_programs`
 
 | Column | Type | Contract |
 |---|---|---|
@@ -153,6 +174,7 @@ Zero source balance: close or retain per lifecycle policy in the merge command; 
 | `cash_out_policy` | string | `prohibited`, `permitted_when_eligible`, `required_on_request_when_eligible` |
 | `cash_out_threshold_cents` | bigint, nullable | |
 | `cash_out_threshold_inclusive` | boolean | |
+| `cash_out_approval_required` | boolean | When true, cash-out needs second user |
 | `active` | boolean | New activations allowed |
 | `lock_version` | integer | Required |
 | timestamps | timestamptz | Required |
@@ -161,18 +183,17 @@ Prefix uniqueness. Prefix, length, authority, and check-digit algorithm cannot c
 
 Seed at least one `system_generated` and one `manual_external` program with non-overlapping prefixes.
 
-## 7. `gift_cards`
+## 8. `gift_cards`
 
 | Column | Type | Contract |
 |---|---|---|
 | `id` | uuid | UUIDv7 PK |
 | `gift_card_program_id` | uuid | Required |
 | `stored_value_account_id` | uuid | Required; unique |
-| `number_digest` | string | Required; unique keyed HMAC of normalized number |
-| `number_ciphertext` | text | Required; Active Record encryption (or equivalent ciphertext column) |
-| `encryption_key_id` | string, nullable | Rotation metadata if not wholly owned by Rails encryption |
-| `number_prefix` | string | Display/routing snapshot |
-| `number_last_four` | string | Display snapshot |
+| `number` | text | Required; Rails Active Record Encryption ciphertext |
+| `number_digest` | string | Required; unique keyed HMAC of the normalized number |
+| `number_prefix` | string | Required; display/routing snapshot |
+| `number_last_four` | string | Required; display snapshot |
 | `status` | string | `active`, `suspended`, `replaced`, `closed` |
 | `customer_id` | uuid, nullable | Optional association; not ownership |
 | `activated_at` | timestamptz | Required after activation |
@@ -182,9 +203,15 @@ Seed at least one `system_generated` and one `manual_external` program with non-
 | `lock_version` | integer | Required |
 | timestamps | timestamptz | Required |
 
-Do not persist plaintext numbers. Lifecycle starts at `active` when activation completes. No preregistration table for manual numbers. No working-transaction reservation table in Phase 10 (generate at completion).
+```ruby
+encrypts :number
+```
 
-## 8. `gift_card_cash_outs`
+Default nondeterministic Active Record Encryption. No caller-selected encryption scheme. No custom per-row key ID. HMAC secret is separate from Active Record Encryption keys. Number identity is immutable after insert.
+
+Do not persist plaintext numbers in logs or public columns. Lifecycle starts at `active` when activation or refund-card creation completes. No preregistration table. No working-transaction reservation table in Phase 10.
+
+## 9. `gift_card_cash_outs`
 
 | Column | Type | Contract |
 |---|---|---|
@@ -198,25 +225,41 @@ Do not persist plaintext numbers. Lifecycle starts at `active` when activation c
 | `business_date` | date | Required |
 | `program_policy_snapshot` | jsonb or typed columns | Policy facts used |
 | `performed_by_id` | uuid | Required |
-| `approved_by_id` | uuid, nullable | When policy requires |
+| `approved_by_id` | uuid, nullable | When `cash_out_approval_required` |
+| `stored_value_operation_id` | uuid, nullable | Unique when present |
 | `posted_at` | timestamptz | Required |
 | timestamps | timestamptz | Required |
 
 Not a generic paid-out. Not a POS tender.
 
-## 9. `gift_card_replacements`
+## 10. `gift_card_replacements`
 
-Original card, replacement card, reason, `performed_by_id`, `approved_by_id`, resulting transfer operation via `gift_card_replacement_id` on the operation.
+| Column | Type | Contract |
+|---|---|---|
+| `id` | uuid | UUIDv7 PK |
+| `original_gift_card_id` | uuid | Required |
+| `replacement_gift_card_id` | uuid | Required; ≠ original |
+| `amount_cents` | bigint | Remaining balance moved |
+| `reason_code` / `reason_name_snapshot` | string | Required |
+| `notes` | text, nullable | |
+| `performed_by_id` | uuid | Required |
+| `approved_by_id` | uuid, nullable | When policy requires; ≠ performer |
+| `stored_value_operation_id` | uuid, nullable | Unique when present |
+| `posted_at` | timestamptz | Required when posted |
+| `reversal_of_id` | uuid, nullable | Unique when present |
+| timestamps | timestamptz | Required |
 
-## 10. POS extensions
+Unique effective replacement per original instrument (partial unique on `original_gift_card_id` where posted and not reversed). Replacement transfers remaining balance and marks the original `replaced`. It is not a refund gift card.
 
-### 10.1 `pos_transactions`
+## 11. POS extensions
+
+### 11.1 `pos_transactions`
 
 Add:
 
 | Column | Type | Contract |
 |---|---|---|
-| `stored_value_issuance_cents` | bigint | Default 0; ≥ 0; sum of issuance amounts |
+| `stored_value_issuance_cents` | bigint | Default 0; ≥ 0; sum of activation/reload issuance amounts |
 | `customer_id` | uuid, nullable | FK → `customers`; optional until complete |
 
 Replace check `pos_transactions_signed_net_matches_components`:
@@ -229,32 +272,40 @@ signed_net_cents = subtotal_cents - discount_cents + tax_cents
 
 Keep `total_cents = abs(signed_net_cents)`.
 
-`customer_id` required at completion when any store-credit or trade-credit tender is present. Gift-card-only tenders do not require it. Customer must be canonical, satisfy active policy, and own the tendered account. Revalidate under lock.
+`customer_id` required at completion when any store-credit or trade-credit tender is present, or when a refund destination is customer store credit. Gift-card-only payments do not require it. Customer must be canonical, satisfy active policy, and own the tendered customer account. Revalidate under lock.
 
 Working mutations of issuances and SV tenders increment `lock_version`.
 
-### 10.2 `pos_stored_value_issuances`
+### 11.2 `pos_stored_value_issuances`
 
 | Column | Type | Contract |
 |---|---|---|
 | `id` | uuid | UUIDv7 PK |
 | `pos_transaction_id` | uuid | Required |
 | `issuance_number` | integer | Dense 1..N per transaction (like `line_number`) |
-| `issuance_type` | string | `activation`, `reload`, `unused_return` |
-| `amount_cents` | bigint | > 0; unused_return amount is the reversed issuance magnitude |
+| `issuance_type` | string | `activation` or `reload` |
+| `amount_cents` | bigint | > 0 |
 | `gift_card_program_id` | uuid, nullable | Required for generate-at-complete activation |
-| `gift_card_id` | uuid, nullable | Null on working generate-at-complete activation; required for reload, unused_return, and manual-number activation once identity is known |
+| `gift_card_id` | uuid, nullable | Null while working for both generated and manual **activation**; required for reload (existing card) |
 | `number_authority` | string | `system_generated` or `manual_external` |
-| `manual_number_digest` | string, nullable | Working-state uniqueness check for keyed manual numbers; not a liability |
-| `stored_value_operation_id` | uuid, nullable | Set at completion |
+| `pending_card_number` | text, nullable | Encrypted working identity for manual activation |
+| `pending_card_number_digest` | string, nullable | Working uniqueness / complete claim |
+| `pending_card_number_prefix` | string, nullable | |
+| `pending_card_number_last_four` | string, nullable | |
+| `stored_value_operation_id` | uuid, nullable | Unique when present; set at completion |
 | `post_void_source_issuance_id` | uuid, nullable | Post-void generated row → source issuance |
-| `unused_return_of_issuance_id` | uuid, nullable | Unused-return row → original activation/reload issuance |
 | `masked_card_snapshot` | string, nullable | Prefix + last four after identity exists |
 | timestamps | timestamptz | Required |
 
-Not a `pos_transaction_lines` row. No `product_variant_id`. Amount is not taxable merchandise and is not a tender.
+```ruby
+encrypts :pending_card_number
+```
 
-### 10.3 `tender_types`
+For manual activation: `gift_card_id` remains null while working. Pending encrypted identity is persisted on the working issuance. Completion creates the final gift card atomically. Completed/public serialization never exposes the pending plaintext. No preregistered inactive gift card is created.
+
+Not a `pos_transaction_lines` row. No `product_variant_id`. Amount is not taxable merchandise and is not a tender. Refund-to-new-gift-card is **not** an issuance row.
+
+### 11.3 `tender_types`
 
 Extend `TenderType::CATEGORIES` with `stored_value`.
 
@@ -262,19 +313,63 @@ Add `stored_value_account_type` (`store_credit` | `trade_credit` | `gift_card`),
 
 System-protected codes: `store_credit`, `trade_credit`, `gift_card` (in addition to `cash`, `card`, `check`). Admins may rename display labels and deactivate subject to policy; they must not change system identity or account type. Admin-created types remain `other`.
 
-Update DB checks on `tender_types` and `pos_tenders` (category list, cash presented/change rules). `cashier_selectable` sort must give `stored_value` an explicit slot. `cashier_payload` includes `stored_value_account_type`.
+Update DB checks on `tender_types` and `pos_tenders` (category list, cash presented/change rules). `cashier_selectable` sort must give `stored_value` an explicit slot. `cashier_payload` includes `stored_value_account_type` and the refund flags below.
 
-`allows_refund`: store and trade credit **true** (refund-to-credit). Gift-card tender **false** in Phase 10 (unused-card return is issuance reversal, not a gift-card refund tender).
+Existing `allows_refund` remains the Phase 6 flag for cash/card/check/other. It is **not** the stored-value destination oracle. Stored-value types use:
 
-### 10.4 `pos_tenders`
+| Column | Meaning |
+|---|---|
+| `allows_original_tender_refund` | Return value to the same account/instrument |
+| `allows_generic_refund_destination` | Accept leftover refund value not originally paid on this type |
+| `allows_refund_instrument_replacement` | Create a new refund gift card for originally gift-card-funded value |
 
-Add `stored_value_operation_id` (nullable FK, unique when present) for completed stored-value tenders. Multiple `stored_value` payment tenders allowed; existing at-most-one cash payment unchanged.
+| Type | Original-tender refund | Generic destination | New refund instrument |
+|---|---:|---:|---:|
+| Store credit | Yes | Yes | No |
+| Trade credit | Yes to original account | No | No |
+| Gift card | Yes when presented/matched | No | Yes |
 
-At most one tender per `(pos_transaction_id, stored_value_account_id)` when one combined amount would suffice (reject duplicate account rows).
+### 11.4 `pos_tenders`
 
-Gift-card tenders snapshot masked identity, not the full number.
+Do **not** add `stored_value_operation_id` on `pos_tenders`. The stored-value operation FK belongs on `pos_stored_value_tender_details`. Multiple `stored_value` payment tenders allowed; existing at-most-one cash payment unchanged.
 
-## 11. Outbox
+At most one payment tender per `(pos_transaction_id, stored_value_account_id)` when one combined amount would suffice.
+
+### 11.5 `pos_stored_value_tender_details`
+
+Exactly one detail row when the tender’s behavioral category is `stored_value`.
+
+| Column | Type | Contract |
+|---|---|---|
+| `id` | uuid | UUIDv7 PK |
+| `pos_tender_id` | uuid | Required; unique |
+| `stored_value_operation_id` | uuid, nullable | Unique when present; set at completion. This is the source-row FK. |
+| `stored_value_account_id` | uuid, nullable | Existing target; null for working `new_gift_card` |
+| `gift_card_id` | uuid, nullable | When the target is a gift card |
+| `destination_mode` | string | `existing_account`, `customer_store_credit`, `new_gift_card` |
+| `gift_card_program_id` | uuid, nullable | For `new_gift_card` |
+| `pending_card_number` | text, nullable | Encrypted working identity for new/manual refund card |
+| `pending_card_number_digest` | string, nullable | |
+| `pending_card_number_prefix` | string, nullable | |
+| `pending_card_number_last_four` | string, nullable | |
+| `masked_card_snapshot` | string, nullable | After identity exists |
+| timestamps | timestamptz | Required |
+
+```ruby
+encrypts :pending_card_number
+```
+
+Rules:
+
+- Payment tender requires an existing target account (`existing_account`).
+- Original gift-card refund requires presented card matching the original tender account.
+- New-gift-card refund has no account/card until completion.
+- Store-credit refund requires transaction customer (`customer_store_credit` or store-credit `existing_account`).
+- Trade credit as a **generic** refund destination is prohibited (original-tender refund to the original trade account remains allowed).
+- Completed detail retains account/card and masked snapshots.
+- New refund card does not increase `stored_value_issuance_cents`.
+
+## 12. Outbox
 
 Same database transaction as the business change ([ADR-010](../../adr/ADR-010-transactional-outbox.md)). Event types (versioned; minimum facts; no full number):
 
@@ -282,6 +377,7 @@ Same database transaction as the business change ([ADR-010](../../adr/ADR-010-tr
 - `stored_value.redeemed`
 - `stored_value.refunded`
 - `stored_value.transferred`
+- `stored_value.adjusted`
 - `stored_value.reversed`
 - `stored_value.cash_out_completed`
 - `gift_card.activated`
@@ -289,15 +385,15 @@ Same database transaction as the business change ([ADR-010](../../adr/ADR-010-tr
 
 These are integration messages, not `financial_events` rows.
 
-## 12. System settings
+## 13. System settings
 
 - Manual-adjustment approval threshold (organization): credits at or above require second user; all debit adjustments require second user.
 - Do not put gift-card cash-out threshold here (program-level).
 
-## 13. Idempotency
+## 14. Idempotency
 
 Reuse `IdempotencyOperation`. POS complete remains `pos.complete_transaction` with `command_payload_hash` excluding generated secrets ([phase10-pos-issuance-and-tenders.md](phase10-pos-issuance-and-tenders.md)). Nested stored-value posts key by POS operation id plus issuance or tender id so complete-retry cannot double-post.
 
-## 14. Merge consumers (Phase 8 checklist)
+## 15. Merge consumers (Phase 8 checklist)
 
 See [phase8-schema.md](../phase8-customer-foundation/phase8-schema.md). Phase 10 adds `Customers::MergeStoredValueAccounts`.

--- a/docs/planning/phase10-stored-value/phase10-user-stories.md
+++ b/docs/planning/phase10-stored-value/phase10-user-stories.md
@@ -15,6 +15,7 @@ GitHub-issue-ready stories. Keep 10.4 issuance and signed-net in the same implem
 - Tables and checks in [phase10-schema.md](phase10-schema.md) §§1–3
 - `balance_cents` rejected on generic update
 - `reversal_of_id` unique when present; no `reversed_by_id` column
+- Source rows hold `stored_value_operation_id`; operations do not hold source FKs
 
 ### US-10.1.2 — Posting service
 
@@ -50,13 +51,17 @@ GitHub-issue-ready stories. Keep 10.4 issuance and signed-net in the same implem
 ### US-10.2.2 — Manual adjust
 
 **As** staff with `stored_value.adjust`  
-**I want** explicit add/remove credit actions  
+**I want** explicit add/remove credit actions on store credit, trade credit, and eligible gift cards  
 **So that** I never edit a balance field.
 
 **Acceptance:**
 
-- Debits always second-user; credits above threshold second-user
+- Explicit credit/debit direction; positive magnitude
+- Reason catalog; no `opening_balance` ordinary reason
+- Debits always second-user; credits at/above threshold second-user
 - Performer cannot self-approve
+- Program maximum and lifecycle checks (active allowed; suspended elevated; replaced/closed blocked)
+- Reverse rather than edit
 - Reason snapshot + audit without secrets
 
 ### US-10.2.3 — Merge transfer
@@ -67,10 +72,11 @@ GitHub-issue-ready stories. Keep 10.4 issuance and signed-net in the same implem
 
 **Acceptance:**
 
-- Matrix in [phase10-plan.md](phase10-plan.md) / schema §5
+- Matrix in [phase10-schema.md](phase10-schema.md) §6
 - Ledger `customer_id` unchanged
 - Concurrent redeem serialized with merge locks
 - Gift-card `customer_id` association reassigned; value not transferred as customer-owned credit
+- Zero-balance source accounts close; no survivor account created for zero
 
 ### US-10.2.4 — Deactivate with balance
 
@@ -90,19 +96,42 @@ GitHub-issue-ready stories. Keep 10.4 issuance and signed-net in the same implem
 **I want** balances and recent operations on customer show  
 **So that** I can explain the account without seeing gift-card full numbers.
 
+### US-10.2.6 — Transfer customer credit
+
+**As** authorized staff with `stored_value.transfer`  
+**I want** to move some or all store/trade credit to another same-type account  
+**So that** misapplied and customer-authorized balances can be corrected without editing history.
+
+**Acceptance:**
+
+- Same type and currency
+- Paired net-zero entries
+- Second user; performer cannot self-approve
+- Partial or full
+- Account consolidation closes source
+- Cross-type conversion blocked
+- Reversal blocked after downstream spend
+- Policy: [phase10-account-transfers-and-adjustments.md](phase10-account-transfers-and-adjustments.md)
+
 ## 10.3 — Gift-card identity
 
 ### US-10.3.1 — Programs
 
 **As** a global administrator  
-**I want** gift-card programs with prefix, length, and cash-out policy  
+**I want** gift-card programs with prefix, length, cash-out policy, and `cash_out_approval_required`  
 **So that** scan namespaces do not collide.
 
 ### US-10.3.2 — Secure instrument
 
 **As** the system  
-**I want** digest + encrypted number + last four  
-**So that** lookup is exact and reprints stay masked by default ([ADR-026](../../adr/ADR-026-gift-card-number-protection.md)).
+**I want** gift-card numbers stored with Rails Active Record Encryption plus an HMAC digest  
+**So that** lookup is exact and only prefix and last four appear outside controlled print services ([ADR-026](../../adr/ADR-026-gift-card-number-protection.md)).
+
+**Acceptance:**
+
+- `encrypts :number`; no custom `encryption_key_id`
+- Digest uniqueness and exact lookup
+- No general reveal permission or reveal screen
 
 ### US-10.3.3 — Inquiry, suspend, replace, associate
 
@@ -122,12 +151,16 @@ GitHub-issue-ready stories. Keep 10.4 issuance and signed-net in the same implem
 
 - [phase10-pos-issuance-and-tenders.md](phase10-pos-issuance-and-tenders.md)
 - DB signed-net identity includes `stored_value_issuance_cents`
-- Envelope golden files updated; Core FKs present
+- Envelope golden files updated; Core FKs on source rows
+- Working manual activation uses encrypted pending identity; `gift_card_id` null until complete
+- Controlled first print after generated-card activation and generated refund cards; complete-retry reprints that outcome; ordinary receipts stay masked
+- Register gift-card scan routing (sale, activation, reload, redeem, refund)
+- Every new POS transaction snapshots `system_settings.base_currency_code`
 
 ### US-10.4.2 — Stored-value tenders
 
 **As** a cashier  
-**I want** system-protected store-credit, trade-credit, and gift-card tenders  
+**I want** system-protected store-credit, trade-credit, and gift-card tenders with destination details  
 **So that** redemption settles amount due against an authoritative balance.
 
 **Acceptance:**
@@ -135,37 +168,44 @@ GitHub-issue-ready stories. Keep 10.4 issuance and signed-net in the same implem
 - Customer required and revalidated for store/trade
 - Multiple SV tenders allowed; lock UUID order
 - Same-transaction activate/reload + redeem forbidden
+- One detail row per stored-value tender
 
-### US-10.4.3 — Refund-to-credit
-
-**As** a cashier  
-**I want** to refund remaining value to store credit  
-**So that** retail returns do not issue trade credit or a new gift card.
-
-### US-10.4.4 — Unused-instrument return
+### US-10.4.3 — Gift-card refund destinations
 
 **As** a cashier  
-**I want** to return an unused activated (or unused reloaded increment) gift card  
-**So that** the customer can receive a refund without a merchandise return or post-void.
+**I want** to refund gift-card-funded value to the presented original card, a new refund card, or store credit  
+**So that** the customer is not forced to create a profile when the original card is missing, and trade credit is never a generic destination.
 
 **Acceptance:**
 
-- [phase10-refund-post-void.md](phase10-refund-post-void.md) unused definition
-- Reverse issuance + refund tenders atomically
+- Presented matching original card
+- New generated or manual refund card (not paid issuance; does not increase `stored_value_issuance_cents`)
+- Customer store credit when a canonical active customer is attached
+- No trade credit as generic destination
+- Value originally paid from trade credit returns to that same trade-credit account
+- Missing original card handled without requiring customer creation
+- Complete-retry of a new refund card creates only one instrument/liability
+- [phase10-refund-post-void.md](phase10-refund-post-void.md)
 
-### US-10.4.5 — Post-void fail-closed
+### US-10.4.4 — Post-void fail-closed
 
 **As** a cashier attempting post-void  
 **I want** a block with downstream stored-value lineage when issued value was spent  
 **So that** no partial post-void occurs.
 
-## 10.5 — Cash-out, closeout, print, nav
+## 10.5 — Cash-out, closeout, recovery print, reporting nav
 
 ### US-10.5.1 — Gift-card cash-out
 
 **As** a store manager with `gift_cards.cash_out`  
 **I want** to pay the full eligible remaining balance from an open Register session  
 **So that** cash-out is not a generic paid-out.
+
+**Acceptance:**
+
+- Reversal requires confirmation that cash physically returned to an open Register session
+- The reversing session receives the positive expected-cash effect
+- Bookkeeping-only reversal is prohibited
 
 ### US-10.5.2 — Expected cash and Z
 
@@ -178,18 +218,22 @@ GitHub-issue-ready stories. Keep 10.4 issuance and signed-net in the same implem
 - Surfaces in [phase10-reporting-closeout.md](phase10-reporting-closeout.md)
 - Closed-session snapshots immutable
 
-### US-10.5.3 — Print and reveal
-
-**As** a cashier  
-**I want** the first activation print to show the generated number, and ordinary reprints to stay masked  
-**So that** complete-retry can print without putting the secret in the public envelope.
-
-**As** a global administrator with `gift_cards.reveal_number`  
-**I want** an audited exception path to recover the credential  
-**So that** a failed physical card can be reprinted without logging the number in audit payloads.
-
-### US-10.5.4 — Admin navigation
+### US-10.5.3 — Exceptional print recovery
 
 **As** authorized staff  
-**I want** gift-card program and operational destinations in the navigation catalog  
-**So that** there are no one-off header links.
+**I want** controlled print recovery of a generated credential with a reason  
+**So that** a failed first print can be recovered without a general reveal screen.
+
+First print of generated activation and refund cards ships in 10.4. This slice adds exceptional recovery, cash-out receipts, and X/Z print polish.
+
+### US-10.5.4 — Cash-out and reporting navigation
+
+**As** authorized staff  
+**I want** cash-out and reporting destinations that first exist in this slice  
+**So that** the catalog stays complete.
+
+10.2 and 10.3 already add their administrative destinations. This slice performs the final navigation audit.
+
+## Deferred policy
+
+Unused-instrument return (cash/card refund of an unused activated gift card that is neither merchandise return nor post-void) is a later POS policy slice. Research remains in git history of this packet; do not implement it in Phase 10.

--- a/docs/planning/phase8-customer-foundation/phase8-schema.md
+++ b/docs/planning/phase8-customer-foundation/phase8-schema.md
@@ -70,7 +70,7 @@ Documentary checklist only — execution lives in explicit calls inside `Custome
 |---|---|
 | `customer_requests` (active statuses) | `Customers::ReassignActiveRequests` — `UPDATE customer_id` to survivor |
 | `customer_requests` (completed, cancelled) | Preserve original `customer_id`; resolve via `canonical` for display/grouping |
-| `stored_value_accounts` (store/trade credit) | `Customers::MergeStoredValueAccounts` — transfer via ledger operation; close source; do not rewrite `customer_id` on operations/entries ([phase10-schema.md](../phase10-stored-value/phase10-schema.md)) |
+| `stored_value_accounts` (store/trade credit) | `Customers::MergeStoredValueAccounts` — transfer the complete source balance into the same-type survivor account; create the survivor account only for a positive transferred balance; close every source customer-owned account, including zero-balance accounts; do not rewrite ledger ownership ([phase10-schema.md](../phase10-stored-value/phase10-schema.md)) |
 | `gift_cards.customer_id` | Reassign optional association to survivor or clear; do not move the gift-card balance as customer-owned credit |
 
 Future phases append inventory rows and add explicit commands (buyback seller records, etc.) — not a plugin registry.

--- a/docs/planning/roadmap.md
+++ b/docs/planning/roadmap.md
@@ -210,15 +210,15 @@ Accounts, operations, entries, posting service, projection verification, outbox 
 
 ### Slice 10.2 — Customer store credit and trade credit
 
-Distinct customer-owned liabilities; merge transfer command; manual adjust; deactivate-with-balance; customer activity.
+Distinct customer-owned liabilities; administrative same-type transfers; account consolidation; merge transfer command; manual adjustment across eligible account types; deactivate-with-balance; customer activity.
 
 ### Slice 10.3 — Gift-card programs and instruments
 
-Bearer identity, numbering and encryption, scan routing, inquiry, suspend, replacement, optional customer association.
+Bearer identity, numbering and Rails encryption, scan routing, inquiry, suspend, replacement, optional customer association.
 
-### Slice 10.4 — POS issuance, tenders, unused return, post-void
+### Slice 10.4 — POS issuance, tenders, refund destinations, post-void
 
-First-class issuance (not a merchandise SKU); `stored_value` tenders; signed-net rewrite; unused-instrument return; post-void fail-closed.
+First-class issuance (not a merchandise SKU); `stored_value` tenders; signed-net rewrite; gift-card refund destinations; original-instrument verification; new refund gift-card creation; post-void fail-closed.
 
 ### Slice 10.5 — Cash-out, closeout, print, nav
 
@@ -226,7 +226,7 @@ Gift-card cash-out vs expected cash; X/Z; receipt/print; administrative navigati
 
 **Deliverable:**
 
-> ShelfSense can issue, activate, reload, redeem, reverse, and reconcile customer credit, trade credit, and gift cards without treating balances as editable fields and without a cross-domain financial-event subledger.
+> ShelfSense can issue, activate, reload, redeem, refund, transfer, consolidate, manually adjust, reverse, cash out, and reconcile store credit, trade credit, and gift cards without editable balances or a cross-domain financial-event subledger.
 
 ## Phase 11 — Cash accountability completion
 

--- a/docs/planning/ux-design-system/surface-contracts.md
+++ b/docs/planning/ux-design-system/surface-contracts.md
@@ -56,7 +56,7 @@ Transaction history must display **snapshots and stored facts**. It must not rec
 - Register basket two-line layout must **not** reverse the print contract.
 - Warm Parchment is a **screen** system; print CSS remains its own target.
 
-Phase 10 stored-value issuance, redemption, remaining balance, cash-out, and unused-instrument return are additional print/history facts specified in [phase10-gift-card-numbering.md](../phase10-stored-value/phase10-gift-card-numbering.md) and [phase10-reporting-closeout.md](../phase10-stored-value/phase10-reporting-closeout.md). Masked identity only on ordinary reprints. Issuance is a distinct basket section, not a merchandise two-line.
+Phase 10 stored-value issuance, redemption, remaining balance, refund destinations, and cash-out are additional print/history facts specified in [phase10-gift-card-numbering.md](../phase10-stored-value/phase10-gift-card-numbering.md) and [phase10-reporting-closeout.md](../phase10-stored-value/phase10-reporting-closeout.md). Masked identity only on ordinary reprints. Issuance is a distinct basket section, not a merchandise two-line.
 
 ## Summary
 


### PR DESCRIPTION
## Summary
- Record direct-to-main merge policy and GitHub tracker (milestone 5, issues #58–#63)
- Move stored-value tender `stored_value_operation_id` onto `pos_stored_value_tender_details`
- Keep Register scan routing and generated-card first print in 10.4; land nav destinations with the slice that introduces screens
- Add transfer/adjustment contract and remaining packet locks

## Verification
- Documentation-only; no application tests

## Documentation and migrations
- `docs/planning/phase10-stored-value/*`, ADR-026, glossary, roadmap, Phase 8 schema pointer, surface-contracts
- No migrations

Closes #58

Made with [Cursor](https://cursor.com)