### PR TITLE
10.2 — Customer store and trade credit

### DIFF
--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -24,6 +24,19 @@ module Admin
     def show
       @customer_requests = @customer.customer_requests.includes(:store, :product_variant).admin_ordered.limit(50)
       @merged_aliases = @customer.merged_aliases.admin_ordered if @customer.canonical?
+      if Authorization::PermissionEvaluator.allowed?(user: current_user, permission_key: "stored_value.view_activity", store: current_store)
+        @stored_value_accounts = @customer.stored_value_accounts
+                                          .where(account_type: StoredValueAccount::CUSTOMER_OWNED_TYPES)
+                                          .where.not(status: "closed").order(:account_type)
+        @stored_value_entries = StoredValueEntry.joins(:stored_value_account)
+                                                .where(stored_value_accounts: {
+                                                  customer_id: @customer.id,
+                                                  account_type: StoredValueAccount::CUSTOMER_OWNED_TYPES
+                                                })
+                                                .includes(:stored_value_operation, :stored_value_account)
+                                                .order(created_at: :desc)
+                                                .limit(25)
+      end
     end
 
     def new
@@ -109,6 +122,13 @@ module Admin
     def destroy
       if @customer.merged?
         redirect_to admin_customer_path(@customer), alert: "Merged customers cannot be deactivated separately."
+        return
+      end
+
+      if StoredValueAccount.where(customer_id: @customer.id, account_type: StoredValueAccount::CUSTOMER_OWNED_TYPES)
+                           .where.not(status: "closed").where("balance_cents > 0").exists?
+        redirect_to admin_customer_path(@customer),
+                    alert: "Cannot deactivate a customer with a nonzero store-credit or trade-credit balance."
         return
       end
 

--- a/app/controllers/admin/stored_value_adjustment_reasons_controller.rb
+++ b/app/controllers/admin/stored_value_adjustment_reasons_controller.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Admin
+  class StoredValueAdjustmentReasonsController < BaseController
+    before_action -> { require_permission!("stored_value.manage_adjustment_reasons") }
+    before_action :set_reason, only: %i[show edit update destroy reactivate]
+
+    def index
+      @reasons = StoredValueAdjustmentReason.admin_ordered
+    end
+
+    def show; end
+
+    def new
+      @reason = StoredValueAdjustmentReason.new(allowed_direction: "either", allowed_account_types: %w[store_credit trade_credit])
+    end
+
+    def create
+      @reason = StoredValueAdjustmentReason.new(reason_params)
+      if create_and_audit!(@reason, action: "stored_value.adjustment_reasons.create", after_values: { code: @reason.code })
+        redirect_to admin_stored_value_adjustment_reason_path(@reason), notice: "Adjustment reason created."
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def edit; end
+
+    def update
+      rescue_stale do
+        if save_and_audit!(
+          @reason,
+          attrs: reason_params.except(:code),
+          action: "stored_value.adjustment_reasons.update",
+          before_keys: %w[name description allowed_direction notes_required approval_required]
+        )
+          redirect_to admin_stored_value_adjustment_reason_path(@reason), notice: "Adjustment reason updated."
+        else
+          render :edit, status: :unprocessable_entity
+        end
+      end
+    end
+
+    def destroy
+      mutate_and_audit!(@reason, action: "stored_value.adjustment_reasons.deactivate") { @reason.update!(active: false) }
+      redirect_to admin_stored_value_adjustment_reasons_path, notice: "Adjustment reason deactivated."
+    end
+
+    def reactivate
+      reactivate_configuration!(
+        @reason,
+        permission_key: "stored_value.manage_adjustment_reasons",
+        audit_action: "stored_value.adjustment_reasons.reactivate",
+        redirect_path: admin_stored_value_adjustment_reason_path(@reason)
+      )
+    end
+
+    private
+
+    def set_reason
+      @reason = StoredValueAdjustmentReason.find(params[:id])
+    end
+
+    def reason_params
+      permitted = params.require(:stored_value_adjustment_reason).permit(
+        :code, :name, :description, :allowed_direction, :notes_required, :approval_required,
+        :display_order, :lock_version, allowed_account_types: []
+      )
+      permitted[:allowed_account_types] = Array(permitted[:allowed_account_types]).compact_blank
+      permitted
+    end
+  end
+end

--- a/app/controllers/admin/stored_value_adjustments_controller.rb
+++ b/app/controllers/admin/stored_value_adjustments_controller.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module Admin
+  class StoredValueAdjustmentsController < BaseController
+    before_action -> { require_permission!("stored_value.adjust") }
+    before_action :set_customer
+
+    def new
+      @account = existing_account_for_params
+      @account_type = @account&.account_type || requested_account_type
+      @reasons = reasons_for(@account_type)
+    end
+
+    def create
+      @account = account_for_create!
+      @account_type = @account.account_type
+      reason = StoredValueAdjustmentReason.find(params.require(:reason_id))
+      direction = params.require(:direction)
+      amount_cents = Money::ParseCents.call(params[:amount])
+      raise StoredValue::Error, "amount is required" if amount_cents.nil?
+
+      approved_by = approver_if_required!(direction: direction, amount_cents: amount_cents, reason: reason)
+      StoredValue::Adjust.call(
+        account: @account,
+        direction: direction,
+        amount_cents: amount_cents,
+        reason: reason,
+        store: operational_store!,
+        performed_by: current_user,
+        approved_by: approved_by,
+        source_id: @account.id,
+        idempotency_key: params[:idempotency_key].presence || SecureRandom.uuid_v7,
+        customer_explanation: params[:customer_explanation],
+        internal_notes: params[:internal_notes]
+      )
+      redirect_to admin_customer_path(@customer), notice: "Stored-value adjustment posted."
+    rescue StoredValue::Error, Money::ParseCents::Error, ArgumentError, ActiveRecord::RecordNotFound => e
+      @account ||= existing_account_for_params
+      @account_type = @account&.account_type || requested_account_type
+      @reasons = reasons_for(@account_type)
+      flash.now[:alert] = e.message
+      render :new, status: :unprocessable_entity
+    end
+
+    private
+
+    def set_customer
+      @customer = Customer.find(params[:customer_id])
+    end
+
+    def existing_account_for_params
+      if params[:stored_value_account_id].present?
+        customer_owned_accounts.find(params[:stored_value_account_id])
+      else
+        customer_owned_accounts.where(account_type: requested_account_type).where.not(status: "closed").order(:id).first
+      end
+    end
+
+    def account_for_create!
+      if params[:stored_value_account_id].present?
+        customer_owned_accounts.find(params[:stored_value_account_id])
+      else
+        StoredValue::EnsureCustomerAccount.call(customer: @customer, account_type: requested_account_type)
+      end
+    end
+
+    def customer_owned_accounts
+      @customer.stored_value_accounts.where(account_type: StoredValueAccount::CUSTOMER_OWNED_TYPES)
+    end
+
+    def requested_account_type
+      params[:account_type].presence_in(StoredValueAccount::CUSTOMER_OWNED_TYPES) || "store_credit"
+    end
+
+    def reasons_for(account_type)
+      StoredValueAdjustmentReason.active.admin_ordered.select { |reason| Array(reason.allowed_account_types).include?(account_type) }
+    end
+
+    def operational_store!
+      current_store || Store.active.order(:name).first || raise(StoredValue::Error, "a store is required")
+    end
+
+    def approver_if_required!(direction:, amount_cents:, reason:)
+      return unless StoredValue::Adjust.second_user_required?(direction: direction, amount_cents: amount_cents, reason: reason)
+
+      StoredValue::AuthenticateApprover.call(
+        username: params[:approver_username],
+        password: params[:approver_password],
+        performer: current_user,
+        permission_key: "stored_value.adjust",
+        store: operational_store!
+      )
+    end
+  end
+end

--- a/app/controllers/admin/stored_value_transfers_controller.rb
+++ b/app/controllers/admin/stored_value_transfers_controller.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Admin
+  class StoredValueTransfersController < BaseController
+    before_action -> { require_permission!("stored_value.transfer") }
+
+    def new
+      @from_customer = Customer.find_by(id: params[:from_customer_id])
+      @account_type = params[:account_type].presence_in(StoredValueAccount::CUSTOMER_OWNED_TYPES) || "store_credit"
+    end
+
+    def create
+      from_customer = Customer.find(params.require(:from_customer_id))
+      to_customer = Customer.find(params.require(:to_customer_id))
+      account_type = params.require(:account_type).presence_in(StoredValueAccount::CUSTOMER_OWNED_TYPES)
+      raise StoredValue::Error, "account type is required" if account_type.blank?
+
+      transfer_type = params[:transfer_type].presence_in(%w[administrative account_consolidation]) || "administrative"
+      from_account = open_customer_account(from_customer, account_type)
+      raise StoredValue::Error, "source has no open #{account_type.humanize.downcase} account" if from_account.nil?
+
+      if transfer_type == "account_consolidation" && from_account.balance_cents.zero?
+        from_account.close_zero!
+        redirect_to admin_customer_path(from_customer), notice: "Zero-balance source account closed. No transfer posted."
+        return
+      end
+
+      amount_cents = if transfer_type == "account_consolidation"
+        from_account.balance_cents
+      else
+        Money::ParseCents.call(params[:amount])
+      end
+      raise StoredValue::Error, "amount must be positive" if amount_cents.nil? || !amount_cents.positive?
+
+      to_account = StoredValue::EnsureCustomerAccount.call(customer: to_customer, account_type: account_type)
+      approved_by = StoredValue::AuthenticateApprover.call(
+        username: params[:approver_username],
+        password: params[:approver_password],
+        performer: current_user,
+        permission_key: "stored_value.transfer",
+        store: operational_store!
+      )
+      StoredValue::Transfer.call(
+        from_account: from_account,
+        to_account: to_account,
+        amount_cents: amount_cents,
+        transfer_type: transfer_type,
+        performed_by: current_user,
+        approved_by: approved_by,
+        store: operational_store!,
+        source_id: from_account.id,
+        idempotency_key: params[:idempotency_key].presence || SecureRandom.uuid_v7,
+        reason_code: params[:reason_code].presence || transfer_type,
+        reason_name_snapshot: params[:reason_name].presence || transfer_type.humanize,
+        notes: params[:notes]
+      )
+      redirect_to admin_customer_path(to_customer), notice: "Stored-value transfer posted."
+    rescue StoredValue::Error, ActiveRecord::RecordNotFound, Money::ParseCents::Error, ArgumentError => e
+      @from_customer = Customer.find_by(id: params[:from_customer_id])
+      @account_type = params[:account_type]
+      flash.now[:alert] = e.message
+      render :new, status: :unprocessable_entity
+    end
+
+    private
+
+    def operational_store!
+      current_store || Store.active.order(:name).first || raise(StoredValue::Error, "a store is required")
+    end
+
+    def open_customer_account(customer, account_type)
+      StoredValueAccount.where(customer_id: customer.id, account_type: account_type)
+                        .where.not(status: "closed").order(:id).first
+    end
+  end
+end

--- a/app/controllers/admin/system_settings_controller.rb
+++ b/app/controllers/admin/system_settings_controller.rb
@@ -16,7 +16,11 @@ module Admin
     def update
       rescue_stale do
         @settings = SystemSettings.current
-        before = @settings.attributes.slice("organization_name", "legal_name", "default_timezone", "default_country_code", "default_receipt_header", "default_receipt_footer")
+        before = @settings.attributes.slice(
+          "organization_name", "legal_name", "default_timezone", "default_country_code",
+          "default_receipt_header", "default_receipt_footer",
+          "stored_value_adjust_credit_approval_threshold_cents"
+        )
         if @settings.update(settings_params)
           Audit::Recorder.record!(
             action: "system_settings.update",
@@ -41,7 +45,7 @@ module Admin
         :organization_name, :legal_name, :base_currency_code, :default_timezone,
         :default_country_code, :default_region_code, :fiscal_year_start_month,
         :default_supplier_cancellation_days, :default_customer_reservation_expiration_days,
-        :default_receipt_header, :default_receipt_footer, :lock_version
+        :default_receipt_header, :default_receipt_footer, :stored_value_adjust_credit_approval_threshold_cents, :lock_version
       )
     end
   end

--- a/app/models/stored_value_account.rb
+++ b/app/models/stored_value_account.rb
@@ -33,6 +33,12 @@ class StoredValueAccount < ApplicationRecord
     CUSTOMER_OWNED_TYPES.include?(account_type)
   end
 
+  def close_zero!(at: Time.current)
+    raise StoredValue::Error, "cannot close an account with a nonzero balance" unless balance_cents.to_i.zero?
+
+    update!(status: "closed", closed_at: at)
+  end
+
   def apply_posted_balance!(cents)
     @allow_balance_write = true
     update!(balance_cents: cents)

--- a/app/models/stored_value_adjustment.rb
+++ b/app/models/stored_value_adjustment.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class StoredValueAdjustment < ApplicationRecord
+  DIRECTIONS = %w[credit debit].freeze
+
+  belongs_to :stored_value_account
+  belongs_to :reason, class_name: "StoredValueAdjustmentReason"
+  belongs_to :store
+  belongs_to :performed_by, class_name: "User"
+  belongs_to :approved_by, class_name: "User", optional: true
+  belongs_to :stored_value_operation, optional: true
+  belongs_to :idempotency_operation
+  belongs_to :reversal_of, class_name: "StoredValueAdjustment", optional: true
+  has_one :reversed_by, class_name: "StoredValueAdjustment", foreign_key: :reversal_of_id, inverse_of: :reversal_of,
+          dependent: :restrict_with_exception
+
+  validates :adjustment_direction, :amount_cents, :reason_code, :reason_name_snapshot, :posted_at, presence: true
+  validates :adjustment_direction, inclusion: { in: DIRECTIONS }
+  validates :amount_cents, numericality: { only_integer: true, greater_than: 0 }
+
+  def readonly?
+    super || persisted?
+  end
+
+  def signed_amount_cents
+    adjustment_direction == "credit" ? amount_cents : -amount_cents
+  end
+end

--- a/app/models/stored_value_adjustment_reason.rb
+++ b/app/models/stored_value_adjustment_reason.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class StoredValueAdjustmentReason < ApplicationRecord
+  DIRECTIONS = %w[credit debit either].freeze
+  ACCOUNT_TYPES = StoredValueAccount::ACCOUNT_TYPES
+
+  validates :code, :name, :allowed_direction, presence: true
+  validates :code, uniqueness: { case_sensitive: false }
+  validates :allowed_direction, inclusion: { in: DIRECTIONS }
+  validates :display_order, numericality: { only_integer: true }
+  validate :allowed_account_types_valid
+  validate :code_immutable, on: :update
+
+  before_validation :normalize_code
+
+  scope :active, -> { where(active: true) }
+  scope :admin_ordered, -> { order(:display_order, :code) }
+
+  def allows?(direction:, account_type:)
+    (allowed_direction == "either" || allowed_direction == direction) &&
+      Array(allowed_account_types).include?(account_type)
+  end
+
+  private
+
+  def normalize_code
+    self.code = code.to_s.strip.downcase
+  end
+
+  def allowed_account_types_valid
+    types = Array(allowed_account_types)
+    errors.add(:allowed_account_types, "can't be blank") if types.blank?
+    extras = types - ACCOUNT_TYPES
+    errors.add(:allowed_account_types, "contains invalid types") if extras.any?
+  end
+
+  def code_immutable
+    errors.add(:code, "cannot change after create") if will_save_change_to_code?
+  end
+end

--- a/app/models/stored_value_operation.rb
+++ b/app/models/stored_value_operation.rb
@@ -11,6 +11,8 @@ class StoredValueOperation < ApplicationRecord
   has_one :reversed_by, class_name: "StoredValueOperation", foreign_key: :reversal_of_id, inverse_of: :reversal_of,
           dependent: :restrict_with_exception
   has_many :stored_value_entries, -> { order(:entry_sequence) }, dependent: :restrict_with_exception
+  has_one :stored_value_adjustment, dependent: :restrict_with_exception
+  has_one :stored_value_transfer, dependent: :restrict_with_exception
 
   validates :operation_type, :business_date, :occurred_at, presence: true
   validates :operation_type, inclusion: { in: OPERATION_TYPES }

--- a/app/models/stored_value_transfer.rb
+++ b/app/models/stored_value_transfer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class StoredValueTransfer < ApplicationRecord
+  TRANSFER_TYPES = %w[customer_merge administrative account_consolidation].freeze
+
+  belongs_to :from_account, class_name: "StoredValueAccount"
+  belongs_to :to_account, class_name: "StoredValueAccount"
+  belongs_to :source_customer, class_name: "Customer", optional: true
+  belongs_to :survivor_customer, class_name: "Customer", optional: true
+  belongs_to :performed_by, class_name: "User"
+  belongs_to :approved_by, class_name: "User", optional: true
+  belongs_to :stored_value_operation, optional: true
+  belongs_to :reversal_of, class_name: "StoredValueTransfer", optional: true
+  belongs_to :merge_idempotency_operation, class_name: "IdempotencyOperation", optional: true
+  has_one :reversed_by, class_name: "StoredValueTransfer", foreign_key: :reversal_of_id, inverse_of: :reversal_of,
+          dependent: :restrict_with_exception
+
+  validates :transfer_type, :amount_cents, :posted_at, presence: true
+  validates :transfer_type, inclusion: { in: TRANSFER_TYPES }
+  validates :amount_cents, numericality: { only_integer: true, greater_than: 0 }
+
+  def readonly?
+    super || persisted?
+  end
+end

--- a/app/models/system_settings.rb
+++ b/app/models/system_settings.rb
@@ -11,6 +11,8 @@ class SystemSettings < ApplicationRecord
             numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validates :default_customer_reservation_expiration_days,
             numericality: { only_integer: true, greater_than: 0 }
+  validates :stored_value_adjust_credit_approval_threshold_cents,
+            numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validates :default_receipt_header, :default_receipt_footer, length: { maximum: Store::RECEIPT_MESSAGE_LIMIT }
   validate :singleton_row
   before_validation :normalize_receipt_messages

--- a/app/services/admin/navigation_catalog.rb
+++ b/app/services/admin/navigation_catalog.rb
@@ -83,8 +83,9 @@ module Admin
             key: :customers,
             label: "Customers",
             destinations: [
-              dest(:customers, "Customers", :admin_customers_path, permission: "customers.view", controllers: %w[admin/customers]),
+              dest(:customers, "Customers", :admin_customers_path, permission: "customers.view", controllers: %w[admin/customers admin/stored_value_adjustments]),
               dest(:customer_requests, "Customer requests", :admin_customer_requests_path, permission: "customers.view", controllers: %w[admin/customer_requests]),
+              dest(:stored_value_transfers, "Stored-value transfers", :new_admin_stored_value_transfer_path, permission: "stored_value.transfer", controllers: %w[admin/stored_value_transfers]),
               dest(:location_ops, "Location ops", :ops_location_path, permission: "customer_requests.locate", requires_store: true, controllers: %w[ops/locations])
             ]
           ),
@@ -102,6 +103,7 @@ module Admin
             label: "Organization configuration",
             destinations: [
               dest(:system_settings, "Settings", :admin_system_settings_path, permission: "system_settings.view", controllers: %w[admin/system_settings]),
+              dest(:stored_value_adjustment_reasons, "Stored-value reasons", :admin_stored_value_adjustment_reasons_path, permission: "stored_value.manage_adjustment_reasons", controllers: %w[admin/stored_value_adjustment_reasons]),
               dest(:stores, "Stores", :admin_stores_path, permission: %w[stores.view stores.create], controllers: %w[admin/stores]),
               dest(:gl_accounts, "GL Accounts", :admin_gl_accounts_path, permission: "gl_accounts.view", controllers: %w[admin/gl_accounts]),
               dest(:tax_classes, "Tax Classes", :admin_tax_classes_path, permission: "tax_classes.view", controllers: %w[admin/tax_classes]),

--- a/app/services/customers/merge_customers.rb
+++ b/app/services/customers/merge_customers.rb
@@ -11,7 +11,8 @@ module Customers
       :source,
       :requests_reassigned_count,
       :aliases_repointed_ids,
-      :replayed
+      :replayed,
+      :stored_value_transfer_ids
     )
 
     def self.call(**attrs)
@@ -68,7 +69,8 @@ module Customers
           source: source,
           requests_reassigned_count: op.operation.result_payload["requests_reassigned_count"].to_i,
           aliases_repointed_ids: Array(op.operation.result_payload["aliases_repointed_ids"]),
-          replayed: true
+          replayed: true,
+          stored_value_transfer_ids: Array(op.operation.result_payload["stored_value_transfer_ids"])
         )
       end
 
@@ -97,6 +99,16 @@ module Customers
             survivor: survivor
           )
 
+          store = @store || Store.active.order(:name).first
+          stored_value_transfer_ids = Customers::MergeStoredValueAccounts.call(
+            source: source,
+            survivor: survivor,
+            actor: @actor,
+            store: store,
+            merge_idempotency_operation: op.operation,
+            correlation_id: @correlation_id
+          )
+
           source.update!(
             merged_into_customer_id: survivor.id,
             active: false
@@ -115,7 +127,8 @@ module Customers
               reason: @reason,
               aliases_repointed_count: aliases_repointed_ids.size,
               aliases_repointed_ids: aliases_repointed_ids.first(50),
-              customer_requests_reassigned_count: requests_reassigned_count
+              customer_requests_reassigned_count: requests_reassigned_count,
+              stored_value_transfer_ids: stored_value_transfer_ids
             }
           )
 
@@ -125,7 +138,8 @@ module Customers
             result_id: survivor.id,
             result_payload: {
               requests_reassigned_count: requests_reassigned_count,
-              aliases_repointed_ids: aliases_repointed_ids
+              aliases_repointed_ids: aliases_repointed_ids,
+              stored_value_transfer_ids: stored_value_transfer_ids
             }
           )
 
@@ -134,11 +148,12 @@ module Customers
             source: source.reload,
             requests_reassigned_count: requests_reassigned_count,
             aliases_repointed_ids: aliases_repointed_ids,
-            replayed: false
+            replayed: false,
+            stored_value_transfer_ids: stored_value_transfer_ids
           )
         end
         result
-      rescue Customers::Error, ActiveRecord::RecordInvalid, ActiveRecord::StaleObjectError => e
+      rescue Customers::Error, StoredValue::Error, ActiveRecord::RecordInvalid, ActiveRecord::StaleObjectError => e
         Idempotency::OperationService.fail!(op.operation, message: e.message)
         raise Customers::Error, e.message
       rescue Idempotency::OperationService::PayloadMismatchError

--- a/app/services/customers/merge_stored_value_accounts.rb
+++ b/app/services/customers/merge_stored_value_accounts.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Customers
+  class MergeStoredValueAccounts
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(source:, survivor:, actor:, store:, merge_idempotency_operation:, correlation_id: nil)
+      @source = source
+      @survivor = survivor
+      @actor = actor
+      @store = store
+      @merge_idempotency_operation = merge_idempotency_operation
+      @correlation_id = correlation_id || SecureRandom.uuid_v7
+    end
+
+    def call
+      transfer_ids = []
+      StoredValueAccount::CUSTOMER_OWNED_TYPES.each do |account_type|
+        source_account = open_account_for(@source, account_type)
+        next unless source_account
+
+        if source_account.balance_cents.zero?
+          source_account.close_zero!
+          next
+        end
+
+        survivor_account = StoredValue::EnsureCustomerAccount.call(
+          customer: @survivor,
+          account_type: account_type
+        )
+        transfer = StoredValue::Transfer.call(
+          from_account: source_account,
+          to_account: survivor_account,
+          amount_cents: source_account.balance_cents,
+          transfer_type: "customer_merge",
+          performed_by: @actor,
+          store: @store,
+          source_id: @source.id,
+          idempotency_key: SecureRandom.uuid_v7,
+          merge_idempotency_operation: @merge_idempotency_operation,
+          correlation_id: @correlation_id
+        )
+        transfer_ids << transfer.id
+      end
+      transfer_ids
+    end
+
+    private
+
+    def open_account_for(customer, account_type)
+      StoredValueAccount.where(customer_id: customer.id, account_type: account_type)
+                        .where.not(status: "closed").order(:id).first
+    end
+  end
+end

--- a/app/services/installation/bootstrap.rb
+++ b/app/services/installation/bootstrap.rb
@@ -59,6 +59,7 @@ module Installation
         ProductForms::Catalog.seed!
         SubjectSchemes::Catalog.seed!
         Inventory::AdjustmentReasons.seed!
+        StoredValue::AdjustmentReasons.seed!
         Pos::TenderTypes.seed!
 
         Audit::Recorder.record!(

--- a/app/services/stored_value/adjust.rb
+++ b/app/services/stored_value/adjust.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+module StoredValue
+  class Adjust
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(
+      account:,
+      direction:,
+      amount_cents:,
+      reason:,
+      store:,
+      performed_by:,
+      source_id:,
+      idempotency_key:,
+      approved_by: nil,
+      customer_explanation: nil,
+      internal_notes: nil,
+      correlation_id: nil
+    )
+      @account = account
+      @direction = direction.to_s
+      @amount_cents = amount_cents
+      @reason = reason
+      @store = store
+      @performed_by = performed_by
+      @source_id = source_id
+      @idempotency_key = idempotency_key
+      @approved_by = approved_by
+      @customer_explanation = customer_explanation
+      @internal_notes = internal_notes
+      @correlation_id = correlation_id || SecureRandom.uuid_v7
+    end
+
+    def call
+      validate!
+      payload = {
+        stored_value_account_id: @account.id,
+        direction: @direction,
+        amount_cents: Integer(@amount_cents),
+        reason_id: @reason.id
+      }
+      op = Idempotency::OperationService.begin!(
+        source_id: @source_id,
+        operation_type: "stored_value_adjust",
+        idempotency_key: @idempotency_key,
+        payload: payload
+      )
+      if op.replayed
+        return StoredValueAdjustment.find(op.operation.result_id) if op.operation.result_id
+
+        raise Error, "idempotent replay missing result"
+      end
+
+      begin
+        result = nil
+        StoredValueAccount.transaction do
+          account = StoredValueAccount.lock.find(@account.id)
+          validate_account!(account)
+          signed = @direction == "credit" ? Integer(@amount_cents) : -Integer(@amount_cents)
+          operation = Post.call(
+            operation_type: "adjust",
+            store: @store,
+            performed_by: @performed_by,
+            source_id: @source_id,
+            idempotency_key: SecureRandom.uuid_v7,
+            entries: [ { account: account, amount_cents: signed } ],
+            reason_code: @reason.code,
+            reason_name_snapshot: @reason.name,
+            notes: @internal_notes,
+            correlation_id: @correlation_id
+          )
+          adjustment = StoredValueAdjustment.create!(
+            stored_value_account: account,
+            adjustment_direction: @direction,
+            amount_cents: Integer(@amount_cents),
+            reason: @reason,
+            reason_code: @reason.code,
+            reason_name_snapshot: @reason.name,
+            customer_explanation: @customer_explanation,
+            internal_notes: @internal_notes,
+            store: @store,
+            performed_by: @performed_by,
+            approved_by: @approved_by,
+            stored_value_operation: operation,
+            idempotency_operation: op.operation,
+            posted_at: Time.current
+          )
+          Idempotency::OperationService.complete!(
+            op.operation,
+            result_type: "StoredValueAdjustment",
+            result_id: adjustment.id
+          )
+          result = adjustment
+        end
+        result
+      rescue Error, ActiveRecord::RecordInvalid, ActiveRecord::StaleObjectError => e
+        Idempotency::OperationService.fail!(op.operation, message: e.message)
+        Audit::Recorder.record!(
+          action: "stored_value.adjust",
+          outcome: "failed",
+          actor_user: @performed_by,
+          store: @store,
+          subject: @account,
+          correlation_id: @correlation_id,
+          reason_text: e.message
+        )
+        raise Error, e.message
+      rescue Idempotency::OperationService::PayloadMismatchError
+        raise
+      end
+    end
+
+    def self.second_user_required?(direction:, amount_cents:, reason:)
+      return true if direction.to_s == "debit"
+      return true if reason.approval_required
+
+      threshold = SystemSettings.current.stored_value_adjust_credit_approval_threshold_cents
+      Integer(amount_cents) >= threshold
+    end
+
+    private
+
+    def validate!
+      raise Error, "direction must be credit or debit" unless %w[credit debit].include?(@direction)
+      raise Error, "amount must be positive" unless Integer(@amount_cents).positive?
+      raise Error, "reason is required" if @reason.blank?
+      raise Error, "reason is not allowed for this adjustment" unless @reason.active? && @reason.allows?(direction: @direction, account_type: @account.account_type)
+      raise Error, "internal notes are required" if @reason.notes_required && @internal_notes.to_s.strip.blank?
+      if self.class.second_user_required?(direction: @direction, amount_cents: @amount_cents, reason: @reason)
+        raise Error, "second-user approval is required" if @approved_by.blank?
+        raise Error, "approver cannot be the performer" if @approved_by.id == @performed_by.id
+      end
+    end
+
+    def validate_account!(account)
+      raise Error, "account is closed" if account.closed?
+      if account.customer_owned?
+        customer = account.customer
+        raise Error, "inactive customers cannot receive new credit" if @direction == "credit" && !customer.active?
+      else
+        raise Error, "gift-card adjustments are not available until gift-card instruments exist" if account.account_type == "gift_card"
+      end
+    end
+  end
+end

--- a/app/services/stored_value/adjustment_reasons.rb
+++ b/app/services/stored_value/adjustment_reasons.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module StoredValue
+  module AdjustmentReasons
+    SEEDS = [
+      {
+        code: "goodwill",
+        name: "Goodwill / accommodation",
+        allowed_direction: "credit",
+        allowed_account_types: %w[store_credit trade_credit gift_card],
+        display_order: 10
+      },
+      {
+        code: "correction_credit",
+        name: "Correction (credit)",
+        allowed_direction: "credit",
+        allowed_account_types: %w[store_credit trade_credit gift_card],
+        notes_required: true,
+        display_order: 20
+      },
+      {
+        code: "correction_debit",
+        name: "Correction (debit)",
+        allowed_direction: "debit",
+        allowed_account_types: %w[store_credit trade_credit gift_card],
+        notes_required: true,
+        display_order: 30
+      },
+      {
+        code: "write_off",
+        name: "Write-off",
+        allowed_direction: "debit",
+        allowed_account_types: %w[store_credit trade_credit gift_card],
+        notes_required: true,
+        approval_required: true,
+        display_order: 40
+      }
+    ].freeze
+
+    def self.seed!
+      SEEDS.each do |attrs|
+        reason = StoredValueAdjustmentReason.find_or_initialize_by(code: attrs[:code])
+        reason.assign_attributes(
+          name: attrs[:name],
+          allowed_direction: attrs[:allowed_direction],
+          allowed_account_types: attrs[:allowed_account_types],
+          notes_required: attrs.fetch(:notes_required, false),
+          approval_required: attrs.fetch(:approval_required, false),
+          display_order: attrs.fetch(:display_order, 0),
+          active: true
+        )
+        reason.save!
+      end
+    end
+  end
+end

--- a/app/services/stored_value/authenticate_approver.rb
+++ b/app/services/stored_value/authenticate_approver.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module StoredValue
+  class AuthenticateApprover
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(username:, password:, performer:, permission_key:, store: nil)
+      @username = username.to_s.strip
+      @password = password
+      @performer = performer
+      @permission_key = permission_key
+      @store = store
+    end
+
+    def call
+      raise Error, "approver credentials are required" if @username.blank? || @password.blank?
+
+      user = User.find_by("lower(username) = ?", @username.downcase)
+      raise Error, "approver credentials are invalid" unless user&.authenticatable?
+      raise Error, "approver credentials are invalid" unless user.authenticate(@password)
+      raise Error, "approver cannot be the performer" if user.id == @performer.id
+      raise Error, "approver cannot be the system actor" if user.system_actor?
+
+      unless Authorization::PermissionEvaluator.allowed?(
+        user: user,
+        permission_key: @permission_key,
+        store: @store
+      )
+        raise Error, "approver is not authorized"
+      end
+
+      user
+    end
+  end
+end

--- a/app/services/stored_value/ensure_customer_account.rb
+++ b/app/services/stored_value/ensure_customer_account.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module StoredValue
+  class EnsureCustomerAccount
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(customer:, account_type:)
+      @customer = customer
+      @account_type = account_type.to_s
+    end
+
+    def call
+      raise Error, "unsupported account type" unless StoredValueAccount::CUSTOMER_OWNED_TYPES.include?(@account_type)
+
+      existing = StoredValueAccount.where(customer_id: @customer.id, account_type: @account_type)
+                                   .where.not(status: "closed").order(:id).first
+      return existing if existing
+
+      OpenAccount.call(account_type: @account_type, customer: @customer)
+    end
+  end
+end

--- a/app/services/stored_value/open_account.rb
+++ b/app/services/stored_value/open_account.rb
@@ -14,6 +14,11 @@ module StoredValue
 
     def call
       raise Error, "account type is required" if @account_type.blank?
+      if StoredValueAccount::CUSTOMER_OWNED_TYPES.include?(@account_type)
+        raise Error, "customer is required" if @customer.blank?
+        raise Error, "customer must be canonical" unless @customer.canonical?
+        raise Error, "inactive customers cannot receive new credit" unless @customer.active?
+      end
 
       currency_code = SystemSettings.current.base_currency_code
       StoredValueAccount.create!(

--- a/app/services/stored_value/transfer.rb
+++ b/app/services/stored_value/transfer.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+module StoredValue
+  class Transfer
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(
+      from_account:,
+      to_account:,
+      amount_cents:,
+      transfer_type:,
+      performed_by:,
+      source_id:,
+      idempotency_key:,
+      store: nil,
+      approved_by: nil,
+      reason_code: nil,
+      reason_name_snapshot: nil,
+      notes: nil,
+      merge_idempotency_operation: nil,
+      correlation_id: nil
+    )
+      @from_account = from_account
+      @to_account = to_account
+      @amount_cents = amount_cents
+      @transfer_type = transfer_type.to_s
+      @performed_by = performed_by
+      @source_id = source_id
+      @idempotency_key = idempotency_key
+      @store = store
+      @approved_by = approved_by
+      @reason_code = reason_code
+      @reason_name_snapshot = reason_name_snapshot
+      @notes = notes
+      @merge_idempotency_operation = merge_idempotency_operation
+      @correlation_id = correlation_id || SecureRandom.uuid_v7
+    end
+
+    def call
+      validate!
+      payload = {
+        from_account_id: @from_account.id,
+        to_account_id: @to_account.id,
+        amount_cents: Integer(@amount_cents),
+        transfer_type: @transfer_type
+      }
+      op = Idempotency::OperationService.begin!(
+        source_id: @source_id,
+        operation_type: "stored_value_transfer",
+        idempotency_key: @idempotency_key,
+        payload: payload
+      )
+      if op.replayed
+        return StoredValueTransfer.find(op.operation.result_id) if op.operation.result_id
+
+        raise Error, "idempotent replay missing result"
+      end
+
+      begin
+        result = nil
+        StoredValueAccount.transaction do
+          ids = [ @from_account.id, @to_account.id ].uniq.sort
+          locked = ids.index_with { |id| StoredValueAccount.lock.find(id) }
+          source = locked.fetch(@from_account.id)
+          destination = locked.fetch(@to_account.id)
+          validate_locked!(source, destination)
+          amount = Integer(@amount_cents)
+          raise Error, "store is required" if @store.blank?
+
+          operation = Post.call(
+            operation_type: "transfer",
+            store: @store,
+            performed_by: @performed_by,
+            source_id: @source_id,
+            idempotency_key: SecureRandom.uuid_v7,
+            entries: [
+              { account: source, amount_cents: -amount },
+              { account: destination, amount_cents: amount }
+            ],
+            reason_code: @reason_code,
+            reason_name_snapshot: @reason_name_snapshot,
+            notes: @notes,
+            correlation_id: @correlation_id
+          )
+          transfer = StoredValueTransfer.create!(
+            transfer_type: @transfer_type,
+            from_account: source,
+            to_account: destination,
+            amount_cents: amount,
+            source_customer_id: source.customer_id,
+            survivor_customer_id: destination.customer_id,
+            reason_code: @reason_code,
+            reason_name_snapshot: @reason_name_snapshot,
+            notes: @notes,
+            performed_by: @performed_by,
+            approved_by: @approved_by,
+            stored_value_operation: operation,
+            posted_at: Time.current,
+            merge_idempotency_operation: @merge_idempotency_operation
+          )
+          close_source_if_needed!(source.reload, amount)
+          Idempotency::OperationService.complete!(
+            op.operation,
+            result_type: "StoredValueTransfer",
+            result_id: transfer.id
+          )
+          result = transfer
+        end
+        result
+      rescue Error, ActiveRecord::RecordInvalid, ActiveRecord::StaleObjectError => e
+        Idempotency::OperationService.fail!(op.operation, message: e.message)
+        Audit::Recorder.record!(
+          action: "stored_value.transfer",
+          outcome: "failed",
+          actor_user: @performed_by,
+          store: @store,
+          subject: @from_account,
+          correlation_id: @correlation_id,
+          reason_text: e.message
+        )
+        raise Error, e.message
+      rescue Idempotency::OperationService::PayloadMismatchError
+        raise
+      end
+    end
+
+    private
+
+    def validate!
+      raise Error, "invalid transfer type" unless StoredValueTransfer::TRANSFER_TYPES.include?(@transfer_type)
+      raise Error, "amount must be positive" unless Integer(@amount_cents).positive?
+      raise Error, "source and destination must differ" if @from_account.id == @to_account.id
+      if @from_account.account_type != @to_account.account_type || @from_account.currency_code != @to_account.currency_code
+        raise Error, "cross-type conversion is prohibited"
+      end
+      unless @transfer_type == "customer_merge"
+        raise Error, "second-user approval is required" if @approved_by.blank?
+        raise Error, "approver cannot be the performer" if @approved_by.id == @performed_by.id
+        raise Error, "reason is required" if @reason_code.to_s.strip.blank?
+      end
+    end
+
+    def validate_locked!(source, destination)
+      raise Error, "source account is closed" if source.closed?
+      raise Error, "destination account is closed" if destination.closed?
+      raise Error, "insufficient source balance" if source.balance_cents < Integer(@amount_cents)
+    end
+
+    def close_source_if_needed!(source, _amount)
+      source.close_zero! if source.balance_cents.zero?
+    end
+  end
+end

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -91,6 +91,55 @@
   </section>
 <% end %>
 
+<% if @stored_value_accounts %>
+  <section class="section surface">
+    <h2 class="section__title">Stored value</h2>
+    <% if @stored_value_accounts.any? %>
+      <% rows = @stored_value_accounts.map { |account|
+           actions = []
+           if effective_permissions.include?("stored_value.adjust") && @customer.active?
+             actions << action_link_to("Adjust", new_admin_customer_stored_value_adjustment_path(@customer, stored_value_account_id: account.id), style: :outline, intent: :neutral)
+           end
+           [
+             account.account_type.humanize,
+             format_money_cents(account.balance_cents),
+             account.status.humanize,
+             safe_join(actions, " ")
+           ]
+         } %>
+      <%= render "shared/data_table", headers: ["Type", "Balance", "Status", ""], rows: rows %>
+    <% else %>
+      <%= render "shared/empty_state", title: "No open stored-value accounts", body: "Store credit and trade credit are created when value is posted." %>
+    <% end %>
+    <% if effective_permissions.include?("stored_value.adjust") && @customer.canonical? && @customer.active? %>
+      <div class="actions">
+        <%= action_link_to("Add store credit", new_admin_customer_stored_value_adjustment_path(@customer, account_type: "store_credit"), style: :solid, intent: :brand) %>
+        <%= action_link_to("Add trade credit", new_admin_customer_stored_value_adjustment_path(@customer, account_type: "trade_credit"), style: :outline, intent: :neutral) %>
+      </div>
+    <% end %>
+    <% if effective_permissions.include?("stored_value.transfer") && @customer.canonical? && @customer.active? %>
+      <div class="actions">
+        <%= action_link_to("Transfer credit", new_admin_stored_value_transfer_path(from_customer_id: @customer.id), style: :outline, intent: :neutral) %>
+      </div>
+    <% end %>
+  </section>
+<% end %>
+
+<% if @stored_value_entries&.any? %>
+  <section class="section">
+    <h2 class="section__title">Recent stored-value activity</h2>
+    <% rows = @stored_value_entries.map { |entry|
+         [
+           entry.stored_value_operation.operation_type.humanize,
+           entry.stored_value_account.account_type.humanize,
+           format_money_cents(entry.amount_cents),
+           format_money_cents(entry.balance_after_cents)
+         ]
+       } %>
+    <%= render "shared/data_table", headers: ["Operation", "Account", "Amount", "Balance after"], rows: rows %>
+  </section>
+<% end %>
+
 <section class="section">
   <h2 class="section__title">Recent requests</h2>
   <% if effective_permissions.include?("customer_requests.manage") && @customer.canonical? && @customer.active? %>

--- a/app/views/admin/stored_value_adjustment_reasons/_form.html.erb
+++ b/app/views/admin/stored_value_adjustment_reasons/_form.html.erb
@@ -1,0 +1,34 @@
+<%= form_with model: [:admin, reason], class: "form" do |form| %>
+  <%= render "shared/form_errors", record: reason %>
+  <%= form.hidden_field :lock_version %>
+  <% unless reason.persisted? %>
+    <div class="form-field"><%= form.label :code %><%= form.text_field :code %></div>
+  <% end %>
+  <div class="form-field"><%= form.label :name %><%= form.text_field :name %></div>
+  <div class="form-field"><%= form.label :description %><%= form.text_area :description, rows: 3 %></div>
+  <div class="form-field">
+    <%= form.label :allowed_direction %>
+    <%= form.select :allowed_direction, StoredValueAdjustmentReason::DIRECTIONS.map { |d| [d.humanize, d] } %>
+  </div>
+  <fieldset class="form-field">
+    <legend>Allowed account types</legend>
+    <% StoredValueAccount::ACCOUNT_TYPES.each do |type| %>
+      <label>
+        <%= check_box_tag "stored_value_adjustment_reason[allowed_account_types][]", type, Array(reason.allowed_account_types).include?(type) %>
+        <%= type.humanize %>
+      </label>
+    <% end %>
+  </fieldset>
+  <div class="form-field">
+    <%= form.check_box :notes_required %>
+    <%= form.label :notes_required, "Notes required" %>
+  </div>
+  <div class="form-field">
+    <%= form.check_box :approval_required %>
+    <%= form.label :approval_required, "Always require second-user approval" %>
+  </div>
+  <div class="actions">
+    <%= action_submit(form, reason.persisted? ? "Save Changes" : "Create reason", style: :solid, intent: :brand) %>
+    <%= action_link_to("Cancel", reason.persisted? ? admin_stored_value_adjustment_reason_path(reason) : admin_stored_value_adjustment_reasons_path, style: :ghost, intent: :neutral) %>
+  </div>
+<% end %>

--- a/app/views/admin/stored_value_adjustment_reasons/edit.html.erb
+++ b/app/views/admin/stored_value_adjustment_reasons/edit.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "Edit #{@reason.code}" %>
+<%= render "shared/page_header", title: "Edit #{@reason.name}" %>
+<%= render "form", reason: @reason %>

--- a/app/views/admin/stored_value_adjustment_reasons/index.html.erb
+++ b/app/views/admin/stored_value_adjustment_reasons/index.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title, "Stored-value reasons" %>
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Stored-value reasons" }
+] %>
+<%= render "shared/page_header",
+      title: "Stored-value adjustment reasons",
+      actions: action_link_to("New reason", new_admin_stored_value_adjustment_reason_path, style: :solid, intent: :brand) %>
+<% rows = @reasons.map { |reason|
+     [
+       link_to(reason.code, admin_stored_value_adjustment_reason_path(reason)),
+       reason.name,
+       reason.allowed_direction.humanize,
+       configuration_status_badge(reason.active?)
+     ]
+   } %>
+<%= render "shared/data_table", headers: ["Code", "Name", "Direction", "Status"], rows: rows %>

--- a/app/views/admin/stored_value_adjustment_reasons/new.html.erb
+++ b/app/views/admin/stored_value_adjustment_reasons/new.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "New stored-value reason" %>
+<%= render "shared/page_header", title: "New stored-value reason" %>
+<%= render "form", reason: @reason %>

--- a/app/views/admin/stored_value_adjustment_reasons/show.html.erb
+++ b/app/views/admin/stored_value_adjustment_reasons/show.html.erb
@@ -1,0 +1,21 @@
+<% content_for :title, @reason.code %>
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Stored-value reasons", path: admin_stored_value_adjustment_reasons_path },
+  { name: @reason.code }
+] %>
+<% actions = [configuration_status_badge(@reason.active?)] %>
+<% if @reason.active? %>
+  <% actions << action_link_to("Edit", edit_admin_stored_value_adjustment_reason_path(@reason), style: :outline, intent: :neutral) %>
+  <% actions << action_button_to("Deactivate", admin_stored_value_adjustment_reason_path(@reason), method: :delete, style: :outline, intent: :warning) %>
+<% else %>
+  <% actions << action_button_to("Reactivate", reactivate_admin_stored_value_adjustment_reason_path(@reason), method: :post, style: :solid, intent: :brand) %>
+<% end %>
+<%= render "shared/page_header", title: @reason.name, actions: safe_join(actions, " ") %>
+<%= render "shared/definition_list", rows: [
+      ["Code", @reason.code],
+      ["Direction", @reason.allowed_direction.humanize],
+      ["Account types", Array(@reason.allowed_account_types).join(", ")],
+      ["Notes required", @reason.notes_required? ? "Yes" : "No"],
+      ["Approval required", @reason.approval_required? ? "Yes" : "No"]
+    ] %>

--- a/app/views/admin/stored_value_adjustments/new.html.erb
+++ b/app/views/admin/stored_value_adjustments/new.html.erb
@@ -1,0 +1,46 @@
+<% content_for :title, "Adjust stored value" %>
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Customers", path: admin_customers_path },
+  { name: @customer.admin_label, path: admin_customer_path(@customer) },
+  { name: "Adjust" }
+] %>
+<%= render "shared/page_header", title: "Adjust #{@account_type.to_s.humanize}" %>
+<%= form_with url: admin_customer_stored_value_adjustments_path(@customer), method: :post, class: "form" do |form| %>
+  <% if @account %>
+    <%= hidden_field_tag :stored_value_account_id, @account.id %>
+  <% else %>
+    <%= hidden_field_tag :account_type, @account_type %>
+  <% end %>
+  <%= hidden_field_tag :idempotency_key, params[:idempotency_key].presence || SecureRandom.uuid_v7 %>
+  <p>Current balance: <%= format_money_cents(@account&.balance_cents || 0) %></p>
+  <div class="form-field">
+    <%= label_tag :direction, "Direction" %>
+    <%= select_tag :direction, options_for_select([%w[Credit credit], %w[Debit debit]], params[:direction]) %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :amount, "Amount" %>
+    <%= text_field_tag :amount, params[:amount], required: true %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :reason_id, "Reason" %>
+    <%= select_tag :reason_id, options_from_collection_for_select(@reasons, :id, :name, params[:reason_id]) %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :internal_notes, "Internal notes" %>
+    <%= text_area_tag :internal_notes, params[:internal_notes], rows: 3 %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :approver_username, "Approver username" %>
+    <%= text_field_tag :approver_username, params[:approver_username] %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :approver_password, "Approver password" %>
+    <%= password_field_tag :approver_password %>
+  </div>
+  <p class="muted">Debits and credits at or above the organization threshold require a second user.</p>
+  <div class="actions">
+    <%= action_submit(form, "Post adjustment", style: :solid, intent: :brand) %>
+    <%= action_link_to("Cancel", admin_customer_path(@customer), style: :ghost, intent: :neutral) %>
+  </div>
+<% end %>

--- a/app/views/admin/stored_value_transfers/new.html.erb
+++ b/app/views/admin/stored_value_transfers/new.html.erb
@@ -1,0 +1,48 @@
+<% content_for :title, "Transfer stored value" %>
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Stored-value transfers" }
+] %>
+<%= render "shared/page_header", title: "Transfer store or trade credit" %>
+<%= form_with url: admin_stored_value_transfers_path, method: :post, class: "form" do |form| %>
+  <%= hidden_field_tag :idempotency_key, params[:idempotency_key].presence || SecureRandom.uuid_v7 %>
+  <div class="form-field">
+    <%= label_tag :from_customer_id, "Source customer ID" %>
+    <%= text_field_tag :from_customer_id, params[:from_customer_id] || @from_customer&.id, required: true %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :to_customer_id, "Destination customer ID" %>
+    <%= text_field_tag :to_customer_id, params[:to_customer_id], required: true %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :account_type, "Account type" %>
+    <%= select_tag :account_type, options_for_select(StoredValueAccount::CUSTOMER_OWNED_TYPES.map { |type| [type.humanize, type] }, params[:account_type] || @account_type) %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :transfer_type, "Transfer type" %>
+    <%= select_tag :transfer_type, options_for_select([%w[Administrative administrative], ["Consolidation (full balance)", "account_consolidation"]], params[:transfer_type]) %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :amount, "Amount (ignored for consolidation)" %>
+    <%= text_field_tag :amount, params[:amount] %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :reason_code, "Reason code" %>
+    <%= text_field_tag :reason_code, params[:reason_code], required: true %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :notes, "Notes" %>
+    <%= text_area_tag :notes, params[:notes], rows: 3 %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :approver_username, "Approver username" %>
+    <%= text_field_tag :approver_username, params[:approver_username], required: true %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :approver_password, "Approver password" %>
+    <%= password_field_tag :approver_password %>
+  </div>
+  <div class="actions">
+    <%= action_submit(form, "Post transfer", style: :solid, intent: :brand) %>
+  </div>
+<% end %>

--- a/app/views/admin/system_settings/edit.html.erb
+++ b/app/views/admin/system_settings/edit.html.erb
@@ -9,6 +9,7 @@
   <p><%= form.label :default_country_code %><%= form.text_field :default_country_code %></p>
   <p><%= form.label :default_region_code %><%= form.text_field :default_region_code %></p>
   <p><%= form.label :fiscal_year_start_month %><%= form.number_field :fiscal_year_start_month %></p>
+  <p><%= form.label :stored_value_adjust_credit_approval_threshold_cents, "Stored-value credit approval threshold (cents)" %><%= form.number_field :stored_value_adjust_credit_approval_threshold_cents %></p>
   <p>
     <%= form.label :default_receipt_header, "Default receipt header message" %>
     <%= form.text_area :default_receipt_header, maxlength: Store::RECEIPT_MESSAGE_LIMIT %>

--- a/app/views/admin/system_settings/show.html.erb
+++ b/app/views/admin/system_settings/show.html.erb
@@ -4,6 +4,7 @@
   <dt>Organization</dt><dd><%= @settings.organization_name %></dd>
   <dt>Legal name</dt><dd><%= @settings.legal_name %></dd>
   <dt>Currency</dt><dd><%= @settings.base_currency_code %></dd>
+  <dt>Stored-value credit approval threshold</dt><dd><%= @settings.stored_value_adjust_credit_approval_threshold_cents %> cents</dd>
   <dt>Timezone</dt><dd><%= @settings.default_timezone %></dd>
   <dt>Country</dt><dd><%= @settings.default_country_code %></dd>
 </dl>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,7 +108,12 @@ Rails.application.routes.draw do
         post :merge
       end
       collection { get :duplicate_check }
+      resources :stored_value_adjustments, only: %i[new create]
     end
+    resources :stored_value_adjustment_reasons do
+      member { post :reactivate }
+    end
+    resources :stored_value_transfers, only: %i[new create]
     resources :customer_requests, only: %i[index show new create] do
       collection do
         get :customer_lookup

--- a/db/migrate/20260826020000_create_phase10_customer_stored_value.rb
+++ b/db/migrate/20260826020000_create_phase10_customer_stored_value.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+class CreatePhase10CustomerStoredValue < ActiveRecord::Migration[8.1]
+  def change
+    add_column :system_settings, :stored_value_adjust_credit_approval_threshold_cents, :bigint, null: false, default: 5000
+    add_check_constraint :system_settings,
+                         "stored_value_adjust_credit_approval_threshold_cents >= 0",
+                         name: "system_settings_sv_adjust_threshold_nonnegative"
+
+    create_uuid_table :stored_value_adjustment_reasons do |t|
+      t.string :code, null: false
+      t.string :name, null: false
+      t.text :description
+      t.string :allowed_direction, null: false
+      t.string :allowed_account_types, array: true, null: false, default: []
+      t.boolean :notes_required, null: false, default: false
+      t.boolean :approval_required, null: false, default: false
+      t.boolean :active, null: false, default: true
+      t.integer :display_order, null: false, default: 0
+      t.integer :lock_version, null: false, default: 0
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+    add_index :stored_value_adjustment_reasons, :code, unique: true
+    add_check_constraint :stored_value_adjustment_reasons,
+                         "allowed_direction IN ('credit', 'debit', 'either')",
+                         name: "stored_value_adjustment_reasons_direction_valid"
+
+    create_uuid_table :stored_value_adjustments do |t|
+      t.uuid :stored_value_account_id, null: false
+      t.string :adjustment_direction, null: false
+      t.bigint :amount_cents, null: false
+      t.uuid :reason_id, null: false
+      t.string :reason_code, null: false
+      t.string :reason_name_snapshot, null: false
+      t.text :customer_explanation
+      t.text :internal_notes
+      t.uuid :store_id, null: false
+      t.uuid :performed_by_id, null: false
+      t.uuid :approved_by_id
+      t.uuid :stored_value_operation_id
+      t.uuid :idempotency_operation_id, null: false
+      t.uuid :reversal_of_id
+      t.timestamptz :posted_at, null: false
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+    add_index :stored_value_adjustments, :stored_value_operation_id, unique: true, where: "stored_value_operation_id IS NOT NULL"
+    add_index :stored_value_adjustments, :idempotency_operation_id
+    add_index :stored_value_adjustments, :reversal_of_id, unique: true, where: "reversal_of_id IS NOT NULL"
+    add_index :stored_value_adjustments, :stored_value_account_id
+    add_foreign_key :stored_value_adjustments, :stored_value_accounts
+    add_foreign_key :stored_value_adjustments, :stored_value_adjustment_reasons, column: :reason_id
+    add_foreign_key :stored_value_adjustments, :stores
+    add_foreign_key :stored_value_adjustments, :users, column: :performed_by_id
+    add_foreign_key :stored_value_adjustments, :users, column: :approved_by_id
+    add_foreign_key :stored_value_adjustments, :stored_value_operations
+    add_foreign_key :stored_value_adjustments, :idempotency_operations
+    add_foreign_key :stored_value_adjustments, :stored_value_adjustments, column: :reversal_of_id
+    add_check_constraint :stored_value_adjustments,
+                         "adjustment_direction IN ('credit', 'debit')",
+                         name: "stored_value_adjustments_direction_valid"
+    add_check_constraint :stored_value_adjustments,
+                         "amount_cents > 0",
+                         name: "stored_value_adjustments_amount_positive"
+    add_check_constraint :stored_value_adjustments,
+                         "approved_by_id IS NULL OR approved_by_id <> performed_by_id",
+                         name: "stored_value_adjustments_approver_differs"
+
+    create_uuid_table :stored_value_transfers do |t|
+      t.string :transfer_type, null: false
+      t.uuid :from_account_id, null: false
+      t.uuid :to_account_id, null: false
+      t.bigint :amount_cents, null: false
+      t.uuid :source_customer_id
+      t.uuid :survivor_customer_id
+      t.string :reason_code
+      t.string :reason_name_snapshot
+      t.text :notes
+      t.uuid :performed_by_id, null: false
+      t.uuid :approved_by_id
+      t.uuid :stored_value_operation_id
+      t.timestamptz :posted_at, null: false
+      t.uuid :reversal_of_id
+      t.uuid :merge_idempotency_operation_id
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+    add_index :stored_value_transfers, :stored_value_operation_id, unique: true, where: "stored_value_operation_id IS NOT NULL"
+    add_index :stored_value_transfers, :reversal_of_id, unique: true, where: "reversal_of_id IS NOT NULL"
+    add_index :stored_value_transfers, :from_account_id
+    add_index :stored_value_transfers, :to_account_id
+    add_foreign_key :stored_value_transfers, :stored_value_accounts, column: :from_account_id
+    add_foreign_key :stored_value_transfers, :stored_value_accounts, column: :to_account_id
+    add_foreign_key :stored_value_transfers, :customers, column: :source_customer_id
+    add_foreign_key :stored_value_transfers, :customers, column: :survivor_customer_id
+    add_foreign_key :stored_value_transfers, :users, column: :performed_by_id
+    add_foreign_key :stored_value_transfers, :users, column: :approved_by_id
+    add_foreign_key :stored_value_transfers, :stored_value_operations
+    add_foreign_key :stored_value_transfers, :stored_value_transfers, column: :reversal_of_id
+    add_foreign_key :stored_value_transfers, :idempotency_operations, column: :merge_idempotency_operation_id
+    add_check_constraint :stored_value_transfers,
+                         "transfer_type IN ('customer_merge', 'administrative', 'account_consolidation')",
+                         name: "stored_value_transfers_type_valid"
+    add_check_constraint :stored_value_transfers,
+                         "amount_cents > 0",
+                         name: "stored_value_transfers_amount_positive"
+    add_check_constraint :stored_value_transfers,
+                         "from_account_id <> to_account_id",
+                         name: "stored_value_transfers_accounts_differ"
+    add_check_constraint :stored_value_transfers,
+                         "approved_by_id IS NULL OR approved_by_id <> performed_by_id",
+                         name: "stored_value_transfers_approver_differs"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_26_010000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_26_020000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -1201,6 +1201,50 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_010000) do
     t.check_constraint "status::text = ANY (ARRAY['active'::character varying, 'suspended'::character varying, 'closed'::character varying]::text[])", name: "stored_value_accounts_status_valid"
   end
 
+  create_table "stored_value_adjustment_reasons", id: :uuid, default: nil, force: :cascade do |t|
+    t.boolean "active", default: true, null: false
+    t.string "allowed_account_types", default: [], null: false, array: true
+    t.string "allowed_direction", null: false
+    t.boolean "approval_required", default: false, null: false
+    t.string "code", null: false
+    t.timestamptz "created_at", null: false
+    t.text "description"
+    t.integer "display_order", default: 0, null: false
+    t.integer "lock_version", default: 0, null: false
+    t.string "name", null: false
+    t.boolean "notes_required", default: false, null: false
+    t.timestamptz "updated_at", null: false
+    t.index ["code"], name: "index_stored_value_adjustment_reasons_on_code", unique: true
+    t.check_constraint "allowed_direction::text = ANY (ARRAY['credit'::character varying, 'debit'::character varying, 'either'::character varying]::text[])", name: "stored_value_adjustment_reasons_direction_valid"
+  end
+
+  create_table "stored_value_adjustments", id: :uuid, default: nil, force: :cascade do |t|
+    t.string "adjustment_direction", null: false
+    t.bigint "amount_cents", null: false
+    t.uuid "approved_by_id"
+    t.timestamptz "created_at", null: false
+    t.text "customer_explanation"
+    t.uuid "idempotency_operation_id", null: false
+    t.text "internal_notes"
+    t.uuid "performed_by_id", null: false
+    t.timestamptz "posted_at", null: false
+    t.string "reason_code", null: false
+    t.uuid "reason_id", null: false
+    t.string "reason_name_snapshot", null: false
+    t.uuid "reversal_of_id"
+    t.uuid "store_id", null: false
+    t.uuid "stored_value_account_id", null: false
+    t.uuid "stored_value_operation_id"
+    t.timestamptz "updated_at", null: false
+    t.index ["idempotency_operation_id"], name: "index_stored_value_adjustments_on_idempotency_operation_id"
+    t.index ["reversal_of_id"], name: "index_stored_value_adjustments_on_reversal_of_id", unique: true, where: "(reversal_of_id IS NOT NULL)"
+    t.index ["stored_value_account_id"], name: "index_stored_value_adjustments_on_stored_value_account_id"
+    t.index ["stored_value_operation_id"], name: "index_stored_value_adjustments_on_stored_value_operation_id", unique: true, where: "(stored_value_operation_id IS NOT NULL)"
+    t.check_constraint "adjustment_direction::text = ANY (ARRAY['credit'::character varying, 'debit'::character varying]::text[])", name: "stored_value_adjustments_direction_valid"
+    t.check_constraint "amount_cents > 0", name: "stored_value_adjustments_amount_positive"
+    t.check_constraint "approved_by_id IS NULL OR approved_by_id <> performed_by_id", name: "stored_value_adjustments_approver_differs"
+  end
+
   create_table "stored_value_entries", id: :uuid, default: nil, force: :cascade do |t|
     t.bigint "amount_cents", null: false
     t.bigint "balance_after_cents", null: false
@@ -1237,6 +1281,34 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_010000) do
     t.index ["reversal_of_id"], name: "index_stored_value_operations_on_reversal_of_id", unique: true, where: "(reversal_of_id IS NOT NULL)"
     t.index ["store_id"], name: "index_stored_value_operations_on_store_id"
     t.check_constraint "operation_type::text = ANY (ARRAY['issue'::character varying, 'activate'::character varying, 'reload'::character varying, 'redeem'::character varying, 'refund'::character varying, 'cash_out'::character varying, 'transfer'::character varying, 'adjust'::character varying, 'reverse'::character varying]::text[])", name: "stored_value_operations_type_valid"
+  end
+
+  create_table "stored_value_transfers", id: :uuid, default: nil, force: :cascade do |t|
+    t.bigint "amount_cents", null: false
+    t.uuid "approved_by_id"
+    t.timestamptz "created_at", null: false
+    t.uuid "from_account_id", null: false
+    t.uuid "merge_idempotency_operation_id"
+    t.text "notes"
+    t.uuid "performed_by_id", null: false
+    t.timestamptz "posted_at", null: false
+    t.string "reason_code"
+    t.string "reason_name_snapshot"
+    t.uuid "reversal_of_id"
+    t.uuid "source_customer_id"
+    t.uuid "stored_value_operation_id"
+    t.uuid "survivor_customer_id"
+    t.uuid "to_account_id", null: false
+    t.string "transfer_type", null: false
+    t.timestamptz "updated_at", null: false
+    t.index ["from_account_id"], name: "index_stored_value_transfers_on_from_account_id"
+    t.index ["reversal_of_id"], name: "index_stored_value_transfers_on_reversal_of_id", unique: true, where: "(reversal_of_id IS NOT NULL)"
+    t.index ["stored_value_operation_id"], name: "index_stored_value_transfers_on_stored_value_operation_id", unique: true, where: "(stored_value_operation_id IS NOT NULL)"
+    t.index ["to_account_id"], name: "index_stored_value_transfers_on_to_account_id"
+    t.check_constraint "amount_cents > 0", name: "stored_value_transfers_amount_positive"
+    t.check_constraint "approved_by_id IS NULL OR approved_by_id <> performed_by_id", name: "stored_value_transfers_approver_differs"
+    t.check_constraint "from_account_id <> to_account_id", name: "stored_value_transfers_accounts_differ"
+    t.check_constraint "transfer_type::text = ANY (ARRAY['customer_merge'::character varying, 'administrative'::character varying, 'account_consolidation'::character varying]::text[])", name: "stored_value_transfers_type_valid"
   end
 
   create_table "stores", id: :uuid, default: nil, force: :cascade do |t|
@@ -1354,12 +1426,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_010000) do
     t.integer "lock_version", default: 0, null: false
     t.string "organization_name", null: false
     t.boolean "singleton_key", default: true, null: false
+    t.bigint "stored_value_adjust_credit_approval_threshold_cents", default: 5000, null: false
     t.timestamptz "updated_at", null: false
     t.index ["singleton_key"], name: "index_system_settings_on_singleton_key", unique: true
     t.check_constraint "default_customer_reservation_expiration_days > 0", name: "system_settings_reservation_days_positive"
     t.check_constraint "default_supplier_cancellation_days >= 0", name: "system_settings_supplier_cancellation_days_nonnegative"
     t.check_constraint "fiscal_year_start_month >= 1 AND fiscal_year_start_month <= 12", name: "system_settings_fiscal_year_start_month_range"
     t.check_constraint "singleton_key = true", name: "system_settings_singleton_key_true"
+    t.check_constraint "stored_value_adjust_credit_approval_threshold_cents >= 0", name: "system_settings_sv_adjust_threshold_nonnegative"
   end
 
   create_table "tax_classes", id: :uuid, default: nil, force: :cascade do |t|
@@ -1571,6 +1645,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_010000) do
   add_foreign_key "store_tax_rules", "tax_classes"
   add_foreign_key "store_taxes", "stores"
   add_foreign_key "stored_value_accounts", "customers"
+  add_foreign_key "stored_value_adjustments", "idempotency_operations"
+  add_foreign_key "stored_value_adjustments", "stored_value_accounts"
+  add_foreign_key "stored_value_adjustments", "stored_value_adjustment_reasons", column: "reason_id"
+  add_foreign_key "stored_value_adjustments", "stored_value_adjustments", column: "reversal_of_id"
+  add_foreign_key "stored_value_adjustments", "stored_value_operations"
+  add_foreign_key "stored_value_adjustments", "stores"
+  add_foreign_key "stored_value_adjustments", "users", column: "approved_by_id"
+  add_foreign_key "stored_value_adjustments", "users", column: "performed_by_id"
   add_foreign_key "stored_value_entries", "stored_value_accounts"
   add_foreign_key "stored_value_entries", "stored_value_entries", column: "reversal_of_id"
   add_foreign_key "stored_value_entries", "stored_value_operations"
@@ -1579,6 +1661,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_010000) do
   add_foreign_key "stored_value_operations", "stored_value_operations", column: "reversal_of_id"
   add_foreign_key "stored_value_operations", "stores"
   add_foreign_key "stored_value_operations", "users", column: "performed_by_id"
+  add_foreign_key "stored_value_transfers", "customers", column: "source_customer_id"
+  add_foreign_key "stored_value_transfers", "customers", column: "survivor_customer_id"
+  add_foreign_key "stored_value_transfers", "idempotency_operations", column: "merge_idempotency_operation_id"
+  add_foreign_key "stored_value_transfers", "stored_value_accounts", column: "from_account_id"
+  add_foreign_key "stored_value_transfers", "stored_value_accounts", column: "to_account_id"
+  add_foreign_key "stored_value_transfers", "stored_value_operations"
+  add_foreign_key "stored_value_transfers", "stored_value_transfers", column: "reversal_of_id"
+  add_foreign_key "stored_value_transfers", "users", column: "approved_by_id"
+  add_foreign_key "stored_value_transfers", "users", column: "performed_by_id"
   add_foreign_key "stores", "users", column: "deactivated_by_id"
   add_foreign_key "subject_headings", "merchandise_classes", column: "suggested_merchandise_class_id"
   add_foreign_key "subject_headings", "subject_schemes"

--- a/docs/planning/phase1-operational-foundation/phase1-schema.md
+++ b/docs/planning/phase1-operational-foundation/phase1-schema.md
@@ -29,6 +29,7 @@ One row representing installation-wide configuration.
 | `default_customer_reservation_expiration_days` | smallint | null: false; default `7`; check `>= 0` | Default for customer reservations |
 | `default_receipt_header` | text | max 500 after trim | Organization default; inherit target |
 | `default_receipt_footer` | text | max 500 after trim | Organization default; inherit target |
+| `stored_value_adjust_credit_approval_threshold_cents` | bigint | null: false; default `5000`; check `>= 0` | Credits at or above this amount require second-user approval; all debits require second-user approval ([phase10-schema.md](../phase10-stored-value/phase10-schema.md) §13) |
 | `initialized_at` | timestamptz |  | Set only as the final successful bootstrap step; null means install incomplete / retryable |
 | `lock_version` | integer | null: false; default `0` | Optimistic concurrency |
 | `created_at` | timestamptz | null: false |  |

--- a/docs/planning/phase10-stored-value/phase10-implementation-plan.md
+++ b/docs/planning/phase10-stored-value/phase10-implementation-plan.md
@@ -50,7 +50,7 @@ Issue branches PR **directly to `main`**. There is no `phase-10-stored-value` in
 | Slice | Status |
 |---|---|
 | 10.1 Stored-value core | Complete (issue [#59](https://github.com/BankEncore/ShelfSense-v1/issues/59)) |
-| 10.2 Customer store/trade credit | Not started |
+| 10.2 Customer store/trade credit | Complete (issue [#60](https://github.com/BankEncore/ShelfSense-v1/issues/60)) |
 | 10.3 Gift-card programs and instruments | Not started |
 | 10.4 POS issuance, tenders, refund destinations, post-void | Not started |
 | 10.5 Cash-out, closeout, print, nav | Not started |

--- a/docs/planning/phase10-stored-value/phase10-schema.md
+++ b/docs/planning/phase10-stored-value/phase10-schema.md
@@ -387,7 +387,7 @@ These are integration messages, not `financial_events` rows.
 
 ## 13. System settings
 
-- Manual-adjustment approval threshold (organization): credits at or above require second user; all debit adjustments require second user.
+- Manual-adjustment approval threshold (organization): `system_settings.stored_value_adjust_credit_approval_threshold_cents` (default 5000). Credits at or above require second user; all debit adjustments require second user.
 - Do not put gift-card cash-out threshold here (program-level).
 
 ## 14. Idempotency

--- a/docs/planning/ux-design-system/navigation-proposal.md
+++ b/docs/planning/ux-design-system/navigation-proposal.md
@@ -154,12 +154,14 @@ UDS-5.0 compared compact **presentations** of this inventory ([uds-5-plan.md](ud
 
 ## Proposed Phase 10 destinations
 
-Not in the UDS-4.1 production inventory until Phase 10.5 implementation updates `Admin::NavigationCatalog`. Do not add one-off header links.
+Destinations land in the slice that introduces the screens. Do not add one-off header links. Customer show balance panels are not a new destination.
 
-| Canonical group | Proposed label → destination | Visibility gate | Rationale |
+| Canonical group | Label → destination | Visibility gate | Slice |
 |---|---|---|---|
-| **Customers** | (customer show activity — not a new index destination) | `stored_value.view_activity` | Balances on existing customer record |
-| **POS operations** | Gift-card programs → `admin_gift_card_programs_path` | `gift_cards.manage_programs` | Program configuration |
-| **POS operations** | Gift cards → `admin_gift_cards_path` | `gift_cards.view` | Masked inquiry and operational administration |
+| **Customers** | (customer show activity — not a new index destination) | `stored_value.view_activity` | 10.2 |
+| **Customers** | Stored-value transfers → `new_admin_stored_value_transfer_path` | `stored_value.transfer` | 10.2 |
+| **Organization configuration** | Stored-value reasons → `admin_stored_value_adjustment_reasons_path` | `stored_value.manage_adjustment_reasons` | 10.2 |
+| **POS operations** | Gift-card programs → `admin_gift_card_programs_path` | `gift_cards.manage_programs` | 10.3 |
+| **POS operations** | Gift cards → `admin_gift_cards_path` | `gift_cards.view` | 10.3 |
 
 Exact path helpers are illustrative. Implementation must keep controllers as the authorization boundary.

--- a/lib/tasks/shelfsense.rake
+++ b/lib/tasks/shelfsense.rake
@@ -49,6 +49,7 @@ namespace :shelfsense do
     Authorization::PermissionCatalog.seed!(granted_by: granted_by)
     ProductForms::Catalog.seed!
     SubjectSchemes::Catalog.seed!
+    StoredValue::AdjustmentReasons.seed!
     after = Role.find_by!(key: "system_administrator").permissions.pluck(:key)
 
     added = after - before

--- a/test/integration/stored_value_customer_credit_test.rb
+++ b/test/integration/stored_value_customer_credit_test.rb
@@ -1,0 +1,221 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class StoredValueCustomerCreditTest < ActionDispatch::IntegrationTest
+  setup do
+    @bootstrap = bootstrap!
+    @admin = @bootstrap[:administrator]
+    @store = @bootstrap[:store]
+    @approver = create_store_manager("sv_ui_approver")
+    @customer = Customer.create!(display_name: "SV Customer", email: "sv.ui@example.com")
+    @goodwill = StoredValueAdjustmentReason.find_by!(code: "goodwill")
+  end
+
+  test "customer show displays balances to staff with view_activity" do
+    account = StoredValue::OpenAccount.call(account_type: "store_credit", customer: @customer)
+    StoredValue::Post.call(
+      operation_type: "issue",
+      store: @store,
+      performed_by: @admin,
+      source_id: account.id,
+      idempotency_key: SecureRandom.uuid_v7,
+      entries: [ { account: account, amount_cents: 125 } ]
+    )
+
+    sign_in_as("admin")
+    get admin_customer_path(@customer)
+    assert_response :success
+    assert_includes response.body, "Stored value"
+    assert_includes response.body, "Store credit"
+    assert_includes response.body, format_cents(125)
+  end
+
+  test "customer show hides stored-value balances without view_activity" do
+    StoredValue::OpenAccount.call(account_type: "store_credit", customer: @customer)
+    create_customers_viewer("sv_view_only")
+    sign_in_as("sv_view_only")
+    post store_selection_path, params: { store_id: @store.id }
+    get admin_customer_path(@customer)
+    assert_response :success
+    assert_not_includes response.body, "Stored value"
+  end
+
+  test "opening the adjust form does not create an account" do
+    sign_in_as("admin")
+    assert_no_difference("StoredValueAccount.count") do
+      get new_admin_customer_stored_value_adjustment_path(@customer, account_type: "store_credit")
+    end
+    assert_response :success
+  end
+
+  test "staff can post a store-credit credit from customer show" do
+    sign_in_as("admin")
+    post admin_customer_stored_value_adjustments_path(@customer), params: {
+      account_type: "store_credit",
+      direction: "credit",
+      amount: "12.50",
+      reason_id: @goodwill.id,
+      idempotency_key: SecureRandom.uuid_v7
+    }
+    assert_redirected_to admin_customer_path(@customer)
+    account = StoredValueAccount.find_by!(customer: @customer, account_type: "store_credit")
+    assert_equal 1250, account.balance_cents
+  end
+
+  test "deactivate is blocked while store credit is nonzero and allowed at zero" do
+    sign_in_as("admin")
+    post admin_customer_stored_value_adjustments_path(@customer), params: {
+      account_type: "store_credit",
+      direction: "credit",
+      amount: "5.00",
+      reason_id: @goodwill.id,
+      idempotency_key: SecureRandom.uuid_v7
+    }
+    delete admin_customer_path(@customer)
+    follow_redirect!
+    assert_match(/nonzero store-credit or trade-credit balance/, flash[:alert].to_s + response.body)
+    assert @customer.reload.active?
+
+    debit_reason = StoredValueAdjustmentReason.find_by!(code: "correction_debit")
+    post admin_customer_stored_value_adjustments_path(@customer), params: {
+      stored_value_account_id: StoredValueAccount.find_by!(customer: @customer, account_type: "store_credit").id,
+      direction: "debit",
+      amount: "5.00",
+      reason_id: debit_reason.id,
+      internal_notes: "clear before deactivate",
+      approver_username: @approver.username,
+      approver_password: "correct-horse-battery",
+      idempotency_key: SecureRandom.uuid_v7
+    }
+    assert_redirected_to admin_customer_path(@customer)
+
+    delete admin_customer_path(@customer)
+    assert_redirected_to admin_customers_path
+    assert_not @customer.reload.active?
+  end
+
+  test "administrative transfer requires a second user and posts to the destination" do
+    source = Customer.create!(display_name: "From SV", email: "sv.from@example.com")
+    destination = Customer.create!(display_name: "To SV", email: "sv.to@example.com")
+    account = StoredValue::OpenAccount.call(account_type: "store_credit", customer: source)
+    StoredValue::Post.call(
+      operation_type: "issue",
+      store: @store,
+      performed_by: @admin,
+      source_id: account.id,
+      idempotency_key: SecureRandom.uuid_v7,
+      entries: [ { account: account, amount_cents: 800 } ]
+    )
+
+    sign_in_as("admin")
+    post admin_stored_value_transfers_path, params: {
+      from_customer_id: source.id,
+      to_customer_id: destination.id,
+      account_type: "store_credit",
+      transfer_type: "administrative",
+      amount: "3.00",
+      reason_code: "misapplied",
+      approver_username: @approver.username,
+      approver_password: "correct-horse-battery",
+      idempotency_key: SecureRandom.uuid_v7
+    }
+    assert_redirected_to admin_customer_path(destination)
+    assert_equal 500, account.reload.balance_cents
+    dest_account = StoredValueAccount.find_by!(customer: destination, account_type: "store_credit")
+    assert_equal 300, dest_account.balance_cents
+    assert account.active?
+  end
+
+  test "associates cannot adjust stored value" do
+    associate = User.create!(
+      username: "sv_associate",
+      display_name: "SV Associate",
+      password: "correct-horse-battery",
+      password_confirmation: "correct-horse-battery"
+    )
+    RoleAssignment.create!(
+      user: associate,
+      role: Role.find_by!(key: "associate"),
+      store: @store,
+      assigned_by: @admin,
+      effective_at: Time.current
+    )
+    sign_in_as("sv_associate")
+    post store_selection_path, params: { store_id: @store.id }
+    post admin_customer_stored_value_adjustments_path(@customer), params: {
+      account_type: "store_credit",
+      direction: "credit",
+      amount: "1.00",
+      reason_id: @goodwill.id
+    }
+    assert_redirected_to root_path
+    assert_equal "denied", AuditEvent.where(action: "authorization.denied", actor_user: associate).order(:created_at).last.outcome
+  end
+
+  test "adjustment reasons catalog is reachable from organization navigation" do
+    sign_in_as("admin")
+    get admin_stored_value_adjustment_reasons_path
+    assert_response :success
+    assert_includes response.body, "goodwill"
+    get admin_products_path
+    assert_includes response.body, admin_stored_value_adjustment_reasons_path
+    assert_includes response.body, new_admin_stored_value_transfer_path
+  end
+
+  private
+
+  def sign_in_as(username)
+    post session_path, params: { session: { username: username, password: "correct-horse-battery" } }
+  end
+
+  def format_cents(cents)
+    ApplicationController.helpers.format_money_cents(cents)
+  end
+
+  def create_store_manager(username)
+    user = User.create!(
+      username: username,
+      display_name: username.titleize,
+      password: "correct-horse-battery",
+      password_confirmation: "correct-horse-battery"
+    )
+    RoleAssignment.create!(
+      user: user,
+      role: Role.find_by!(key: "store_manager"),
+      store: @store,
+      assigned_by: @admin,
+      effective_at: Time.current
+    )
+    user
+  end
+
+  def create_customers_viewer(username)
+    role = Role.create!(
+      key: "sv_cust_view_#{SecureRandom.hex(3)}",
+      name: "Customer view only",
+      assignment_scope: "store",
+      system_role: false,
+      active: true
+    )
+    RolePermission.create!(
+      role: role,
+      permission: Permission.find_by!(key: "customers.view"),
+      granted_by: @admin
+    )
+    user = User.create!(
+      username: username,
+      display_name: username.titleize,
+      password: "correct-horse-battery",
+      password_confirmation: "correct-horse-battery"
+    )
+    RoleAssignment.create!(
+      user: user,
+      role: role,
+      store: @store,
+      assigned_by: @admin,
+      effective_at: Time.current
+    )
+    user
+  end
+end

--- a/test/services/admin/navigation_view_model_test.rb
+++ b/test/services/admin/navigation_view_model_test.rb
@@ -28,6 +28,8 @@ class Admin::NavigationViewModelTest < ActiveSupport::TestCase
     assert purchasing.destinations.any? { |d| d.key == :receiving_ops }
     assert purchasing.destinations.any? { |d| d.key == :draft_po_ops }
     assert nav.groups.find { |g| g.key == :customers }.destinations.any? { |d| d.key == :location_ops }
+    assert nav.groups.find { |g| g.key == :customers }.destinations.any? { |d| d.key == :stored_value_transfers }
+    assert nav.groups.find { |g| g.key == :organization_configuration }.destinations.any? { |d| d.key == :stored_value_adjustment_reasons }
     assert nav.groups.find { |g| g.key == :pos_operations }.destinations.any? { |d| d.key == :pos }
 
     assert nav.groups.find { |g| g.key == :merchandise }.current

--- a/test/services/customers/merge_customers_test.rb
+++ b/test/services/customers/merge_customers_test.rb
@@ -213,5 +213,37 @@ module Customers
       end
       assert_match(/email or phone/, error.message)
     end
+
+    test "merges positive store credit and closes a zero-balance trade-credit source without creating a survivor account" do
+      source_store = StoredValue::OpenAccount.call(account_type: "store_credit", customer: @source)
+      source_trade = StoredValue::OpenAccount.call(account_type: "trade_credit", customer: @source)
+      StoredValue::Post.call(
+        operation_type: "issue",
+        store: @store,
+        performed_by: @actor,
+        source_id: source_store.id,
+        idempotency_key: SecureRandom.uuid_v7,
+        entries: [ { account: source_store, amount_cents: 250 } ]
+      )
+
+      result = Customers::MergeCustomers.call(
+        source: @source,
+        survivor: @survivor,
+        actor: @actor,
+        reason: "same person",
+        idempotency_key: SecureRandom.uuid_v7,
+        store: @store
+      )
+
+      assert_equal 1, result.stored_value_transfer_ids.size
+      assert source_store.reload.closed?
+      assert_equal 0, source_store.balance_cents
+      assert_equal @source.id, source_store.customer_id
+      assert source_trade.reload.closed?
+      survivor_store = StoredValueAccount.find_by!(customer: @survivor, account_type: "store_credit")
+      assert_equal 250, survivor_store.balance_cents
+      assert_nil StoredValueAccount.find_by(customer: @survivor, account_type: "trade_credit")
+      assert_equal @source.id, source_store.stored_value_entries.first.stored_value_account.customer_id
+    end
   end
 end

--- a/test/services/installation/bootstrap_test.rb
+++ b/test/services/installation/bootstrap_test.rb
@@ -52,6 +52,9 @@ class Installation::BootstrapTest < ActiveSupport::TestCase
     assert_includes actions, "installation.started"
     assert_includes actions, "installation.completed"
     assert AuditEvent.where(actor_type: "system").exists?
+    assert StoredValueAdjustmentReason.exists?(code: "goodwill")
+    assert_not StoredValueAdjustmentReason.exists?(code: "opening_balance")
+    assert_equal 5000, result[:settings].stored_value_adjust_credit_approval_threshold_cents
   end
 
   test "rejects a second bootstrap after initialization" do

--- a/test/services/stored_value/adjust_test.rb
+++ b/test/services/stored_value/adjust_test.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module StoredValue
+  class AdjustTest < ActiveSupport::TestCase
+    setup do
+      @bootstrap = bootstrap!
+      @store = @bootstrap[:store]
+      @actor = @bootstrap[:administrator]
+      @approver = create_store_manager("sv_approver")
+      @customer = Customer.create!(display_name: "Credit Customer", email: "sv.adjust@example.com")
+      @account = StoredValue::OpenAccount.call(account_type: "store_credit", customer: @customer)
+      @goodwill = StoredValueAdjustmentReason.find_by!(code: "goodwill")
+      @debit_reason = StoredValueAdjustmentReason.find_by!(code: "correction_debit")
+    end
+
+    test "credits store credit through an adjust operation and never edits the balance field" do
+      adjustment = credit!(500)
+
+      assert_equal "credit", adjustment.adjustment_direction
+      assert_equal 500, adjustment.amount_cents
+      assert_equal "goodwill", adjustment.reason_code
+      assert_equal 500, @account.reload.balance_cents
+      assert_equal "adjust", adjustment.stored_value_operation.operation_type
+      assert_equal 500, adjustment.stored_value_operation.stored_value_entries.sole.amount_cents
+      assert OutboxMessage.exists?(event_type: "stored_value.adjusted", aggregate_id: adjustment.stored_value_operation_id)
+      assert_not StoredValueAdjustmentReason.exists?(code: "opening_balance")
+    end
+
+    test "small credits do not require a second user" do
+      adjustment = credit!(100)
+
+      assert_nil adjustment.approved_by_id
+    end
+
+    test "credits at the organization threshold require a second user" do
+      error = assert_raises(StoredValue::Error) { credit!(5000, approved_by: nil) }
+      assert_match(/second-user/, error.message)
+
+      adjustment = credit!(5000, approved_by: @approver)
+      assert_equal @approver.id, adjustment.approved_by_id
+    end
+
+    test "debits always require a second user and notes when the reason requires them" do
+      credit!(200)
+      error = assert_raises(StoredValue::Error) do
+        debit!(50, approved_by: nil, notes: "correction")
+      end
+      assert_match(/second-user/, error.message)
+
+      error = assert_raises(StoredValue::Error) { debit!(50, approved_by: @approver, notes: "") }
+      assert_match(/notes are required/, error.message)
+
+      adjustment = debit!(50, approved_by: @approver, notes: "fix over-credit")
+      assert_equal 150, @account.reload.balance_cents
+      assert_equal @approver.id, adjustment.approved_by_id
+    end
+
+    test "performer cannot self-approve" do
+      error = assert_raises(StoredValue::Error) { credit!(5000, approved_by: @actor) }
+      assert_match(/approver cannot be the performer/, error.message)
+    end
+
+    test "inactive customers cannot receive new credit" do
+      @customer.update!(active: false)
+      error = assert_raises(StoredValue::Error) { credit!(100) }
+      assert_match(/inactive customers cannot receive new credit/, error.message)
+    end
+
+    test "gift-card adjustments are blocked until instruments exist" do
+      card = StoredValue::OpenAccount.call(account_type: "gift_card")
+      error = assert_raises(StoredValue::Error) do
+        StoredValue::Adjust.call(
+          account: card,
+          direction: "credit",
+          amount_cents: 100,
+          reason: @goodwill,
+          store: @store,
+          performed_by: @actor,
+          source_id: card.id,
+          idempotency_key: SecureRandom.uuid_v7
+        )
+      end
+      assert_match(/gift-card adjustments are not available/, error.message)
+    end
+
+    test "idempotent retry returns the same adjustment" do
+      key = SecureRandom.uuid_v7
+      first = credit!(250, key: key)
+      second = credit!(250, key: key)
+
+      assert_equal first.id, second.id
+      assert_equal 1, StoredValueAdjustment.count
+      assert_equal 250, @account.reload.balance_cents
+    end
+
+    test "accounts are created only for active canonical customers" do
+      merged_source = Customer.create!(display_name: "Alias", email: "sv.alias@example.com")
+      Customers::MergeCustomers.call(
+        source: merged_source,
+        survivor: @customer,
+        actor: @actor,
+        reason: "same person",
+        idempotency_key: SecureRandom.uuid_v7,
+        store: @store
+      )
+      error = assert_raises(StoredValue::Error) do
+        StoredValue::OpenAccount.call(account_type: "trade_credit", customer: merged_source.reload)
+      end
+      assert_match(/canonical/, error.message)
+    end
+
+    private
+
+    def credit!(amount_cents, approved_by: nil, key: SecureRandom.uuid_v7)
+      StoredValue::Adjust.call(
+        account: @account,
+        direction: "credit",
+        amount_cents: amount_cents,
+        reason: @goodwill,
+        store: @store,
+        performed_by: @actor,
+        approved_by: approved_by,
+        source_id: @account.id,
+        idempotency_key: key
+      )
+    end
+
+    def debit!(amount_cents, approved_by:, notes:)
+      StoredValue::Adjust.call(
+        account: @account,
+        direction: "debit",
+        amount_cents: amount_cents,
+        reason: @debit_reason,
+        store: @store,
+        performed_by: @actor,
+        approved_by: approved_by,
+        source_id: @account.id,
+        idempotency_key: SecureRandom.uuid_v7,
+        internal_notes: notes
+      )
+    end
+
+    def create_store_manager(username)
+      user = User.create!(
+        username: username,
+        display_name: username.titleize,
+        password: "correct-horse-battery",
+        password_confirmation: "correct-horse-battery"
+      )
+      RoleAssignment.create!(
+        user: user,
+        role: Role.find_by!(key: "store_manager"),
+        store: @store,
+        assigned_by: @actor,
+        effective_at: Time.current
+      )
+      user
+    end
+  end
+end

--- a/test/services/stored_value/transfer_test.rb
+++ b/test/services/stored_value/transfer_test.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module StoredValue
+  class TransferTest < ActiveSupport::TestCase
+    setup do
+      @bootstrap = bootstrap!
+      @store = @bootstrap[:store]
+      @actor = @bootstrap[:administrator]
+      @approver = create_store_manager("sv_xfer_approver")
+      @source_customer = Customer.create!(display_name: "Source Credit", email: "sv.src@example.com")
+      @dest_customer = Customer.create!(display_name: "Dest Credit", email: "sv.dst@example.com")
+      @from = StoredValue::OpenAccount.call(account_type: "store_credit", customer: @source_customer)
+      @to = StoredValue::OpenAccount.call(account_type: "store_credit", customer: @dest_customer)
+      fund!(@from, 400)
+    end
+
+    test "administrative partial transfer leaves source open and nets to zero" do
+      transfer = transfer!(amount_cents: 150, transfer_type: "administrative")
+
+      assert_equal 250, @from.reload.balance_cents
+      assert_equal 150, @to.reload.balance_cents
+      assert @from.active?
+      assert_equal 0, transfer.stored_value_operation.stored_value_entries.sum(:amount_cents)
+      assert OutboxMessage.exists?(event_type: "stored_value.transferred", aggregate_id: transfer.stored_value_operation_id)
+    end
+
+    test "consolidation moves the full balance and closes source" do
+      transfer = transfer!(amount_cents: 400, transfer_type: "account_consolidation")
+
+      assert_equal 0, @from.reload.balance_cents
+      assert @from.closed?
+      assert_equal 400, @to.reload.balance_cents
+      assert_equal "account_consolidation", transfer.transfer_type
+    end
+
+    test "cross-type conversion is prohibited" do
+      trade = StoredValue::OpenAccount.call(account_type: "trade_credit", customer: @dest_customer)
+      error = assert_raises(StoredValue::Error) do
+        transfer!(amount_cents: 50, transfer_type: "administrative", to_account: trade)
+      end
+      assert_match(/cross-type conversion is prohibited/, error.message)
+    end
+
+    test "second user is required and cannot be the performer" do
+      error = assert_raises(StoredValue::Error) do
+        transfer!(amount_cents: 50, transfer_type: "administrative", approved_by: nil)
+      end
+      assert_match(/second-user/, error.message)
+
+      error = assert_raises(StoredValue::Error) do
+        transfer!(amount_cents: 50, transfer_type: "administrative", approved_by: @actor)
+      end
+      assert_match(/approver cannot be the performer/, error.message)
+    end
+
+    test "customer merge does not require stored_value.transfer approval" do
+      transfer = StoredValue::Transfer.call(
+        from_account: @from,
+        to_account: @to,
+        amount_cents: 400,
+        transfer_type: "customer_merge",
+        performed_by: @actor,
+        store: @store,
+        source_id: @source_customer.id,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+
+      assert_nil transfer.approved_by_id
+      assert @from.reload.closed?
+      assert_equal 400, @to.reload.balance_cents
+    end
+
+    private
+
+    def fund!(account, amount_cents)
+      StoredValue::Post.call(
+        operation_type: "issue",
+        store: @store,
+        performed_by: @actor,
+        source_id: account.id,
+        idempotency_key: SecureRandom.uuid_v7,
+        entries: [ { account: account, amount_cents: amount_cents } ]
+      )
+    end
+
+    def transfer!(amount_cents:, transfer_type:, to_account: @to, approved_by: @approver)
+      StoredValue::Transfer.call(
+        from_account: @from,
+        to_account: to_account,
+        amount_cents: amount_cents,
+        transfer_type: transfer_type,
+        performed_by: @actor,
+        approved_by: approved_by,
+        store: @store,
+        source_id: @from.id,
+        idempotency_key: SecureRandom.uuid_v7,
+        reason_code: "test_transfer",
+        reason_name_snapshot: "Test transfer"
+      )
+    end
+
+    def create_store_manager(username)
+      user = User.create!(
+        username: username,
+        display_name: username.titleize,
+        password: "correct-horse-battery",
+        password_confirmation: "correct-horse-battery"
+      )
+      RoleAssignment.create!(
+        user: user,
+        role: Role.find_by!(key: "store_manager"),
+        store: @store,
+        assigned_by: @actor,
+        effective_at: Time.current
+      )
+      user
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Open store-credit and trade-credit accounts only for active canonical customers, with currency snapshotted from system settings
- Manual credit/debit posts through `StoredValue::Adjust` (second-user on all debits and credits at/above the org threshold; gift-card adjust waits for 10.3)
- Same-type administrative transfer and consolidation post paired net-zero entries; `Customers::MergeStoredValueAccounts` runs inside merge and closes zero-balance sources without creating a survivor account
- Customer deactivate is blocked while store/trade credit is nonzero; customer show activity, reason catalog, and transfer screens land with their nav destinations

## Verification
- `./dev/rails-docker bin/rails test`
- `./dev/rails-docker bin/rubocop`
- `./dev/rails-docker bin/brakeman --no-pager`
- `./dev/rails-docker bin/bundler-audit`

## Documentation and migrations
- `db/migrate/20260826020000_create_phase10_customer_stored_value.rb` (reversible `change`)
- `db/schema.rb` regenerated
- Slice 10.2 marked Complete in phase10-implementation-plan.md

Closes #60

Made with [Cursor](https://cursor.com)