### PR TITLE
10.1 — Stored-value core ledger

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -12,6 +12,7 @@ class Customer < ApplicationRecord
            inverse_of: :merged_into_customer,
            dependent: :restrict_with_exception
   has_many :customer_requests, dependent: :restrict_with_exception
+  has_many :stored_value_accounts, dependent: :restrict_with_exception
 
   validates :display_name, presence: true
   validates :preferred_contact_method, inclusion: { in: PREFERRED_CONTACT_METHODS }

--- a/app/models/stored_value_account.rb
+++ b/app/models/stored_value_account.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+class StoredValueAccount < ApplicationRecord
+  ACCOUNT_TYPES = %w[store_credit trade_credit gift_card].freeze
+  STATUSES = %w[active suspended closed].freeze
+  CUSTOMER_OWNED_TYPES = %w[store_credit trade_credit].freeze
+
+  belongs_to :customer, optional: true
+  has_many :stored_value_entries, dependent: :restrict_with_exception
+
+  validates :account_type, :currency_code, :status, :opened_at, presence: true
+  validates :account_type, inclusion: { in: ACCOUNT_TYPES }
+  validates :status, inclusion: { in: STATUSES }
+  validates :currency_code, length: { is: 3 }
+  validates :balance_cents, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validate :customer_matches_account_type
+  validate :closed_consistency
+  validate :type_and_currency_immutable, on: :update
+
+  def active?
+    status == "active"
+  end
+
+  def suspended?
+    status == "suspended"
+  end
+
+  def closed?
+    status == "closed"
+  end
+
+  def customer_owned?
+    CUSTOMER_OWNED_TYPES.include?(account_type)
+  end
+
+  def apply_posted_balance!(cents)
+    @allow_balance_write = true
+    update!(balance_cents: cents)
+  ensure
+    @allow_balance_write = false
+  end
+
+  def balance_cents=(value)
+    if persisted? && !@allow_balance_write
+      raise StoredValue::Error, "balance_cents cannot be assigned via generic update"
+    end
+
+    super
+  end
+
+  private
+
+  def customer_matches_account_type
+    if customer_owned?
+      errors.add(:customer_id, "is required") if customer_id.blank?
+    elsif account_type == "gift_card" && customer_id.present?
+      errors.add(:customer_id, "must be blank for gift-card accounts")
+    end
+  end
+
+  def closed_consistency
+    if status == "closed"
+      errors.add(:closed_at, "is required") if closed_at.blank?
+      errors.add(:balance_cents, "must be zero when closed") unless balance_cents.to_i.zero?
+    elsif closed_at.present?
+      errors.add(:closed_at, "must be blank unless closed")
+    end
+  end
+
+  def type_and_currency_immutable
+    errors.add(:account_type, "cannot change after open") if will_save_change_to_account_type?
+    errors.add(:currency_code, "cannot change after open") if will_save_change_to_currency_code?
+  end
+end

--- a/app/models/stored_value_entry.rb
+++ b/app/models/stored_value_entry.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class StoredValueEntry < ApplicationRecord
+  belongs_to :stored_value_operation
+  belongs_to :stored_value_account
+  belongs_to :reversal_of, class_name: "StoredValueEntry", optional: true
+  has_one :reversed_by, class_name: "StoredValueEntry", foreign_key: :reversal_of_id, inverse_of: :reversal_of,
+          dependent: :restrict_with_exception
+
+  validates :entry_sequence, :amount_cents, :balance_after_cents, presence: true
+  validates :entry_sequence, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :amount_cents, numericality: { only_integer: true, other_than: 0 }
+  validates :balance_after_cents, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+
+  def readonly?
+    super || persisted?
+  end
+end

--- a/app/models/stored_value_operation.rb
+++ b/app/models/stored_value_operation.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class StoredValueOperation < ApplicationRecord
+  OPERATION_TYPES = %w[issue activate reload redeem refund cash_out transfer adjust reverse].freeze
+
+  belongs_to :store
+  belongs_to :performed_by, class_name: "User"
+  belongs_to :pos_session, optional: true
+  belongs_to :idempotency_operation
+  belongs_to :reversal_of, class_name: "StoredValueOperation", optional: true
+  has_one :reversed_by, class_name: "StoredValueOperation", foreign_key: :reversal_of_id, inverse_of: :reversal_of,
+          dependent: :restrict_with_exception
+  has_many :stored_value_entries, -> { order(:entry_sequence) }, dependent: :restrict_with_exception
+
+  validates :operation_type, :business_date, :occurred_at, presence: true
+  validates :operation_type, inclusion: { in: OPERATION_TYPES }
+
+  def readonly?
+    super || persisted?
+  end
+
+  def reverse?
+    operation_type == "reverse"
+  end
+
+  def reversed?
+    reversed_by.present?
+  end
+end

--- a/app/services/authorization/permission_catalog.rb
+++ b/app/services/authorization/permission_catalog.rb
@@ -121,6 +121,19 @@ module Authorization
       { key: "purchase_receipts.compensate", group_key: "purchase_receipts", name: "Authorize compensating adjustments when exact receipt reversal is unsafe", scope_type: "either" }
     ].freeze
 
+    PHASE10_PERMISSIONS = [
+      { key: "stored_value.view_activity", group_key: "stored_value", name: "View stored-value activity", scope_type: "either" },
+      { key: "stored_value.adjust", group_key: "stored_value", name: "Adjust stored-value accounts", scope_type: "either" },
+      { key: "stored_value.transfer", group_key: "stored_value", name: "Transfer stored-value accounts", scope_type: "either" },
+      { key: "stored_value.manage_adjustment_reasons", group_key: "stored_value", name: "Manage stored-value adjustment reasons", scope_type: "global" },
+      { key: "gift_cards.manage_programs", group_key: "gift_cards", name: "Manage gift-card programs", scope_type: "global" },
+      { key: "gift_cards.view", group_key: "gift_cards", name: "View gift cards", scope_type: "either" },
+      { key: "gift_cards.suspend", group_key: "gift_cards", name: "Suspend or reinstate gift cards", scope_type: "either" },
+      { key: "gift_cards.replace", group_key: "gift_cards", name: "Replace gift cards", scope_type: "either" },
+      { key: "gift_cards.associate_customer", group_key: "gift_cards", name: "Associate gift cards with customers", scope_type: "either" },
+      { key: "gift_cards.cash_out", group_key: "gift_cards", name: "Cash out gift cards", scope_type: "either" }
+    ].freeze
+
     PHASE9_PERMISSIONS = [
       { key: "product_forms.view", group_key: "product_forms", name: "View product forms", scope_type: "either" },
       { key: "product_forms.update", group_key: "product_forms", name: "Update product forms", scope_type: "global" },
@@ -134,7 +147,7 @@ module Authorization
     ].freeze
 
     PERMISSIONS = (
-      PHASE1_PERMISSIONS + PHASE2_PERMISSIONS + PHASE3_PERMISSIONS + PHASE4_PERMISSIONS + PHASE7_PERMISSIONS + PHASE9_PERMISSIONS
+      PHASE1_PERMISSIONS + PHASE2_PERMISSIONS + PHASE3_PERMISSIONS + PHASE4_PERMISSIONS + PHASE7_PERMISSIONS + PHASE9_PERMISSIONS + PHASE10_PERMISSIONS
     ).freeze
 
     STORE_MANAGER_PHASE2_VIEWS = %w[
@@ -153,6 +166,17 @@ module Authorization
       product_forms.view
       subject_schemes.view
       subject_headings.view
+    ].freeze
+
+    STORE_MANAGER_PHASE10 = %w[
+      stored_value.view_activity
+      stored_value.adjust
+      stored_value.transfer
+      gift_cards.view
+      gift_cards.suspend
+      gift_cards.replace
+      gift_cards.associate_customer
+      gift_cards.cash_out
     ].freeze
 
     STORE_MANAGER_PHASE3 = %w[
@@ -219,7 +243,7 @@ module Authorization
           registers.manage
           registers.deactivate
           audit_events.view
-        ] + STORE_MANAGER_PHASE2_VIEWS + STORE_MANAGER_PHASE3 + STORE_MANAGER_PHASE4 + STORE_MANAGER_PHASE7 + STORE_MANAGER_PHASE9_VIEWS
+        ] + STORE_MANAGER_PHASE2_VIEWS + STORE_MANAGER_PHASE3 + STORE_MANAGER_PHASE4 + STORE_MANAGER_PHASE7 + STORE_MANAGER_PHASE9_VIEWS + STORE_MANAGER_PHASE10
       },
       {
         key: "associate",

--- a/app/services/stored_value.rb
+++ b/app/services/stored_value.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module StoredValue
+  class Error < StandardError; end
+
+  OUTBOX_EVENT_TYPES = {
+    "issue" => "stored_value.issued",
+    "activate" => "gift_card.activated",
+    "reload" => "stored_value.issued",
+    "redeem" => "stored_value.redeemed",
+    "refund" => "stored_value.refunded",
+    "cash_out" => "stored_value.cash_out_completed",
+    "transfer" => "stored_value.transferred",
+    "adjust" => "stored_value.adjusted",
+    "reverse" => "stored_value.reversed"
+  }.freeze
+end

--- a/app/services/stored_value/open_account.rb
+++ b/app/services/stored_value/open_account.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module StoredValue
+  class OpenAccount
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(account_type:, customer: nil, opened_at: Time.current)
+      @account_type = account_type.to_s
+      @customer = customer
+      @opened_at = opened_at
+    end
+
+    def call
+      raise Error, "account type is required" if @account_type.blank?
+
+      currency_code = SystemSettings.current.base_currency_code
+      StoredValueAccount.create!(
+        account_type: @account_type,
+        customer: @customer,
+        currency_code: currency_code,
+        balance_cents: 0,
+        status: "active",
+        opened_at: @opened_at
+      )
+    end
+  end
+end

--- a/app/services/stored_value/post.rb
+++ b/app/services/stored_value/post.rb
@@ -1,0 +1,206 @@
+# frozen_string_literal: true
+
+module StoredValue
+  class Post
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(
+      operation_type:,
+      store:,
+      performed_by:,
+      source_id:,
+      idempotency_key:,
+      entries:,
+      business_date: nil,
+      occurred_at: nil,
+      pos_session: nil,
+      reason_code: nil,
+      reason_name_snapshot: nil,
+      notes: nil,
+      reversal_of: nil,
+      reversal_entry_map: {},
+      outbox_event_type: nil,
+      correlation_id: nil
+    )
+      @operation_type = operation_type.to_s
+      @store = store
+      @performed_by = performed_by
+      @source_id = source_id
+      @idempotency_key = idempotency_key
+      @entries = Array(entries)
+      @business_date = business_date
+      @occurred_at = occurred_at
+      @pos_session = pos_session
+      @reason_code = reason_code
+      @reason_name_snapshot = reason_name_snapshot
+      @notes = notes
+      @reversal_of = reversal_of
+      @reversal_entry_map = reversal_entry_map
+      @outbox_event_type = outbox_event_type
+      @correlation_id = correlation_id || SecureRandom.uuid_v7
+    end
+
+    def call
+      raise Error, "actor is required" if @performed_by.blank?
+      raise Error, "store is required" if @store.blank?
+      raise Error, "idempotency key is required" if @idempotency_key.blank?
+      raise Error, "source id is required" if @source_id.blank?
+      raise Error, "at least one entry is required" if @entries.empty?
+
+      payload = command_payload
+      op = Idempotency::OperationService.begin!(
+        source_id: @source_id,
+        operation_type: "stored_value_post",
+        idempotency_key: @idempotency_key,
+        payload: payload
+      )
+      if op.replayed
+        return StoredValueOperation.find(op.operation.result_id) if op.operation.result_id
+
+        raise Error, "idempotent replay missing result"
+      end
+
+      begin
+        result = nil
+        StoredValueAccount.transaction do
+          occurred_at = @occurred_at || Time.current
+          business_date = @business_date || BusinessDate.for_store(@store, at: occurred_at)
+          account_ids = @entries.map { |entry| account_for(entry).id }.uniq.sort
+          locked = account_ids.index_with { |id| StoredValueAccount.lock.find(id) }
+
+          posted = []
+          @entries.each_with_index do |entry, index|
+            account = locked.fetch(account_for(entry).id)
+            amount = Integer(entry.fetch(:amount_cents))
+            raise Error, "entry amount must be nonzero" if amount.zero?
+            raise Error, "closed accounts cannot receive entries" if account.closed?
+            raise Error, "currency mismatch" if posted.any? && account.currency_code != posted.first[:account].currency_code
+
+            next_balance = account.balance_cents + amount
+            raise Error, "balance cannot be negative" if next_balance.negative?
+
+            account.apply_posted_balance!(next_balance)
+            posted << {
+              account: account,
+              amount_cents: amount,
+              balance_after_cents: next_balance,
+              reversal_of: @reversal_entry_map[index]
+            }
+          end
+
+          if @operation_type == "transfer"
+            net = posted.sum { |row| row[:amount_cents] }
+            raise Error, "transfer entries must net to zero" unless net.zero?
+            raise Error, "transfer requires at least two entries" if posted.size < 2
+          end
+
+          operation = StoredValueOperation.create!(
+            operation_type: @operation_type,
+            store: @store,
+            business_date: business_date,
+            occurred_at: occurred_at,
+            performed_by: @performed_by,
+            pos_session: @pos_session,
+            idempotency_operation: op.operation,
+            reversal_of: @reversal_of,
+            reason_code: @reason_code,
+            reason_name_snapshot: @reason_name_snapshot,
+            notes: @notes
+          )
+
+          posted.each_with_index do |row, sequence|
+            StoredValueEntry.create!(
+              stored_value_operation: operation,
+              stored_value_account: row[:account],
+              entry_sequence: sequence,
+              amount_cents: row[:amount_cents],
+              balance_after_cents: row[:balance_after_cents],
+              reversal_of: row[:reversal_of]
+            )
+          end
+
+          Audit::Recorder.record!(
+            action: "stored_value.post",
+            outcome: "succeeded",
+            actor_user: @performed_by,
+            store: @store,
+            subject: operation,
+            correlation_id: @correlation_id,
+            after_values: {
+              operation_type: operation.operation_type,
+              account_ids: posted.map { |row| row[:account].id },
+              amounts_cents: posted.map { |row| row[:amount_cents] }
+            }
+          )
+
+          Outbox::Recorder.record!(
+            event_type: @outbox_event_type || StoredValue::OUTBOX_EVENT_TYPES.fetch(@operation_type),
+            aggregate: operation,
+            payload: {
+              operation_id: operation.id,
+              operation_type: operation.operation_type,
+              store_id: @store.id,
+              business_date: business_date.iso8601,
+              entries: posted.map { |row|
+                {
+                  account_id: row[:account].id,
+                  amount_cents: row[:amount_cents],
+                  balance_after_cents: row[:balance_after_cents]
+                }
+              }
+            },
+            occurred_at: occurred_at,
+            correlation_id: @correlation_id
+          )
+
+          Idempotency::OperationService.complete!(
+            op.operation,
+            result_type: "StoredValueOperation",
+            result_id: operation.id,
+            result_payload: { operation_type: operation.operation_type }
+          )
+
+          result = operation
+        end
+        result
+      rescue Error, ActiveRecord::RecordInvalid, ActiveRecord::StaleObjectError, ActiveRecord::RecordNotUnique => e
+        Idempotency::OperationService.fail!(op.operation, message: e.message)
+        Audit::Recorder.record!(
+          action: "stored_value.post",
+          outcome: "failed",
+          actor_user: @performed_by,
+          store: @store,
+          subject: @reversal_of,
+          correlation_id: @correlation_id,
+          reason_text: e.message
+        )
+        raise Error, e.message
+      rescue Idempotency::OperationService::PayloadMismatchError
+        raise
+      end
+    end
+
+    private
+
+    def account_for(entry)
+      entry[:account] || StoredValueAccount.find(entry.fetch(:stored_value_account_id))
+    end
+
+    def command_payload
+      {
+        operation_type: @operation_type,
+        store_id: @store.id,
+        pos_session_id: @pos_session&.id,
+        reversal_of_id: @reversal_of&.id,
+        entries: @entries.map { |entry|
+          {
+            stored_value_account_id: account_for(entry).id,
+            amount_cents: Integer(entry.fetch(:amount_cents))
+          }
+        }
+      }
+    end
+  end
+end

--- a/app/services/stored_value/reverse.rb
+++ b/app/services/stored_value/reverse.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module StoredValue
+  class Reverse
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(
+      operation:,
+      performed_by:,
+      source_id:,
+      idempotency_key:,
+      store: nil,
+      notes: nil,
+      correlation_id: nil
+    )
+      @original = operation
+      @performed_by = performed_by
+      @source_id = source_id
+      @idempotency_key = idempotency_key
+      @store = store || operation.store
+      @notes = notes
+      @correlation_id = correlation_id || SecureRandom.uuid_v7
+    end
+
+    def call
+      raise Error, "operation is required" if @original.blank?
+
+      original = StoredValueOperation.find(@original.id)
+      raise Error, "cannot reverse a reversal" if original.reverse?
+      raise Error, "operation already reversed" if original.reversed?
+
+      entries = original.stored_value_entries.order(:entry_sequence).to_a
+      Post.call(
+        operation_type: "reverse",
+        store: @store,
+        performed_by: @performed_by,
+        source_id: @source_id,
+        idempotency_key: @idempotency_key,
+        entries: entries.map { |entry| { account: entry.stored_value_account, amount_cents: -entry.amount_cents } },
+        reversal_of: original,
+        reversal_entry_map: entries.each_with_index.to_h { |entry, index| [ index, entry ] },
+        notes: @notes,
+        correlation_id: @correlation_id
+      )
+    end
+  end
+end

--- a/app/services/stored_value/verify_projection.rb
+++ b/app/services/stored_value/verify_projection.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module StoredValue
+  class VerifyProjection
+    Drift = Data.define(:account, :projected_cents, :ledger_cents)
+
+    def self.call
+      new.call
+    end
+
+    def call
+      ledger_sums = StoredValueEntry.group(:stored_value_account_id).sum(:amount_cents)
+      StoredValueAccount.order(:id).filter_map do |account|
+        ledger_cents = ledger_sums.fetch(account.id, 0)
+        next if account.balance_cents == ledger_cents
+
+        Drift.new(account: account, projected_cents: account.balance_cents, ledger_cents: ledger_cents)
+      end
+    end
+  end
+end

--- a/db/migrate/20260826010000_create_phase10_stored_value_core.rb
+++ b/db/migrate/20260826010000_create_phase10_stored_value_core.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+class CreatePhase10StoredValueCore < ActiveRecord::Migration[8.1]
+  def change
+    create_uuid_table :stored_value_accounts do |t|
+      t.string :account_type, null: false
+      t.uuid :customer_id
+      t.string :currency_code, limit: 3, null: false
+      t.bigint :balance_cents, null: false, default: 0
+      t.string :status, null: false, default: "active"
+      t.timestamptz :opened_at, null: false
+      t.timestamptz :closed_at
+      t.integer :lock_version, null: false, default: 0
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+    add_index :stored_value_accounts, %i[customer_id account_type],
+              unique: true,
+              where: "customer_id IS NOT NULL AND status <> 'closed'",
+              name: "index_stored_value_accounts_one_open_per_customer_type"
+    add_index :stored_value_accounts, :customer_id
+    add_foreign_key :stored_value_accounts, :customers
+    add_check_constraint :stored_value_accounts,
+                         "account_type IN ('store_credit', 'trade_credit', 'gift_card')",
+                         name: "stored_value_accounts_type_valid"
+    add_check_constraint :stored_value_accounts,
+                         "status IN ('active', 'suspended', 'closed')",
+                         name: "stored_value_accounts_status_valid"
+    add_check_constraint :stored_value_accounts,
+                         "balance_cents >= 0",
+                         name: "stored_value_accounts_balance_nonnegative"
+    add_check_constraint :stored_value_accounts,
+                         "char_length(currency_code) = 3",
+                         name: "stored_value_accounts_currency_length"
+    add_check_constraint :stored_value_accounts,
+                         "(account_type IN ('store_credit', 'trade_credit') AND customer_id IS NOT NULL) OR (account_type = 'gift_card' AND customer_id IS NULL)",
+                         name: "stored_value_accounts_customer_matches_type"
+    add_check_constraint :stored_value_accounts,
+                         "(status <> 'closed' AND closed_at IS NULL) OR (status = 'closed' AND closed_at IS NOT NULL AND balance_cents = 0)",
+                         name: "stored_value_accounts_closed_consistency"
+
+    create_uuid_table :stored_value_operations do |t|
+      t.string :operation_type, null: false
+      t.uuid :store_id, null: false
+      t.date :business_date, null: false
+      t.timestamptz :occurred_at, null: false
+      t.uuid :performed_by_id, null: false
+      t.uuid :pos_session_id
+      t.uuid :idempotency_operation_id, null: false
+      t.uuid :reversal_of_id
+      t.string :reason_code
+      t.string :reason_name_snapshot
+      t.text :notes
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+    add_index :stored_value_operations, :idempotency_operation_id, unique: true
+    add_index :stored_value_operations, :reversal_of_id, unique: true, where: "reversal_of_id IS NOT NULL"
+    add_index :stored_value_operations, :store_id
+    add_index :stored_value_operations, :performed_by_id
+    add_index :stored_value_operations, :pos_session_id
+    add_foreign_key :stored_value_operations, :stores
+    add_foreign_key :stored_value_operations, :users, column: :performed_by_id
+    add_foreign_key :stored_value_operations, :pos_sessions
+    add_foreign_key :stored_value_operations, :idempotency_operations
+    add_foreign_key :stored_value_operations, :stored_value_operations, column: :reversal_of_id
+    add_check_constraint :stored_value_operations,
+                         "operation_type IN ('issue', 'activate', 'reload', 'redeem', 'refund', 'cash_out', 'transfer', 'adjust', 'reverse')",
+                         name: "stored_value_operations_type_valid"
+
+    create_uuid_table :stored_value_entries do |t|
+      t.uuid :stored_value_operation_id, null: false
+      t.uuid :stored_value_account_id, null: false
+      t.integer :entry_sequence, null: false
+      t.bigint :amount_cents, null: false
+      t.bigint :balance_after_cents, null: false
+      t.uuid :reversal_of_id
+      t.timestamptz :created_at, null: false
+    end
+    add_index :stored_value_entries, %i[stored_value_operation_id entry_sequence],
+              unique: true,
+              name: "index_stored_value_entries_on_operation_and_sequence"
+    add_index :stored_value_entries, :stored_value_account_id
+    add_index :stored_value_entries, :reversal_of_id, unique: true, where: "reversal_of_id IS NOT NULL"
+    add_foreign_key :stored_value_entries, :stored_value_operations
+    add_foreign_key :stored_value_entries, :stored_value_accounts
+    add_foreign_key :stored_value_entries, :stored_value_entries, column: :reversal_of_id
+    add_check_constraint :stored_value_entries,
+                         "entry_sequence >= 0",
+                         name: "stored_value_entries_sequence_nonnegative"
+    add_check_constraint :stored_value_entries,
+                         "amount_cents <> 0",
+                         name: "stored_value_entries_amount_nonzero"
+    add_check_constraint :stored_value_entries,
+                         "balance_after_cents >= 0",
+                         name: "stored_value_entries_balance_after_nonnegative"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_24_130000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_26_010000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -1180,6 +1180,65 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_24_130000) do
     t.check_constraint "rate_percent >= 0::numeric AND rate_percent <= 100::numeric", name: "store_taxes_rate_percent_range"
   end
 
+  create_table "stored_value_accounts", id: :uuid, default: nil, force: :cascade do |t|
+    t.string "account_type", null: false
+    t.bigint "balance_cents", default: 0, null: false
+    t.timestamptz "closed_at"
+    t.timestamptz "created_at", null: false
+    t.string "currency_code", limit: 3, null: false
+    t.uuid "customer_id"
+    t.integer "lock_version", default: 0, null: false
+    t.timestamptz "opened_at", null: false
+    t.string "status", default: "active", null: false
+    t.timestamptz "updated_at", null: false
+    t.index ["customer_id", "account_type"], name: "index_stored_value_accounts_one_open_per_customer_type", unique: true, where: "((customer_id IS NOT NULL) AND ((status)::text <> 'closed'::text))"
+    t.index ["customer_id"], name: "index_stored_value_accounts_on_customer_id"
+    t.check_constraint "(account_type::text = ANY (ARRAY['store_credit'::character varying, 'trade_credit'::character varying]::text[])) AND customer_id IS NOT NULL OR account_type::text = 'gift_card'::text AND customer_id IS NULL", name: "stored_value_accounts_customer_matches_type"
+    t.check_constraint "account_type::text = ANY (ARRAY['store_credit'::character varying, 'trade_credit'::character varying, 'gift_card'::character varying]::text[])", name: "stored_value_accounts_type_valid"
+    t.check_constraint "balance_cents >= 0", name: "stored_value_accounts_balance_nonnegative"
+    t.check_constraint "char_length(currency_code::text) = 3", name: "stored_value_accounts_currency_length"
+    t.check_constraint "status::text <> 'closed'::text AND closed_at IS NULL OR status::text = 'closed'::text AND closed_at IS NOT NULL AND balance_cents = 0", name: "stored_value_accounts_closed_consistency"
+    t.check_constraint "status::text = ANY (ARRAY['active'::character varying, 'suspended'::character varying, 'closed'::character varying]::text[])", name: "stored_value_accounts_status_valid"
+  end
+
+  create_table "stored_value_entries", id: :uuid, default: nil, force: :cascade do |t|
+    t.bigint "amount_cents", null: false
+    t.bigint "balance_after_cents", null: false
+    t.timestamptz "created_at", null: false
+    t.integer "entry_sequence", null: false
+    t.uuid "reversal_of_id"
+    t.uuid "stored_value_account_id", null: false
+    t.uuid "stored_value_operation_id", null: false
+    t.index ["reversal_of_id"], name: "index_stored_value_entries_on_reversal_of_id", unique: true, where: "(reversal_of_id IS NOT NULL)"
+    t.index ["stored_value_account_id"], name: "index_stored_value_entries_on_stored_value_account_id"
+    t.index ["stored_value_operation_id", "entry_sequence"], name: "index_stored_value_entries_on_operation_and_sequence", unique: true
+    t.check_constraint "amount_cents <> 0", name: "stored_value_entries_amount_nonzero"
+    t.check_constraint "balance_after_cents >= 0", name: "stored_value_entries_balance_after_nonnegative"
+    t.check_constraint "entry_sequence >= 0", name: "stored_value_entries_sequence_nonnegative"
+  end
+
+  create_table "stored_value_operations", id: :uuid, default: nil, force: :cascade do |t|
+    t.date "business_date", null: false
+    t.timestamptz "created_at", null: false
+    t.uuid "idempotency_operation_id", null: false
+    t.text "notes"
+    t.timestamptz "occurred_at", null: false
+    t.string "operation_type", null: false
+    t.uuid "performed_by_id", null: false
+    t.uuid "pos_session_id"
+    t.string "reason_code"
+    t.string "reason_name_snapshot"
+    t.uuid "reversal_of_id"
+    t.uuid "store_id", null: false
+    t.timestamptz "updated_at", null: false
+    t.index ["idempotency_operation_id"], name: "index_stored_value_operations_on_idempotency_operation_id", unique: true
+    t.index ["performed_by_id"], name: "index_stored_value_operations_on_performed_by_id"
+    t.index ["pos_session_id"], name: "index_stored_value_operations_on_pos_session_id"
+    t.index ["reversal_of_id"], name: "index_stored_value_operations_on_reversal_of_id", unique: true, where: "(reversal_of_id IS NOT NULL)"
+    t.index ["store_id"], name: "index_stored_value_operations_on_store_id"
+    t.check_constraint "operation_type::text = ANY (ARRAY['issue'::character varying, 'activate'::character varying, 'reload'::character varying, 'redeem'::character varying, 'refund'::character varying, 'cash_out'::character varying, 'transfer'::character varying, 'adjust'::character varying, 'reverse'::character varying]::text[])", name: "stored_value_operations_type_valid"
+  end
+
   create_table "stores", id: :uuid, default: nil, force: :cascade do |t|
     t.boolean "active", default: true, null: false
     t.string "city"
@@ -1511,6 +1570,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_24_130000) do
   add_foreign_key "store_tax_rules", "store_taxes"
   add_foreign_key "store_tax_rules", "tax_classes"
   add_foreign_key "store_taxes", "stores"
+  add_foreign_key "stored_value_accounts", "customers"
+  add_foreign_key "stored_value_entries", "stored_value_accounts"
+  add_foreign_key "stored_value_entries", "stored_value_entries", column: "reversal_of_id"
+  add_foreign_key "stored_value_entries", "stored_value_operations"
+  add_foreign_key "stored_value_operations", "idempotency_operations"
+  add_foreign_key "stored_value_operations", "pos_sessions"
+  add_foreign_key "stored_value_operations", "stored_value_operations", column: "reversal_of_id"
+  add_foreign_key "stored_value_operations", "stores"
+  add_foreign_key "stored_value_operations", "users", column: "performed_by_id"
   add_foreign_key "stores", "users", column: "deactivated_by_id"
   add_foreign_key "subject_headings", "merchandise_classes", column: "suggested_merchandise_class_id"
   add_foreign_key "subject_headings", "subject_schemes"

--- a/docs/planning/phase10-stored-value/phase10-implementation-plan.md
+++ b/docs/planning/phase10-stored-value/phase10-implementation-plan.md
@@ -49,7 +49,7 @@ Issue branches PR **directly to `main`**. There is no `phase-10-stored-value` in
 
 | Slice | Status |
 |---|---|
-| 10.1 Stored-value core | Not started |
+| 10.1 Stored-value core | Complete (issue [#59](https://github.com/BankEncore/ShelfSense-v1/issues/59)) |
 | 10.2 Customer store/trade credit | Not started |
 | 10.3 Gift-card programs and instruments | Not started |
 | 10.4 POS issuance, tenders, refund destinations, post-void | Not started |

--- a/test/services/stored_value/post_test.rb
+++ b/test/services/stored_value/post_test.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module StoredValue
+  class PostTest < ActiveSupport::TestCase
+    setup do
+      @bootstrap = bootstrap!
+      @store = @bootstrap[:store]
+      @actor = @bootstrap[:administrator]
+      @customer = Customer.create!(display_name: "Credit Customer", email: "credit@example.com")
+      @account = StoredValue::OpenAccount.call(account_type: "store_credit", customer: @customer)
+    end
+
+    test "posts a credit, updates projection, and writes audit and outbox in the same transaction" do
+      operation = post_credit(500)
+
+      assert_equal "issue", operation.operation_type
+      assert_equal 500, @account.reload.balance_cents
+      entry = operation.stored_value_entries.sole
+      assert_equal 500, entry.amount_cents
+      assert_equal 500, entry.balance_after_cents
+      assert_equal 0, entry.entry_sequence
+      assert AuditEvent.exists?(action: "stored_value.post", outcome: "succeeded", subject_id: operation.id)
+      assert OutboxMessage.exists?(event_type: "stored_value.issued", aggregate_id: operation.id)
+      assert_nil StoredValueOperation.column_names.find { |name| name.end_with?("_source_id") || name == "source_type" }
+      assert_not StoredValueOperation.column_names.include?("reversed_by_id")
+    end
+
+    test "rejects generic balance assignment" do
+      error = assert_raises(StoredValue::Error) { @account.update!(balance_cents: 99) }
+      assert_match(/balance_cents cannot be assigned/, error.message)
+      assert_equal 0, @account.reload.balance_cents
+    end
+
+    test "rejects negative balances and records a failed audit outside the rolled-back mutation" do
+      post_credit(100)
+      before_entries = StoredValueEntry.count
+      before_ops = StoredValueOperation.count
+
+      error = assert_raises(StoredValue::Error) { post_debit(200) }
+      assert_match(/negative/, error.message)
+      assert_equal 100, @account.reload.balance_cents
+      assert_equal before_entries, StoredValueEntry.count
+      assert_equal before_ops, StoredValueOperation.count
+      assert AuditEvent.exists?(action: "stored_value.post", outcome: "failed")
+      assert_equal 1, OutboxMessage.where(event_type: "stored_value.issued").count
+    end
+
+    test "idempotent retry returns the same operation" do
+      key = SecureRandom.uuid_v7
+      source = SecureRandom.uuid_v7
+      first = post_credit(250, key: key, source: source)
+      second = post_credit(250, key: key, source: source)
+
+      assert_equal first.id, second.id
+      assert_equal 1, StoredValueOperation.count
+      assert_equal 250, @account.reload.balance_cents
+    end
+
+    test "payload mismatch is an error" do
+      key = SecureRandom.uuid_v7
+      source = SecureRandom.uuid_v7
+      post_credit(250, key: key, source: source)
+
+      assert_raises(Idempotency::OperationService::PayloadMismatchError) do
+        post_credit(400, key: key, source: source)
+      end
+    end
+
+    test "locks accounts in UUID order for a transfer that nets to zero" do
+      other = Customer.create!(display_name: "Other", email: "other@example.com")
+      destination = StoredValue::OpenAccount.call(account_type: "store_credit", customer: other)
+      post_credit(300)
+
+      ordered = [ @account, destination ].sort_by(&:id)
+      operation = StoredValue::Post.call(
+        operation_type: "transfer",
+        store: @store,
+        performed_by: @actor,
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7,
+        entries: [
+          { account: ordered.last, amount_cents: 125 },
+          { account: ordered.first, amount_cents: -125 }
+        ]
+      )
+
+      assert_equal 2, operation.stored_value_entries.count
+      assert_equal 0, operation.stored_value_entries.sum(:amount_cents)
+      assert_equal "stored_value.transferred", OutboxMessage.order(:created_at).last.event_type
+    end
+
+    test "database rejects a reversed_by_id column and uniqueness of reversal_of_id" do
+      assert_not StoredValueAccount.column_names.include?("reversed_by_id")
+      first = post_credit(50)
+      StoredValue::Reverse.call(
+        operation: first,
+        performed_by: @actor,
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+
+      assert_raises(StoredValue::Error) do
+        StoredValue::Reverse.call(
+          operation: first,
+          performed_by: @actor,
+          source_id: SecureRandom.uuid_v7,
+          idempotency_key: SecureRandom.uuid_v7
+        )
+      end
+    end
+
+    test "reverse restores the projection through compensating entries" do
+      original = post_credit(80)
+      reversal = StoredValue::Reverse.call(
+        operation: original,
+        performed_by: @actor,
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+
+      assert_equal "reverse", reversal.operation_type
+      assert_equal original.id, reversal.reversal_of_id
+      assert_equal original.id, reversal.reversal_of.id
+      assert_equal reversal.id, original.reload.reversed_by.id
+      assert_equal 0, @account.reload.balance_cents
+      assert_equal(-80, reversal.stored_value_entries.sole.amount_cents)
+    end
+
+    test "verify projection reports drift without repairing" do
+      post_credit(40)
+      StoredValueAccount.where(id: @account.id).update_all(balance_cents: 7)
+
+      drifts = StoredValue::VerifyProjection.call
+      drift = drifts.find { |item| item.account.id == @account.id }
+
+      assert_equal 7, drift.projected_cents
+      assert_equal 40, drift.ledger_cents
+      assert_equal 7, @account.reload.balance_cents
+    end
+
+    test "seeded phase 10 permissions grant store managers but not associates the exceptional keys" do
+      Authorization::PermissionCatalog.seed!(granted_by: @actor)
+      manager = Role.find_by!(key: "store_manager")
+      associate = Role.find_by!(key: "associate")
+      admin = Role.find_by!(key: "system_administrator")
+
+      assert manager.permissions.exists?(key: "stored_value.adjust")
+      assert manager.permissions.exists?(key: "gift_cards.cash_out")
+      assert_not manager.permissions.exists?(key: "gift_cards.manage_programs")
+      assert_not manager.permissions.exists?(key: "stored_value.manage_adjustment_reasons")
+      assert_not associate.permissions.exists?(key: "stored_value.adjust")
+      assert admin.permissions.exists?(key: "gift_cards.manage_programs")
+      assert_not Permission.exists?(key: "gift_cards.reveal_number")
+    end
+
+    test "currency is snapshotted from system settings and is not caller-selectable" do
+      assert_equal SystemSettings.current.base_currency_code, @account.currency_code
+      error = assert_raises(ActiveRecord::RecordInvalid) { @account.update!(currency_code: "EUR") }
+      assert_match(/cannot change/, error.message)
+    end
+
+    test "gift-card accounts cannot have a customer_id" do
+      card_account = StoredValue::OpenAccount.call(account_type: "gift_card")
+      assert_nil card_account.customer_id
+      invalid = StoredValueAccount.new(
+        account_type: "gift_card",
+        customer: @customer,
+        currency_code: "USD",
+        opened_at: Time.current
+      )
+      assert_not invalid.valid?
+    end
+
+    private
+
+    def post_credit(amount_cents, key: SecureRandom.uuid_v7, source: SecureRandom.uuid_v7)
+      StoredValue::Post.call(
+        operation_type: "issue",
+        store: @store,
+        performed_by: @actor,
+        source_id: source,
+        idempotency_key: key,
+        entries: [ { account: @account, amount_cents: amount_cents } ]
+      )
+    end
+
+    def post_debit(amount_cents)
+      StoredValue::Post.call(
+        operation_type: "redeem",
+        store: @store,
+        performed_by: @actor,
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7,
+        entries: [ { account: @account, amount_cents: -amount_cents } ]
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add \`stored_value_accounts\`, \`stored_value_operations\`, and \`stored_value_entries\` with database checks
- \`StoredValue::Post\` locks accounts in UUID order, rejects negatives, and commits audit/outbox with the mutation
- Failed posts record audit outside the rolled-back transaction; projection verification reports drift without repair
- Seed Phase 10 permission keys; store managers get operational keys, not program/reason catalog manage

## Verification
- \`./dev/rails-docker bin/rails test test/services/stored_value/post_test.rb test/services/installation/bootstrap_test.rb\`
- \`./dev/rails-docker bin/rubocop\` (changed files)
- \`./dev/rails-docker bin/brakeman --no-pager\`
- \`./dev/rails-docker bin/bundler-audit\`

## Documentation and migrations
- \`db/migrate/20260826010000_create_phase10_stored_value_core.rb\` (reversible \`change\`)
- \`db/schema.rb\` regenerated
- Slice 10.1 marked Complete in phase10-implementation-plan.md

Closes #59

Made with [Cursor](https://cursor.com)