### PR TITLE
10.3 — Gift-card programs and instruments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,9 @@
 # Recreate the web container after changing this file: docker compose up -d --force-recreate web
 
 ISBNDB_API_KEY=
+
+# Production only. Docker/test/CI use documented test keys when these are unset.
+# ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY=
+# ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY=
+# ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT=
+# GIFT_CARD_NUMBER_HMAC_KEY=

--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -37,6 +37,9 @@ module Admin
                                                 .order(created_at: :desc)
                                                 .limit(25)
       end
+      if Authorization::PermissionEvaluator.allowed?(user: current_user, permission_key: "gift_cards.view", store: current_store)
+        @associated_gift_cards = @customer.gift_cards.includes(:gift_card_program, :stored_value_account).order(:created_at)
+      end
     end
 
     def new

--- a/app/controllers/admin/gift_card_adjustments_controller.rb
+++ b/app/controllers/admin/gift_card_adjustments_controller.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Admin
+  class GiftCardAdjustmentsController < BaseController
+    before_action -> { require_permission!("stored_value.adjust") }
+    before_action :set_gift_card
+
+    def new
+      @account = @gift_card.stored_value_account
+      @reasons = StoredValueAdjustmentReason.active.admin_ordered.select { |reason|
+        Array(reason.allowed_account_types).include?("gift_card")
+      }
+    end
+
+    def create
+      @account = @gift_card.stored_value_account
+      reason = StoredValueAdjustmentReason.find(params.require(:reason_id))
+      direction = params.require(:direction)
+      amount_cents = Money::ParseCents.call(params[:amount])
+      raise StoredValue::Error, "amount is required" if amount_cents.nil?
+
+      approved_by = approver_if_required!(direction: direction, amount_cents: amount_cents, reason: reason)
+      StoredValue::Adjust.call(
+        account: @account,
+        direction: direction,
+        amount_cents: amount_cents,
+        reason: reason,
+        store: operational_store!,
+        performed_by: current_user,
+        approved_by: approved_by,
+        source_id: @account.id,
+        idempotency_key: params[:idempotency_key].presence || SecureRandom.uuid_v7,
+        internal_notes: params[:internal_notes]
+      )
+      redirect_to admin_gift_card_path(@gift_card), notice: "Stored-value adjustment posted."
+    rescue StoredValue::Error, Money::ParseCents::Error, ArgumentError => e
+      @reasons = StoredValueAdjustmentReason.active.admin_ordered.select { |reason|
+        Array(reason.allowed_account_types).include?("gift_card")
+      }
+      flash.now[:alert] = e.message
+      render :new, status: :unprocessable_entity
+    end
+
+    private
+
+    def set_gift_card
+      @gift_card = GiftCard.find(params[:gift_card_id])
+    end
+
+    def operational_store!
+      current_store || Store.active.order(:name).first || raise(StoredValue::Error, "a store is required")
+    end
+
+    def approver_if_required!(direction:, amount_cents:, reason:)
+      return unless StoredValue::Adjust.second_user_required?(
+        direction: direction,
+        amount_cents: amount_cents,
+        reason: reason,
+        account: @account
+      )
+
+      StoredValue::AuthenticateApprover.call(
+        username: params[:approver_username],
+        password: params[:approver_password],
+        performer: current_user,
+        permission_key: "stored_value.adjust",
+        store: operational_store!
+      )
+    end
+  end
+end

--- a/app/controllers/admin/gift_card_programs_controller.rb
+++ b/app/controllers/admin/gift_card_programs_controller.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Admin
+  class GiftCardProgramsController < BaseController
+    before_action -> { require_permission!("gift_cards.manage_programs") }
+    before_action :set_program, only: %i[show edit update destroy reactivate]
+
+    def index
+      @programs = GiftCardProgram.admin_ordered
+    end
+
+    def show; end
+
+    def new
+      @program = GiftCardProgram.new(
+        number_authority: "system_generated",
+        number_length: GiftCardProgram::PHASE10_NUMBER_LENGTH,
+        check_digit_algorithm: "luhn",
+        cash_out_policy: "permitted_when_eligible",
+        reload_allowed: true
+      )
+    end
+
+    def create
+      @program = GiftCardProgram.new(program_params)
+      if create_and_audit!(@program, action: "gift_cards.programs.create", after_values: { code: @program.code, prefix: @program.prefix })
+        redirect_to admin_gift_card_program_path(@program), notice: "Gift-card program created."
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def edit; end
+
+    def update
+      rescue_stale do
+        if save_and_audit!(
+          @program,
+          attrs: program_params.except(:code),
+          action: "gift_cards.programs.update",
+          before_keys: %w[name active reload_allowed cash_out_policy cash_out_approval_required]
+        )
+          redirect_to admin_gift_card_program_path(@program), notice: "Gift-card program updated."
+        else
+          render :edit, status: :unprocessable_entity
+        end
+      end
+    end
+
+    def destroy
+      mutate_and_audit!(@program, action: "gift_cards.programs.deactivate") { @program.update!(active: false) }
+      redirect_to admin_gift_card_programs_path, notice: "Gift-card program deactivated."
+    end
+
+    def reactivate
+      reactivate_configuration!(
+        @program,
+        permission_key: "gift_cards.manage_programs",
+        audit_action: "gift_cards.programs.reactivate",
+        redirect_path: admin_gift_card_program_path(@program)
+      )
+    end
+
+    private
+
+    def set_program
+      @program = GiftCardProgram.find(params[:id])
+    end
+
+    def program_params
+      params.require(:gift_card_program).permit(
+        :code, :name, :number_authority, :prefix, :number_length, :check_digit_algorithm,
+        :reload_allowed, :minimum_activation_cents, :maximum_balance_cents, :cash_out_policy,
+        :cash_out_threshold_cents, :cash_out_threshold_inclusive, :cash_out_approval_required,
+        :lock_version
+      )
+    end
+  end
+end

--- a/app/controllers/admin/gift_cards_controller.rb
+++ b/app/controllers/admin/gift_cards_controller.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+module Admin
+  class GiftCardsController < BaseController
+    before_action -> { require_permission!("gift_cards.view") }, only: %i[index show inquiry resolve_inquiry]
+    before_action -> { require_permission!("gift_cards.suspend") }, only: %i[suspend reinstate]
+    before_action -> { require_permission!("gift_cards.replace") }, only: %i[replace create_replacement]
+    before_action -> { require_permission!("gift_cards.associate_customer") }, only: %i[associate update_association]
+    before_action :set_gift_card, only: %i[show suspend reinstate replace create_replacement associate update_association]
+
+    def index
+      @gift_cards = GiftCard.includes(:gift_card_program, :stored_value_account, :customer).admin_ordered.limit(100)
+    end
+
+    def show; end
+
+    def inquiry; end
+
+    def resolve_inquiry
+      card = GiftCards::Resolver.call(raw_number: params[:card_number], actor: current_user, store: current_store)
+      Audit::Recorder.record!(
+        action: "gift_cards.inquiry",
+        outcome: "succeeded",
+        actor_user: current_user,
+        store: current_store,
+        subject: card,
+        after_values: { number_last_four: card.number_last_four, status: card.status }
+      )
+      redirect_to admin_gift_card_path(card)
+    rescue GiftCards::Error => e
+      flash.now[:alert] = e.message
+      render :inquiry, status: :unprocessable_entity
+    end
+
+    def suspend
+      GiftCards::Suspend.call(
+        gift_card: @gift_card,
+        actor: current_user,
+        store: operational_store,
+        expected_lock_version: params[:lock_version]
+      )
+      redirect_to admin_gift_card_path(@gift_card), notice: "Gift card suspended."
+    rescue GiftCards::Error, ActiveRecord::StaleObjectError => e
+      redirect_to admin_gift_card_path(@gift_card), alert: e.message
+    end
+
+    def reinstate
+      GiftCards::Reinstate.call(
+        gift_card: @gift_card,
+        actor: current_user,
+        store: operational_store,
+        expected_lock_version: params[:lock_version]
+      )
+      redirect_to admin_gift_card_path(@gift_card), notice: "Gift card reinstated."
+    rescue GiftCards::Error, ActiveRecord::StaleObjectError => e
+      redirect_to admin_gift_card_path(@gift_card), alert: e.message
+    end
+
+    def replace; end
+
+    def create_replacement
+      replacement = GiftCards::Replace.call(
+        gift_card: @gift_card,
+        performed_by: current_user,
+        store: operational_store!,
+        source_id: @gift_card.id,
+        idempotency_key: params[:idempotency_key].presence || SecureRandom.uuid_v7,
+        reason_code: params[:reason_code],
+        reason_name_snapshot: params[:reason_name].presence || params[:reason_code],
+        number: params[:card_number],
+        notes: params[:notes]
+      )
+      redirect_to admin_gift_card_path(replacement.replacement_gift_card), notice: "Gift card replaced."
+    rescue GiftCards::Error, StoredValue::Error => e
+      flash.now[:alert] = e.message
+      render :replace, status: :unprocessable_entity
+    end
+
+    def associate
+      @customer = @gift_card.customer
+    end
+
+    def update_association
+      customer = params[:customer_id].present? ? Customer.find(params[:customer_id]) : nil
+      GiftCards::AssociateCustomer.call(
+        gift_card: @gift_card,
+        actor: current_user,
+        customer: customer,
+        store: operational_store,
+        expected_lock_version: params[:lock_version]
+      )
+      redirect_to admin_gift_card_path(@gift_card), notice: "Customer association updated."
+    rescue GiftCards::Error, ActiveRecord::RecordInvalid, ActiveRecord::StaleObjectError => e
+      flash.now[:alert] = e.message
+      render :associate, status: :unprocessable_entity
+    end
+
+    private
+
+    def set_gift_card
+      @gift_card = GiftCard.find(params[:id])
+    end
+
+    def operational_store
+      current_store || Store.active.order(:name).first
+    end
+
+    def operational_store!
+      operational_store || raise(GiftCards::Error, "a store is required")
+    end
+  end
+end

--- a/app/controllers/admin/stored_value_adjustments_controller.rb
+++ b/app/controllers/admin/stored_value_adjustments_controller.rb
@@ -81,7 +81,7 @@ module Admin
     end
 
     def approver_if_required!(direction:, amount_cents:, reason:)
-      return unless StoredValue::Adjust.second_user_required?(direction: direction, amount_cents: amount_cents, reason: reason)
+      return unless StoredValue::Adjust.second_user_required?(direction: direction, amount_cents: amount_cents, reason: reason, account: @account)
 
       StoredValue::AuthenticateApprover.call(
         username: params[:approver_username],

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -13,6 +13,7 @@ class Customer < ApplicationRecord
            dependent: :restrict_with_exception
   has_many :customer_requests, dependent: :restrict_with_exception
   has_many :stored_value_accounts, dependent: :restrict_with_exception
+  has_many :gift_cards, dependent: :restrict_with_exception
 
   validates :display_name, presence: true
   validates :preferred_contact_method, inclusion: { in: PREFERRED_CONTACT_METHODS }

--- a/app/models/gift_card.rb
+++ b/app/models/gift_card.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+class GiftCard < ApplicationRecord
+  STATUSES = %w[active suspended replaced closed].freeze
+
+  encrypts :number
+
+  belongs_to :gift_card_program
+  belongs_to :stored_value_account
+  belongs_to :customer, optional: true
+  belongs_to :activated_store, class_name: "Store"
+  belongs_to :replaced_by, class_name: "GiftCard", optional: true
+  has_one :replaced_from, class_name: "GiftCard", foreign_key: :replaced_by_id, inverse_of: :replaced_by,
+          dependent: :restrict_with_exception
+
+  validates :number, :number_digest, :number_prefix, :number_last_four, :status, :activated_at, presence: true
+  validates :status, inclusion: { in: STATUSES }
+  validates :number_digest, uniqueness: true
+  validates :number_last_four, length: { is: 4 }
+  validate :customer_must_be_canonical_when_present
+  validate :number_identity_immutable, on: :update
+  before_validation :assign_number_identity, on: :create
+
+  scope :active, -> { where(status: "active") }
+  scope :admin_ordered, -> { order(activated_at: :desc) }
+
+  def active?
+    status == "active"
+  end
+
+  def suspended?
+    status == "suspended"
+  end
+
+  def replaced?
+    status == "replaced"
+  end
+
+  def closed?
+    status == "closed"
+  end
+
+  def masked_number
+    "#{number_prefix}••••#{number_last_four}"
+  end
+
+  def balance_cents
+    stored_value_account.balance_cents
+  end
+
+  private
+
+  def assign_number_identity
+    normalized = GiftCards::Number.normalize(number)
+    self.number = normalized
+    self.number_digest = GiftCards::Number.digest(normalized)
+    self.number_prefix = gift_card_program.prefix
+    self.number_last_four = GiftCards::Number.last_four(normalized)
+  end
+
+  def customer_must_be_canonical_when_present
+    return unless will_save_change_to_customer_id?
+    return if customer.blank?
+    return if customer.canonical? && customer.active?
+
+    errors.add(:customer_id, "must be an active canonical customer")
+  end
+
+  def number_identity_immutable
+    %i[number_digest number_prefix number_last_four gift_card_program_id stored_value_account_id].each do |attr|
+      errors.add(attr, "cannot change after issue") if will_save_change_to_attribute?(attr)
+    end
+  end
+end

--- a/app/models/gift_card_program.rb
+++ b/app/models/gift_card_program.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+class GiftCardProgram < ApplicationRecord
+  AUTHORITIES = %w[system_generated manual_external].freeze
+  CASH_OUT_POLICIES = %w[prohibited permitted_when_eligible required_on_request_when_eligible].freeze
+  PHASE10_NUMBER_LENGTH = 20
+  MERCHANDISE_SCAN_LENGTHS = [ 12, 13 ].freeze
+
+  has_many :gift_cards, dependent: :restrict_with_exception
+
+  validates :code, :name, :number_authority, :prefix, :check_digit_algorithm, :cash_out_policy, presence: true
+  validates :code, uniqueness: { case_sensitive: false }
+  validates :prefix, uniqueness: true, format: { with: /\A\d+\z/, message: "must be numeric" }
+  validates :number_authority, inclusion: { in: AUTHORITIES }
+  validates :cash_out_policy, inclusion: { in: CASH_OUT_POLICIES }
+  validates :check_digit_algorithm, inclusion: { in: %w[luhn] }
+  validates :number_length, inclusion: { in: [ PHASE10_NUMBER_LENGTH ] }
+  validates :minimum_activation_cents, :maximum_balance_cents, :cash_out_threshold_cents,
+            numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
+  validate :prefix_does_not_collide_with_merchandise
+  validate :identity_immutable_after_activation, on: :update
+  validate :code_immutable, on: :update
+  before_validation :normalize_identity
+
+  scope :active, -> { where(active: true) }
+  scope :admin_ordered, -> { order(:code) }
+
+  def system_generated?
+    number_authority == "system_generated"
+  end
+
+  def manual_external?
+    number_authority == "manual_external"
+  end
+
+  def activation_exists?
+    gift_cards.exists?
+  end
+
+  def masked_example
+    "#{prefix}#{'•' * (number_length - prefix.length - 4)}####"
+  end
+
+  private
+
+  def normalize_identity
+    self.code = code.to_s.strip.downcase
+    self.prefix = prefix.to_s.strip
+  end
+
+  def prefix_does_not_collide_with_merchandise
+    return if prefix.blank? || number_length.blank?
+    return unless MERCHANDISE_SCAN_LENGTHS.include?(number_length)
+
+    errors.add(:number_length, "collides with merchandise identifier namespaces")
+  end
+
+  def identity_immutable_after_activation
+    return unless activation_exists?
+
+    %i[prefix number_length number_authority check_digit_algorithm].each do |attr|
+      errors.add(attr, "cannot change after a card has been activated") if will_save_change_to_attribute?(attr)
+    end
+  end
+
+  def code_immutable
+    errors.add(:code, "cannot change after create") if will_save_change_to_code?
+  end
+end

--- a/app/models/gift_card_replacement.rb
+++ b/app/models/gift_card_replacement.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class GiftCardReplacement < ApplicationRecord
+  belongs_to :original_gift_card, class_name: "GiftCard"
+  belongs_to :replacement_gift_card, class_name: "GiftCard"
+  belongs_to :performed_by, class_name: "User"
+  belongs_to :approved_by, class_name: "User", optional: true
+  belongs_to :stored_value_operation, optional: true
+  belongs_to :reversal_of, class_name: "GiftCardReplacement", optional: true
+  has_one :reversed_by, class_name: "GiftCardReplacement", foreign_key: :reversal_of_id, inverse_of: :reversal_of,
+          dependent: :restrict_with_exception
+
+  validates :amount_cents, :reason_code, :reason_name_snapshot, :posted_at, presence: true
+  validates :amount_cents, numericality: { only_integer: true, greater_than: 0 }
+
+  def readonly?
+    super || persisted?
+  end
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -34,6 +34,7 @@ class Product < ApplicationRecord
   validates :series_position, numericality: { greater_than_or_equal_to: -99_999.999, less_than_or_equal_to: 99_999.999 }, allow_nil: true
   validate :validate_changed_category
   validate :validate_assignable_product_form
+  validate :lookup_code_not_gift_card_shape
   validate :identifier_write_rules
   validate :validate_field_sources
   after_save { self.identifier_writes_enabled = false }
@@ -111,5 +112,13 @@ class Product < ApplicationRecord
     if industry_identifier_changed? && !identifier_writes_enabled
       errors.add(:industry_identifier, "must be changed through Identifiers::AssignProductIndustry")
     end
+  end
+
+  def lookup_code_not_gift_card_shape
+    return if lookup_code.blank?
+    return unless GiftCardProgram.table_exists?
+    return unless GiftCards::Number.matches_active_program?(lookup_code)
+
+    errors.add(:lookup_code, "matches an active gift-card number shape")
   end
 end

--- a/app/models/stored_value_account.rb
+++ b/app/models/stored_value_account.rb
@@ -7,6 +7,7 @@ class StoredValueAccount < ApplicationRecord
 
   belongs_to :customer, optional: true
   has_many :stored_value_entries, dependent: :restrict_with_exception
+  has_one :gift_card, dependent: :restrict_with_exception
 
   validates :account_type, :currency_code, :status, :opened_at, presence: true
   validates :account_type, inclusion: { in: ACCOUNT_TYPES }

--- a/app/models/stored_value_operation.rb
+++ b/app/models/stored_value_operation.rb
@@ -13,6 +13,7 @@ class StoredValueOperation < ApplicationRecord
   has_many :stored_value_entries, -> { order(:entry_sequence) }, dependent: :restrict_with_exception
   has_one :stored_value_adjustment, dependent: :restrict_with_exception
   has_one :stored_value_transfer, dependent: :restrict_with_exception
+  has_one :gift_card_replacement, dependent: :restrict_with_exception
 
   validates :operation_type, :business_date, :occurred_at, presence: true
   validates :operation_type, inclusion: { in: OPERATION_TYPES }

--- a/app/services/admin/navigation_catalog.rb
+++ b/app/services/admin/navigation_catalog.rb
@@ -95,7 +95,9 @@ module Admin
             destinations: [
               dest(:pos, "POS", :pos_path, permission: "pos.transact", requires_store: true, controllers: %w[pos/homes pos/enters pos/workspaces pos/preferred_registers pos/active_sessions pos/session_closes pos/register_closes pos/closed_sessions pos/x_reports pos/reports pos/reporting_period_zs pos/reporting_period_finalizations pos/return_items pos/post_voids pos/completed_transactions]),
               dest(:pos_transactions, "Transactions", :pos_transactions_path, permission: "pos.transact", requires_store: true, controllers: %w[pos/transactions]),
-              dest(:tender_types, "Tender types", :admin_tender_types_path, permission: "pos.manage_tender_types", controllers: %w[admin/tender_types])
+              dest(:tender_types, "Tender types", :admin_tender_types_path, permission: "pos.manage_tender_types", controllers: %w[admin/tender_types]),
+              dest(:gift_card_programs, "Gift-card programs", :admin_gift_card_programs_path, permission: "gift_cards.manage_programs", controllers: %w[admin/gift_card_programs]),
+              dest(:gift_cards, "Gift cards", :inquiry_admin_gift_cards_path, permission: "gift_cards.view", controllers: %w[admin/gift_cards admin/gift_card_adjustments])
             ]
           ),
           Group.new(

--- a/app/services/customers/merge_stored_value_accounts.rb
+++ b/app/services/customers/merge_stored_value_accounts.rb
@@ -44,6 +44,10 @@ module Customers
         )
         transfer_ids << transfer.id
       end
+
+      GiftCard.where(customer_id: @source.id).order(:id).each do |card|
+        card.update!(customer: @survivor)
+      end
       transfer_ids
     end
 

--- a/app/services/gift_cards.rb
+++ b/app/services/gift_cards.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module GiftCards
+  class Error < StandardError; end
+
+  GENERIC_INQUIRY_FAILURE = "Gift card was not found or cannot be used."
+end

--- a/app/services/gift_cards/associate_customer.rb
+++ b/app/services/gift_cards/associate_customer.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module GiftCards
+  class AssociateCustomer
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(gift_card:, actor:, customer: nil, store: nil, expected_lock_version: nil)
+      @gift_card = gift_card
+      @actor = actor
+      @customer = customer
+      @store = store
+      @expected_lock_version = expected_lock_version
+    end
+
+    def call
+      GiftCard.transaction do
+        card = GiftCard.lock.find(@gift_card.id)
+        raise GiftCards::Error, "replaced or closed cards cannot change association" if card.replaced? || card.closed?
+        assert_lock!(card)
+        before = card.customer_id
+        card.update!(customer: @customer)
+        Audit::Recorder.record!(
+          action: "gift_cards.associate_customer",
+          outcome: "succeeded",
+          actor_user: @actor,
+          store: @store,
+          subject: card,
+          before_values: { customer_id: before },
+          after_values: { customer_id: card.customer_id, number_last_four: card.number_last_four }
+        )
+        card
+      end
+    end
+
+    private
+
+    def assert_lock!(card)
+      return if @expected_lock_version.blank?
+      raise ActiveRecord::StaleObjectError.new(card, "associate") if card.lock_version != @expected_lock_version.to_i
+    end
+  end
+end

--- a/app/services/gift_cards/fund.rb
+++ b/app/services/gift_cards/fund.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module GiftCards
+  class Fund
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(gift_card:, amount_cents:, store:, performed_by:, source_id: nil, idempotency_key: nil)
+      @gift_card = gift_card
+      @amount_cents = amount_cents
+      @store = store
+      @performed_by = performed_by
+      @source_id = source_id || gift_card.id
+      @idempotency_key = idempotency_key || SecureRandom.uuid_v7
+    end
+
+    def call
+      raise GiftCards::Error, "amount must be positive" unless Integer(@amount_cents).positive?
+
+      StoredValue::Post.call(
+        operation_type: "activate",
+        store: @store,
+        performed_by: @performed_by,
+        source_id: @source_id,
+        idempotency_key: @idempotency_key,
+        entries: [ { account: @gift_card.stored_value_account, amount_cents: Integer(@amount_cents) } ]
+      )
+      @gift_card.reload
+    end
+  end
+end

--- a/app/services/gift_cards/luhn.rb
+++ b/app/services/gift_cards/luhn.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module GiftCards
+  module Luhn
+    module_function
+
+    def check_digit(body)
+      digits = body.to_s.chars.map(&:to_i)
+      raise ArgumentError, "Luhn body must be digits" unless body.to_s.match?(/\A\d+\z/)
+
+      sum = luhn_sum("#{body}0")
+      (10 - (sum % 10)) % 10
+    end
+
+    def valid?(value)
+      return false unless value.to_s.match?(/\A\d+\z/)
+      return false if value.to_s.length < 2
+
+      (luhn_sum(value) % 10).zero?
+    end
+
+    def luhn_sum(value)
+      value.to_s.chars.map(&:to_i).reverse.each_with_index.sum do |digit, index|
+        if index.odd?
+          doubled = digit * 2
+          doubled > 9 ? doubled - 9 : doubled
+        else
+          digit
+        end
+      end
+    end
+  end
+end

--- a/app/services/gift_cards/number.rb
+++ b/app/services/gift_cards/number.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module GiftCards
+  module Number
+    module_function
+
+    PHASE10_LENGTH = 20
+
+    def normalize(raw)
+      raw.to_s.gsub(/[\s-]/, "")
+    end
+
+    def digest(normalized)
+      key = Rails.application.config.x.gift_card_number_hmac_key
+      raise GiftCards::Error, "gift-card HMAC key is not configured" if key.blank?
+
+      OpenSSL::HMAC.hexdigest("SHA256", key, normalized)
+    end
+
+    def last_four(normalized)
+      normalized.to_s[-4, 4]
+    end
+
+    def generate(program)
+      prefix = program.prefix
+      length = program.number_length
+      body_length = length - prefix.length - 1
+      raise GiftCards::Error, "program prefix is too long for the number length" if body_length < 1
+
+      25.times do
+        body = format("%0#{body_length}d", SecureRandom.random_number(10**body_length))
+        candidate = "#{prefix}#{body}#{Luhn.check_digit("#{prefix}#{body}")}"
+        next if GiftCard.exists?(number_digest: digest(candidate))
+
+        return candidate
+      end
+      raise GiftCards::Error, "unable to allocate a unique gift-card number"
+    end
+
+    def shape_match?(normalized, program:)
+      normalized.match?(/\A\d+\z/) &&
+        normalized.length == program.number_length &&
+        normalized.start_with?(program.prefix) &&
+        Luhn.valid?(normalized)
+    end
+
+    def matches_active_program?(raw)
+      normalized = normalize(raw)
+      return false unless normalized.match?(/\A\d+\z/)
+
+      GiftCardProgram.active.find_each.any? { |program| shape_match?(normalized, program: program) }
+    end
+  end
+end

--- a/app/services/gift_cards/programs.rb
+++ b/app/services/gift_cards/programs.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module GiftCards
+  module Programs
+    SEEDS = [
+      {
+        code: "generated",
+        name: "Store generated",
+        number_authority: "system_generated",
+        prefix: "801",
+        reload_allowed: true,
+        cash_out_policy: "permitted_when_eligible",
+        cash_out_threshold_cents: 1000,
+        cash_out_threshold_inclusive: true,
+        cash_out_approval_required: false
+      },
+      {
+        code: "manual",
+        name: "Physical / external",
+        number_authority: "manual_external",
+        prefix: "802",
+        reload_allowed: true,
+        cash_out_policy: "prohibited",
+        cash_out_approval_required: false
+      }
+    ].freeze
+
+    def self.seed!
+      SEEDS.each do |attrs|
+        program = GiftCardProgram.find_or_initialize_by(code: attrs[:code])
+        next if program.persisted? && program.activation_exists?
+
+        program.assign_attributes(
+          name: attrs[:name],
+          number_authority: attrs[:number_authority],
+          prefix: attrs[:prefix],
+          number_length: GiftCardProgram::PHASE10_NUMBER_LENGTH,
+          check_digit_algorithm: "luhn",
+          reload_allowed: attrs.fetch(:reload_allowed, true),
+          cash_out_policy: attrs[:cash_out_policy],
+          cash_out_threshold_cents: attrs[:cash_out_threshold_cents],
+          cash_out_threshold_inclusive: attrs.fetch(:cash_out_threshold_inclusive, true),
+          cash_out_approval_required: attrs.fetch(:cash_out_approval_required, false),
+          active: true
+        )
+        program.save!
+      end
+    end
+  end
+end

--- a/app/services/gift_cards/provision_instrument.rb
+++ b/app/services/gift_cards/provision_instrument.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module GiftCards
+  class ProvisionInstrument
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(program:, store:, number: nil, customer: nil, activated_at: Time.current)
+      @program = program
+      @store = store
+      @number = number
+      @customer = customer
+      @activated_at = activated_at
+    end
+
+    def call
+      raise GiftCards::Error, "program is required" if @program.blank?
+      raise GiftCards::Error, "program is not active" unless @program.active?
+      raise GiftCards::Error, "store is required" if @store.blank?
+
+      number = resolved_number
+      validate_number!(number)
+      account = StoredValue::OpenAccount.call(account_type: "gift_card")
+      GiftCard.create!(
+        gift_card_program: @program,
+        stored_value_account: account,
+        number: number,
+        status: "active",
+        customer: @customer,
+        activated_at: @activated_at,
+        activated_store: @store
+      )
+    end
+
+    private
+
+    def resolved_number
+      if @program.system_generated?
+        return GiftCards::Number.generate(@program) if @number.blank?
+
+        GiftCards::Number.normalize(@number)
+      else
+        raise GiftCards::Error, "a card number is required" if @number.blank?
+
+        GiftCards::Number.normalize(@number)
+      end
+    end
+
+    def validate_number!(number)
+      unless GiftCards::Number.shape_match?(number, program: @program)
+        raise GiftCards::Error, "card number is not valid for this program"
+      end
+      if GiftCard.exists?(number_digest: GiftCards::Number.digest(number))
+        raise GiftCards::Error, "card number is already in use"
+      end
+    end
+  end
+end

--- a/app/services/gift_cards/reinstate.rb
+++ b/app/services/gift_cards/reinstate.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module GiftCards
+  class Reinstate
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(gift_card:, actor:, store: nil, expected_lock_version: nil)
+      @gift_card = gift_card
+      @actor = actor
+      @store = store
+      @expected_lock_version = expected_lock_version
+    end
+
+    def call
+      GiftCard.transaction do
+        card = GiftCard.lock.find(@gift_card.id)
+        raise GiftCards::Error, "only suspended gift cards can be reinstated" unless card.suspended?
+        assert_lock!(card)
+        account = StoredValueAccount.lock.find(card.stored_value_account_id)
+        card.update!(status: "active")
+        account.update!(status: "active") unless account.active?
+        Audit::Recorder.record!(
+          action: "gift_cards.reinstate",
+          outcome: "succeeded",
+          actor_user: @actor,
+          store: @store,
+          subject: card,
+          after_values: { status: "active", number_last_four: card.number_last_four }
+        )
+        card
+      end
+    end
+
+    private
+
+    def assert_lock!(card)
+      return if @expected_lock_version.blank?
+      raise ActiveRecord::StaleObjectError.new(card, "reinstate") if card.lock_version != @expected_lock_version.to_i
+    end
+  end
+end

--- a/app/services/gift_cards/replace.rb
+++ b/app/services/gift_cards/replace.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+module GiftCards
+  class Replace
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(
+      gift_card:,
+      performed_by:,
+      store:,
+      source_id:,
+      idempotency_key:,
+      reason_code:,
+      reason_name_snapshot:,
+      number: nil,
+      approved_by: nil,
+      notes: nil,
+      correlation_id: nil
+    )
+      @gift_card = gift_card
+      @performed_by = performed_by
+      @store = store
+      @source_id = source_id
+      @idempotency_key = idempotency_key
+      @reason_code = reason_code
+      @reason_name_snapshot = reason_name_snapshot
+      @number = number
+      @approved_by = approved_by
+      @notes = notes
+      @correlation_id = correlation_id || SecureRandom.uuid_v7
+    end
+
+    def call
+      raise GiftCards::Error, "reason is required" if @reason_code.to_s.strip.blank?
+
+      payload = {
+        original_gift_card_id: @gift_card.id,
+        reason_code: @reason_code.to_s
+      }
+      op = Idempotency::OperationService.begin!(
+        source_id: @source_id,
+        operation_type: "gift_card_replace",
+        idempotency_key: @idempotency_key,
+        payload: payload
+      )
+      if op.replayed
+        return GiftCardReplacement.find(op.operation.result_id) if op.operation.result_id
+
+        raise GiftCards::Error, "idempotent replay missing result"
+      end
+
+      begin
+        result = nil
+        GiftCard.transaction do
+          original = GiftCard.lock.find(@gift_card.id)
+          raise GiftCards::Error, "replaced or closed cards cannot be replaced" if original.replaced? || original.closed?
+
+          account = StoredValueAccount.lock.find(original.stored_value_account_id)
+          amount = account.balance_cents
+          raise GiftCards::Error, "replacement requires a remaining balance" unless amount.positive?
+
+          replacement_card = ProvisionInstrument.call(
+            program: original.gift_card_program,
+            store: @store,
+            number: @number,
+            customer: original.customer
+          )
+          operation = StoredValue::Post.call(
+            operation_type: "transfer",
+            store: @store,
+            performed_by: @performed_by,
+            source_id: @source_id,
+            idempotency_key: SecureRandom.uuid_v7,
+            entries: [
+              { account: account, amount_cents: -amount },
+              { account: replacement_card.stored_value_account, amount_cents: amount }
+            ],
+            reason_code: @reason_code,
+            reason_name_snapshot: @reason_name_snapshot,
+            notes: @notes,
+            outbox_event_type: "gift_card.replaced",
+            correlation_id: @correlation_id
+          )
+          account.reload.close_zero!
+          original.update!(status: "replaced", replaced_by: replacement_card)
+          replacement = GiftCardReplacement.create!(
+            original_gift_card: original,
+            replacement_gift_card: replacement_card,
+            amount_cents: amount,
+            reason_code: @reason_code,
+            reason_name_snapshot: @reason_name_snapshot,
+            notes: @notes,
+            performed_by: @performed_by,
+            approved_by: @approved_by,
+            stored_value_operation: operation,
+            posted_at: Time.current
+          )
+          Idempotency::OperationService.complete!(
+            op.operation,
+            result_type: "GiftCardReplacement",
+            result_id: replacement.id
+          )
+          result = replacement
+        end
+        result
+      rescue GiftCards::Error, StoredValue::Error, ActiveRecord::RecordInvalid, ActiveRecord::StaleObjectError => e
+        Idempotency::OperationService.fail!(op.operation, message: e.message)
+        Audit::Recorder.record!(
+          action: "gift_cards.replace",
+          outcome: "failed",
+          actor_user: @performed_by,
+          store: @store,
+          subject: @gift_card,
+          correlation_id: @correlation_id,
+          reason_text: e.message
+        )
+        raise GiftCards::Error, e.message
+      rescue Idempotency::OperationService::PayloadMismatchError
+        raise
+      end
+    end
+  end
+end

--- a/app/services/gift_cards/resolver.rb
+++ b/app/services/gift_cards/resolver.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module GiftCards
+  class Resolver
+    FAILURE_WINDOW = 15.minutes
+    FAILURE_LIMIT = 8
+
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(raw_number:, actor:, store: nil)
+      @raw_number = raw_number
+      @actor = actor
+      @store = store
+    end
+
+    def call
+      enforce_throttle!
+      normalized = GiftCards::Number.normalize(@raw_number)
+      card = lookup(normalized)
+      unless card
+        record_failure!
+        raise GiftCards::Error, GENERIC_INQUIRY_FAILURE
+      end
+
+      card
+    end
+
+    private
+
+    def lookup(normalized)
+      return if normalized.blank?
+      return unless normalized.match?(/\A\d+\z/)
+
+      digest = GiftCards::Number.digest(normalized)
+      GiftCard.find_by(number_digest: digest)
+    end
+
+    def enforce_throttle!
+      failures = AuditEvent.where(action: "gift_cards.inquiry", outcome: "failed", actor_user_id: @actor&.id)
+                           .where("occurred_at > ?", FAILURE_WINDOW.ago)
+                           .count
+      raise GiftCards::Error, GENERIC_INQUIRY_FAILURE if failures >= FAILURE_LIMIT
+    end
+
+    def record_failure!
+      Audit::Recorder.record!(
+        action: "gift_cards.inquiry",
+        outcome: "failed",
+        actor_user: @actor,
+        store: @store,
+        reason_text: GENERIC_INQUIRY_FAILURE
+      )
+    end
+  end
+end

--- a/app/services/gift_cards/suspend.rb
+++ b/app/services/gift_cards/suspend.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module GiftCards
+  class Suspend
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(gift_card:, actor:, store: nil, expected_lock_version: nil)
+      @gift_card = gift_card
+      @actor = actor
+      @store = store
+      @expected_lock_version = expected_lock_version
+    end
+
+    def call
+      GiftCard.transaction do
+        card = GiftCard.lock.find(@gift_card.id)
+        raise GiftCards::Error, "only active gift cards can be suspended" unless card.active?
+        assert_lock!(card)
+        account = StoredValueAccount.lock.find(card.stored_value_account_id)
+        card.update!(status: "suspended")
+        account.update!(status: "suspended") unless account.suspended?
+        Audit::Recorder.record!(
+          action: "gift_cards.suspend",
+          outcome: "succeeded",
+          actor_user: @actor,
+          store: @store,
+          subject: card,
+          after_values: { status: "suspended", number_last_four: card.number_last_four }
+        )
+        card
+      end
+    end
+
+    private
+
+    def assert_lock!(card)
+      return if @expected_lock_version.blank?
+      raise ActiveRecord::StaleObjectError.new(card, "suspend") if card.lock_version != @expected_lock_version.to_i
+    end
+  end
+end

--- a/app/services/installation/bootstrap.rb
+++ b/app/services/installation/bootstrap.rb
@@ -60,6 +60,7 @@ module Installation
         SubjectSchemes::Catalog.seed!
         Inventory::AdjustmentReasons.seed!
         StoredValue::AdjustmentReasons.seed!
+        GiftCards::Programs.seed!
         Pos::TenderTypes.seed!
 
         Audit::Recorder.record!(

--- a/app/services/stored_value/adjust.rb
+++ b/app/services/stored_value/adjust.rb
@@ -113,9 +113,10 @@ module StoredValue
       end
     end
 
-    def self.second_user_required?(direction:, amount_cents:, reason:)
+    def self.second_user_required?(direction:, amount_cents:, reason:, account: nil)
       return true if direction.to_s == "debit"
       return true if reason.approval_required
+      return true if account&.account_type == "gift_card" && account.gift_card&.suspended?
 
       threshold = SystemSettings.current.stored_value_adjust_credit_approval_threshold_cents
       Integer(amount_cents) >= threshold
@@ -140,9 +141,26 @@ module StoredValue
       if account.customer_owned?
         customer = account.customer
         raise Error, "inactive customers cannot receive new credit" if @direction == "credit" && !customer.active?
-      else
-        raise Error, "gift-card adjustments are not available until gift-card instruments exist" if account.account_type == "gift_card"
+      elsif account.account_type == "gift_card"
+        validate_gift_card!(account)
       end
+    end
+
+    def validate_gift_card!(account)
+      card = account.gift_card
+      raise Error, "gift-card instrument is missing" if card.blank?
+      raise Error, "replaced gift cards cannot be adjusted" if card.replaced?
+      raise Error, "closed gift cards cannot be adjusted" if card.closed?
+      if card.suspended?
+        raise Error, "second-user approval is required for suspended gift cards" if @approved_by.blank?
+        raise Error, "approver cannot be the performer" if @approved_by.id == @performed_by.id
+      end
+      return unless @direction == "credit"
+
+      maximum = card.gift_card_program.maximum_balance_cents
+      return if maximum.blank?
+
+      raise Error, "credit would exceed the program maximum balance" if account.balance_cents + Integer(@amount_cents) > maximum
     end
   end
 end

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -140,6 +140,24 @@
   </section>
 <% end %>
 
+<% if @associated_gift_cards %>
+  <section class="section surface">
+    <h2 class="section__title">Associated gift cards</h2>
+    <% if @associated_gift_cards.any? %>
+      <% rows = @associated_gift_cards.map { |card|
+           [
+             link_to(card.masked_number, admin_gift_card_path(card)),
+             card.status.humanize,
+             format_money_cents(card.balance_cents)
+           ]
+         } %>
+      <%= render "shared/data_table", headers: ["Card", "Status", "Balance"], rows: rows %>
+    <% else %>
+      <%= render "shared/empty_state", title: "No associated gift cards", body: "Optional association does not transfer ownership of the balance." %>
+    <% end %>
+  </section>
+<% end %>
+
 <section class="section">
   <h2 class="section__title">Recent requests</h2>
   <% if effective_permissions.include?("customer_requests.manage") && @customer.canonical? && @customer.active? %>

--- a/app/views/admin/gift_card_adjustments/new.html.erb
+++ b/app/views/admin/gift_card_adjustments/new.html.erb
@@ -1,0 +1,34 @@
+<% content_for :title, "Adjust gift card" %>
+<%= render "shared/page_header", title: "Adjust #{@gift_card.masked_number}" %>
+<%= form_with url: admin_gift_card_stored_value_adjustments_path(@gift_card), method: :post, class: "form" do |form| %>
+  <%= hidden_field_tag :idempotency_key, params[:idempotency_key].presence || SecureRandom.uuid_v7 %>
+  <p>Current balance: <%= format_money_cents(@account.balance_cents) %></p>
+  <div class="form-field">
+    <%= label_tag :direction, "Direction" %>
+    <%= select_tag :direction, options_for_select([%w[Credit credit], %w[Debit debit]], params[:direction]) %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :amount, "Amount" %>
+    <%= text_field_tag :amount, params[:amount], required: true %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :reason_id, "Reason" %>
+    <%= select_tag :reason_id, options_from_collection_for_select(@reasons, :id, :name, params[:reason_id]) %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :internal_notes, "Internal notes" %>
+    <%= text_area_tag :internal_notes, params[:internal_notes], rows: 3 %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :approver_username, "Approver username" %>
+    <%= text_field_tag :approver_username, params[:approver_username] %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :approver_password, "Approver password" %>
+    <%= password_field_tag :approver_password %>
+  </div>
+  <div class="actions">
+    <%= action_submit(form, "Post adjustment", style: :solid, intent: :brand) %>
+    <%= action_link_to("Cancel", admin_gift_card_path(@gift_card), style: :ghost, intent: :neutral) %>
+  </div>
+<% end %>

--- a/app/views/admin/gift_card_programs/_form.html.erb
+++ b/app/views/admin/gift_card_programs/_form.html.erb
@@ -1,0 +1,39 @@
+<%= form_with model: [:admin, program], class: "form" do |form| %>
+  <%= render "shared/form_errors", record: program %>
+  <%= form.hidden_field :lock_version %>
+  <%= form.hidden_field :number_length %>
+  <%= form.hidden_field :check_digit_algorithm %>
+  <% unless program.persisted? %>
+    <div class="form-field"><%= form.label :code %><%= form.text_field :code %></div>
+  <% end %>
+  <div class="form-field"><%= form.label :name %><%= form.text_field :name %></div>
+  <div class="form-field"><%= form.label :prefix %><%= form.text_field :prefix, readonly: program.activation_exists? %></div>
+  <div class="form-field">
+    <%= form.label :number_authority %>
+    <%= form.select :number_authority, GiftCardProgram::AUTHORITIES.map { |value| [value.humanize, value] }, {}, disabled: program.activation_exists? %>
+  </div>
+  <div class="form-field">
+    <%= form.check_box :reload_allowed %>
+    <%= form.label :reload_allowed, "Reload allowed" %>
+  </div>
+  <div class="form-field">
+    <%= form.label :maximum_balance_cents, "Maximum balance (cents)" %>
+    <%= form.number_field :maximum_balance_cents %>
+  </div>
+  <div class="form-field">
+    <%= form.label :cash_out_policy %>
+    <%= form.select :cash_out_policy, GiftCardProgram::CASH_OUT_POLICIES.map { |value| [value.humanize, value] } %>
+  </div>
+  <div class="form-field">
+    <%= form.label :cash_out_threshold_cents, "Cash-out threshold (cents)" %>
+    <%= form.number_field :cash_out_threshold_cents %>
+  </div>
+  <div class="form-field">
+    <%= form.check_box :cash_out_approval_required %>
+    <%= form.label :cash_out_approval_required, "Cash-out requires second-user approval" %>
+  </div>
+  <div class="actions">
+    <%= action_submit(form, program.persisted? ? "Save Changes" : "Create program", style: :solid, intent: :brand) %>
+    <%= action_link_to("Cancel", program.persisted? ? admin_gift_card_program_path(program) : admin_gift_card_programs_path, style: :ghost, intent: :neutral) %>
+  </div>
+<% end %>

--- a/app/views/admin/gift_card_programs/edit.html.erb
+++ b/app/views/admin/gift_card_programs/edit.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "Edit #{@program.code}" %>
+<%= render "shared/page_header", title: "Edit #{@program.name}" %>
+<%= render "form", program: @program %>

--- a/app/views/admin/gift_card_programs/index.html.erb
+++ b/app/views/admin/gift_card_programs/index.html.erb
@@ -1,0 +1,18 @@
+<% content_for :title, "Gift-card programs" %>
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Gift-card programs" }
+] %>
+<%= render "shared/page_header",
+      title: "Gift-card programs",
+      actions: action_link_to("New program", new_admin_gift_card_program_path, style: :solid, intent: :brand) %>
+<% rows = @programs.map { |program|
+     [
+       link_to(program.code, admin_gift_card_program_path(program)),
+       program.name,
+       program.prefix,
+       program.number_authority.humanize,
+       configuration_status_badge(program.active?)
+     ]
+   } %>
+<%= render "shared/data_table", headers: ["Code", "Name", "Prefix", "Authority", "Status"], rows: rows %>

--- a/app/views/admin/gift_card_programs/new.html.erb
+++ b/app/views/admin/gift_card_programs/new.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "New gift-card program" %>
+<%= render "shared/page_header", title: "New gift-card program" %>
+<%= render "form", program: @program %>

--- a/app/views/admin/gift_card_programs/show.html.erb
+++ b/app/views/admin/gift_card_programs/show.html.erb
@@ -1,0 +1,24 @@
+<% content_for :title, @program.code %>
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Gift-card programs", path: admin_gift_card_programs_path },
+  { name: @program.code }
+] %>
+<% actions = [configuration_status_badge(@program.active?)] %>
+<% if @program.active? %>
+  <% actions << action_link_to("Edit", edit_admin_gift_card_program_path(@program), style: :outline, intent: :neutral) %>
+  <% actions << action_button_to("Deactivate", admin_gift_card_program_path(@program), method: :delete, style: :outline, intent: :warning) %>
+<% else %>
+  <% actions << action_button_to("Reactivate", reactivate_admin_gift_card_program_path(@program), method: :post, style: :solid, intent: :brand) %>
+<% end %>
+<%= render "shared/page_header", title: @program.name, actions: safe_join(actions, " ") %>
+<%= render "shared/definition_list", rows: [
+      ["Code", @program.code],
+      ["Prefix", @program.prefix],
+      ["Length", @program.number_length],
+      ["Authority", @program.number_authority.humanize],
+      ["Reload allowed", @program.reload_allowed? ? "Yes" : "No"],
+      ["Cash-out policy", @program.cash_out_policy.humanize],
+      ["Cash-out approval required", @program.cash_out_approval_required? ? "Yes" : "No"],
+      ["Maximum balance", (@program.maximum_balance_cents ? format_money_cents(@program.maximum_balance_cents) : "None")]
+    ] %>

--- a/app/views/admin/gift_cards/associate.html.erb
+++ b/app/views/admin/gift_cards/associate.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, "Associate customer" %>
+<%= render "shared/page_header", title: "Associate #{@gift_card.masked_number}" %>
+<%= form_with url: associate_admin_gift_card_path(@gift_card), method: :patch, class: "form" do |form| %>
+  <%= hidden_field_tag :lock_version, @gift_card.lock_version %>
+  <div class="form-field">
+    <%= label_tag :customer_id, "Customer ID (blank to clear)" %>
+    <%= text_field_tag :customer_id, params[:customer_id] || @gift_card.customer_id %>
+  </div>
+  <div class="actions">
+    <%= action_submit(form, "Save association", style: :solid, intent: :brand) %>
+    <%= action_link_to("Cancel", admin_gift_card_path(@gift_card), style: :ghost, intent: :neutral) %>
+  </div>
+<% end %>

--- a/app/views/admin/gift_cards/index.html.erb
+++ b/app/views/admin/gift_cards/index.html.erb
@@ -1,0 +1,18 @@
+<% content_for :title, "Gift cards" %>
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Gift cards" }
+] %>
+<%= render "shared/page_header",
+      title: "Gift cards",
+      actions: action_link_to("Inquire", inquiry_admin_gift_cards_path, style: :solid, intent: :brand) %>
+<p class="muted">Inquiry is exact-match only. Lists show prefix and last four, never the full number.</p>
+<% rows = @gift_cards.map { |card|
+     [
+       link_to(card.masked_number, admin_gift_card_path(card)),
+       card.gift_card_program.name,
+       format_money_cents(card.balance_cents),
+       card.status.humanize
+     ]
+   } %>
+<%= render "shared/data_table", headers: ["Card", "Program", "Balance", "Status"], rows: rows %>

--- a/app/views/admin/gift_cards/inquiry.html.erb
+++ b/app/views/admin/gift_cards/inquiry.html.erb
@@ -1,0 +1,16 @@
+<% content_for :title, "Gift-card inquiry" %>
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Gift cards", path: admin_gift_cards_path },
+  { name: "Inquiry" }
+] %>
+<%= render "shared/page_header", title: "Inquire by number" %>
+<%= form_with url: inquiry_admin_gift_cards_path, method: :post, class: "form" do |form| %>
+  <div class="form-field">
+    <%= label_tag :card_number, "Card number" %>
+    <%= password_field_tag :card_number, nil, autocomplete: "off" %>
+  </div>
+  <div class="actions">
+    <%= action_submit(form, "Look up", style: :solid, intent: :brand) %>
+  </div>
+<% end %>

--- a/app/views/admin/gift_cards/replace.html.erb
+++ b/app/views/admin/gift_cards/replace.html.erb
@@ -1,0 +1,24 @@
+<% content_for :title, "Replace #{@gift_card.masked_number}" %>
+<%= render "shared/page_header", title: "Replace #{@gift_card.masked_number}" %>
+<p>Remaining balance <%= format_money_cents(@gift_card.balance_cents) %> moves to a new instrument. The original card is marked replaced.</p>
+<%= form_with url: replace_admin_gift_card_path(@gift_card), method: :post, class: "form" do |form| %>
+  <%= hidden_field_tag :idempotency_key, params[:idempotency_key].presence || SecureRandom.uuid_v7 %>
+  <div class="form-field">
+    <%= label_tag :reason_code, "Reason code" %>
+    <%= text_field_tag :reason_code, params[:reason_code], required: true %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :notes, "Notes" %>
+    <%= text_area_tag :notes, params[:notes], rows: 3 %>
+  </div>
+  <% if @gift_card.gift_card_program.manual_external? %>
+    <div class="form-field">
+      <%= label_tag :card_number, "Replacement card number" %>
+      <%= password_field_tag :card_number, nil, autocomplete: "off" %>
+    </div>
+  <% end %>
+  <div class="actions">
+    <%= action_submit(form, "Post replacement", style: :solid, intent: :brand) %>
+    <%= action_link_to("Cancel", admin_gift_card_path(@gift_card), style: :ghost, intent: :neutral) %>
+  </div>
+<% end %>

--- a/app/views/admin/gift_cards/show.html.erb
+++ b/app/views/admin/gift_cards/show.html.erb
@@ -1,0 +1,30 @@
+<% content_for :title, @gift_card.masked_number %>
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Gift cards", path: admin_gift_cards_path },
+  { name: @gift_card.masked_number }
+] %>
+<% actions = [] %>
+<% if @gift_card.active? && effective_permissions.include?("gift_cards.suspend") %>
+  <% actions << action_button_to("Suspend", suspend_admin_gift_card_path(@gift_card), method: :post, style: :outline, intent: :warning, params: { lock_version: @gift_card.lock_version }) %>
+<% end %>
+<% if @gift_card.suspended? && effective_permissions.include?("gift_cards.suspend") %>
+  <% actions << action_button_to("Reinstate", reinstate_admin_gift_card_path(@gift_card), method: :post, style: :solid, intent: :brand, params: { lock_version: @gift_card.lock_version }) %>
+<% end %>
+<% if (@gift_card.active? || @gift_card.suspended?) && effective_permissions.include?("gift_cards.replace") %>
+  <% actions << action_link_to("Replace", replace_admin_gift_card_path(@gift_card), style: :outline, intent: :neutral) %>
+<% end %>
+<% if !@gift_card.replaced? && !@gift_card.closed? && effective_permissions.include?("gift_cards.associate_customer") %>
+  <% actions << action_link_to("Associate customer", associate_admin_gift_card_path(@gift_card), style: :outline, intent: :neutral) %>
+<% end %>
+<% if !@gift_card.replaced? && !@gift_card.closed? && effective_permissions.include?("stored_value.adjust") %>
+  <% actions << action_link_to("Adjust", new_admin_gift_card_stored_value_adjustment_path(@gift_card), style: :outline, intent: :neutral) %>
+<% end %>
+<%= render "shared/page_header", title: @gift_card.masked_number, actions: safe_join(actions, " ") %>
+<%= render "shared/definition_list", rows: [
+      ["Program", @gift_card.gift_card_program.name],
+      ["Status", @gift_card.status.humanize],
+      ["Balance", format_money_cents(@gift_card.balance_cents)],
+      ["Customer", (@gift_card.customer ? link_to(@gift_card.customer.admin_label, admin_customer_path(@gift_card.customer)) : "None")],
+      ["Activated store", @gift_card.activated_store.admin_label]
+    ] %>

--- a/config/initializers/active_record_encryption.rb
+++ b/config/initializers/active_record_encryption.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require Rails.root.join("lib/shelfsense/test_secrets")
+
+Rails.application.configure do
+  test_keys = !Rails.env.production?
+  primary = ENV["ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY"].presence
+  deterministic = ENV["ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY"].presence
+  salt = ENV["ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT"].presence
+  hmac = ENV["GIFT_CARD_NUMBER_HMAC_KEY"].presence
+
+  if test_keys
+    primary ||= Shelfsense::TestSecrets::ENCRYPTION_PRIMARY_KEY
+    deterministic ||= Shelfsense::TestSecrets::ENCRYPTION_DETERMINISTIC_KEY
+    salt ||= Shelfsense::TestSecrets::ENCRYPTION_KEY_DERIVATION_SALT
+    hmac ||= Shelfsense::TestSecrets::GIFT_CARD_NUMBER_HMAC_KEY
+  elsif [ primary, deterministic, salt, hmac ].any?(&:blank?)
+    raise "Active Record Encryption keys and GIFT_CARD_NUMBER_HMAC_KEY must be set in production"
+  end
+
+  config.active_record.encryption.primary_key = primary
+  config.active_record.encryption.deterministic_key = deterministic
+  config.active_record.encryption.key_derivation_salt = salt
+  config.x.gift_card_number_hmac_key = hmac
+end

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -5,5 +5,5 @@
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += [
   :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc,
-  :isbndb_api_key
+  :isbndb_api_key, :card_number, :pending_card_number, :gift_card_number
 ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,6 +114,24 @@ Rails.application.routes.draw do
       member { post :reactivate }
     end
     resources :stored_value_transfers, only: %i[new create]
+    resources :gift_card_programs do
+      member { post :reactivate }
+    end
+    resources :gift_cards, only: %i[index show] do
+      collection do
+        get :inquiry
+        post :inquiry, action: :resolve_inquiry
+      end
+      member do
+        post :suspend
+        post :reinstate
+        get :replace
+        post :replace, action: :create_replacement
+        get :associate
+        patch :associate, action: :update_association
+      end
+      resources :stored_value_adjustments, only: %i[new create], controller: "gift_card_adjustments"
+    end
     resources :customer_requests, only: %i[index show new create] do
       collection do
         get :customer_lookup

--- a/db/migrate/20260826030000_create_phase10_gift_card_instruments.rb
+++ b/db/migrate/20260826030000_create_phase10_gift_card_instruments.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+class CreatePhase10GiftCardInstruments < ActiveRecord::Migration[8.1]
+  def change
+    create_uuid_table :gift_card_programs do |t|
+      t.string :code, null: false
+      t.string :name, null: false
+      t.string :number_authority, null: false
+      t.string :prefix, null: false
+      t.integer :number_length, null: false, default: 20
+      t.string :check_digit_algorithm, null: false, default: "luhn"
+      t.boolean :reload_allowed, null: false, default: true
+      t.bigint :minimum_activation_cents
+      t.bigint :maximum_balance_cents
+      t.string :cash_out_policy, null: false
+      t.bigint :cash_out_threshold_cents
+      t.boolean :cash_out_threshold_inclusive, null: false, default: true
+      t.boolean :cash_out_approval_required, null: false, default: false
+      t.boolean :active, null: false, default: true
+      t.integer :lock_version, null: false, default: 0
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+    add_index :gift_card_programs, :code, unique: true
+    add_index :gift_card_programs, :prefix, unique: true
+    add_check_constraint :gift_card_programs,
+                         "number_authority IN ('system_generated', 'manual_external')",
+                         name: "gift_card_programs_authority_valid"
+    add_check_constraint :gift_card_programs,
+                         "check_digit_algorithm = 'luhn'",
+                         name: "gift_card_programs_check_digit_valid"
+    add_check_constraint :gift_card_programs,
+                         "number_length = 20",
+                         name: "gift_card_programs_length_phase10"
+    add_check_constraint :gift_card_programs,
+                         "cash_out_policy IN ('prohibited', 'permitted_when_eligible', 'required_on_request_when_eligible')",
+                         name: "gift_card_programs_cash_out_policy_valid"
+    add_check_constraint :gift_card_programs,
+                         "prefix ~ '^[0-9]+$'",
+                         name: "gift_card_programs_prefix_numeric"
+
+    create_uuid_table :gift_cards do |t|
+      t.uuid :gift_card_program_id, null: false
+      t.uuid :stored_value_account_id, null: false
+      t.text :number, null: false
+      t.string :number_digest, null: false
+      t.string :number_prefix, null: false
+      t.string :number_last_four, null: false
+      t.string :status, null: false, default: "active"
+      t.uuid :customer_id
+      t.timestamptz :activated_at, null: false
+      t.uuid :activated_store_id, null: false
+      t.uuid :replaced_by_id
+      t.timestamptz :closed_at
+      t.integer :lock_version, null: false, default: 0
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+    add_index :gift_cards, :number_digest, unique: true
+    add_index :gift_cards, :stored_value_account_id, unique: true
+    add_index :gift_cards, :gift_card_program_id
+    add_index :gift_cards, :customer_id
+    add_foreign_key :gift_cards, :gift_card_programs
+    add_foreign_key :gift_cards, :stored_value_accounts
+    add_foreign_key :gift_cards, :customers
+    add_foreign_key :gift_cards, :stores, column: :activated_store_id
+    add_foreign_key :gift_cards, :gift_cards, column: :replaced_by_id
+    add_check_constraint :gift_cards,
+                         "status IN ('active', 'suspended', 'replaced', 'closed')",
+                         name: "gift_cards_status_valid"
+    add_check_constraint :gift_cards,
+                         "char_length(number_last_four) = 4",
+                         name: "gift_cards_last_four_length"
+
+    create_uuid_table :gift_card_replacements do |t|
+      t.uuid :original_gift_card_id, null: false
+      t.uuid :replacement_gift_card_id, null: false
+      t.bigint :amount_cents, null: false
+      t.string :reason_code, null: false
+      t.string :reason_name_snapshot, null: false
+      t.text :notes
+      t.uuid :performed_by_id, null: false
+      t.uuid :approved_by_id
+      t.uuid :stored_value_operation_id
+      t.timestamptz :posted_at, null: false
+      t.uuid :reversal_of_id
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+    add_index :gift_card_replacements, :stored_value_operation_id, unique: true, where: "stored_value_operation_id IS NOT NULL"
+    add_index :gift_card_replacements, :reversal_of_id, unique: true, where: "reversal_of_id IS NOT NULL"
+    add_index :gift_card_replacements, :original_gift_card_id, unique: true,
+              where: "reversal_of_id IS NULL",
+              name: "index_gift_card_replacements_one_effective_per_original"
+    add_index :gift_card_replacements, :replacement_gift_card_id
+    add_foreign_key :gift_card_replacements, :gift_cards, column: :original_gift_card_id
+    add_foreign_key :gift_card_replacements, :gift_cards, column: :replacement_gift_card_id
+    add_foreign_key :gift_card_replacements, :users, column: :performed_by_id
+    add_foreign_key :gift_card_replacements, :users, column: :approved_by_id
+    add_foreign_key :gift_card_replacements, :stored_value_operations
+    add_foreign_key :gift_card_replacements, :gift_card_replacements, column: :reversal_of_id
+    add_check_constraint :gift_card_replacements,
+                         "amount_cents > 0",
+                         name: "gift_card_replacements_amount_positive"
+    add_check_constraint :gift_card_replacements,
+                         "original_gift_card_id <> replacement_gift_card_id",
+                         name: "gift_card_replacements_cards_differ"
+    add_check_constraint :gift_card_replacements,
+                         "approved_by_id IS NULL OR approved_by_id <> performed_by_id",
+                         name: "gift_card_replacements_approver_differs"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_26_020000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_26_030000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -220,6 +220,80 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_020000) do
     t.index ["sales_returns_gl_account_id"], name: "index_departments_on_sales_returns_gl_account_id"
     t.index ["sales_revenue_gl_account_id"], name: "index_departments_on_sales_revenue_gl_account_id"
     t.check_constraint "code::text ~ '^[a-z0-9]+(_[a-z0-9]+)*$'::text", name: "departments_code_format"
+  end
+
+  create_table "gift_card_programs", id: :uuid, default: nil, force: :cascade do |t|
+    t.boolean "active", default: true, null: false
+    t.boolean "cash_out_approval_required", default: false, null: false
+    t.string "cash_out_policy", null: false
+    t.bigint "cash_out_threshold_cents"
+    t.boolean "cash_out_threshold_inclusive", default: true, null: false
+    t.string "check_digit_algorithm", default: "luhn", null: false
+    t.string "code", null: false
+    t.timestamptz "created_at", null: false
+    t.integer "lock_version", default: 0, null: false
+    t.bigint "maximum_balance_cents"
+    t.bigint "minimum_activation_cents"
+    t.string "name", null: false
+    t.string "number_authority", null: false
+    t.integer "number_length", default: 20, null: false
+    t.string "prefix", null: false
+    t.boolean "reload_allowed", default: true, null: false
+    t.timestamptz "updated_at", null: false
+    t.index ["code"], name: "index_gift_card_programs_on_code", unique: true
+    t.index ["prefix"], name: "index_gift_card_programs_on_prefix", unique: true
+    t.check_constraint "cash_out_policy::text = ANY (ARRAY['prohibited'::character varying, 'permitted_when_eligible'::character varying, 'required_on_request_when_eligible'::character varying]::text[])", name: "gift_card_programs_cash_out_policy_valid"
+    t.check_constraint "check_digit_algorithm::text = 'luhn'::text", name: "gift_card_programs_check_digit_valid"
+    t.check_constraint "number_authority::text = ANY (ARRAY['system_generated'::character varying, 'manual_external'::character varying]::text[])", name: "gift_card_programs_authority_valid"
+    t.check_constraint "number_length = 20", name: "gift_card_programs_length_phase10"
+    t.check_constraint "prefix::text ~ '^[0-9]+$'::text", name: "gift_card_programs_prefix_numeric"
+  end
+
+  create_table "gift_card_replacements", id: :uuid, default: nil, force: :cascade do |t|
+    t.bigint "amount_cents", null: false
+    t.uuid "approved_by_id"
+    t.timestamptz "created_at", null: false
+    t.text "notes"
+    t.uuid "original_gift_card_id", null: false
+    t.uuid "performed_by_id", null: false
+    t.timestamptz "posted_at", null: false
+    t.string "reason_code", null: false
+    t.string "reason_name_snapshot", null: false
+    t.uuid "replacement_gift_card_id", null: false
+    t.uuid "reversal_of_id"
+    t.uuid "stored_value_operation_id"
+    t.timestamptz "updated_at", null: false
+    t.index ["original_gift_card_id"], name: "index_gift_card_replacements_one_effective_per_original", unique: true, where: "(reversal_of_id IS NULL)"
+    t.index ["replacement_gift_card_id"], name: "index_gift_card_replacements_on_replacement_gift_card_id"
+    t.index ["reversal_of_id"], name: "index_gift_card_replacements_on_reversal_of_id", unique: true, where: "(reversal_of_id IS NOT NULL)"
+    t.index ["stored_value_operation_id"], name: "index_gift_card_replacements_on_stored_value_operation_id", unique: true, where: "(stored_value_operation_id IS NOT NULL)"
+    t.check_constraint "amount_cents > 0", name: "gift_card_replacements_amount_positive"
+    t.check_constraint "approved_by_id IS NULL OR approved_by_id <> performed_by_id", name: "gift_card_replacements_approver_differs"
+    t.check_constraint "original_gift_card_id <> replacement_gift_card_id", name: "gift_card_replacements_cards_differ"
+  end
+
+  create_table "gift_cards", id: :uuid, default: nil, force: :cascade do |t|
+    t.timestamptz "activated_at", null: false
+    t.uuid "activated_store_id", null: false
+    t.timestamptz "closed_at"
+    t.timestamptz "created_at", null: false
+    t.uuid "customer_id"
+    t.uuid "gift_card_program_id", null: false
+    t.integer "lock_version", default: 0, null: false
+    t.text "number", null: false
+    t.string "number_digest", null: false
+    t.string "number_last_four", null: false
+    t.string "number_prefix", null: false
+    t.uuid "replaced_by_id"
+    t.string "status", default: "active", null: false
+    t.uuid "stored_value_account_id", null: false
+    t.timestamptz "updated_at", null: false
+    t.index ["customer_id"], name: "index_gift_cards_on_customer_id"
+    t.index ["gift_card_program_id"], name: "index_gift_cards_on_gift_card_program_id"
+    t.index ["number_digest"], name: "index_gift_cards_on_number_digest", unique: true
+    t.index ["stored_value_account_id"], name: "index_gift_cards_on_stored_value_account_id", unique: true
+    t.check_constraint "char_length(number_last_four::text) = 4", name: "gift_cards_last_four_length"
+    t.check_constraint "status::text = ANY (ARRAY['active'::character varying, 'suspended'::character varying, 'replaced'::character varying, 'closed'::character varying]::text[])", name: "gift_cards_status_valid"
   end
 
   create_table "gl_accounts", id: :uuid, default: nil, force: :cascade do |t|
@@ -1531,6 +1605,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_020000) do
   add_foreign_key "departments", "gl_accounts", column: "receiving_clearing_gl_account_id"
   add_foreign_key "departments", "gl_accounts", column: "sales_returns_gl_account_id"
   add_foreign_key "departments", "gl_accounts", column: "sales_revenue_gl_account_id"
+  add_foreign_key "gift_card_replacements", "gift_card_replacements", column: "reversal_of_id"
+  add_foreign_key "gift_card_replacements", "gift_cards", column: "original_gift_card_id"
+  add_foreign_key "gift_card_replacements", "gift_cards", column: "replacement_gift_card_id"
+  add_foreign_key "gift_card_replacements", "stored_value_operations"
+  add_foreign_key "gift_card_replacements", "users", column: "approved_by_id"
+  add_foreign_key "gift_card_replacements", "users", column: "performed_by_id"
+  add_foreign_key "gift_cards", "customers"
+  add_foreign_key "gift_cards", "gift_card_programs"
+  add_foreign_key "gift_cards", "gift_cards", column: "replaced_by_id"
+  add_foreign_key "gift_cards", "stored_value_accounts"
+  add_foreign_key "gift_cards", "stores", column: "activated_store_id"
   add_foreign_key "gl_accounts", "gl_accounts", column: "parent_id"
   add_foreign_key "identifier_registry", "inventory_units", on_delete: :nullify
   add_foreign_key "identifier_registry", "product_variants", on_delete: :nullify

--- a/docs/development.md
+++ b/docs/development.md
@@ -86,6 +86,19 @@ The `db` hostname is the Compose service name and is reachable from the `web` co
 
 The PostgreSQL image applies `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB` only when initializing an empty data volume. Changing those values in `compose.yml` does not rewrite an existing database volume.
 
+## Gift-card encryption keys (Phase 10)
+
+Gift-card numbers use Rails Active Record Encryption plus a separate HMAC digest ([ADR-026](adr/ADR-026-gift-card-number-protection.md)). Docker, test, and CI use the documented **test** keys in `lib/shelfsense/test_secrets.rb` when environment variables are unset. These values are not production secrets.
+
+| Variable | Purpose |
+|---|---|
+| `ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY` | Rails `encrypts` primary key |
+| `ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY` | Rails deterministic key (unused by gift-card numbers; still required by Rails) |
+| `ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT` | Rails key-derivation salt |
+| `GIFT_CARD_NUMBER_HMAC_KEY` | HMAC-SHA256 lookup digest (not an Active Record Encryption key) |
+
+Production must set all four from the deployment environment. Do not commit production keys, plaintext gift-card numbers, or decryptable fixtures. Tests generate synthetic numbers and encrypt them with the test keys. Existing installations need `shelfsense:seed_permissions` (and `GiftCards::Programs.seed!`) after this slice.
+
 Do not commit production credentials. Production values must come from the deployment environment. The ERB in `config/database.yml` must not use strict `ENV.fetch` calls without defaults for production-only variables, because Rails evaluates the entire file before selecting an environment; strict production lookups would also break development and CI startup.
 
 Optional catalog enrichment (Phase 9) reads `ISBNDB_API_KEY` from the environment. Leave it unset in CI; tests stub the HTTP client. For local live lookups, copy `.env.example` to `.env` (gitignored) and set the key. Docker Compose interpolates it into the `web` service. Recreate that service after changing `.env` (`docker compose up -d --force-recreate web`). Never commit the key, a filled `.env`, or `compose.override.yml`; never log the key or store it in audit events.

--- a/docs/planning/phase10-stored-value/phase10-implementation-plan.md
+++ b/docs/planning/phase10-stored-value/phase10-implementation-plan.md
@@ -51,7 +51,7 @@ Issue branches PR **directly to `main`**. There is no `phase-10-stored-value` in
 |---|---|
 | 10.1 Stored-value core | Complete (issue [#59](https://github.com/BankEncore/ShelfSense-v1/issues/59)) |
 | 10.2 Customer store/trade credit | Complete (issue [#60](https://github.com/BankEncore/ShelfSense-v1/issues/60)) |
-| 10.3 Gift-card programs and instruments | Not started |
+| 10.3 Gift-card programs and instruments | Complete (issue [#61](https://github.com/BankEncore/ShelfSense-v1/issues/61)) |
 | 10.4 POS issuance, tenders, refund destinations, post-void | Not started |
 | 10.5 Cash-out, closeout, print, nav | Not started |
 

--- a/docs/planning/ux-design-system/navigation-proposal.md
+++ b/docs/planning/ux-design-system/navigation-proposal.md
@@ -162,6 +162,6 @@ Destinations land in the slice that introduces the screens. Do not add one-off h
 | **Customers** | Stored-value transfers → `new_admin_stored_value_transfer_path` | `stored_value.transfer` | 10.2 |
 | **Organization configuration** | Stored-value reasons → `admin_stored_value_adjustment_reasons_path` | `stored_value.manage_adjustment_reasons` | 10.2 |
 | **POS operations** | Gift-card programs → `admin_gift_card_programs_path` | `gift_cards.manage_programs` | 10.3 |
-| **POS operations** | Gift cards → `admin_gift_cards_path` | `gift_cards.view` | 10.3 |
+| **POS operations** | Gift cards → `inquiry_admin_gift_cards_path` | `gift_cards.view` | 10.3 |
 
 Exact path helpers are illustrative. Implementation must keep controllers as the authorization boundary.

--- a/lib/shelfsense/test_secrets.rb
+++ b/lib/shelfsense/test_secrets.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Documented non-production Active Record Encryption keys and HMAC secret.
+# Production must set these via the environment. Do not use these values outside
+# local Docker, test, and CI. See docs/development.md.
+module Shelfsense
+  module TestSecrets
+    ENCRYPTION_PRIMARY_KEY = "0000000000000000000000000000000000000000000000000000000000000001"
+    ENCRYPTION_DETERMINISTIC_KEY = "0000000000000000000000000000000000000000000000000000000000000002"
+    ENCRYPTION_KEY_DERIVATION_SALT = "0000000000000000000000000000000000000000000000000000000000000003"
+    GIFT_CARD_NUMBER_HMAC_KEY = "shelfsense-test-gift-card-hmac-key-not-for-production"
+  end
+end

--- a/lib/tasks/shelfsense.rake
+++ b/lib/tasks/shelfsense.rake
@@ -50,6 +50,7 @@ namespace :shelfsense do
     ProductForms::Catalog.seed!
     SubjectSchemes::Catalog.seed!
     StoredValue::AdjustmentReasons.seed!
+    GiftCards::Programs.seed!
     after = Role.find_by!(key: "system_administrator").permissions.pluck(:key)
 
     added = after - before

--- a/test/integration/gift_cards_admin_test.rb
+++ b/test/integration/gift_cards_admin_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class GiftCardsAdminTest < ActionDispatch::IntegrationTest
+  setup do
+    @bootstrap = bootstrap!
+    @admin = @bootstrap[:administrator]
+    @store = @bootstrap[:store]
+    GiftCards::Programs.seed!
+    @program = GiftCardProgram.find_by!(code: "generated")
+  end
+
+  test "inquiry finds a masked card and never renders the full number" do
+    number = GiftCards::Number.generate(@program)
+    card = GiftCards::ProvisionInstrument.call(program: @program, store: @store, number: number)
+    GiftCards::Fund.call(gift_card: card, amount_cents: 150, store: @store, performed_by: @admin)
+
+    sign_in_as("admin")
+    get inquiry_admin_gift_cards_path
+    assert_response :success
+
+    post inquiry_admin_gift_cards_path, params: { card_number: number }
+    assert_redirected_to admin_gift_card_path(card)
+    follow_redirect!
+    assert_response :success
+    assert_includes response.body, card.masked_number
+    assert_not_includes response.body, number
+    get admin_products_path
+    assert_includes response.body, inquiry_admin_gift_cards_path
+    assert_includes response.body, admin_gift_card_programs_path
+  end
+
+  test "associates cannot inquire gift cards" do
+    associate = User.create!(
+      username: "gc_associate",
+      display_name: "GC Associate",
+      password: "correct-horse-battery",
+      password_confirmation: "correct-horse-battery"
+    )
+    RoleAssignment.create!(
+      user: associate,
+      role: Role.find_by!(key: "associate"),
+      store: @store,
+      assigned_by: @admin,
+      effective_at: Time.current
+    )
+    sign_in_as("gc_associate")
+    post store_selection_path, params: { store_id: @store.id }
+    get inquiry_admin_gift_cards_path
+    assert_redirected_to root_path
+  end
+
+  private
+
+  def sign_in_as(username)
+    post session_path, params: { session: { username: username, password: "correct-horse-battery" } }
+  end
+end

--- a/test/services/admin/navigation_view_model_test.rb
+++ b/test/services/admin/navigation_view_model_test.rb
@@ -31,6 +31,8 @@ class Admin::NavigationViewModelTest < ActiveSupport::TestCase
     assert nav.groups.find { |g| g.key == :customers }.destinations.any? { |d| d.key == :stored_value_transfers }
     assert nav.groups.find { |g| g.key == :organization_configuration }.destinations.any? { |d| d.key == :stored_value_adjustment_reasons }
     assert nav.groups.find { |g| g.key == :pos_operations }.destinations.any? { |d| d.key == :pos }
+    assert nav.groups.find { |g| g.key == :pos_operations }.destinations.any? { |d| d.key == :gift_cards }
+    assert nav.groups.find { |g| g.key == :pos_operations }.destinations.any? { |d| d.key == :gift_card_programs }
 
     assert nav.groups.find { |g| g.key == :merchandise }.current
     assert_equal :products, nav.current_destination.key

--- a/test/services/gift_cards/instruments_test.rb
+++ b/test/services/gift_cards/instruments_test.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GiftCards
+  class InstrumentsTest < ActiveSupport::TestCase
+    setup do
+      @bootstrap = bootstrap!
+      @store = @bootstrap[:store]
+      @actor = @bootstrap[:administrator]
+      GiftCards::Programs.seed!
+      @program = GiftCardProgram.find_by!(code: "generated")
+      @manual = GiftCardProgram.find_by!(code: "manual")
+    end
+
+    test "seeded programs use non-overlapping prefixes and do not collide with merchandise length" do
+      assert_equal "801", @program.prefix
+      assert_equal "802", @manual.prefix
+      assert_not_equal @program.prefix, @manual.prefix
+      assert_equal 20, @program.number_length
+      assert @program.system_generated?
+      assert @manual.manual_external?
+    end
+
+    test "stores numbers with encryption and lookup by hmac digest" do
+      number = GiftCards::Number.generate(@program)
+      card = GiftCards::ProvisionInstrument.call(program: @program, store: @store, number: number)
+      GiftCards::Fund.call(gift_card: card, amount_cents: 250, store: @store, performed_by: @actor)
+
+      raw = GiftCard.connection.select_value(
+        GiftCard.sanitize_sql_array([ "SELECT number FROM gift_cards WHERE id = ?", card.id ])
+      )
+      assert_equal number, card.number
+      assert_equal GiftCards::Number.digest(number), card.number_digest
+      assert_not_equal number, raw
+      assert_equal number[-4, 4], card.number_last_four
+      assert_nil GiftCard.column_names.find { |name| name == "encryption_key_id" }
+      assert_not Permission.exists?(key: "gift_cards.reveal_number")
+
+      found = GiftCards::Resolver.call(raw_number: number, actor: @actor, store: @store)
+      assert_equal card.id, found.id
+    end
+
+    test "inquiry failure is generic and does not persist the submitted number" do
+      error = assert_raises(GiftCards::Error) do
+        GiftCards::Resolver.call(raw_number: "80100000000000000000", actor: @actor, store: @store)
+      end
+      assert_equal GiftCards::GENERIC_INQUIRY_FAILURE, error.message
+      event = AuditEvent.where(action: "gift_cards.inquiry", outcome: "failed").order(:created_at).last
+      assert event
+      refute_includes event.attributes.to_json, "80100000000000000000"
+    end
+
+    test "suspend and reinstate keep the ledger account in sync" do
+      card = GiftCards::ProvisionInstrument.call(program: @program, store: @store)
+      GiftCards::Suspend.call(gift_card: card, actor: @actor, store: @store)
+      assert card.reload.suspended?
+      assert card.stored_value_account.reload.suspended?
+
+      GiftCards::Reinstate.call(gift_card: card, actor: @actor, store: @store)
+      assert card.reload.active?
+      assert card.stored_value_account.reload.active?
+    end
+
+    test "replacement moves remaining balance and does not rewrite ledger customer ownership" do
+      customer = Customer.create!(display_name: "Card Holder", email: "card.holder@example.com")
+      card = GiftCards::ProvisionInstrument.call(program: @program, store: @store, customer: customer)
+      GiftCards::Fund.call(gift_card: card, amount_cents: 700, store: @store, performed_by: @actor)
+
+      replacement = GiftCards::Replace.call(
+        gift_card: card,
+        performed_by: @actor,
+        store: @store,
+        source_id: card.id,
+        idempotency_key: SecureRandom.uuid_v7,
+        reason_code: "lost",
+        reason_name_snapshot: "Lost card"
+      )
+
+      assert card.reload.replaced?
+      assert_equal 0, card.stored_value_account.reload.balance_cents
+      assert card.stored_value_account.closed?
+      new_card = replacement.replacement_gift_card
+      assert_equal 700, new_card.stored_value_account.reload.balance_cents
+      assert_equal customer.id, new_card.customer_id
+      assert_nil new_card.stored_value_account.customer_id
+      assert OutboxMessage.exists?(event_type: "gift_card.replaced")
+      assert_not_includes AuditEvent.order(:created_at).last.after_values.to_s, new_card.number
+    end
+
+    test "merge reassigns gift-card customer association without transferring instrument value" do
+      source = Customer.create!(display_name: "Source Card", email: "src.card@example.com")
+      survivor = Customer.create!(display_name: "Survivor Card", email: "surv.card@example.com")
+      card = GiftCards::ProvisionInstrument.call(program: @program, store: @store, customer: source)
+      GiftCards::Fund.call(gift_card: card, amount_cents: 300, store: @store, performed_by: @actor)
+
+      Customers::MergeCustomers.call(
+        source: source,
+        survivor: survivor,
+        actor: @actor,
+        reason: "same person",
+        idempotency_key: SecureRandom.uuid_v7,
+        store: @store
+      )
+
+      assert_equal survivor.id, card.reload.customer_id
+      assert_equal 300, card.stored_value_account.reload.balance_cents
+      assert_nil StoredValueAccount.find_by(customer: survivor, account_type: "gift_card")
+    end
+  end
+end

--- a/test/services/installation/bootstrap_test.rb
+++ b/test/services/installation/bootstrap_test.rb
@@ -54,6 +54,8 @@ class Installation::BootstrapTest < ActiveSupport::TestCase
     assert AuditEvent.where(actor_type: "system").exists?
     assert StoredValueAdjustmentReason.exists?(code: "goodwill")
     assert_not StoredValueAdjustmentReason.exists?(code: "opening_balance")
+    assert GiftCardProgram.exists?(code: "generated")
+    assert GiftCardProgram.exists?(code: "manual")
     assert_equal 5000, result[:settings].stored_value_adjust_credit_approval_threshold_cents
   end
 

--- a/test/services/stored_value/adjust_test.rb
+++ b/test/services/stored_value/adjust_test.rb
@@ -68,21 +68,48 @@ module StoredValue
       assert_match(/inactive customers cannot receive new credit/, error.message)
     end
 
-    test "gift-card adjustments are blocked until instruments exist" do
-      card = StoredValue::OpenAccount.call(account_type: "gift_card")
+    test "adjusts an active gift card and blocks replaced cards" do
+      GiftCards::Programs.seed!
+      program = GiftCardProgram.find_by!(code: "generated")
+      card = GiftCards::ProvisionInstrument.call(program: program, store: @store)
+      GiftCards::Fund.call(gift_card: card, amount_cents: 400, store: @store, performed_by: @actor)
+
+      adjustment = StoredValue::Adjust.call(
+        account: card.stored_value_account,
+        direction: "credit",
+        amount_cents: 100,
+        reason: @goodwill,
+        store: @store,
+        performed_by: @actor,
+        source_id: card.stored_value_account_id,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+      assert_equal 500, card.stored_value_account.reload.balance_cents
+      assert_equal "adjust", adjustment.stored_value_operation.operation_type
+
+      GiftCards::Replace.call(
+        gift_card: card,
+        performed_by: @actor,
+        store: @store,
+        source_id: card.id,
+        idempotency_key: SecureRandom.uuid_v7,
+        reason_code: "lost",
+        reason_name_snapshot: "Lost card"
+      )
       error = assert_raises(StoredValue::Error) do
         StoredValue::Adjust.call(
-          account: card,
+          account: card.stored_value_account.reload,
           direction: "credit",
-          amount_cents: 100,
+          amount_cents: 10,
           reason: @goodwill,
           store: @store,
           performed_by: @actor,
-          source_id: card.id,
+          source_id: card.stored_value_account_id,
           idempotency_key: SecureRandom.uuid_v7
         )
       end
-      assert_match(/gift-card adjustments are not available/, error.message)
+      assert card.reload.replaced?
+      assert_match(/closed|replaced/, error.message)
     end
 
     test "idempotent retry returns the same adjustment" do


### PR DESCRIPTION
## Summary
- Gift-card programs and instruments with Rails \`encrypts :number\`, HMAC digest lookup, and documented Docker/test/CI encryption keys
- Administrative inquiry resolver (exact match, generic failure, throttle) without Register scan routing
- Suspend/reinstate, replacement (ledger transfer of remaining balance), optional customer association, and gift-card adjust/merge association
- Navigation destinations for programs and inquiry; no production admin action funds a card outside stored-value posting

## Verification
- \`./dev/rails-docker bin/rails test\`
- \`./dev/rails-docker bin/rubocop\`
- \`./dev/rails-docker bin/brakeman --no-pager\`
- \`./dev/rails-docker bin/bundler-audit\`

## Documentation and migrations
- \`db/migrate/20260826030000_create_phase10_gift_card_instruments.rb\` (reversible \`change\`)
- \`db/schema.rb\` regenerated
- Test-key convention documented in development.md
- Slice 10.3 marked Complete in phase10-implementation-plan.md

Closes #61

Made with [Cursor](https://cursor.com)