### PR TITLE
10.4 — POS stored-value issuance, tenders, and first print

### DIFF
--- a/app/controllers/pos/workspaces_controller.rb
+++ b/app/controllers/pos/workspaces_controller.rb
@@ -294,14 +294,27 @@ module Pos
         direction = Pos::Support.settlement_direction(@transaction)
         case direction
         when :refund
-          Pos::AddRefundTender.call(
-            transaction: @transaction,
-            actor: current_user,
-            expected_lock_version: expected_lock_version,
-            tender_type: type,
-            amount_cents: amount,
-            external_reference: params[:external_reference]
-          )
+          if type.stored_value?
+            Pos::AddStoredValueRefundTender.call(
+              transaction: @transaction,
+              actor: current_user,
+              expected_lock_version: expected_lock_version,
+              tender_type: type,
+              amount_cents: amount,
+              destination_mode: stored_value_destination_mode(type),
+              card_number: params[:card_number],
+              gift_card_program: find_optional_gift_card_program
+            )
+          else
+            Pos::AddRefundTender.call(
+              transaction: @transaction,
+              actor: current_user,
+              expected_lock_version: expected_lock_version,
+              tender_type: type,
+              amount_cents: amount,
+              external_reference: params[:external_reference]
+            )
+          end
         when :payment
           if type.cash?
             Pos::TenderCash.call(
@@ -309,6 +322,15 @@ module Pos
               actor: current_user,
               expected_lock_version: expected_lock_version,
               amount_presented_cents: amount
+            )
+          elsif type.stored_value?
+            Pos::AddStoredValueTender.call(
+              transaction: @transaction,
+              actor: current_user,
+              expected_lock_version: expected_lock_version,
+              tender_type: type,
+              amount_cents: amount,
+              card_number: params[:card_number]
             )
           else
             Pos::AddTender.call(
@@ -327,6 +349,69 @@ module Pos
         apply_post_tender_view!
         respond_workspace
       end
+    end
+
+    def stored_value_issuance
+      rescue_workspace(error_mode: "sale_entry") do
+        amount = Money::ParseCents.call(params[:issuance_amount])
+        raise Pos::Error, "issuance amount is required" if amount.nil?
+
+        Pos::AddStoredValueIssuance.call(
+          transaction: @transaction,
+          actor: current_user,
+          expected_lock_version: expected_lock_version,
+          issuance_type: params.require(:issuance_type),
+          amount_cents: amount,
+          gift_card_program: find_optional_gift_card_program,
+          card_number: params[:card_number]
+        )
+        @transaction.reload
+        @ui_mode = "sale_entry"
+        respond_workspace
+      end
+    end
+
+    def remove_stored_value_issuance
+      rescue_workspace(error_mode: "sale_entry") do
+        issuance = @transaction.pos_stored_value_issuances.find(params.require(:issuance_id))
+        Pos::RemoveStoredValueIssuance.call(
+          transaction: @transaction,
+          actor: current_user,
+          expected_lock_version: expected_lock_version,
+          issuance: issuance
+        )
+        @transaction.reload
+        @ui_mode = "sale_entry"
+        respond_workspace
+      end
+    end
+
+    def attach_customer
+      rescue_workspace(error_mode: "sale_entry") do
+        customer = Customer.find(params.require(:customer_id))
+        Pos::AttachCustomer.call(
+          transaction: @transaction,
+          actor: current_user,
+          expected_lock_version: expected_lock_version,
+          customer: customer
+        )
+        @transaction.reload
+        @ui_mode = "sale_entry"
+        respond_workspace
+      end
+    end
+
+    def customer_search
+      rows = Customers::Search.call(query: params[:q], mode: :operational, limit: 20)
+      render json: {
+        results: rows.map { |row|
+          customer = row.customer
+          {
+            id: customer.id,
+            label: [ customer.display_name, customer.email, customer.phone ].compact.join(" · ")
+          }
+        }
+      }
     end
 
     def remove_tender
@@ -442,6 +527,8 @@ module Pos
         original_transaction_line: :pos_transaction
       )
       @tenders = @transaction.pos_tenders.ordered.to_a
+      @issuances = @transaction.pos_stored_value_issuances.ordered.to_a
+      @gift_card_programs = GiftCardProgram.active.admin_ordered.to_a
       @tender = @tenders.find { |tender| pos_workspace_cash_payment?(tender) }
       @settlement_direction = Pos::Support.settlement_direction(@transaction)
       @remaining_payment_cents = Pos::Support.remaining_payment_cents(@transaction)
@@ -684,6 +771,22 @@ module Pos
       tender.cash? && tender.direction == "payment"
     end
 
+    def find_optional_gift_card_program
+      id = params[:gift_card_program_id].presence
+      return if id.blank?
+
+      GiftCardProgram.find_by(id: id)
+    end
+
+    def stored_value_destination_mode(type)
+      explicit = params[:destination_mode].presence
+      return explicit if explicit.present?
+      return "new_gift_card" if type.code == "gift_card" && params[:card_number].blank?
+      return "customer_store_credit" if type.code == "store_credit"
+
+      "existing_account"
+    end
+
     def find_optional_variant
       id = params[:product_variant_id].presence
       return if id.blank?
@@ -718,6 +821,17 @@ module Pos
       payload[:variants] = Array(result.variants).map { |variant| serialize_variant(variant) }
       payload[:units] = Array(result.units).map { |unit| serialize_unit(unit) }
       payload[:products] = Array(result.products).map { |product| serialize_product(product) }
+      if result.outcome == :gift_card
+        payload[:found] = result.gift_card.present?
+        payload[:gift_card_id] = result.gift_card&.id
+        payload[:masked_number] = result.gift_card&.masked_number
+        payload[:status] = result.gift_card&.status
+        payload[:balance_cents] = result.gift_card&.balance_cents
+        payload[:program_id] = result.gift_card_program&.id
+        payload[:program_code] = result.gift_card_program&.code
+        payload[:number_authority] = result.gift_card_program&.number_authority
+        payload[:reload_allowed] = result.gift_card_program&.reload_allowed
+      end
       payload
     end
 

--- a/app/javascript/controllers/register_workspace_controller.js
+++ b/app/javascript/controllers/register_workspace_controller.js
@@ -25,6 +25,11 @@ export default class extends Controller {
     "referenceInput",
     "referenceField",
     "referenceWrap",
+    "giftCardNumberWrap",
+    "giftCardNumberField",
+    "cardNumberInput",
+    "issuanceCardNumber",
+    "destinationModeInput",
     "referenceLabel",
     "removeTenderInput",
     "quantityLineInput",
@@ -101,6 +106,7 @@ export default class extends Controller {
     "cardButton",
     "checkButton",
     "otherButton",
+    "storedValueButton",
     "otherOverlay",
     "otherList",
     "searchOverlay",
@@ -336,6 +342,11 @@ export default class extends Controller {
       this.chooseOther()
       return
     }
+    if (key === "F5") {
+      event.preventDefault()
+      this.chooseStoredValue()
+      return
+    }
 
     if (this.modeValue === "tender") {
       if (key === "F8") {
@@ -544,6 +555,20 @@ export default class extends Controller {
       const capture = this.hasReferenceWrapTarget && !this.referenceWrapTarget.hidden && this.hasReferenceFieldTarget
       this.referenceInputTarget.value = capture ? this.referenceFieldTarget.value.trim() : ""
     }
+    if (this.hasCardNumberInputTarget) {
+      const captureCard = this.hasGiftCardNumberWrapTarget && !this.giftCardNumberWrapTarget.hidden && this.hasGiftCardNumberFieldTarget
+      this.cardNumberInputTarget.value = captureCard ? this.giftCardNumberFieldTarget.value.trim() : ""
+    }
+    if (this.hasDestinationModeInputTarget) {
+      const type = this.selectedTenderType()
+      if (this.settlementValue === "refund" && type?.stored_value_account_type === "gift_card" && !(this.cardNumberInputTarget?.value)) {
+        this.destinationModeInputTarget.value = "new_gift_card"
+      } else if (this.settlementValue === "refund" && type?.stored_value_account_type === "store_credit") {
+        this.destinationModeInputTarget.value = "customer_store_credit"
+      } else {
+        this.destinationModeInputTarget.value = type?.category === "stored_value" ? "existing_account" : ""
+      }
+    }
     this.beginFlight()
     this.tenderFormTarget.requestSubmit()
   }
@@ -579,7 +604,7 @@ export default class extends Controller {
   enterTender() {
     if (this.inFlight) return
     if (this.modeValue !== "sale_entry") return
-    if (!this.element.querySelector(".pos-lines tbody tr")) {
+    if (!this.hasCommercialContent()) {
       this.showFeedback("Add merchandise before taking a tender.")
       return
     }
@@ -622,6 +647,24 @@ export default class extends Controller {
     this.openOtherPicker(types)
   }
 
+  chooseStoredValue() {
+    if (this.inFlight) return
+    if (this.modeValue !== "sale_entry" && this.modeValue !== "tender") return
+    if (!this.ensureTenderable()) return
+    const types = this.typesForCategory("stored_value")
+    if (types.length === 0) {
+      this.showFeedback("Stored-value tender is not available.")
+      return
+    }
+    if (types.length === 1) {
+      this.beginTenderMode()
+      this.applyTenderType(types[0])
+      this.prefillRemaining()
+      return
+    }
+    this.openOtherPicker(types)
+  }
+
   chooseTenderCategory(category) {
     if (this.inFlight) return
     if (this.modeValue !== "sale_entry" && this.modeValue !== "tender") return
@@ -643,7 +686,7 @@ export default class extends Controller {
 
   ensureTenderable() {
     if (this.modeValue === "tender") return true
-    if (!this.element.querySelector(".pos-lines tbody tr")) {
+    if (!this.hasCommercialContent()) {
       this.showFeedback("Add merchandise before taking a tender.")
       return false
     }
@@ -698,6 +741,7 @@ export default class extends Controller {
     if (category === "cash") return "Cash"
     if (category === "card") return "Card"
     if (category === "check") return "Check"
+    if (category === "stored_value") return "Stored value"
     return "Other"
   }
 
@@ -828,6 +872,9 @@ export default class extends Controller {
           variantId: result.variant?.id,
           prompt: this.variantLabel(result.variant)
         })
+        return
+      case "gift_card":
+        this.handleGiftCardScan(result)
         return
       default:
         this.showFeedback(result.message || "merchandise not found")
@@ -1456,6 +1503,55 @@ export default class extends Controller {
       this.setFieldLabel(cash ? `${dueText}. Cash presented` : `${dueText}. ${name} amount`)
     }
     this.toggleReferenceField(type.reference_policy)
+    this.toggleGiftCardNumberField(type)
+  }
+
+  toggleGiftCardNumberField(type) {
+    if (!this.hasGiftCardNumberWrapTarget) return
+    const show = this.modeValue === "tender" && type?.stored_value_account_type === "gift_card"
+    this.giftCardNumberWrapTarget.hidden = !show
+    if (!show && this.hasGiftCardNumberFieldTarget) this.giftCardNumberFieldTarget.value = ""
+  }
+
+  hasCommercialContent() {
+    return Boolean(this.element.querySelector(".pos-lines tbody tr") || this.element.querySelector(".pos-issuance"))
+  }
+
+  handleGiftCardScan(result) {
+    const scanned = this.hasFieldTarget ? this.fieldTarget.value.trim() : ""
+    if (this.hasIdentifierInputTarget) this.identifierInputTarget.value = ""
+    if (this.hasFieldTarget) this.fieldTarget.value = ""
+
+    if (result.found) {
+      if (this.settlementValue === "payment" && this.remainingCents() > 0) {
+        const gift = this.typesForCategory("stored_value").find((type) => type.stored_value_account_type === "gift_card")
+        if (!gift) {
+          this.showFeedback("Gift card tender is not available.")
+          this.enableReadyActions()
+          this.restoreFocus()
+          return
+        }
+        this.beginTenderMode()
+        this.applyTenderType(gift)
+        if (this.hasGiftCardNumberFieldTarget) this.giftCardNumberFieldTarget.value = scanned
+        this.prefillRemaining()
+        this.enableReadyActions()
+        return
+      }
+      this.showFeedback(result.masked_number ? `Gift card ${result.masked_number}` : "Gift card on file")
+      this.enableReadyActions()
+      this.restoreFocus()
+      return
+    }
+
+    if (result.number_authority === "manual_external" && this.hasIssuanceCardNumberTarget) {
+      this.issuanceCardNumberTarget.value = scanned
+      this.showFeedback("Gift card not on file. Enter an activation amount.")
+    } else {
+      this.showFeedback(result.message || "gift card not on file")
+    }
+    this.enableReadyActions()
+    this.restoreFocus()
   }
 
   cashTenderIndex() {
@@ -2062,24 +2158,25 @@ export default class extends Controller {
   }
 
   disableMutationControls() {
-    ["returnButton", "quantityButton", "overrideButton", "discountButton", "taxClassButton", "tenderButton", "removeButton", "cancelButton", "retry", "abandonButton", "cashButton", "cardButton", "checkButton", "otherButton"].forEach((name) => {
+    ["returnButton", "quantityButton", "overrideButton", "discountButton", "taxClassButton", "tenderButton", "removeButton", "cancelButton", "retry", "abandonButton", "cashButton", "cardButton", "checkButton", "otherButton", "storedValueButton"].forEach((name) => {
       this.setActionEnabled(name, false)
     })
   }
 
   enableTenderIdentityButtons() {
-    const hasLines = Boolean(this.element.querySelector(".pos-lines tbody tr"))
+    const hasLines = this.hasCommercialContent()
     const enabled = hasLines && (this.modeValue === "sale_entry" || this.modeValue === "tender")
     this.setActionEnabled("cashButton", enabled && this.typesForCategory("cash").length > 0)
     this.setActionEnabled("cardButton", enabled && this.typesForCategory("card").length > 0)
     this.setActionEnabled("checkButton", enabled && this.typesForCategory("check").length > 0)
     this.setActionEnabled("otherButton", enabled && this.otherTypes().length > 0)
+    this.setActionEnabled("storedValueButton", enabled && this.typesForCategory("stored_value").length > 0)
   }
 
   enableReadyActions() {
     if (this.modeValue === "sale_entry") {
       const hasSelection = Boolean(this.selectedRow())
-      const hasLines = Boolean(this.element.querySelector(".pos-lines tbody tr"))
+      const hasLines = this.hasCommercialContent()
       const returnLine = this.selectedReturnLine()
       const quantityOk = hasSelection && !this.selectedUnitLine() && !this.selectedQuantityBlocked()
       this.setActionEnabled("returnButton", true)
@@ -2209,7 +2306,7 @@ export default class extends Controller {
   requestFunctionKeyLock() {
     const keyboard = navigator.keyboard
     if (!keyboard || typeof keyboard.lock !== "function") return
-    keyboard.lock(["F1", "F2", "F3", "F4", "F6", "F7", "F8", "F9", "F10"]).catch(() => {})
+    keyboard.lock(["F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10"]).catch(() => {})
   }
 
   releaseFunctionKeyLock() {
@@ -2225,7 +2322,7 @@ export default class extends Controller {
   }
 
   claimedFunctionKey(key) {
-    return key === "F1" || key === "F2" || key === "F3" || key === "F4" || key === "F6" || key === "F7" || key === "F8" || key === "F9" || key === "F10"
+    return key === "F1" || key === "F2" || key === "F3" || key === "F4" || key === "F5" || key === "F6" || key === "F7" || key === "F8" || key === "F9" || key === "F10"
   }
 
   claimFunctionKey(event) {

--- a/app/models/pos_stored_value_issuance.rb
+++ b/app/models/pos_stored_value_issuance.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+class PosStoredValueIssuance < ApplicationRecord
+  ISSUANCE_TYPES = %w[activation reload].freeze
+  AUTHORITIES = %w[system_generated manual_external].freeze
+
+  encrypts :pending_card_number
+
+  belongs_to :pos_transaction
+  belongs_to :gift_card_program, optional: true
+  belongs_to :gift_card, optional: true
+  belongs_to :stored_value_operation, optional: true
+  belongs_to :post_void_source_issuance, class_name: "PosStoredValueIssuance", optional: true
+
+  validates :issuance_number, :issuance_type, :amount_cents, :number_authority, presence: true
+  validates :issuance_type, inclusion: { in: ISSUANCE_TYPES }
+  validates :number_authority, inclusion: { in: AUTHORITIES }
+  validates :amount_cents, numericality: { only_integer: true, greater_than: 0 }
+  validates :issuance_number, numericality: { only_integer: true, greater_than: 0 }
+  validate :reload_requires_card
+  validate :activation_requires_program
+  before_validation :assign_pending_identity, if: -> { pending_card_number.present? && will_save_change_to_pending_card_number? }
+
+  scope :ordered, -> { order(:issuance_number, :id) }
+
+  def activation?
+    issuance_type == "activation"
+  end
+
+  def reload_issuance?
+    issuance_type == "reload"
+  end
+
+  def post_void_generated?
+    post_void_source_issuance_id.present?
+  end
+
+  def system_generated?
+    number_authority == "system_generated"
+  end
+
+  def readonly?
+    super || (persisted? && pos_transaction&.commercially_immutable?)
+  end
+
+  private
+
+  def assign_pending_identity
+    normalized = GiftCards::Number.normalize(pending_card_number)
+    self.pending_card_number = normalized
+    self.pending_card_number_digest = GiftCards::Number.digest(normalized)
+    self.pending_card_number_last_four = GiftCards::Number.last_four(normalized)
+    self.pending_card_number_prefix = gift_card_program&.prefix
+  end
+
+  def reload_requires_card
+    return unless reload_issuance?
+
+    errors.add(:gift_card_id, "is required for reload") if gift_card_id.blank?
+  end
+
+  def activation_requires_program
+    return unless activation?
+
+    errors.add(:gift_card_program_id, "is required for activation") if gift_card_program_id.blank?
+  end
+end

--- a/app/models/pos_stored_value_tender_detail.rb
+++ b/app/models/pos_stored_value_tender_detail.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class PosStoredValueTenderDetail < ApplicationRecord
+  DESTINATION_MODES = %w[existing_account customer_store_credit new_gift_card].freeze
+
+  encrypts :pending_card_number
+
+  belongs_to :pos_tender
+  belongs_to :stored_value_operation, optional: true
+  belongs_to :stored_value_account, optional: true
+  belongs_to :gift_card, optional: true
+  belongs_to :gift_card_program, optional: true
+
+  validates :destination_mode, presence: true, inclusion: { in: DESTINATION_MODES }
+  validate :existing_account_has_target
+  before_validation :assign_pending_identity, if: -> { pending_card_number.present? && will_save_change_to_pending_card_number? }
+
+  def existing_account?
+    destination_mode == "existing_account"
+  end
+
+  def customer_store_credit?
+    destination_mode == "customer_store_credit"
+  end
+
+  def new_gift_card?
+    destination_mode == "new_gift_card"
+  end
+
+  def readonly?
+    super || (persisted? && pos_tender&.pos_transaction&.commercially_immutable?)
+  end
+
+  private
+
+  def assign_pending_identity
+    normalized = GiftCards::Number.normalize(pending_card_number)
+    self.pending_card_number = normalized
+    self.pending_card_number_digest = GiftCards::Number.digest(normalized)
+    self.pending_card_number_last_four = GiftCards::Number.last_four(normalized)
+    self.pending_card_number_prefix = gift_card_program&.prefix
+  end
+
+  def existing_account_has_target
+    return unless existing_account?
+    return if stored_value_account_id.present?
+
+    errors.add(:stored_value_account_id, "is required for an existing account")
+  end
+end

--- a/app/models/pos_tender.rb
+++ b/app/models/pos_tender.rb
@@ -9,6 +9,7 @@ class PosTender < ApplicationRecord
   belongs_to :pos_transaction
   belongs_to :configured_tender_type, class_name: "TenderType", foreign_key: :tender_type_id
   belongs_to :post_void_source_tender, class_name: "PosTender", optional: true
+  has_one :stored_value_tender_detail, class_name: "PosStoredValueTenderDetail", dependent: :destroy
 
   validates :configured_tender_type, :tender_number, :tender_type, :tender_name, :behavioral_category,
             :direction, :amount_cents, presence: true
@@ -26,6 +27,10 @@ class PosTender < ApplicationRecord
 
   def cash?
     behavioral_category == "cash"
+  end
+
+  def stored_value?
+    behavioral_category == "stored_value"
   end
 
   def readonly?

--- a/app/models/pos_transaction.rb
+++ b/app/models/pos_transaction.rb
@@ -8,11 +8,13 @@ class PosTransaction < ApplicationRecord
   belongs_to :pos_session
   belongs_to :reporting_period, class_name: "PosReportingPeriod"
   belongs_to :cashier_user, class_name: "User"
+  belongs_to :customer, optional: true
   belongs_to :post_void_of, class_name: "PosTransaction", foreign_key: :post_void_of_transaction_id, optional: true
   has_one :post_void, class_name: "PosTransaction", foreign_key: :post_void_of_transaction_id, dependent: :restrict_with_exception
   has_many :pos_transaction_lines, -> { order(:line_number) }, dependent: :destroy
   has_many :pos_controlled_actions, dependent: :destroy
   has_many :pos_tenders, -> { ordered }, dependent: :destroy
+  has_many :pos_stored_value_issuances, -> { ordered }, dependent: :destroy
   has_many :pos_operations, dependent: :restrict_with_exception
 
   validates :status, :currency_code, presence: true

--- a/app/models/tender_type.rb
+++ b/app/models/tender_type.rb
@@ -4,9 +4,10 @@ class TenderType < ApplicationRecord
   include UuidV7PrimaryKey
   include HasMachineCode
 
-  CATEGORIES = %w[cash card check other].freeze
+  CATEGORIES = %w[cash card check stored_value other].freeze
   REFERENCE_POLICIES = %w[omitted optional required].freeze
-  SYSTEM_CODES = %w[cash card check].freeze
+  SYSTEM_CODES = %w[cash card check store_credit trade_credit gift_card].freeze
+  STORED_VALUE_ACCOUNT_TYPES = %w[store_credit trade_credit gift_card].freeze
 
   has_many :pos_tenders, foreign_key: :tender_type_id, inverse_of: :configured_tender_type, dependent: :restrict_with_exception
 
@@ -14,7 +15,9 @@ class TenderType < ApplicationRecord
   validates :code, uniqueness: true, format: { with: Codes::Normalizer::FORMAT }
   validates :behavioral_category, inclusion: { in: CATEGORIES }
   validates :external_reference_policy, inclusion: { in: REFERENCE_POLICIES }
+  validates :stored_value_account_type, inclusion: { in: STORED_VALUE_ACCOUNT_TYPES }, allow_nil: true
   validate :protected_identity_rules
+  validate :stored_value_account_type_matches_category
   validate :unprotected_category_is_other
   validate :cash_keeps_omitted_reference
   validate :cash_keeps_allows_refund
@@ -25,7 +28,7 @@ class TenderType < ApplicationRecord
   scope :admin_ordered, -> { order(:behavioral_category, :code) }
   scope :cashier_selectable, -> {
     active.order(
-      Arel.sql("CASE behavioral_category WHEN 'cash' THEN 0 WHEN 'card' THEN 1 WHEN 'check' THEN 2 ELSE 3 END"),
+      Arel.sql("CASE behavioral_category WHEN 'cash' THEN 0 WHEN 'card' THEN 1 WHEN 'check' THEN 2 WHEN 'stored_value' THEN 3 ELSE 4 END"),
       :code
     )
   }
@@ -37,6 +40,10 @@ class TenderType < ApplicationRecord
 
   def cash?
     behavioral_category == "cash"
+  end
+
+  def stored_value?
+    behavioral_category == "stored_value"
   end
 
   def other?
@@ -66,7 +73,11 @@ class TenderType < ApplicationRecord
       name: name,
       category: behavioral_category,
       reference_policy: external_reference_policy,
-      allows_refund: allows_refund
+      allows_refund: allows_refund,
+      stored_value_account_type: stored_value_account_type,
+      allows_original_tender_refund: allows_original_tender_refund,
+      allows_generic_refund_destination: allows_generic_refund_destination,
+      allows_refund_instrument_replacement: allows_refund_instrument_replacement
     }
   end
 
@@ -88,6 +99,9 @@ class TenderType < ApplicationRecord
     end
     if will_save_change_to_code? && persisted?
       errors.add(:code, "cannot be changed for a system identity")
+    end
+    if stored_value? && will_save_change_to_stored_value_account_type? && persisted?
+      errors.add(:stored_value_account_type, "cannot be changed for a system identity")
     end
     if cash? && will_save_change_to_active? && !active?
       errors.add(:active, "cannot deactivate Cash")
@@ -120,5 +134,13 @@ class TenderType < ApplicationRecord
     return if allows_refund
 
     errors.add(:allows_refund, "must remain true for Cash")
+  end
+
+  def stored_value_account_type_matches_category
+    if stored_value?
+      errors.add(:stored_value_account_type, "is required for stored-value tenders") if stored_value_account_type.blank?
+    elsif stored_value_account_type.present?
+      errors.add(:stored_value_account_type, "must be blank unless stored value")
+    end
   end
 end

--- a/app/services/gift_cards/lookup.rb
+++ b/app/services/gift_cards/lookup.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module GiftCards
+  class Lookup
+    def self.by_number(raw)
+      normalized = Number.normalize(raw)
+      return if normalized.blank?
+      return unless normalized.match?(/\A\d+\z/)
+
+      GiftCard.find_by(number_digest: Number.digest(normalized))
+    end
+
+    def self.program_for(raw)
+      normalized = Number.normalize(raw)
+      return if normalized.blank?
+
+      GiftCardProgram.active.find { |program| Number.shape_match?(normalized, program: program) }
+    end
+  end
+end

--- a/app/services/pos/add_refund_tender.rb
+++ b/app/services/pos/add_refund_tender.rb
@@ -19,6 +19,7 @@ module Pos
       Pos::Support.authorize!(@actor, @transaction.store)
       Pos::Support.require_active_context!(@transaction.store, @transaction.register)
       Pos::Support.require_transaction_cashier!(@actor, @transaction)
+      raise Pos::Error, "use stored-value tender for stored value" if @tender_type.stored_value?
       raise Pos::Error, "tender is not available" unless @tender_type.active?
       raise Pos::Error, "tender does not allow refunds" unless @tender_type.allows_refund?
       raise Pos::Error, "amount must be positive" unless @amount_cents.positive?
@@ -31,7 +32,7 @@ module Pos
 
       PosTransaction.transaction do
         transaction = Pos::Support.lock_working_transaction!(@transaction, @expected_lock_version)
-        raise Pos::Error, "transaction has no merchandise" if transaction.pos_transaction_lines.none?
+        Pos::Support.require_commercial_content!(transaction)
         raise Pos::Error, "transaction does not require a refund" if transaction.signed_net_cents >= 0
         unless Pos::Support.settlement_direction(transaction) == :refund
           raise Pos::Error, "transaction does not require a refund"

--- a/app/services/pos/add_stored_value_issuance.rb
+++ b/app/services/pos/add_stored_value_issuance.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+module Pos
+  class AddStoredValueIssuance
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(
+      transaction:,
+      actor:,
+      expected_lock_version:,
+      issuance_type:,
+      amount_cents:,
+      gift_card_program: nil,
+      card_number: nil
+    )
+      @transaction = transaction
+      @actor = actor
+      @expected_lock_version = expected_lock_version
+      @issuance_type = issuance_type.to_s
+      @amount_cents = amount_cents.to_i
+      @gift_card_program = gift_card_program
+      @card_number = card_number.to_s.strip.presence
+    end
+
+    def call
+      Pos::Support.authorize!(@actor, @transaction.store)
+      Pos::Support.require_active_context!(@transaction.store, @transaction.register)
+      Pos::Support.require_transaction_cashier!(@actor, @transaction)
+      raise Pos::Error, "issuance type is invalid" unless PosStoredValueIssuance::ISSUANCE_TYPES.include?(@issuance_type)
+      raise Pos::Error, "amount must be positive" unless @amount_cents.positive?
+
+      PosTransaction.transaction do
+        transaction = Pos::Support.lock_working_transaction!(@transaction, @expected_lock_version)
+        Pos::Support.clear_working_tenders!(transaction)
+        issuance = case @issuance_type
+        when "activation"
+          build_activation!(transaction)
+        when "reload"
+          build_reload!(transaction)
+        end
+        issuance.save!
+        Pos::Support.refresh_totals!(transaction)
+        Pos::Support.touch_working_transaction!(transaction)
+        issuance
+      end
+    rescue GiftCards::Error => e
+      raise Pos::Error, e.message
+    end
+
+    private
+
+    def build_activation!(transaction)
+      program = @gift_card_program || GiftCards::Lookup.program_for(@card_number)
+      raise Pos::Error, "gift-card program is required" if program.blank?
+      raise Pos::Error, "gift-card program is not active" unless program.active?
+      if program.minimum_activation_cents.present? && @amount_cents < program.minimum_activation_cents
+        raise Pos::Error, "activation is below the program minimum"
+      end
+      if program.maximum_balance_cents.present? && @amount_cents > program.maximum_balance_cents
+        raise Pos::Error, "activation exceeds the program maximum"
+      end
+
+      issuance = transaction.pos_stored_value_issuances.new(
+        issuance_number: Pos::Support.next_issuance_number(transaction),
+        issuance_type: "activation",
+        amount_cents: @amount_cents,
+        gift_card_program: program,
+        number_authority: program.number_authority
+      )
+      if program.manual_external?
+        raise Pos::Error, "a card number is required" if @card_number.blank?
+
+        number = GiftCards::Number.normalize(@card_number)
+        unless GiftCards::Number.shape_match?(number, program: program)
+          raise Pos::Error, "card number is not valid for this program"
+        end
+        if GiftCards::Lookup.by_number(number) || PosStoredValueIssuance.exists?(pending_card_number_digest: GiftCards::Number.digest(number))
+          raise Pos::Error, "card number is already in use"
+        end
+        issuance.pending_card_number = number
+      elsif @card_number.present?
+        raise Pos::Error, "system-generated activations cannot take a card number"
+      end
+      issuance
+    end
+
+    def build_reload!(transaction)
+      raise Pos::Error, "a card number is required" if @card_number.blank?
+
+      card = GiftCards::Lookup.by_number(@card_number)
+      raise Pos::Error, "gift card is not available" unless card
+      raise Pos::Error, "gift card is not available" unless card.active?
+      raise Pos::Error, "reload is not allowed for this program" unless card.gift_card_program.reload_allowed?
+      program = card.gift_card_program
+      next_balance = card.stored_value_account.balance_cents + @amount_cents
+      if program.maximum_balance_cents.present? && next_balance > program.maximum_balance_cents
+        raise Pos::Error, "reload exceeds the program maximum"
+      end
+
+      transaction.pos_stored_value_issuances.new(
+        issuance_number: Pos::Support.next_issuance_number(transaction),
+        issuance_type: "reload",
+        amount_cents: @amount_cents,
+        gift_card_program: program,
+        gift_card: card,
+        number_authority: program.number_authority,
+        masked_card_snapshot: card.masked_number
+      )
+    end
+  end
+end

--- a/app/services/pos/add_stored_value_refund_tender.rb
+++ b/app/services/pos/add_stored_value_refund_tender.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+module Pos
+  class AddStoredValueRefundTender
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(
+      transaction:,
+      actor:,
+      expected_lock_version:,
+      tender_type:,
+      amount_cents:,
+      destination_mode:,
+      card_number: nil,
+      gift_card_program: nil
+    )
+      @transaction = transaction
+      @actor = actor
+      @expected_lock_version = expected_lock_version
+      @tender_type = tender_type
+      @amount_cents = amount_cents.to_i
+      @destination_mode = destination_mode.to_s
+      @card_number = card_number.to_s.strip.presence
+      @gift_card_program = gift_card_program
+    end
+
+    def call
+      Pos::Support.authorize!(@actor, @transaction.store)
+      Pos::Support.require_active_context!(@transaction.store, @transaction.register)
+      Pos::Support.require_transaction_cashier!(@actor, @transaction)
+      raise Pos::Error, "tender is not available" unless @tender_type.active?
+      raise Pos::Error, "tender is not stored value" unless @tender_type.stored_value?
+      raise Pos::Error, "amount must be positive" unless @amount_cents.positive?
+      unless PosStoredValueTenderDetail::DESTINATION_MODES.include?(@destination_mode)
+        raise Pos::Error, "refund destination is invalid"
+      end
+
+      PosTransaction.transaction do
+        transaction = Pos::Support.lock_working_transaction!(@transaction, @expected_lock_version)
+        Pos::Support.require_commercial_content!(transaction)
+        raise Pos::Error, "transaction does not require a refund" unless Pos::Support.settlement_direction(transaction) == :refund
+        remaining = Pos::Support.remaining_refund_cents(transaction)
+        raise Pos::Error, "no remaining refund amount" if remaining <= 0
+        raise Pos::Error, "amount is greater than remaining refund" if @amount_cents > remaining
+
+        detail_attrs = build_detail_attrs!(transaction)
+        tender = transaction.pos_tenders.new(
+          direction: "refund",
+          tender_number: Pos::Support.next_tender_number(transaction),
+          amount_cents: @amount_cents,
+          amount_presented_cents: nil,
+          change_cents: nil
+        )
+        Pos::Support.snapshot_tender_identity!(tender, @tender_type)
+        tender.save!
+        tender.create_stored_value_tender_detail!(detail_attrs)
+        Pos::Support.touch_working_transaction!(transaction)
+        tender
+      end
+    rescue GiftCards::Error => e
+      raise Pos::Error, e.message
+    end
+
+    private
+
+    def build_detail_attrs!(transaction)
+      case @destination_mode
+      when "existing_account"
+        existing_account_attrs!(transaction)
+      when "customer_store_credit"
+        store_credit_attrs!(transaction)
+      when "new_gift_card"
+        new_gift_card_attrs!(transaction)
+      end
+    end
+
+    def existing_account_attrs!(transaction)
+      case @tender_type.stored_value_account_type
+      when "gift_card"
+        raise Pos::Error, "original gift-card refund requires a presented card" if @card_number.blank?
+        raise Pos::Error, "gift card cannot receive this refund" unless original_gift_card_funded?(transaction)
+
+        card = GiftCards::Lookup.by_number(@card_number)
+        raise Pos::Error, "gift card is not available" unless card&.active?
+        unless original_gift_card_accounts(transaction).include?(card.stored_value_account_id)
+          raise Pos::Error, "presented gift card does not match the original tender"
+        end
+        { destination_mode: "existing_account", stored_value_account: card.stored_value_account, gift_card: card, masked_card_snapshot: card.masked_number }
+      when "trade_credit"
+        raise Pos::Error, "trade credit is not a generic refund destination" unless @tender_type.allows_original_tender_refund?
+        account_ids = original_trade_credit_accounts(transaction)
+        raise Pos::Error, "trade credit can only return to the original account" if account_ids.empty?
+        raise Pos::Error, "a customer is required" if transaction.customer.blank?
+
+        account = StoredValueAccount.where(id: account_ids, customer_id: transaction.customer_id, account_type: "trade_credit")
+                                    .where.not(status: "closed").order(:id).first
+        raise Pos::Error, "original trade-credit account is not available" unless account&.active?
+
+        { destination_mode: "existing_account", stored_value_account: account }
+      when "store_credit"
+        raise Pos::Error, "a customer is required" if transaction.customer.blank?
+        raise Pos::Error, "customer must be an active canonical customer" unless transaction.customer.canonical? && transaction.customer.active?
+
+        account = StoredValueAccount.where(customer_id: transaction.customer_id, account_type: "store_credit")
+                                    .where.not(status: "closed").order(:id).first
+        { destination_mode: "existing_account", stored_value_account: account }.compact
+      else
+        raise Pos::Error, "refund destination is invalid"
+      end
+    end
+
+    def store_credit_attrs!(transaction)
+      raise Pos::Error, "store credit cannot receive this refund" unless @tender_type.code == "store_credit"
+      raise Pos::Error, "a customer is required" if transaction.customer.blank?
+      raise Pos::Error, "customer must be an active canonical customer" unless transaction.customer.canonical? && transaction.customer.active?
+
+      { destination_mode: "customer_store_credit" }
+    end
+
+    def new_gift_card_attrs!(transaction)
+      raise Pos::Error, "new refund gift cards require the gift-card tender" unless @tender_type.code == "gift_card"
+      raise Pos::Error, "new refund gift card is not allowed" unless @tender_type.allows_refund_instrument_replacement?
+      raise Pos::Error, "new gift card cannot receive this refund" unless original_gift_card_funded?(transaction)
+
+      program = @gift_card_program || GiftCards::Lookup.program_for(@card_number)
+      raise Pos::Error, "gift-card program is required" if program.blank?
+      raise Pos::Error, "gift-card program is not active" unless program.active?
+
+      attrs = { destination_mode: "new_gift_card", gift_card_program: program }
+      if program.manual_external?
+        raise Pos::Error, "a card number is required" if @card_number.blank?
+
+        number = GiftCards::Number.normalize(@card_number)
+        unless GiftCards::Number.shape_match?(number, program: program)
+          raise Pos::Error, "card number is not valid for this program"
+        end
+        if GiftCards::Lookup.by_number(number)
+          raise Pos::Error, "card number is already in use"
+        end
+        attrs[:pending_card_number] = number
+      elsif @card_number.present?
+        raise Pos::Error, "system-generated refund cards cannot take a card number"
+      end
+      attrs
+    end
+
+    def original_gift_card_funded?(transaction)
+      original_gift_card_accounts(transaction).any?
+    end
+
+    def original_gift_card_accounts(transaction)
+      original_payment_accounts(transaction, "gift_card")
+    end
+
+    def original_trade_credit_accounts(transaction)
+      original_payment_accounts(transaction, "trade_credit")
+    end
+
+    def original_payment_accounts(transaction, tender_code)
+      original_ids = transaction.pos_transaction_lines.filter_map(&:original_transaction_line_id)
+      return [] if original_ids.empty?
+
+      original_transaction_ids = PosTransactionLine.where(id: original_ids).distinct.pluck(:pos_transaction_id)
+      PosTender.where(pos_transaction_id: original_transaction_ids, tender_type: tender_code, direction: "payment")
+               .includes(:stored_value_tender_detail)
+               .filter_map { |tender| tender.stored_value_tender_detail&.stored_value_account_id }
+               .uniq
+    end
+  end
+end

--- a/app/services/pos/add_stored_value_tender.rb
+++ b/app/services/pos/add_stored_value_tender.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+module Pos
+  class AddStoredValueTender
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(transaction:, actor:, expected_lock_version:, tender_type:, amount_cents:, card_number: nil)
+      @transaction = transaction
+      @actor = actor
+      @expected_lock_version = expected_lock_version
+      @tender_type = tender_type
+      @amount_cents = amount_cents.to_i
+      @card_number = card_number.to_s.strip.presence
+    end
+
+    def call
+      Pos::Support.authorize!(@actor, @transaction.store)
+      Pos::Support.require_active_context!(@transaction.store, @transaction.register)
+      Pos::Support.require_transaction_cashier!(@actor, @transaction)
+      raise Pos::Error, "tender is not available" unless @tender_type.active?
+      raise Pos::Error, "tender is not stored value" unless @tender_type.stored_value?
+      raise Pos::Error, "amount must be positive" unless @amount_cents.positive?
+
+      PosTransaction.transaction do
+        transaction = Pos::Support.lock_working_transaction!(@transaction, @expected_lock_version)
+        Pos::Support.require_commercial_content!(transaction)
+        raise Pos::Error, "cannot redeem stored value on a ticket with gift-card issuance" if transaction.pos_stored_value_issuances.any?
+        raise Pos::Error, "transaction does not require payment" unless Pos::Support.settlement_direction(transaction) == :payment
+        remaining = Pos::Support.remaining_payment_cents(transaction)
+        raise Pos::Error, "no remaining amount due" if remaining <= 0
+        raise Pos::Error, "amount is greater than remaining due" if @amount_cents > remaining
+
+        account = resolve_account!(transaction)
+        if duplicate_account?(transaction, account)
+          raise Pos::Error, "this stored-value account is already on the transaction"
+        end
+        if account.balance_cents < @amount_cents
+          raise Pos::Error, "stored-value balance is insufficient"
+        end
+
+        tender = transaction.pos_tenders.new(
+          direction: "payment",
+          tender_number: Pos::Support.next_tender_number(transaction),
+          amount_cents: @amount_cents,
+          amount_presented_cents: nil,
+          change_cents: nil
+        )
+        Pos::Support.snapshot_tender_identity!(tender, @tender_type)
+        tender.save!
+        card = account.gift_card
+        tender.create_stored_value_tender_detail!(
+          destination_mode: "existing_account",
+          stored_value_account: account,
+          gift_card: card,
+          masked_card_snapshot: card&.masked_number
+        )
+        Pos::Support.touch_working_transaction!(transaction)
+        tender
+      end
+    rescue GiftCards::Error => e
+      raise Pos::Error, e.message
+    end
+
+    private
+
+    def resolve_account!(transaction)
+      case @tender_type.stored_value_account_type
+      when "gift_card"
+        raise Pos::Error, "a card number is required" if @card_number.blank?
+
+        card = GiftCards::Lookup.by_number(@card_number)
+        raise Pos::Error, "gift card is not available" unless card&.active?
+
+        card.stored_value_account
+      when "store_credit", "trade_credit"
+        customer = transaction.customer
+        raise Pos::Error, "a customer is required" if customer.blank?
+        raise Pos::Error, "customer must be an active canonical customer" unless customer.canonical? && customer.active?
+
+        account = StoredValueAccount.where(customer_id: customer.id, account_type: @tender_type.stored_value_account_type)
+                                    .where.not(status: "closed").order(:id).first
+        raise Pos::Error, "customer stored-value account is not available" unless account&.active?
+
+        account
+      else
+        raise Pos::Error, "tender is not stored value"
+      end
+    end
+
+    def duplicate_account?(transaction, account)
+      transaction.pos_tenders.payments.any? { |tender|
+        tender.stored_value_tender_detail&.stored_value_account_id == account.id
+      }
+    end
+  end
+end

--- a/app/services/pos/add_tender.rb
+++ b/app/services/pos/add_tender.rb
@@ -20,6 +20,7 @@ module Pos
       Pos::Support.require_active_context!(@transaction.store, @transaction.register)
       Pos::Support.require_transaction_cashier!(@actor, @transaction)
       raise Pos::Error, "use cash tender for Cash" if @tender_type.cash?
+      raise Pos::Error, "use stored-value tender for stored value" if @tender_type.stored_value?
       raise Pos::Error, "tender is not available" unless @tender_type.active?
       raise Pos::Error, "amount must be positive" unless @amount_cents.positive?
       if @tender_type.reference_required? && @external_reference.blank?
@@ -31,7 +32,7 @@ module Pos
 
       PosTransaction.transaction do
         transaction = Pos::Support.lock_working_transaction!(@transaction, @expected_lock_version)
-        raise Pos::Error, "transaction has no merchandise" if transaction.pos_transaction_lines.none?
+        Pos::Support.require_commercial_content!(transaction)
         raise Pos::Error, "transaction does not require payment" unless Pos::Support.settlement_direction(transaction) == :payment
 
         remaining = Pos::Support.remaining_payment_cents(transaction)

--- a/app/services/pos/attach_customer.rb
+++ b/app/services/pos/attach_customer.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Pos
+  class AttachCustomer
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(transaction:, actor:, expected_lock_version:, customer:)
+      @transaction = transaction
+      @actor = actor
+      @expected_lock_version = expected_lock_version
+      @customer = customer
+    end
+
+    def call
+      Pos::Support.authorize!(@actor, @transaction.store)
+      Pos::Support.require_active_context!(@transaction.store, @transaction.register)
+      Pos::Support.require_transaction_cashier!(@actor, @transaction)
+      raise Pos::Error, "customer is required" if @customer.blank?
+      raise Pos::Error, "customer must be an active canonical customer" unless @customer.canonical? && @customer.active?
+
+      PosTransaction.transaction do
+        transaction = Pos::Support.lock_working_transaction!(@transaction, @expected_lock_version)
+        transaction.update!(customer: @customer)
+        Pos::Support.touch_working_transaction!(transaction)
+        transaction
+      end
+    end
+  end
+end

--- a/app/services/pos/complete_stored_value.rb
+++ b/app/services/pos/complete_stored_value.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+module Pos
+  class CompleteStoredValue
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(transaction:, actor:, operation:)
+      @transaction = transaction
+      @actor = actor
+      @operation = operation
+    end
+
+    def call
+      issuances = @transaction.pos_stored_value_issuances.ordered.to_a
+      tenders = stored_value_tenders
+      if issuances.any? && tenders.any? { |tender| tender.direction == "payment" }
+        raise Pos::Error, "cannot activate or reload and redeem stored value on the same transaction"
+      end
+
+      require_customer!(tenders)
+      issuances.each { |issuance| post_issuance!(issuance) }
+      tenders.each { |tender| post_tender!(tender) }
+    rescue StoredValue::Error, GiftCards::Error => e
+      raise Pos::Error, e.message
+    end
+
+    private
+
+    def stored_value_tenders
+      @transaction.pos_tenders.ordered.select(&:stored_value?)
+    end
+
+    def require_customer!(tenders)
+      needs_customer = tenders.any? { |tender|
+        type = tender.configured_tender_type
+        next false unless type&.stored_value?
+
+        type.stored_value_account_type.in?(%w[store_credit trade_credit]) ||
+          tender.stored_value_tender_detail&.customer_store_credit?
+      }
+      return unless needs_customer
+
+      customer = @transaction.customer
+      raise Pos::Error, "a customer is required" if customer.blank?
+      raise Pos::Error, "customer must be an active canonical customer" unless customer.canonical? && customer.active?
+    end
+
+    def post_issuance!(issuance)
+      return if issuance.stored_value_operation_id.present?
+
+      card = if issuance.reload_issuance?
+        issuance.gift_card
+      else
+        provision_activation_card!(issuance)
+      end
+      raise Pos::Error, "gift card is not available" unless card&.active?
+
+      operation = StoredValue::Post.call(
+        operation_type: issuance.issuance_type == "reload" ? "reload" : "activate",
+        store: @transaction.store,
+        performed_by: @actor,
+        source_id: @operation.id,
+        idempotency_key: Pos::Support.nested_stored_value_idempotency_key(@operation.id, "issuance", issuance.id),
+        pos_session: @transaction.pos_session,
+        business_date: @transaction.reporting_period.business_date,
+        entries: [ { account: card.stored_value_account, amount_cents: issuance.amount_cents } ]
+      )
+      issuance.update!(
+        gift_card: card,
+        stored_value_operation: operation,
+        masked_card_snapshot: card.masked_number,
+        pending_card_number: nil,
+        pending_card_number_digest: nil,
+        pending_card_number_prefix: nil,
+        pending_card_number_last_four: nil
+      )
+    end
+
+    def provision_activation_card!(issuance)
+      program = issuance.gift_card_program
+      raise Pos::Error, "gift-card program is required" if program.blank?
+
+      number = if program.system_generated?
+        nil
+      else
+        issuance.pending_card_number
+      end
+      GiftCards::ProvisionInstrument.call(
+        program: program,
+        store: @transaction.store,
+        number: number,
+        customer: @transaction.customer
+      )
+    end
+
+    def post_tender!(tender)
+      detail = tender.stored_value_tender_detail
+      raise Pos::Error, "stored-value tender is missing its detail" if detail.blank?
+      return if detail.stored_value_operation_id.present?
+
+      account = resolve_tender_account!(tender, detail)
+      amount = tender.direction == "payment" ? -tender.amount_cents : tender.amount_cents
+      if tender.direction == "payment" && account.balance_cents < tender.amount_cents
+        raise Pos::Error, "stored-value balance is insufficient"
+      end
+
+      operation = StoredValue::Post.call(
+        operation_type: tender.direction == "payment" ? "redeem" : "refund",
+        store: @transaction.store,
+        performed_by: @actor,
+        source_id: @operation.id,
+        idempotency_key: Pos::Support.nested_stored_value_idempotency_key(@operation.id, "tender", tender.id),
+        pos_session: @transaction.pos_session,
+        business_date: @transaction.reporting_period.business_date,
+        entries: [ { account: account, amount_cents: amount } ]
+      )
+      card = detail.gift_card || account.gift_card
+      detail.update!(
+        stored_value_operation: operation,
+        stored_value_account: account,
+        gift_card: card,
+        masked_card_snapshot: card&.masked_number || detail.masked_card_snapshot,
+        pending_card_number: nil,
+        pending_card_number_digest: nil,
+        pending_card_number_prefix: nil,
+        pending_card_number_last_four: nil
+      )
+    end
+
+    def resolve_tender_account!(tender, detail)
+      if detail.new_gift_card?
+        card = provision_refund_card!(detail)
+        detail.gift_card = card
+        return card.stored_value_account
+      end
+      if detail.customer_store_credit?
+        return StoredValue::EnsureCustomerAccount.call(customer: @transaction.customer, account_type: "store_credit")
+      end
+
+      account = detail.stored_value_account
+      raise Pos::Error, "stored-value account is required" if account.blank?
+      if tender.configured_tender_type.stored_value_account_type.in?(%w[store_credit trade_credit])
+        unless account.customer_id == @transaction.customer_id
+          raise Pos::Error, "stored-value account does not belong to this customer"
+        end
+      end
+      raise Pos::Error, "stored-value account is not available" unless account.active?
+
+      account
+    end
+
+    def provision_refund_card!(detail)
+      program = detail.gift_card_program
+      raise Pos::Error, "gift-card program is required" if program.blank?
+
+      GiftCards::ProvisionInstrument.call(
+        program: program,
+        store: @transaction.store,
+        number: program.manual_external? ? detail.pending_card_number : nil,
+        customer: @transaction.customer
+      )
+    end
+  end
+end

--- a/app/services/pos/complete_transaction.rb
+++ b/app/services/pos/complete_transaction.rb
@@ -9,7 +9,7 @@ module Pos
     end
 
     def self.command_payload(transaction:, operation_id:, expected_lock_version:, expected_total_cents:, expected_signed_net_cents: nil)
-      {
+      payload = {
         "transaction_id" => transaction.id.to_s,
         "operation_id" => operation_id.to_s,
         "expected_lock_version" => expected_lock_version.to_i,
@@ -18,8 +18,38 @@ module Pos
           transaction: transaction,
           expected_total_cents: expected_total_cents,
           expected_signed_net_cents: expected_signed_net_cents
-        )
+        ),
+        "stored_value_issuance_cents" => transaction.stored_value_issuance_cents.to_i,
+        "customer_id" => transaction.customer_id&.to_s,
+        "issuances" => transaction.pos_stored_value_issuances.ordered.map { |issuance|
+          {
+            "issuance_id" => issuance.id.to_s,
+            "issuance_type" => issuance.issuance_type,
+            "amount_cents" => issuance.amount_cents,
+            "gift_card_program_id" => issuance.gift_card_program_id&.to_s,
+            "gift_card_id" => issuance.gift_card_id&.to_s,
+            "number_authority" => issuance.number_authority
+          }
+        },
+        "stored_value_tenders" => transaction.pos_tenders.ordered.select(&:stored_value?).map { |tender|
+          detail = tender.stored_value_tender_detail
+          {
+            "tender_id" => tender.id.to_s,
+            "tender_type" => tender.tender_type,
+            "direction" => tender.direction,
+            "amount_cents" => tender.amount_cents,
+            "destination_mode" => detail&.destination_mode,
+            "stored_value_account_id" => detail&.stored_value_account_id&.to_s,
+            "gift_card_id" => detail&.gift_card_id&.to_s,
+            "gift_card_program_id" => detail&.gift_card_program_id&.to_s
+          }
+        }
       }
+      payload = payload.compact
+      payload.delete("issuances") if payload["issuances"].blank?
+      payload.delete("stored_value_tenders") if payload["stored_value_tenders"].blank?
+      payload.delete("stored_value_issuance_cents") if payload["stored_value_issuance_cents"].to_i.zero?
+      payload
     end
 
     def self.resolve_expected_signed_net_cents!(transaction:, expected_total_cents:, expected_signed_net_cents:)
@@ -134,6 +164,7 @@ module Pos
           raise Pos::Error, "expected signed net does not match"
         end
         settle_tenders!(transaction)
+        Pos::CompleteStoredValue.call(transaction: transaction, actor: @actor, operation: operation)
 
         completion_time = Time.current
         business_date = transaction.reporting_period.business_date
@@ -166,7 +197,7 @@ module Pos
       raise Pos::Error, "register does not match reporting period" unless transaction.register_id == period.register_id
       raise Pos::Error, "reporting period does not match session" unless transaction.reporting_period_id == session.reporting_period_id
       raise Pos::Error, "store does not match register" unless transaction.store_id == transaction.register.store_id
-      raise Pos::Error, "transaction has no merchandise" if transaction.pos_transaction_lines.none?
+      Pos::Support.require_commercial_content!(transaction)
     end
 
     def lock_original_sale_lines!(transaction)
@@ -343,7 +374,7 @@ module Pos
       operation.update!(
         status: "completed",
         fact_type: PosOperation::FACT_TYPE,
-        schema_version: 2,
+        schema_version: 3,
         pos_transaction_id: transaction.id,
         store_id: transaction.store_id,
         register_id: transaction.register_id,

--- a/app/services/pos/completed_envelope_builder.rb
+++ b/app/services/pos/completed_envelope_builder.rb
@@ -17,7 +17,7 @@ module Pos
 
     def call
       envelope = {
-        "schema_version" => 2,
+        "schema_version" => 3,
         "operation" => {
           "operation_id" => @operation_id.to_s,
           "fact_type" => PosOperation::FACT_TYPE
@@ -48,12 +48,16 @@ module Pos
           "return_discount_cents" => @transaction.return_discount_cents,
           "return_tax_cents" => @transaction.return_tax_cents,
           "return_total_cents" => @transaction.return_total_cents,
-          "signed_net_cents" => @transaction.signed_net_cents
+          "signed_net_cents" => @transaction.signed_net_cents,
+          "stored_value_issuance_cents" => @transaction.stored_value_issuance_cents
         },
         "lines" => @transaction.pos_transaction_lines.reload.map { |line| envelope_line(line) },
         "tenders" => @transaction.pos_tenders.ordered.map { |tender| envelope_tender(tender) }
       }
       envelope["transaction"]["discount_cents"] = @transaction.discount_cents unless @transaction.discount_cents.zero?
+      envelope["transaction"]["customer_id"] = @transaction.customer_id.to_s if @transaction.customer_id.present?
+      issuances = @transaction.pos_stored_value_issuances.ordered.map { |issuance| envelope_issuance(issuance) }
+      envelope["issuances"] = issuances if issuances.any?
       actions = @transaction.pos_controlled_actions.order(:executed_at, :id).map { |action| envelope_controlled_action(action) }
       envelope["controlled_actions"] = actions if actions.any?
       if @transaction.post_void?
@@ -218,6 +222,33 @@ module Pos
       end
       payload["external_reference"] = tender.external_reference if tender.external_reference.present?
       payload["post_void_source_tender_id"] = tender.post_void_source_tender_id.to_s if tender.post_void_source_tender_id.present?
+      detail = tender.stored_value_tender_detail
+      if detail
+        stored_value = {
+          "destination_mode" => detail.destination_mode,
+          "stored_value_operation_id" => detail.stored_value_operation_id&.to_s
+        }
+        stored_value["stored_value_account_id"] = detail.stored_value_account_id.to_s if detail.stored_value_account_id.present?
+        stored_value["gift_card_id"] = detail.gift_card_id.to_s if detail.gift_card_id.present?
+        stored_value["masked_card"] = detail.masked_card_snapshot if detail.masked_card_snapshot.present?
+        payload["stored_value"] = stored_value
+      end
+      payload
+    end
+
+    def envelope_issuance(issuance)
+      payload = {
+        "issuance_id" => issuance.id.to_s,
+        "issuance_number" => issuance.issuance_number,
+        "issuance_type" => issuance.issuance_type,
+        "amount_cents" => issuance.amount_cents,
+        "number_authority" => issuance.number_authority,
+        "stored_value_operation_id" => issuance.stored_value_operation_id&.to_s
+      }
+      payload["gift_card_id"] = issuance.gift_card_id.to_s if issuance.gift_card_id.present?
+      payload["gift_card_program_id"] = issuance.gift_card_program_id.to_s if issuance.gift_card_program_id.present?
+      payload["masked_card"] = issuance.masked_card_snapshot if issuance.masked_card_snapshot.present?
+      payload["post_void_source_issuance_id"] = issuance.post_void_source_issuance_id.to_s if issuance.post_void_source_issuance_id.present?
       payload
     end
   end

--- a/app/services/pos/completed_transaction_facts.rb
+++ b/app/services/pos/completed_transaction_facts.rb
@@ -45,8 +45,8 @@ module Pos
       raise Pos::Error, "completed envelope is missing register number" unless positive_integer?(receipt["register_number"])
       raise Pos::Error, "completed envelope fact_type is invalid" unless @envelope.dig("operation", "fact_type") == PosOperation::FACT_TYPE
       version = @envelope.fetch("schema_version")
-      raise Pos::Error, "completed envelope schema_version is invalid" unless [ 1, 2 ].include?(version)
-      return unless version == 2
+      raise Pos::Error, "completed envelope schema_version is invalid" unless [ 1, 2, 3 ].include?(version)
+      return unless version >= 2
 
       signed_net = @envelope.fetch("transaction")["signed_net_cents"]
       raise Pos::Error, "completed envelope is missing signed_net_cents" unless signed_net.is_a?(Integer)
@@ -57,6 +57,7 @@ module Pos
       verify_controlled_actions!
       verify_line_pricing_keys!
       verify_unlinked_return_facts!
+      verify_issuances! if version >= 3
     end
 
     private
@@ -132,7 +133,8 @@ module Pos
       end
 
       sale_total = subtotal - discount + tax
-      unless signed_net == sale_total - return_total
+      issuance = schema_version >= 3 ? optional_integer!(transaction, "stored_value_issuance_cents") : 0
+      unless signed_net == sale_total + issuance - return_total
         raise Pos::Error, "completed envelope signed_net_cents is invalid"
       end
       unless total == signed_net.abs
@@ -318,6 +320,26 @@ module Pos
         elsif targeting.any? { |action| action["action"] == "unlinked_return" }
           raise Pos::Error, "completed envelope cannot include unlinked_return action"
         end
+      end
+    end
+
+    def schema_version
+      @envelope.fetch("schema_version")
+    end
+
+    def verify_issuances!
+      transaction = @envelope.fetch("transaction")
+      raise Pos::Error, "completed envelope is missing stored_value_issuance_cents" unless transaction["stored_value_issuance_cents"].is_a?(Integer)
+
+      issuances = @envelope["issuances"]
+      return if issuances.nil?
+      raise Pos::Error, "completed envelope issuances are invalid" unless issuances.is_a?(Array)
+
+      issuances.each do |issuance|
+        raise Pos::Error, "completed envelope issuance is invalid" unless issuance.is_a?(Hash)
+        raise Pos::Error, "completed envelope is missing issuance type" if issuance["issuance_type"].blank?
+        raise Pos::Error, "completed envelope is missing issuance amount" unless issuance["amount_cents"].is_a?(Integer)
+        raise Pos::Error, "completed envelope cannot include a gift-card number" if issuance.key?("number") || issuance.key?("pending_card_number")
       end
     end
 

--- a/app/services/pos/customer_receipt.rb
+++ b/app/services/pos/customer_receipt.rb
@@ -124,6 +124,7 @@ module Pos
 
     def show_detail_totals?
       @transaction.discount_cents.positive? || @transaction.return_total_cents.positive? ||
+        @transaction.stored_value_issuance_cents.to_i != 0 ||
         @transaction.pos_transaction_lines.any?(&:return?)
     end
 
@@ -216,7 +217,30 @@ module Pos
     end
 
     def customer_lines
-      @transaction.pos_transaction_lines.map { |line| build_line(line) }
+      @transaction.pos_transaction_lines.map { |line| build_line(line) } + issuance_lines
+    end
+
+    def issuance_lines
+      @transaction.pos_stored_value_issuances.ordered.map do |issuance|
+        label = issuance.activation? ? "Gift card activation" : "Gift card reload"
+        masked = issuance.masked_card_snapshot
+        Line.new(
+          kind_banner: nil,
+          identifier: masked.to_s,
+          condition: nil,
+          description: [ label, issuance.gift_card_program&.name, masked ].compact.join(" · "),
+          amount_cents: issuance.post_void_generated? ? -issuance.amount_cents : issuance.amount_cents,
+          tax_indicators: "",
+          quantity: 1,
+          unit_price_cents: issuance.amount_cents,
+          show_unit_price: false,
+          extended_price_cents: issuance.amount_cents,
+          discount_cents: 0,
+          discount_label: nil,
+          original_reference: nil,
+          unlinked: false
+        )
+      end
     end
 
     def build_line(line)
@@ -300,7 +324,7 @@ module Pos
         raise Pos::Error, "receipt tax components do not equal persisted tax"
       end
 
-      computed = subtotal_cents + total_tax_cents
+      computed = subtotal_cents + total_tax_cents + @transaction.stored_value_issuance_cents.to_i
       return if computed == signed_net_cents
 
       raise Pos::Error, "receipt total does not equal signed_net_cents"

--- a/app/services/pos/first_print.rb
+++ b/app/services/pos/first_print.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Pos
+  class FirstPrint
+    Credential = Struct.new(:kind, :masked_number, :number, :amount_cents, :program_name, keyword_init: true)
+
+    def self.call(transaction)
+      new(transaction).call
+    end
+
+    def initialize(transaction)
+      @transaction = transaction
+    end
+
+    def call
+      credentials = []
+      @transaction.pos_stored_value_issuances.ordered.each do |issuance|
+        next unless issuance.system_generated?
+        card = issuance.gift_card
+        next if card.blank?
+
+        credentials << Credential.new(
+          kind: issuance.issuance_type,
+          masked_number: card.masked_number,
+          number: card.number,
+          amount_cents: issuance.amount_cents,
+          program_name: card.gift_card_program.name
+        )
+      end
+      @transaction.pos_tenders.ordered.each do |tender|
+        detail = tender.stored_value_tender_detail
+        next unless detail&.new_gift_card?
+
+        card = detail.gift_card
+        next unless card&.gift_card_program&.system_generated?
+
+        credentials << Credential.new(
+          kind: "refund_gift_card",
+          masked_number: card.masked_number,
+          number: card.number,
+          amount_cents: tender.amount_cents,
+          program_name: card.gift_card_program.name
+        )
+      end
+      credentials
+    end
+  end
+end

--- a/app/services/pos/post_void_integrity.rb
+++ b/app/services/pos/post_void_integrity.rb
@@ -19,6 +19,7 @@ module Pos
 
       verify_lines!
       verify_tenders!
+      verify_issuances!
       verify_no_sale_actions!
     end
 
@@ -103,6 +104,24 @@ module Pos
       raise Pos::Error, "post-void is missing the post_void fact" unless actions.one? { |action| action.action_type == "post_void" }
       extras = actions.reject { |action| action.action_type == "post_void" }
       raise Pos::Error, "post-void cannot copy sale or unlinked controlled actions" if extras.any?
+    end
+
+    def verify_issuances!
+      source_rows = @source.pos_stored_value_issuances.ordered.to_a
+      reversal_rows = @reversal.pos_stored_value_issuances.ordered.to_a
+      raise Pos::Error, "post-void must reverse every source issuance" unless source_rows.size == reversal_rows.size
+      used_ids = reversal_rows.filter_map(&:post_void_source_issuance_id)
+      raise Pos::Error, "post-void issuance lineage is incomplete" unless used_ids.sort == source_rows.map(&:id).sort
+
+      reversal_rows.each do |issuance|
+        source = issuance.post_void_source_issuance
+        raise Pos::Error, "post-void issuance is missing the source issuance" if source.nil?
+        unless issuance.amount_cents == source.amount_cents &&
+               issuance.issuance_type == source.issuance_type &&
+               issuance.gift_card_id == source.gift_card_id
+          raise Pos::Error, "post-void issuance does not match the source"
+        end
+      end
     end
 
     def opposite_direction?(source, line)

--- a/app/services/pos/post_void_stored_value.rb
+++ b/app/services/pos/post_void_stored_value.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+module Pos
+  class PostVoidStoredValue
+    def self.copy_rows!(source:, reversal:)
+      new(source: source, reversal: reversal, actor: nil, operation: nil).copy_rows!
+    end
+
+    def self.reverse!(source:, reversal:, actor:, operation:)
+      new(source: source, reversal: reversal, actor: actor, operation: operation).reverse!
+    end
+
+    def initialize(source:, reversal:, actor:, operation:)
+      @source = source
+      @reversal = reversal
+      @actor = actor
+      @operation = operation
+    end
+
+    def copy_rows!
+      copy_issuances!
+      copy_tender_details!
+    end
+
+    def reverse!
+      reverse_source_operations!
+    rescue StoredValue::Error => e
+      raise Pos::Error, post_void_blocked_message(e)
+    end
+
+    private
+
+    def copy_issuances!
+      @source.pos_stored_value_issuances.ordered.each_with_index do |source_issuance, index|
+        @reversal.pos_stored_value_issuances.create!(
+          issuance_number: index + 1,
+          issuance_type: source_issuance.issuance_type,
+          amount_cents: source_issuance.amount_cents,
+          gift_card_program: source_issuance.gift_card_program,
+          gift_card: source_issuance.gift_card,
+          number_authority: source_issuance.number_authority,
+          masked_card_snapshot: source_issuance.masked_card_snapshot,
+          post_void_source_issuance: source_issuance
+        )
+      end
+    end
+
+    def copy_tender_details!
+      @reversal.pos_tenders.ordered.each do |reversal_tender|
+        source = reversal_tender.post_void_source_tender
+        detail = source&.stored_value_tender_detail
+        next if detail.blank?
+
+        reversal_tender.create_stored_value_tender_detail!(
+          destination_mode: detail.destination_mode,
+          stored_value_account: detail.stored_value_account,
+          gift_card: detail.gift_card,
+          gift_card_program: detail.gift_card_program,
+          masked_card_snapshot: detail.masked_card_snapshot
+        )
+      end
+    end
+
+    def reverse_source_operations!
+      operations.each do |original|
+        next if original.reversed?
+
+        reversed = StoredValue::Reverse.call(
+          operation: original,
+          performed_by: @actor,
+          source_id: @operation.id,
+          idempotency_key: Pos::Support.nested_stored_value_idempotency_key(@operation.id, "reverse", original.id),
+          store: @reversal.store
+        )
+        link_reversal!(original, reversed)
+      end
+    end
+
+    def operations
+      ids = @source.pos_stored_value_issuances.filter_map(&:stored_value_operation_id)
+      ids += @source.pos_tenders.filter_map { |tender| tender.stored_value_tender_detail&.stored_value_operation_id }
+      StoredValueOperation.where(id: ids).order(:occurred_at, :id).to_a.reverse
+    end
+
+    def link_reversal!(original, reversed)
+      @reversal.pos_stored_value_issuances.where(post_void_source_issuance_id: original_issuance_ids(original)).find_each do |issuance|
+        issuance.update!(stored_value_operation: reversed)
+      end
+      @reversal.pos_tenders.each do |tender|
+        detail = tender.stored_value_tender_detail
+        next unless detail
+        next unless tender.post_void_source_tender&.stored_value_tender_detail&.stored_value_operation_id == original.id
+
+        detail.update!(stored_value_operation: reversed)
+      end
+    end
+
+    def original_issuance_ids(original)
+      @source.pos_stored_value_issuances.where(stored_value_operation_id: original.id).pluck(:id)
+    end
+
+    def post_void_blocked_message(error)
+      return error.message unless error.message.to_s.include?("negative")
+
+      downstream = downstream_operation_ids
+      suffix = downstream.any? ? " Downstream operations: #{downstream.join(', ')}." : ""
+      "Post-void cannot be completed because downstream stored-value activity cannot be fully reversed.#{suffix}"
+    end
+
+    def downstream_operation_ids
+      account_ids = operations.flat_map { |operation| operation.stored_value_entries.map(&:stored_value_account_id) }.uniq
+      return [] if account_ids.empty?
+
+      original_ids = operations.map(&:id)
+      StoredValueOperation.where(
+        id: StoredValueEntry.where(stored_value_account_id: account_ids).select(:stored_value_operation_id)
+      ).where.not(id: original_ids)
+       .where.not(operation_type: "reverse")
+       .order(:occurred_at, :id)
+       .limit(8)
+       .pluck(:id)
+    end
+  end
+end

--- a/app/services/pos/post_void_transaction.rb
+++ b/app/services/pos/post_void_transaction.rb
@@ -135,7 +135,7 @@ module Pos
         end
 
         source_lines = source.pos_transaction_lines.lock.order(:id).to_a
-        raise Pos::Error, "transaction has no merchandise" if source_lines.empty?
+        raise Pos::Error, "transaction has no merchandise" if source_lines.empty? && source.pos_stored_value_issuances.none?
         refuse_linked_returns!(source_lines)
         validate_card_reversals!(source)
 
@@ -158,6 +158,7 @@ module Pos
         Pos::PostVoidIntegrity.verify!(source: source, reversal: reversal)
         Pos::CompletedTransactionIntegrity.verify!(reversal)
         settle_generated_tenders!(reversal)
+        Pos::PostVoidStoredValue.reverse!(source: source, reversal: reversal, actor: @actor, operation: operation)
 
         completion_time = Time.current
         business_date = session.reporting_period.business_date
@@ -196,7 +197,7 @@ module Pos
     def clear_or_refuse_working_basket!(session)
       working = session.pos_transactions.working.first
       return if working.nil?
-      if working.pos_transaction_lines.exists? || working.pos_tenders.exists?
+      if working.pos_transaction_lines.exists? || working.pos_tenders.exists? || working.pos_stored_value_issuances.exists?
         raise Pos::Error, "Complete or cancel the current transaction before post-void."
       end
 
@@ -235,6 +236,7 @@ module Pos
         cashier_user: session.cashier_user,
         status: "working",
         currency_code: source.currency_code,
+        customer: source.customer,
         post_void_of_transaction_id: source.id
       )
       source_lines.each_with_index do |source_line, index|
@@ -285,6 +287,7 @@ module Pos
         end
         reversal.pos_tenders.create!(attrs)
       end
+      Pos::PostVoidStoredValue.copy_rows!(source: source, reversal: reversal)
       reversal
     end
 
@@ -399,7 +402,7 @@ module Pos
       operation.update!(
         status: "completed",
         fact_type: PosOperation::FACT_TYPE,
-        schema_version: 2,
+        schema_version: 3,
         pos_transaction_id: transaction.id,
         store_id: transaction.store_id,
         register_id: transaction.register_id,

--- a/app/services/pos/remove_stored_value_issuance.rb
+++ b/app/services/pos/remove_stored_value_issuance.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Pos
+  class RemoveStoredValueIssuance
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(transaction:, actor:, expected_lock_version:, issuance:)
+      @transaction = transaction
+      @actor = actor
+      @expected_lock_version = expected_lock_version
+      @issuance = issuance
+    end
+
+    def call
+      Pos::Support.authorize!(@actor, @transaction.store)
+      Pos::Support.require_active_context!(@transaction.store, @transaction.register)
+      Pos::Support.require_transaction_cashier!(@actor, @transaction)
+
+      PosTransaction.transaction do
+        transaction = Pos::Support.lock_working_transaction!(@transaction, @expected_lock_version)
+        issuance = transaction.pos_stored_value_issuances.find(@issuance.id)
+        issuance.destroy!
+        Pos::Support.clear_working_tenders!(transaction)
+        Pos::Support.refresh_totals!(transaction)
+        Pos::Support.touch_working_transaction!(transaction)
+        transaction
+      end
+    end
+  end
+end

--- a/app/services/pos/resolve_merchandise_for_sale.rb
+++ b/app/services/pos/resolve_merchandise_for_sale.rb
@@ -12,6 +12,8 @@ module Pos
       :units,
       :product,
       :products,
+      :gift_card,
+      :gift_card_program,
       :message,
       keyword_init: true
     )
@@ -44,6 +46,10 @@ module Pos
     private
 
     def resolve_identifier
+      if GiftCards::Number.matches_active_program?(@identifier)
+        return resolve_gift_card
+      end
+
       result = Identifiers::Lookup.call(@identifier)
       case result.status
       when :not_found, :retired
@@ -61,6 +67,17 @@ module Pos
       else
         unavailable("merchandise not found")
       end
+    end
+
+    def resolve_gift_card
+      program = GiftCards::Lookup.program_for(@identifier)
+      card = GiftCards::Lookup.by_number(@identifier)
+      Result.new(
+        outcome: :gift_card,
+        gift_card: card,
+        gift_card_program: program,
+        message: card ? nil : "gift card not on file"
+      )
     end
 
     # POS eligibility for a matched product identity: the matcher intentionally does

--- a/app/services/pos/resume_or_start_transaction.rb
+++ b/app/services/pos/resume_or_start_transaction.rb
@@ -6,10 +6,10 @@ module Pos
       new(**attrs).call
     end
 
-    def initialize(session:, actor:, currency_code: "USD")
+    def initialize(session:, actor:, currency_code: nil)
       @session = session
       @actor = actor
-      @currency_code = currency_code
+      @currency_code = currency_code.presence || SystemSettings.current.base_currency_code
     end
 
     def call

--- a/app/services/pos/start_transaction.rb
+++ b/app/services/pos/start_transaction.rb
@@ -6,10 +6,10 @@ module Pos
       new(**attrs).call
     end
 
-    def initialize(session:, actor:, currency_code: "USD")
+    def initialize(session:, actor:, currency_code: nil)
       @session = session
       @actor = actor
-      @currency_code = currency_code
+      @currency_code = currency_code.presence || SystemSettings.current.base_currency_code
     end
 
     def call

--- a/app/services/pos/support.rb
+++ b/app/services/pos/support.rb
@@ -103,7 +103,7 @@ module Pos
       tenders = transaction.pos_tenders.to_a
       case settlement_direction(transaction)
       when :none
-        transaction.pos_transaction_lines.any? && tenders.empty?
+        commercial_content?(transaction) && tenders.empty?
       when :payment
         tenders.any? &&
           tenders.all? { |tender| tender.direction == "payment" } &&
@@ -172,6 +172,30 @@ module Pos
       line.line_total_cents = line.net_merchandise_amount_cents + line.line_tax_cents
     end
 
+    def commercial_content?(transaction)
+      transaction.pos_transaction_lines.any? || transaction.pos_stored_value_issuances.any?
+    end
+
+    def require_commercial_content!(transaction)
+      return if commercial_content?(transaction)
+
+      raise Pos::Error, "transaction has no merchandise"
+    end
+
+    def nested_stored_value_idempotency_key(operation_id, kind, record_id)
+      Digest::UUID.uuid_v5(operation_id.to_s, "#{kind}:#{record_id}")
+    end
+
+    def next_issuance_number(transaction)
+      (transaction.pos_stored_value_issuances.maximum(:issuance_number) || 0) + 1
+    end
+
+    def issuance_contribution_cents(transaction)
+      transaction.pos_stored_value_issuances.sum { |issuance|
+        issuance.post_void_generated? ? -issuance.amount_cents : issuance.amount_cents
+      }
+    end
+
     def refresh_totals!(transaction)
       lines = transaction.pos_transaction_lines.reload
       sale_lines = lines.select(&:sale?)
@@ -188,7 +212,9 @@ module Pos
       transaction.return_total_cents =
         transaction.return_subtotal_cents - transaction.return_discount_cents + transaction.return_tax_cents
 
-      transaction.signed_net_cents = sale_total - transaction.return_total_cents
+      transaction.pos_stored_value_issuances.reload
+      transaction.stored_value_issuance_cents = issuance_contribution_cents(transaction)
+      transaction.signed_net_cents = sale_total + transaction.stored_value_issuance_cents - transaction.return_total_cents
       transaction.total_cents = transaction.signed_net_cents.abs
       transaction.save!
     end

--- a/app/services/pos/tender_cash.rb
+++ b/app/services/pos/tender_cash.rb
@@ -21,7 +21,7 @@ module Pos
 
       PosTransaction.transaction do
         transaction = Pos::Support.lock_working_transaction!(@transaction, @expected_lock_version)
-        raise Pos::Error, "transaction has no merchandise" if transaction.pos_transaction_lines.none?
+        Pos::Support.require_commercial_content!(transaction)
 
         cash_type = Pos::Support.cash_tender_type
         raise Pos::Error, "Cash is not available" unless cash_type.active?

--- a/app/services/pos/tender_types.rb
+++ b/app/services/pos/tender_types.rb
@@ -5,7 +5,40 @@ module Pos
     SEEDS = [
       { code: "cash", name: "Cash", behavioral_category: "cash", external_reference_policy: "omitted", allows_refund: true },
       { code: "card", name: "External Card", behavioral_category: "card", external_reference_policy: "optional", allows_refund: true },
-      { code: "check", name: "Check", behavioral_category: "check", external_reference_policy: "optional", allows_refund: false }
+      { code: "check", name: "Check", behavioral_category: "check", external_reference_policy: "optional", allows_refund: false },
+      {
+        code: "store_credit",
+        name: "Store credit",
+        behavioral_category: "stored_value",
+        stored_value_account_type: "store_credit",
+        external_reference_policy: "omitted",
+        allows_refund: true,
+        allows_original_tender_refund: true,
+        allows_generic_refund_destination: true,
+        allows_refund_instrument_replacement: false
+      },
+      {
+        code: "trade_credit",
+        name: "Trade credit",
+        behavioral_category: "stored_value",
+        stored_value_account_type: "trade_credit",
+        external_reference_policy: "omitted",
+        allows_refund: true,
+        allows_original_tender_refund: true,
+        allows_generic_refund_destination: false,
+        allows_refund_instrument_replacement: false
+      },
+      {
+        code: "gift_card",
+        name: "Gift card",
+        behavioral_category: "stored_value",
+        stored_value_account_type: "gift_card",
+        external_reference_policy: "omitted",
+        allows_refund: true,
+        allows_original_tender_refund: true,
+        allows_generic_refund_destination: false,
+        allows_refund_instrument_replacement: true
+      }
     ].freeze
 
     def self.seed!
@@ -14,8 +47,12 @@ module Pos
         type.assign_attributes(
           name: type.new_record? ? attrs[:name] : type.name,
           behavioral_category: attrs[:behavioral_category],
+          stored_value_account_type: attrs[:stored_value_account_type],
           external_reference_policy: type.new_record? ? attrs[:external_reference_policy] : type.external_reference_policy,
           allows_refund: type.new_record? ? attrs[:allows_refund] : type.allows_refund,
+          allows_original_tender_refund: type.new_record? ? attrs.fetch(:allows_original_tender_refund, false) : type.allows_original_tender_refund,
+          allows_generic_refund_destination: type.new_record? ? attrs.fetch(:allows_generic_refund_destination, false) : type.allows_generic_refund_destination,
+          allows_refund_instrument_replacement: type.new_record? ? attrs.fetch(:allows_refund_instrument_replacement, false) : type.allows_refund_instrument_replacement,
           system_protected: true,
           active: type.new_record? ? true : type.active
         )

--- a/app/views/pos/completed_transactions/show.html.erb
+++ b/app/views/pos/completed_transactions/show.html.erb
@@ -15,6 +15,24 @@
     <p class="pos-receipt__ref"><%= @transaction.transaction_reference %></p>
     <%= render "pos/receipts/post_void_banner", transaction: @transaction, linked: true %>
 
+    <% credentials = Pos::FirstPrint.call(@transaction) %>
+    <% if credentials.any? %>
+      <section class="pos-first-print" data-controller="pos-receipt">
+        <h2>Gift card credentials</h2>
+        <p>Print these numbers now. Ordinary receipts stay masked.</p>
+        <ul>
+          <% credentials.each do |credential| %>
+            <li>
+              <%= credential.kind.humanize %>
+              · <%= credential.program_name %>
+              · <%= format_money_cents(credential.amount_cents) %>
+              · <%= credential.number %>
+            </li>
+          <% end %>
+        </ul>
+      </section>
+    <% end %>
+
     <dl class="pos-receipt__totals">
       <%= render "pos/receipts/directional_totals", transaction: @transaction %>
       <% @tenders.each do |tender| %>

--- a/app/views/pos/receipts/_directional_totals.html.erb
+++ b/app/views/pos/receipts/_directional_totals.html.erb
@@ -24,5 +24,8 @@
     <div><dt>Tax reversal</dt><dd><%= format_signed_money_cents(-transaction.return_tax_cents) %></dd></div>
     <div><dt>Returns total</dt><dd><%= format_signed_money_cents(-transaction.return_total_cents) %></dd></div>
   <% end %>
+  <% if transaction.stored_value_issuance_cents.to_i != 0 %>
+    <div><dt>Gift cards</dt><dd><%= format_signed_money_cents(transaction.stored_value_issuance_cents) %></dd></div>
+  <% end %>
   <div><dt>Net</dt><dd><%= format_signed_money_cents(transaction.signed_net_cents) %></dd></div>
 <% end %>

--- a/app/views/pos/workspaces/_surface.html.erb
+++ b/app/views/pos/workspaces/_surface.html.erb
@@ -55,6 +55,8 @@
   end
   sale_lines = lines.select(&:sale?)
   return_lines = lines.select(&:return?)
+  issuances = @issuances || @transaction.pos_stored_value_issuances.ordered.to_a
+  gift_card_programs = @gift_card_programs || GiftCardProgram.active.admin_ordered.to_a
 %>
 
 <div id="pos_workspace"
@@ -89,7 +91,7 @@
           <%= link_to "POS Home", pos_path, class: "pos-header__link" %>
           <%= link_to "Transactions", pos_transactions_path, class: "pos-header__link" %>
           <%= link_to "X Report", pos_x_report_path, class: "pos-header__link" %>
-          <% if @ui_mode == "sale_entry" && lines.empty? && tenders.empty? %>
+          <% if @ui_mode == "sale_entry" && lines.empty? && tenders.empty? && issuances.empty? %>
             <%= action_button_to "Close register", pos_register_close_path, style: :outline, intent: :neutral, size: :standard, method: :post,
                   params: { session_id: @session_record.id, register_id: @register.id } %>
           <% end %>
@@ -181,6 +183,73 @@
             <% end %>
           </tbody>
         </table>
+        <% if issuances.any? || (@ui_mode == "sale_entry" && gift_card_programs.any?) %>
+          <section class="pos-issuances" aria-label="Gift cards">
+            <h2 class="pos-issuances__title">Gift cards</h2>
+            <% issuances.each do |issuance| %>
+              <div class="pos-issuance">
+                <%= issuance.activation? ? "Activation" : "Reload" %>
+                · <%= format_money_cents(issuance.amount_cents) %>
+                <% if issuance.masked_card_snapshot.present? || issuance.pending_card_number_last_four.present? %>
+                  · <%= issuance.masked_card_snapshot.presence || "#{issuance.pending_card_number_prefix}••••#{issuance.pending_card_number_last_four}" %>
+                <% elsif issuance.gift_card_program %>
+                  · <%= issuance.gift_card_program.name %>
+                <% end %>
+                <% if @ui_mode == "sale_entry" %>
+                  <%= button_to "Remove",
+                        pos_register_remove_stored_value_issuance_path(register_scope),
+                        method: :post,
+                        params: { lock_version: @transaction.lock_version, register_id: @register.id, issuance_id: issuance.id },
+                        form: { data: { turbo: true } },
+                        class: "btn btn--ghost" %>
+                <% end %>
+              </div>
+            <% end %>
+            <% if @ui_mode == "sale_entry" && gift_card_programs.any? %>
+              <%= form_with url: pos_register_stored_value_issuance_path(register_scope), method: :post, class: "pos-issuance-form" do %>
+                <%= hidden_field_tag :register_id, @register.id %>
+                <%= hidden_field_tag :lock_version, @transaction.lock_version %>
+                <label>
+                  Type
+                  <select name="issuance_type">
+                    <option value="activation">Activation</option>
+                    <option value="reload">Reload</option>
+                  </select>
+                </label>
+                <label>
+                  Program
+                  <select name="gift_card_program_id">
+                    <% gift_card_programs.each do |program| %>
+                      <option value="<%= program.id %>"><%= program.name %></option>
+                    <% end %>
+                  </select>
+                </label>
+                <label>
+                  Amount
+                  <input name="issuance_amount" inputmode="decimal" autocomplete="off">
+                </label>
+                <label>
+                  Card number
+                  <input name="card_number" autocomplete="off" data-register-workspace-target="issuanceCardNumber">
+                </label>
+                <%= submit_tag "Add gift card", class: "btn btn--solid btn--brand" %>
+              <% end %>
+            <% end %>
+          </section>
+        <% end %>
+        <% if @transaction.customer %>
+          <p class="pos-customer">Customer · <%= @transaction.customer.display_name %></p>
+        <% elsif @ui_mode == "sale_entry" %>
+          <%= form_with url: pos_register_attach_customer_path(register_scope), method: :post, class: "pos-customer-form" do %>
+            <%= hidden_field_tag :register_id, @register.id %>
+            <%= hidden_field_tag :lock_version, @transaction.lock_version %>
+            <label>
+              Customer id
+              <input name="customer_id" autocomplete="off">
+            </label>
+            <%= submit_tag "Attach customer", class: "btn btn--outline" %>
+          <% end %>
+        <% end %>
       </div>
 
       <aside id="pos_totals" class="pos-totals">
@@ -195,6 +264,9 @@
           <% if @transaction.return_discount_cents.positive? %>
             <div>Discount reversal  <%= format_signed_money_cents(@transaction.return_discount_cents) %></div>
           <% end %>
+        <% end %>
+        <% if @transaction.stored_value_issuance_cents.to_i != 0 %>
+          <div>Gift cards  <%= format_signed_money_cents(@transaction.stored_value_issuance_cents) %></div>
         <% end %>
         <div>Net  <%= format_signed_money_cents(@transaction.signed_net_cents) %></div>
         <% tenders.each do |working_tender| %>
@@ -235,6 +307,13 @@
              autocomplete="off"
              <%= "disabled" if locked || @ui_mode == "completion_pending" %>
              <%= "autofocus" unless locked || @ui_mode == "completion_failed" || completion_recovery %>>
+      <div data-register-workspace-target="giftCardNumberWrap" hidden>
+        <label for="pos-gift-card-number-field">Gift card number</label>
+        <input id="pos-gift-card-number-field"
+               class="pos-command__field"
+               data-register-workspace-target="giftCardNumberField"
+               autocomplete="off">
+      </div>
       <div data-register-workspace-target="referenceWrap" <%= "hidden" unless show_reference %>>
         <label for="pos-reference-field" data-register-workspace-target="referenceLabel">
           <%= selected_tender_type&.reference_field_label || "Reference" %>
@@ -285,6 +364,8 @@
                 data: { action: "register-workspace#chooseCheck", register_workspace_target: "checkButton" } %>
           <%= action_button "Other (F4)", style: :outline, intent: :neutral, size: :large, disabled: true,
                 data: { action: "register-workspace#chooseOther", register_workspace_target: "otherButton" } %>
+          <%= action_button "Stored value (F5)", style: :outline, intent: :neutral, size: :large, disabled: true,
+                data: { action: "register-workspace#chooseStoredValue", register_workspace_target: "storedValueButton" } %>
           <%= action_button (even_exchange ? "Complete (+)" : (refund_mode ? "Refund (+)" : "Tender (+)")),
                 style: :outline, intent: :neutral, size: :large, disabled: true,
                 data: { action: "register-workspace#enterTender", register_workspace_target: "tenderButton" } %>
@@ -345,6 +426,8 @@
       <%= hidden_field_tag :tender_amount, "", data: { register_workspace_target: "presentedInput" } %>
       <%= hidden_field_tag :tender_type_id, selected_tender_type&.id, data: { register_workspace_target: "tenderTypeInput" } %>
       <%= hidden_field_tag :external_reference, "", data: { register_workspace_target: "referenceInput" } %>
+      <%= hidden_field_tag :card_number, "", data: { register_workspace_target: "cardNumberInput" } %>
+      <%= hidden_field_tag :destination_mode, "", data: { register_workspace_target: "destinationModeInput" } %>
     <% end %>
 
     <%= form_with url: pos_register_remove_tender_path(register_scope), method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "removeTenderForm", turbo: true } } do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -212,6 +212,10 @@ Rails.application.routes.draw do
     post "register/abandon_tender", to: "workspaces#abandon_tender"
     post "register/cancel", to: "workspaces#cancel"
     post "register/tender", to: "workspaces#tender"
+    post "register/stored_value_issuance", to: "workspaces#stored_value_issuance"
+    post "register/remove_stored_value_issuance", to: "workspaces#remove_stored_value_issuance"
+    post "register/attach_customer", to: "workspaces#attach_customer"
+    get "register/customer_search", to: "workspaces#customer_search", as: :register_customer_search
     post "register/remove_tender", to: "workspaces#remove_tender"
     post "register/continue", to: "workspaces#continue"
     get "transactions/:transaction_id/return_items", to: "return_items#show", as: :transaction_return_items

--- a/db/migrate/20260826040000_create_phase10_pos_stored_value.rb
+++ b/db/migrate/20260826040000_create_phase10_pos_stored_value.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+class CreatePhase10PosStoredValue < ActiveRecord::Migration[8.1]
+  def change
+    add_column :pos_transactions, :stored_value_issuance_cents, :bigint, null: false, default: 0
+    add_column :pos_transactions, :customer_id, :uuid
+    add_index :pos_transactions, :customer_id
+    add_foreign_key :pos_transactions, :customers
+
+    remove_check_constraint :pos_transactions, name: "pos_transactions_signed_net_matches_components"
+    add_check_constraint :pos_transactions,
+                         "signed_net_cents = (subtotal_cents - discount_cents + tax_cents + stored_value_issuance_cents - return_total_cents)",
+                         name: "pos_transactions_signed_net_matches_components"
+
+    add_column :tender_types, :stored_value_account_type, :string
+    add_column :tender_types, :allows_original_tender_refund, :boolean, null: false, default: false
+    add_column :tender_types, :allows_generic_refund_destination, :boolean, null: false, default: false
+    add_column :tender_types, :allows_refund_instrument_replacement, :boolean, null: false, default: false
+
+    remove_check_constraint :tender_types, name: "tender_types_category_valid"
+    add_check_constraint :tender_types,
+                         "behavioral_category IN ('cash', 'card', 'check', 'other', 'stored_value')",
+                         name: "tender_types_category_valid"
+    add_check_constraint :tender_types,
+                         "(behavioral_category = 'stored_value' AND stored_value_account_type IN ('store_credit', 'trade_credit', 'gift_card')) OR (behavioral_category <> 'stored_value' AND stored_value_account_type IS NULL)",
+                         name: "tender_types_sv_account_type_matches"
+
+    remove_check_constraint :pos_tenders, name: "pos_tenders_category_valid"
+    add_check_constraint :pos_tenders,
+                         "behavioral_category IN ('cash', 'card', 'check', 'other', 'stored_value')",
+                         name: "pos_tenders_category_valid"
+
+    remove_check_constraint :pos_tenders, name: "pos_tenders_cash_presented_matches"
+    add_check_constraint :pos_tenders,
+                         <<~SQL.squish,
+                           (behavioral_category = 'cash' AND direction = 'payment' AND amount_presented_cents IS NOT NULL AND change_cents IS NOT NULL AND amount_presented_cents >= 0 AND change_cents >= 0 AND amount_presented_cents = (amount_cents + change_cents))
+                           OR (behavioral_category = 'cash' AND direction = 'refund' AND amount_presented_cents IS NULL AND change_cents IS NULL)
+                           OR (behavioral_category IN ('card', 'check', 'other', 'stored_value') AND amount_presented_cents IS NULL AND change_cents IS NULL)
+                         SQL
+                         name: "pos_tenders_cash_presented_matches"
+
+    create_uuid_table :pos_stored_value_issuances do |t|
+      t.uuid :pos_transaction_id, null: false
+      t.integer :issuance_number, null: false
+      t.string :issuance_type, null: false
+      t.bigint :amount_cents, null: false
+      t.uuid :gift_card_program_id
+      t.uuid :gift_card_id
+      t.string :number_authority, null: false
+      t.text :pending_card_number
+      t.string :pending_card_number_digest
+      t.string :pending_card_number_prefix
+      t.string :pending_card_number_last_four
+      t.uuid :stored_value_operation_id
+      t.uuid :post_void_source_issuance_id
+      t.string :masked_card_snapshot
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+    add_index :pos_stored_value_issuances, [ :pos_transaction_id, :issuance_number ], unique: true,
+              name: "index_pos_sv_issuances_on_txn_and_number"
+    add_index :pos_stored_value_issuances, :stored_value_operation_id, unique: true,
+              where: "stored_value_operation_id IS NOT NULL",
+              name: "index_pos_sv_issuances_on_operation"
+    add_index :pos_stored_value_issuances, :pending_card_number_digest, unique: true,
+              where: "pending_card_number_digest IS NOT NULL",
+              name: "index_pos_sv_issuances_on_pending_digest"
+    add_index :pos_stored_value_issuances, :gift_card_program_id
+    add_index :pos_stored_value_issuances, :gift_card_id
+    add_index :pos_stored_value_issuances, :post_void_source_issuance_id
+    add_foreign_key :pos_stored_value_issuances, :pos_transactions
+    add_foreign_key :pos_stored_value_issuances, :gift_card_programs
+    add_foreign_key :pos_stored_value_issuances, :gift_cards
+    add_foreign_key :pos_stored_value_issuances, :stored_value_operations
+    add_foreign_key :pos_stored_value_issuances, :pos_stored_value_issuances, column: :post_void_source_issuance_id
+    add_check_constraint :pos_stored_value_issuances,
+                         "issuance_type IN ('activation', 'reload')",
+                         name: "pos_sv_issuances_type_valid"
+    add_check_constraint :pos_stored_value_issuances,
+                         "number_authority IN ('system_generated', 'manual_external')",
+                         name: "pos_sv_issuances_authority_valid"
+    add_check_constraint :pos_stored_value_issuances,
+                         "amount_cents > 0",
+                         name: "pos_sv_issuances_amount_positive"
+    add_check_constraint :pos_stored_value_issuances,
+                         "issuance_type <> 'reload' OR gift_card_id IS NOT NULL",
+                         name: "pos_sv_issuances_reload_has_card"
+
+    create_uuid_table :pos_stored_value_tender_details do |t|
+      t.uuid :pos_tender_id, null: false
+      t.uuid :stored_value_operation_id
+      t.uuid :stored_value_account_id
+      t.uuid :gift_card_id
+      t.string :destination_mode, null: false
+      t.uuid :gift_card_program_id
+      t.text :pending_card_number
+      t.string :pending_card_number_digest
+      t.string :pending_card_number_prefix
+      t.string :pending_card_number_last_four
+      t.string :masked_card_snapshot
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+    add_index :pos_stored_value_tender_details, :pos_tender_id, unique: true
+    add_index :pos_stored_value_tender_details, :stored_value_operation_id, unique: true,
+              where: "stored_value_operation_id IS NOT NULL",
+              name: "index_pos_sv_tender_details_on_operation"
+    add_index :pos_stored_value_tender_details, :pending_card_number_digest, unique: true,
+              where: "pending_card_number_digest IS NOT NULL",
+              name: "index_pos_sv_tender_details_on_pending_digest"
+    add_index :pos_stored_value_tender_details, :stored_value_account_id
+    add_index :pos_stored_value_tender_details, :gift_card_id
+    add_index :pos_stored_value_tender_details, :gift_card_program_id
+    add_foreign_key :pos_stored_value_tender_details, :pos_tenders
+    add_foreign_key :pos_stored_value_tender_details, :stored_value_operations
+    add_foreign_key :pos_stored_value_tender_details, :stored_value_accounts
+    add_foreign_key :pos_stored_value_tender_details, :gift_cards
+    add_foreign_key :pos_stored_value_tender_details, :gift_card_programs
+    add_check_constraint :pos_stored_value_tender_details,
+                         "destination_mode IN ('existing_account', 'customer_store_credit', 'new_gift_card')",
+                         name: "pos_sv_tender_details_mode_valid"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_26_030000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_26_040000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -757,6 +757,58 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_030000) do
     t.check_constraint "status::text = ANY (ARRAY['open'::character varying::text, 'closed'::character varying::text])", name: "pos_sessions_status_valid"
   end
 
+  create_table "pos_stored_value_issuances", id: :uuid, default: nil, force: :cascade do |t|
+    t.bigint "amount_cents", null: false
+    t.timestamptz "created_at", null: false
+    t.uuid "gift_card_id"
+    t.uuid "gift_card_program_id"
+    t.integer "issuance_number", null: false
+    t.string "issuance_type", null: false
+    t.string "masked_card_snapshot"
+    t.string "number_authority", null: false
+    t.text "pending_card_number"
+    t.string "pending_card_number_digest"
+    t.string "pending_card_number_last_four"
+    t.string "pending_card_number_prefix"
+    t.uuid "pos_transaction_id", null: false
+    t.uuid "post_void_source_issuance_id"
+    t.uuid "stored_value_operation_id"
+    t.timestamptz "updated_at", null: false
+    t.index ["gift_card_id"], name: "index_pos_stored_value_issuances_on_gift_card_id"
+    t.index ["gift_card_program_id"], name: "index_pos_stored_value_issuances_on_gift_card_program_id"
+    t.index ["pending_card_number_digest"], name: "index_pos_sv_issuances_on_pending_digest", unique: true, where: "(pending_card_number_digest IS NOT NULL)"
+    t.index ["pos_transaction_id", "issuance_number"], name: "index_pos_sv_issuances_on_txn_and_number", unique: true
+    t.index ["post_void_source_issuance_id"], name: "idx_on_post_void_source_issuance_id_8d6ed268d9"
+    t.index ["stored_value_operation_id"], name: "index_pos_sv_issuances_on_operation", unique: true, where: "(stored_value_operation_id IS NOT NULL)"
+    t.check_constraint "amount_cents > 0", name: "pos_sv_issuances_amount_positive"
+    t.check_constraint "issuance_type::text <> 'reload'::text OR gift_card_id IS NOT NULL", name: "pos_sv_issuances_reload_has_card"
+    t.check_constraint "issuance_type::text = ANY (ARRAY['activation'::character varying, 'reload'::character varying]::text[])", name: "pos_sv_issuances_type_valid"
+    t.check_constraint "number_authority::text = ANY (ARRAY['system_generated'::character varying, 'manual_external'::character varying]::text[])", name: "pos_sv_issuances_authority_valid"
+  end
+
+  create_table "pos_stored_value_tender_details", id: :uuid, default: nil, force: :cascade do |t|
+    t.timestamptz "created_at", null: false
+    t.string "destination_mode", null: false
+    t.uuid "gift_card_id"
+    t.uuid "gift_card_program_id"
+    t.string "masked_card_snapshot"
+    t.text "pending_card_number"
+    t.string "pending_card_number_digest"
+    t.string "pending_card_number_last_four"
+    t.string "pending_card_number_prefix"
+    t.uuid "pos_tender_id", null: false
+    t.uuid "stored_value_account_id"
+    t.uuid "stored_value_operation_id"
+    t.timestamptz "updated_at", null: false
+    t.index ["gift_card_id"], name: "index_pos_stored_value_tender_details_on_gift_card_id"
+    t.index ["gift_card_program_id"], name: "index_pos_stored_value_tender_details_on_gift_card_program_id"
+    t.index ["pending_card_number_digest"], name: "index_pos_sv_tender_details_on_pending_digest", unique: true, where: "(pending_card_number_digest IS NOT NULL)"
+    t.index ["pos_tender_id"], name: "index_pos_stored_value_tender_details_on_pos_tender_id", unique: true
+    t.index ["stored_value_account_id"], name: "idx_on_stored_value_account_id_33336ce9b4"
+    t.index ["stored_value_operation_id"], name: "index_pos_sv_tender_details_on_operation", unique: true, where: "(stored_value_operation_id IS NOT NULL)"
+    t.check_constraint "destination_mode::text = ANY (ARRAY['existing_account'::character varying, 'customer_store_credit'::character varying, 'new_gift_card'::character varying]::text[])", name: "pos_sv_tender_details_mode_valid"
+  end
+
   create_table "pos_tenders", id: :uuid, default: nil, force: :cascade do |t|
     t.bigint "amount_cents", null: false
     t.bigint "amount_presented_cents"
@@ -779,8 +831,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_030000) do
     t.index ["post_void_source_tender_id"], name: "index_pos_tenders_one_post_void_source", unique: true, where: "(post_void_source_tender_id IS NOT NULL)"
     t.index ["tender_type_id"], name: "index_pos_tenders_on_tender_type_id"
     t.check_constraint "amount_cents >= 0", name: "pos_tenders_amount_nonnegative"
-    t.check_constraint "behavioral_category::text = 'cash'::text AND direction::text = 'payment'::text AND amount_presented_cents IS NOT NULL AND change_cents IS NOT NULL AND amount_presented_cents >= 0 AND change_cents >= 0 AND amount_presented_cents = (amount_cents + change_cents) OR behavioral_category::text = 'cash'::text AND direction::text = 'refund'::text AND amount_presented_cents IS NULL AND change_cents IS NULL OR (behavioral_category::text = ANY (ARRAY['card'::character varying::text, 'check'::character varying::text, 'other'::character varying::text])) AND amount_presented_cents IS NULL AND change_cents IS NULL", name: "pos_tenders_cash_presented_matches"
-    t.check_constraint "behavioral_category::text = ANY (ARRAY['cash'::character varying::text, 'card'::character varying::text, 'check'::character varying::text, 'other'::character varying::text])", name: "pos_tenders_category_valid"
+    t.check_constraint "behavioral_category::text = 'cash'::text AND direction::text = 'payment'::text AND amount_presented_cents IS NOT NULL AND change_cents IS NOT NULL AND amount_presented_cents >= 0 AND change_cents >= 0 AND amount_presented_cents = (amount_cents + change_cents) OR behavioral_category::text = 'cash'::text AND direction::text = 'refund'::text AND amount_presented_cents IS NULL AND change_cents IS NULL OR (behavioral_category::text = ANY (ARRAY['card'::character varying, 'check'::character varying, 'other'::character varying, 'stored_value'::character varying]::text[])) AND amount_presented_cents IS NULL AND change_cents IS NULL", name: "pos_tenders_cash_presented_matches"
+    t.check_constraint "behavioral_category::text = ANY (ARRAY['cash'::character varying, 'card'::character varying, 'check'::character varying, 'other'::character varying, 'stored_value'::character varying]::text[])", name: "pos_tenders_category_valid"
     t.check_constraint "direction::text = ANY (ARRAY['payment'::character varying::text, 'refund'::character varying::text])", name: "pos_tenders_direction_valid"
     t.check_constraint "post_void_source_tender_id IS NULL OR post_void_source_tender_id <> id", name: "pos_tenders_post_void_source_not_self"
     t.check_constraint "tender_number >= 1", name: "pos_tenders_number_positive"
@@ -847,6 +899,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_030000) do
     t.timestamptz "completed_at"
     t.timestamptz "created_at", null: false
     t.string "currency_code", limit: 3, null: false
+    t.uuid "customer_id"
     t.bigint "discount_cents", default: 0, null: false
     t.integer "lock_version", default: 0, null: false
     t.timestamptz "occurred_at"
@@ -864,12 +917,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_030000) do
     t.string "status", null: false
     t.uuid "store_id", null: false
     t.integer "store_number_snapshot"
+    t.bigint "stored_value_issuance_cents", default: 0, null: false
     t.bigint "subtotal_cents", default: 0, null: false
     t.bigint "tax_cents", default: 0, null: false
     t.bigint "total_cents", default: 0, null: false
     t.string "transaction_reference"
     t.timestamptz "updated_at", null: false
     t.index ["cashier_user_id"], name: "index_pos_transactions_on_cashier_user_id"
+    t.index ["customer_id"], name: "index_pos_transactions_on_customer_id"
     t.index ["pos_session_id"], name: "index_pos_transactions_on_pos_session_id"
     t.index ["pos_session_id"], name: "index_pos_transactions_one_working_per_session", unique: true, where: "((status)::text = 'working'::text)"
     t.index ["post_void_of_transaction_id"], name: "index_pos_transactions_one_post_void_per_source", unique: true, where: "(post_void_of_transaction_id IS NOT NULL)"
@@ -883,7 +938,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_030000) do
     t.check_constraint "post_void_of_transaction_id IS NULL OR post_void_of_transaction_id <> id", name: "pos_transactions_post_void_not_self"
     t.check_constraint "return_subtotal_cents >= 0 AND return_discount_cents >= 0 AND return_tax_cents >= 0 AND return_total_cents >= 0", name: "pos_transactions_return_totals_nonnegative"
     t.check_constraint "return_total_cents = (return_subtotal_cents - return_discount_cents + return_tax_cents)", name: "pos_transactions_return_total_matches_components"
-    t.check_constraint "signed_net_cents = (subtotal_cents - discount_cents + tax_cents - return_total_cents)", name: "pos_transactions_signed_net_matches_components"
+    t.check_constraint "signed_net_cents = (subtotal_cents - discount_cents + tax_cents + stored_value_issuance_cents - return_total_cents)", name: "pos_transactions_signed_net_matches_components"
     t.check_constraint "status::text = 'working'::text AND receipt_sequence IS NULL AND store_number_snapshot IS NULL AND register_number_snapshot IS NULL AND occurred_at IS NULL AND business_date IS NULL AND completed_at IS NULL AND cancelled_at IS NULL OR status::text = 'completed'::text AND receipt_sequence IS NOT NULL AND store_number_snapshot IS NOT NULL AND register_number_snapshot IS NOT NULL AND occurred_at IS NOT NULL AND business_date IS NOT NULL AND completed_at IS NOT NULL AND cancelled_at IS NULL OR status::text = 'cancelled'::text AND receipt_sequence IS NULL AND store_number_snapshot IS NULL AND register_number_snapshot IS NULL AND occurred_at IS NULL AND business_date IS NULL AND completed_at IS NULL AND cancelled_at IS NOT NULL", name: "pos_transactions_status_null_rules"
     t.check_constraint "status::text = ANY (ARRAY['working'::character varying::text, 'completed'::character varying::text, 'cancelled'::character varying::text])", name: "pos_transactions_status_valid"
     t.check_constraint "total_cents = abs(signed_net_cents)", name: "pos_transactions_total_matches_abs_signed_net"
@@ -1525,17 +1580,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_030000) do
 
   create_table "tender_types", id: :uuid, default: nil, force: :cascade do |t|
     t.boolean "active", default: true, null: false
+    t.boolean "allows_generic_refund_destination", default: false, null: false
+    t.boolean "allows_original_tender_refund", default: false, null: false
     t.boolean "allows_refund", default: false, null: false
+    t.boolean "allows_refund_instrument_replacement", default: false, null: false
     t.string "behavioral_category", null: false
     t.string "code", null: false
     t.timestamptz "created_at", null: false
     t.string "external_reference_policy", null: false
     t.integer "lock_version", default: 0, null: false
     t.string "name", null: false
+    t.string "stored_value_account_type"
     t.boolean "system_protected", default: false, null: false
     t.timestamptz "updated_at", null: false
     t.index ["code"], name: "index_tender_types_on_code", unique: true
-    t.check_constraint "behavioral_category::text = ANY (ARRAY['cash'::character varying::text, 'card'::character varying::text, 'check'::character varying::text, 'other'::character varying::text])", name: "tender_types_category_valid"
+    t.check_constraint "behavioral_category::text = 'stored_value'::text AND (stored_value_account_type::text = ANY (ARRAY['store_credit'::character varying, 'trade_credit'::character varying, 'gift_card'::character varying]::text[])) OR behavioral_category::text <> 'stored_value'::text AND stored_value_account_type IS NULL", name: "tender_types_sv_account_type_matches"
+    t.check_constraint "behavioral_category::text = ANY (ARRAY['cash'::character varying, 'card'::character varying, 'check'::character varying, 'other'::character varying, 'stored_value'::character varying]::text[])", name: "tender_types_category_valid"
     t.check_constraint "code::text <> 'cash'::text OR allows_refund = true", name: "tender_types_cash_allows_refund"
     t.check_constraint "external_reference_policy::text = ANY (ARRAY['omitted'::character varying::text, 'optional'::character varying::text, 'required'::character varying::text])", name: "tender_types_reference_policy_valid"
   end
@@ -1665,6 +1725,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_030000) do
   add_foreign_key "pos_sessions", "registers"
   add_foreign_key "pos_sessions", "stores"
   add_foreign_key "pos_sessions", "users", column: "cashier_user_id"
+  add_foreign_key "pos_stored_value_issuances", "gift_card_programs"
+  add_foreign_key "pos_stored_value_issuances", "gift_cards"
+  add_foreign_key "pos_stored_value_issuances", "pos_stored_value_issuances", column: "post_void_source_issuance_id"
+  add_foreign_key "pos_stored_value_issuances", "pos_transactions"
+  add_foreign_key "pos_stored_value_issuances", "stored_value_operations"
+  add_foreign_key "pos_stored_value_tender_details", "gift_card_programs"
+  add_foreign_key "pos_stored_value_tender_details", "gift_cards"
+  add_foreign_key "pos_stored_value_tender_details", "pos_tenders"
+  add_foreign_key "pos_stored_value_tender_details", "stored_value_accounts"
+  add_foreign_key "pos_stored_value_tender_details", "stored_value_operations"
   add_foreign_key "pos_tenders", "pos_tenders", column: "post_void_source_tender_id", on_delete: :restrict
   add_foreign_key "pos_tenders", "pos_transactions"
   add_foreign_key "pos_tenders", "tender_types", on_delete: :restrict
@@ -1676,6 +1746,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_030000) do
   add_foreign_key "pos_transaction_lines", "product_variants"
   add_foreign_key "pos_transaction_lines", "tax_classes"
   add_foreign_key "pos_transaction_lines", "tax_classes", column: "default_tax_class_id"
+  add_foreign_key "pos_transactions", "customers"
   add_foreign_key "pos_transactions", "pos_reporting_periods", column: "reporting_period_id"
   add_foreign_key "pos_transactions", "pos_sessions"
   add_foreign_key "pos_transactions", "pos_transactions", column: "post_void_of_transaction_id", on_delete: :restrict

--- a/docs/planning/phase10-stored-value/phase10-implementation-plan.md
+++ b/docs/planning/phase10-stored-value/phase10-implementation-plan.md
@@ -52,7 +52,7 @@ Issue branches PR **directly to `main`**. There is no `phase-10-stored-value` in
 | 10.1 Stored-value core | Complete (issue [#59](https://github.com/BankEncore/ShelfSense-v1/issues/59)) |
 | 10.2 Customer store/trade credit | Complete (issue [#60](https://github.com/BankEncore/ShelfSense-v1/issues/60)) |
 | 10.3 Gift-card programs and instruments | Complete (issue [#61](https://github.com/BankEncore/ShelfSense-v1/issues/61)) |
-| 10.4 POS issuance, tenders, refund destinations, post-void | Not started |
+| 10.4 POS issuance, tenders, refund destinations, post-void | Complete (issue [#62](https://github.com/BankEncore/ShelfSense-v1/issues/62)) |
 | 10.5 Cash-out, closeout, print, nav | Not started |
 
 ## Integration notes

--- a/docs/planning/phase10-stored-value/phase10-schema.md
+++ b/docs/planning/phase10-stored-value/phase10-schema.md
@@ -259,7 +259,7 @@ Add:
 
 | Column | Type | Contract |
 |---|---|---|
-| `stored_value_issuance_cents` | bigint | Default 0; ≥ 0; sum of activation/reload issuance amounts |
+| `stored_value_issuance_cents` | bigint | Default 0; sum of activation/reload issuance amounts. Post-void reversals persist the negated contribution so signed-net stays one formula. |
 | `customer_id` | uuid, nullable | FK → `customers`; optional until complete |
 
 Replace check `pos_transactions_signed_net_matches_components`:

--- a/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/controlled-actions.md
+++ b/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/controlled-actions.md
@@ -437,7 +437,7 @@ Second-actor success: approval event with the **approver** as audit actor, plus 
 
 Architectural lock: each 6.4 action has a **visible, keyboard-accessible control** and applies to the **selected line**. Disabled with no selection, empty basket, or completion in flight.
 
-Current bindings in [register-workspace.md](../phase5-cash-register/register-workspace.md) (F5 override, F6 discount, F7 Tax Class) are **superseded by 6.7** ([pos-workflow.md](pos-workflow.md)): F6 **Price** (override on ordinary sale lines; open-price edit on open-price lines), F7 discount, Tax Class visible-only, F5 unbound. Policy, fingerprints, and overlay rules in this document remain authoritative. Enter-in-overlay behavior is 6.7 §7.
+Current bindings in [register-workspace.md](../phase5-cash-register/register-workspace.md) (F5 override, F6 discount, F7 Tax Class) are **superseded by 6.7** ([pos-workflow.md](pos-workflow.md)): F6 **Price** (override on ordinary sale lines; open-price edit on open-price lines), F7 discount, Tax Class visible-only. Phase 10.4 binds F5 to stored-value tenders. Policy, fingerprints, and overlay rules in this document remain authoritative. Enter-in-overlay behavior is 6.7 §7.
 
 Approval overlay is a **second** overlay besides cancel:
 

--- a/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/mvp-contract.md
+++ b/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/mvp-contract.md
@@ -59,7 +59,8 @@ correction relationships
 
 ```text
 schema_version: 1   # envelopes already written (Phase 4/5)
-schema_version: 2   # all new completions once 6.1 ships v2 construction
+schema_version: 2   # 6.1 commercial expansion (stored envelopes remain valid)
+schema_version: 3   # all new completions once 10.4 ships stored-value issuance on signed-net
 ```
 
 Existing stored envelopes stay v1. Material semantic changes (sign rules, tax rate scale, identity fields) already required a new version in v1; v2 is that additive commercial expansion.

--- a/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/pos-workflow.md
+++ b/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/pos-workflow.md
@@ -29,7 +29,7 @@ scan unique sellable → add immediately
 - opens Linked/Unlinked chooser (keyboard)
 post-void remains history-only
 F10 opens history; working basket untouched
-F5 left unbound (browser)
+F5 stored-value tenders (Phase 10.4; Keyboard Lock includes F5)
 + = Cash with remaining prefilled (not a generic “any tender”)
 Enter in scanner-sensitive fields resolves; never confirms cancel
 ```
@@ -200,7 +200,7 @@ The cookie confers neither authorization nor Session ownership.
 | F2 | Card |
 | F3 | Check |
 | F4 | Other |
-| F5 | unbound (browser) |
+| F5 | stored-value tenders |
 | F6 | **Price** on selected sale line (§9.3) |
 | F7 | line discount on selected sale line |
 | F8 | remove selected line or selected tender |
@@ -210,9 +210,9 @@ The cookie confers neither authorization nor Session ownership.
 
 Intercept `/`, `*`, `-`, `+` only when the primary field is **empty** (same pattern as today’s `*` / `+`). A hyphen or slash inside a typed/scanned identifier is not Return or Search.
 
-Extend Keyboard Lock to F1–F4 and F6–F10. **Never** lock F5. Postpone Ctrl/Cmd/Alt.
+Extend Keyboard Lock to F1–F10. Phase 10.4 binds F5 to stored-value tenders (6.7 left it unbound). Postpone Ctrl/Cmd/Alt.
 
-Every shortcut has a visible, focusable control. Unavailable keys explain why (§12.2) — no silent no-op for F1–F4 / F6 / F7 / F8 / `*` / `+` when the cashier has reason to think they should work.
+Every shortcut has a visible, focusable control. Unavailable keys explain why (§12.2) — no silent no-op for F1–F5 / F6 / F7 / F8 / `*` / `+` when the cashier has reason to think they should work.
 
 F6/F7 remain disabled on **return** lines ([returns.md](returns.md)). Tax Class stays a **visible control** only (no F-key).
 

--- a/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/post-void.md
+++ b/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/post-void.md
@@ -169,7 +169,7 @@ No Session ⇒ `Open a register before processing a post-void.` A **nonempty** w
 ```text
 command_type = pos.post_void_transaction
 fact_type    = pos.transaction_completed
-schema_version = 2
+schema_version = 3   # new completions; stored v1/v2 envelopes remain valid
 ```
 
 Narrowly generalize `Pos::OperationLease` to accept `command_type`. Ordinary complete defaults to `pos.complete_transaction` and stays unchanged.

--- a/test/integration/pos_register_test.rb
+++ b/test/integration/pos_register_test.rb
@@ -124,7 +124,9 @@ class PosRegisterTest < ActionDispatch::IntegrationTest
     assert_equal true, by_id.fetch(cash.id.to_s).fetch("allows_refund")
     assert_equal true, by_id.fetch(card.id.to_s).fetch("allows_refund")
     assert_equal false, by_id.fetch(voucher.id.to_s).fetch("allows_refund")
-    assert_equal %w[cash card check other other], payload.map { |row| row.fetch("category") }
+    gift_card = TenderType.find_by!(code: "gift_card")
+    assert_equal "gift_card", by_id.fetch(gift_card.id.to_s).fetch("stored_value_account_type")
+    assert_equal %w[cash card check stored_value stored_value stored_value other other], payload.map { |row| row.fetch("category") }
   end
 
   test "workspace can take Card then Cash and complete" do

--- a/test/services/pos/complete_transaction_test.rb
+++ b/test/services/pos/complete_transaction_test.rb
@@ -277,7 +277,7 @@ class PosCompleteTransactionTest < ActiveSupport::TestCase
 
   test "headless vertical slice matches Phase 4 acceptance" do
     envelope = Pos::CompleteTransaction.call(**complete_args).operation.envelope
-    assert_equal 2, envelope.fetch("schema_version")
+    assert_equal 3, envelope.fetch("schema_version")
     assert_equal envelope.fetch("transaction").fetch("total_cents"), envelope.fetch("transaction").fetch("signed_net_cents")
     assert_equal 0, envelope.fetch("transaction").fetch("return_subtotal_cents")
     assert_equal 0, envelope.fetch("transaction").fetch("return_discount_cents")

--- a/test/services/pos/merchandise_breadth_test.rb
+++ b/test/services/pos/merchandise_breadth_test.rb
@@ -123,7 +123,7 @@ class PosMerchandiseBreadthTest < ActiveSupport::TestCase
     unit_line = transaction.pos_transaction_lines.find_by!(inventory_unit_id: @unit.id)
     service_line = transaction.pos_transaction_lines.find_by!(product_variant_id: @non_inventory.id)
 
-    assert_equal 2, envelope.fetch("schema_version")
+    assert_equal 3, envelope.fetch("schema_version")
     assert_equal transaction.total_cents, envelope.fetch("transaction").fetch("signed_net_cents")
     assert_equal @unit.id.to_s, envelope.fetch("lines").find { |line| line["inventory_unit_id"] }.fetch("inventory_unit_id")
     refute envelope.fetch("lines").find { |line| line["product_variant_id"] == @standard.id }.key?("inventory_unit_id")

--- a/test/services/pos/post_void_transaction_test.rb
+++ b/test/services/pos/post_void_transaction_test.rb
@@ -52,6 +52,8 @@ class PosPostVoidTransactionTest < ActiveSupport::TestCase
     assert_nil reversal_line.return_reason_code
     assert_equal source_line.line_total_cents, reversal_line.line_total_cents
     assert_equal(-source.signed_net_cents, reversal.signed_net_cents)
+    assert_equal 0, reversal.stored_value_issuance_cents
+    assert_equal 3, envelope.fetch("schema_version")
     assert_equal source.currency_code, reversal.currency_code
     refute_equal source.transaction_reference, reversal.transaction_reference
     assert_equal source.reporting_period.business_date, reversal.business_date

--- a/test/services/pos/stored_value_completion_test.rb
+++ b/test/services/pos/stored_value_completion_test.rb
@@ -1,0 +1,367 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PosStoredValueCompletionTest < ActiveSupport::TestCase
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    @tax = tax_class(code: "physical_book", name: "Physical book")
+    StoreTaxes::Create.call(
+      store: @store,
+      actor: @actor,
+      name: "Illinois State",
+      rate_percent: "5.000",
+      calculation_order: 1,
+      applies_by_tax_class_id: { @tax.id => true }
+    )
+    @variant = pos_sellable_variant(actor: @actor, tax_class: @tax)
+    open_quantity_stock(store: @store, variant: @variant, actor: @actor, quantity: 10, unit_cost_cents: 100)
+    @context = pos_open_context(store: @store, actor: @actor, opening_float_cents: 10_000)
+    GiftCards::Programs.seed!
+    Pos::TenderTypes.seed!
+    @program = GiftCardProgram.find_by!(code: "generated")
+    @gift_card_type = TenderType.find_by!(code: "gift_card")
+    @store_credit_type = TenderType.find_by!(code: "store_credit")
+    @trade_credit_type = TenderType.find_by!(code: "trade_credit")
+    @cash = TenderType.find_by!(code: "cash")
+  end
+
+  test "generated activation increases signed net, posts activate, and first print decrypts" do
+    transaction = Pos::StartTransaction.call(session: @context[:session], actor: @actor)
+    assert_equal SystemSettings.current.base_currency_code, transaction.currency_code
+
+    Pos::AddStoredValueIssuance.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      issuance_type: "activation",
+      amount_cents: 2500,
+      gift_card_program: @program
+    )
+    transaction.reload
+    assert_equal 2500, transaction.stored_value_issuance_cents
+    assert_equal 2500, transaction.signed_net_cents
+    assert_equal 0, transaction.sale_total_cents
+
+    Pos::TenderCash.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      amount_presented_cents: 2500
+    )
+    result = complete_current!(transaction.reload)
+    issuance = result.transaction.pos_stored_value_issuances.sole
+    card = issuance.gift_card
+
+    assert result.transaction.completed?
+    assert_equal "activate", issuance.stored_value_operation.operation_type
+    assert_equal 2500, card.stored_value_account.balance_cents
+    assert_equal 3, result.operation.envelope.fetch("schema_version")
+    assert_equal 2500, result.operation.envelope.dig("transaction", "stored_value_issuance_cents")
+    refute result.operation.envelope.to_s.include?(card.number)
+    credentials = Pos::FirstPrint.call(result.transaction)
+    assert_equal 1, credentials.size
+    assert_equal card.number, credentials.first.number
+    Pos::CompletedTransactionFacts.new(result.operation.envelope).verify!
+    assert_equal result.transaction.signed_net_cents, Pos::CustomerReceipt.build(result.transaction).signed_net_cents
+  end
+
+  test "gift-card redeem posts a negative redeem and rejects same-ticket issuance" do
+    card = GiftCards::ProvisionInstrument.call(program: @program, store: @store)
+    GiftCards::Fund.call(gift_card: card, amount_cents: 5000, store: @store, performed_by: @actor)
+
+    transaction = start_sale
+    error = assert_raises(Pos::Error) do
+      Pos::AddStoredValueIssuance.call(
+        transaction: transaction,
+        actor: @actor,
+        expected_lock_version: transaction.lock_version,
+        issuance_type: "activation",
+        amount_cents: 1000,
+        gift_card_program: @program
+      )
+      Pos::AddStoredValueTender.call(
+        transaction: transaction.reload,
+        actor: @actor,
+        expected_lock_version: transaction.lock_version,
+        tender_type: @gift_card_type,
+        amount_cents: 1000,
+        card_number: card.number
+      )
+    end
+    assert_match(/cannot redeem stored value on a ticket with gift-card issuance/, error.message)
+    Pos::CancelTransaction.call(
+      transaction: transaction.reload,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version
+    )
+
+    transaction = start_sale
+    Pos::AddStoredValueTender.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      tender_type: @gift_card_type,
+      amount_cents: transaction.signed_net_cents,
+      card_number: card.number
+    )
+    result = complete_current!(transaction.reload)
+    detail = result.transaction.pos_tenders.sole.stored_value_tender_detail
+    assert_equal "redeem", detail.stored_value_operation.operation_type
+    assert_equal 5000 - result.transaction.signed_net_cents, card.stored_value_account.reload.balance_cents
+  end
+
+  test "store-credit payment requires a customer and trade credit is not a generic refund destination" do
+    customer = Customer.create!(display_name: "POS Customer", email: "pos.sv@example.com")
+    account = StoredValue::EnsureCustomerAccount.call(customer: customer, account_type: "store_credit")
+    StoredValue::Adjust.call(
+      account: account,
+      direction: "credit",
+      amount_cents: 3000,
+      reason: StoredValueAdjustmentReason.find_by!(code: "goodwill"),
+      store: @store,
+      performed_by: @actor,
+      source_id: SecureRandom.uuid_v7,
+      idempotency_key: SecureRandom.uuid_v7
+    )
+
+    transaction = start_sale
+    error = assert_raises(Pos::Error) do
+      Pos::AddStoredValueTender.call(
+        transaction: transaction,
+        actor: @actor,
+        expected_lock_version: transaction.lock_version,
+        tender_type: @store_credit_type,
+        amount_cents: 1000
+      )
+    end
+    assert_match(/customer is required/, error.message)
+
+    Pos::AttachCustomer.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      customer: customer
+    )
+    Pos::AddStoredValueTender.call(
+      transaction: transaction.reload,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      tender_type: @store_credit_type,
+      amount_cents: transaction.signed_net_cents
+    )
+    result = complete_current!(transaction.reload)
+    assert_equal "redeem", result.transaction.pos_tenders.sole.stored_value_tender_detail.stored_value_operation.operation_type
+
+    refund_txn = Pos::StartTransaction.call(session: @context[:session], actor: @actor)
+    Pos::AddLinkedReturnLine.call(
+      transaction: refund_txn,
+      actor: @actor,
+      expected_lock_version: refund_txn.lock_version,
+      original_line: result.transaction.pos_transaction_lines.first,
+      quantity: 1,
+      reason_code: "changed_mind"
+    )
+    refund_txn.reload
+    Pos::AttachCustomer.call(
+      transaction: refund_txn,
+      actor: @actor,
+      expected_lock_version: refund_txn.lock_version,
+      customer: customer
+    )
+    error = assert_raises(Pos::Error) do
+      Pos::AddStoredValueRefundTender.call(
+        transaction: refund_txn.reload,
+        actor: @actor,
+        expected_lock_version: refund_txn.lock_version,
+        tender_type: @trade_credit_type,
+        amount_cents: -refund_txn.signed_net_cents,
+        destination_mode: "existing_account"
+      )
+    end
+    assert_match(/original account|trade credit/, error.message)
+
+    Pos::AddStoredValueRefundTender.call(
+      transaction: refund_txn.reload,
+      actor: @actor,
+      expected_lock_version: refund_txn.lock_version,
+      tender_type: @store_credit_type,
+      amount_cents: -refund_txn.signed_net_cents,
+      destination_mode: "customer_store_credit"
+    )
+    refund_result = complete_current!(refund_txn.reload, expected_signed_net_cents: refund_txn.signed_net_cents)
+    assert_equal "refund", refund_result.transaction.pos_tenders.sole.stored_value_tender_detail.stored_value_operation.operation_type
+  end
+
+  test "trade-credit original tender refunds return to the same account" do
+    customer = Customer.create!(display_name: "Trade Customer", email: "pos.trade@example.com")
+    account = StoredValue::EnsureCustomerAccount.call(customer: customer, account_type: "trade_credit")
+    StoredValue::Adjust.call(
+      account: account,
+      direction: "credit",
+      amount_cents: 3000,
+      reason: StoredValueAdjustmentReason.find_by!(code: "goodwill"),
+      store: @store,
+      performed_by: @actor,
+      source_id: SecureRandom.uuid_v7,
+      idempotency_key: SecureRandom.uuid_v7
+    )
+    opening_balance = account.reload.balance_cents
+
+    transaction = start_sale
+    Pos::AttachCustomer.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      customer: customer
+    )
+    Pos::AddStoredValueTender.call(
+      transaction: transaction.reload,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      tender_type: @trade_credit_type,
+      amount_cents: transaction.signed_net_cents
+    )
+    sale = complete_current!(transaction.reload).transaction
+    assert_equal opening_balance - sale.signed_net_cents, account.reload.balance_cents
+
+    refund_txn = Pos::StartTransaction.call(session: @context[:session], actor: @actor)
+    Pos::AddLinkedReturnLine.call(
+      transaction: refund_txn,
+      actor: @actor,
+      expected_lock_version: refund_txn.lock_version,
+      original_line: sale.pos_transaction_lines.first,
+      quantity: 1,
+      reason_code: "changed_mind"
+    )
+    Pos::AttachCustomer.call(
+      transaction: refund_txn.reload,
+      actor: @actor,
+      expected_lock_version: refund_txn.lock_version,
+      customer: customer
+    )
+    Pos::AddStoredValueRefundTender.call(
+      transaction: refund_txn.reload,
+      actor: @actor,
+      expected_lock_version: refund_txn.lock_version,
+      tender_type: @trade_credit_type,
+      amount_cents: -refund_txn.signed_net_cents,
+      destination_mode: "existing_account"
+    )
+    refund = complete_current!(refund_txn.reload, expected_signed_net_cents: refund_txn.signed_net_cents).transaction
+    assert_equal "refund", refund.pos_tenders.sole.stored_value_tender_detail.stored_value_operation.operation_type
+    assert_equal account.id, refund.pos_tenders.sole.stored_value_tender_detail.stored_value_account_id
+    assert_equal opening_balance, account.reload.balance_cents
+  end
+
+  test "gift-card shaped scans do not resolve as merchandise" do
+    number = GiftCards::Number.generate(@program)
+    result = Pos::ResolveMerchandiseForSale.call(store: @store, identifier: number)
+    assert_equal :gift_card, result.outcome
+    assert_nil result.gift_card
+    assert_equal @program.id, result.gift_card_program.id
+  end
+
+  test "post-void reverses activation and blocks when downstream spend would overdraw" do
+    transaction = Pos::StartTransaction.call(session: @context[:session], actor: @actor)
+    Pos::AddStoredValueIssuance.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      issuance_type: "activation",
+      amount_cents: 2500,
+      gift_card_program: @program
+    )
+    Pos::TenderCash.call(
+      transaction: transaction.reload,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      amount_presented_cents: 2500
+    )
+    source = complete_current!(transaction.reload).transaction
+    card = source.pos_stored_value_issuances.sole.gift_card
+
+    reversal = Pos::PostVoidTransaction.call(
+      source: source,
+      actor: @actor,
+      session: @context[:session],
+      operation_id: SecureRandom.uuid_v7,
+      reversal_transaction_id: SecureRandom.uuid_v7,
+      reason_code: "entered_in_error"
+    ).transaction
+    assert_equal(-source.signed_net_cents, reversal.signed_net_cents)
+    assert_equal 0, card.stored_value_account.reload.balance_cents
+
+    activation = Pos::StartTransaction.call(session: @context[:session], actor: @actor)
+    Pos::AddStoredValueIssuance.call(
+      transaction: activation,
+      actor: @actor,
+      expected_lock_version: activation.lock_version,
+      issuance_type: "activation",
+      amount_cents: 2500,
+      gift_card_program: @program
+    )
+    Pos::TenderCash.call(
+      transaction: activation.reload,
+      actor: @actor,
+      expected_lock_version: activation.lock_version,
+      amount_presented_cents: 2500
+    )
+    loaded = complete_current!(activation.reload).transaction
+    funded = loaded.pos_stored_value_issuances.sole.gift_card
+    spend = start_sale
+    Pos::AddStoredValueTender.call(
+      transaction: spend,
+      actor: @actor,
+      expected_lock_version: spend.lock_version,
+      tender_type: @gift_card_type,
+      amount_cents: spend.signed_net_cents,
+      card_number: funded.number
+    )
+    complete_current!(spend.reload)
+
+    error = assert_raises(Pos::Error) do
+      Pos::PostVoidTransaction.call(
+        source: loaded,
+        actor: @actor,
+        session: @context[:session],
+        operation_id: SecureRandom.uuid_v7,
+        reversal_transaction_id: SecureRandom.uuid_v7,
+        reason_code: "entered_in_error"
+      )
+    end
+    assert_match(/downstream stored-value activity/, error.message)
+  end
+
+  test "v2 completed envelopes remain acceptable after the v3 signed-net rewrite" do
+    payload = JSON.parse(File.read(Rails.root.join("test/fixtures/files/pos/completed_pos_operation_v2/cash_sale.json")))
+    assert_equal 2, payload.fetch("schema_version")
+    Pos::CompletedTransactionFacts.new(payload).verify!
+  end
+
+  private
+
+  def start_sale
+    transaction = Pos::StartTransaction.call(session: @context[:session], actor: @actor)
+    Pos::AddMerchandise.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      identifier: @variant.sku
+    )
+    transaction.reload
+  end
+
+  def complete_current!(transaction, expected_signed_net_cents: transaction.signed_net_cents)
+    Pos::CompleteTransaction.call(
+      transaction: transaction,
+      actor: @actor,
+      operation_id: SecureRandom.uuid_v7,
+      expected_lock_version: transaction.lock_version,
+      expected_total_cents: transaction.total_cents,
+      expected_signed_net_cents: expected_signed_net_cents
+    )
+  end
+end

--- a/test/services/pos/tender_breadth_test.rb
+++ b/test/services/pos/tender_breadth_test.rb
@@ -25,8 +25,8 @@ class PosTenderBreadthTest < ActiveSupport::TestCase
   end
 
   test "seeded identities are protected Cash Card and Check" do
-    assert_equal %w[card cash check], TenderType.order(:code).pluck(:code)
-    assert TenderType.where(system_protected: true).where(code: %w[cash card check]).count == 3
+    assert_equal %w[card cash check gift_card store_credit trade_credit], TenderType.order(:code).pluck(:code)
+    assert TenderType.where(system_protected: true).where(code: %w[cash card check gift_card store_credit trade_credit]).count == 6
     assert_equal "omitted", @cash.external_reference_policy
     assert_equal "optional", @card.external_reference_policy
   end

--- a/test/system/pos_register_workspace_test.rb
+++ b/test/system/pos_register_workspace_test.rb
@@ -211,12 +211,15 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     refute_match(/rgba\(\s*0,\s*0,\s*0,\s*0\s*\)/, background)
   end
 
-  test "f6 and f7 open controlled-action overlays and f5 is unbound" do
+  test "f5 opens stored-value tenders and f6 and f7 open controlled-action overlays" do
     open_register
     add_current_sku
 
     send_keys :f5
-    assert_no_selector "#pos_control_overlay", visible: true
+    assert_selector "#pos_other_overlay", visible: true
+    assert_selector "#pos_other_overlay li", text: "Gift card"
+    send_keys :escape
+    assert_no_selector "#pos_other_overlay", visible: true
 
     send_keys :f6
     assert_selector "#pos_control_overlay", visible: true
@@ -677,6 +680,19 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
   end
 
   private
+
+  test "gift-card shaped scan does not add merchandise" do
+    GiftCards::Programs.seed!
+    program = GiftCardProgram.find_by!(code: "generated")
+    number = GiftCards::Number.generate(program)
+
+    open_register
+    field = find("#pos-command-field")
+    field.fill_in with: number
+    field.send_keys :enter
+    assert_text(/gift card not on file/i, wait: 10)
+    assert_no_selector "tbody tr"
+  end
 
   def sign_in_admin
     visit new_session_path


### PR DESCRIPTION
## Summary
- Gift-card activation/reload is `pos_stored_value_issuances` (not a SKU or tender). Signed-net becomes `subtotal - discount + tax + stored_value_issuance_cents - return_total`; new tickets snapshot `SystemSettings.current.base_currency_code`.
- Protected `stored_value` tenders (`store_credit`, `trade_credit`, `gift_card`) with details owning `stored_value_operation_id`. Refunds return originally trade-credit-funded value to that same account; trade credit is never a generic destination. New refund cards do not increase issuance cents.
- Register gift-card-shaped scans route before merchandise lookup. Controlled first print delivers generated activation and generated refund credentials (complete-retry of that outcome). Post-void reverses stored value and fails closed on downstream spend. New completions persist envelope schema 3; stored v1/v2 envelopes remain valid.

## Verification
- `./dev/rails-docker bin/rails test` (1059 runs, 0 failures, 1 skip)
- `./dev/rails-docker bin/rubocop`
- `./dev/rails-docker bin/brakeman --no-pager`
- `./dev/rails-docker bin/bundler-audit`

## Documentation and migrations
- `db/migrate/20260826040000_create_phase10_pos_stored_value.rb` (reversible `change`)
- `db/schema.rb` regenerated
- Slice 10.4 marked Complete in phase10-implementation-plan.md
- Keyboard contract: F5 is stored-value tenders (6.7 left it unbound)

Closes #62


Made with [Cursor](https://cursor.com)