### PR TITLE
10.5 — Gift-card cash-out, closeout, and print recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The operational foundation through **Phase 9** is implemented on `main`, includi
 - Catalog and bibliographic enrichment with reviewed external-data apply
 - The Warm Parchment UX foundation, grouped administrative navigation, ActionButtonHelper adoption on reference and non-purchasing screens, and UDS-5 administrative composition (compact nav and Product reference family)
 
-Forward domain work is sequenced in the [canonical roadmap](docs/planning/roadmap.md). Phase 10 (stored value) is proposed but is not identified as the primary stream; later phases cover cash accountability, used buyback, customer-service expansion, and financial/reporting closeout.
+Forward domain work is sequenced in the [canonical roadmap](docs/planning/roadmap.md). Phase 10 stored-value slices 10.1–10.5 land on `main`; the milestone stays open until the [manual test plan](docs/planning/phase10-stored-value/phase10-manual-test-plan.md) is executed. Later phases cover cash accountability, used buyback, customer-service expansion, and financial/reporting closeout.
 
 ## Technology
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1533,7 +1533,7 @@ input[type="submit"]:disabled,
   min-height: 100vh;
   display: grid;
   grid-template-rows: auto 1fr auto auto auto;
-  min-width: 1280px;
+  min-width: min(1280px, 100%);
 }
 
 .pos-header {
@@ -1572,6 +1572,35 @@ input[type="submit"]:disabled,
 .pos-basket {
   overflow: auto;
   padding: var(--space-3);
+  min-width: 0;
+}
+
+.pos-issuances {
+  margin-top: var(--space-3);
+}
+
+.pos-issuance-form,
+.pos-customer-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  align-items: end;
+  max-width: 100%;
+}
+
+.pos-issuance-form label,
+.pos-customer-form label {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+.pos-issuance-form input,
+.pos-issuance-form select,
+.pos-customer-form input {
+  min-width: 0;
+  max-width: 12rem;
 }
 
 .pos-lines {

--- a/app/controllers/admin/gift_cards_controller.rb
+++ b/app/controllers/admin/gift_cards_controller.rb
@@ -2,11 +2,11 @@
 
 module Admin
   class GiftCardsController < BaseController
-    before_action -> { require_permission!("gift_cards.view") }, only: %i[index show inquiry resolve_inquiry]
+    before_action -> { require_permission!("gift_cards.view") }, only: %i[index show inquiry resolve_inquiry print_recovery create_print_recovery]
     before_action -> { require_permission!("gift_cards.suspend") }, only: %i[suspend reinstate]
     before_action -> { require_permission!("gift_cards.replace") }, only: %i[replace create_replacement]
     before_action -> { require_permission!("gift_cards.associate_customer") }, only: %i[associate update_association]
-    before_action :set_gift_card, only: %i[show suspend reinstate replace create_replacement associate update_association]
+    before_action :set_gift_card, only: %i[show suspend reinstate replace create_replacement associate update_association print_recovery create_print_recovery]
 
     def index
       @gift_cards = GiftCard.includes(:gift_card_program, :stored_value_account, :customer).admin_ordered.limit(100)
@@ -78,6 +78,21 @@ module Admin
 
     def associate
       @customer = @gift_card.customer
+    end
+
+    def print_recovery; end
+
+    def create_print_recovery
+      @recovered_number = GiftCards::PrintRecovery.call(
+        gift_card: @gift_card,
+        actor: current_user,
+        store: operational_store,
+        reason: params[:reason]
+      )
+      render :print_recovery
+    rescue GiftCards::Error => e
+      flash.now[:alert] = e.message
+      render :print_recovery, status: :unprocessable_entity
     end
 
     def update_association

--- a/app/controllers/admin/stored_value_reports_controller.rb
+++ b/app/controllers/admin/stored_value_reports_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Admin
+  class StoredValueReportsController < BaseController
+    before_action -> { require_permission!("stored_value.view_activity") }
+
+    def show
+      open_accounts = StoredValueAccount.where.not(status: "closed")
+      @liability_rows = StoredValueAccount::ACCOUNT_TYPES.map do |type|
+        scoped = open_accounts.where(account_type: type)
+        [ type.humanize, scoped.count, scoped.sum(:balance_cents) ]
+      end
+      @cash_outs = GiftCardCashOut.originals.includes(:gift_card, :register, :pos_session).order(posted_at: :desc).limit(50)
+    end
+  end
+end

--- a/app/controllers/pos/cash_outs_controller.rb
+++ b/app/controllers/pos/cash_outs_controller.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module Pos
+  class CashOutsController < BaseController
+    before_action :require_cash_out_permission!
+    before_action :load_open_session!, except: :show
+    before_action :load_cash_out!, only: %i[show reverse]
+
+    def new; end
+
+    def lookup
+      @card_number = params[:card_number]
+      resolve_card
+      @error = "gift card is not available" if @card_number.present? && @gift_card.blank?
+      render :new
+    end
+
+    def create
+      card = GiftCards::Lookup.by_number(params[:card_number])
+      raise GiftCards::Error, "gift card is not available" if card.blank?
+
+      cash_out = GiftCards::CashOut.call(
+        gift_card: card,
+        session: @session_record,
+        actor: current_user,
+        source_id: params[:source_id].presence || SecureRandom.uuid_v7,
+        idempotency_key: params[:idempotency_key].presence || SecureRandom.uuid_v7,
+        customer_requested: params[:customer_requested],
+        approver_username: params[:approver_username],
+        approver_password: params[:approver_password]
+      )
+      redirect_to pos_cash_out_path(cash_out)
+    rescue GiftCards::Error, Pos::Denied => e
+      @error = e.message
+      @card_number = params[:card_number]
+      resolve_card
+      render :new, status: :unprocessable_entity
+    end
+
+    def show; end
+
+    def reverse
+      reversal = GiftCards::ReverseCashOut.call(
+        cash_out: @cash_out,
+        session: @session_record,
+        actor: current_user,
+        source_id: params[:source_id].presence || SecureRandom.uuid_v7,
+        idempotency_key: params[:idempotency_key].presence || SecureRandom.uuid_v7,
+        physical_cash_returned: params[:physical_cash_returned],
+        approver_username: params[:approver_username],
+        approver_password: params[:approver_password]
+      )
+      redirect_to pos_cash_out_path(reversal), notice: "Cash-out reversed. Expected cash includes the returned cash on this session."
+    rescue GiftCards::Error, Pos::Denied => e
+      @error = e.message
+      render :show, status: :unprocessable_entity
+    end
+
+    private
+
+    def require_cash_out_permission!
+      return if Authorization::PermissionEvaluator.allowed?(
+        user: current_user,
+        permission_key: "gift_cards.cash_out",
+        store: current_store
+      )
+
+      redirect_to pos_path, alert: "You are not authorized to cash out gift cards."
+    end
+
+    def load_open_session!
+      @session_record = cashier_target_session
+      unless @session_record
+        redirect_to pos_register_enter_path, alert: "Open a register before cashing out a gift card."
+      end
+    end
+
+    def load_cash_out!
+      @cash_out = GiftCardCashOut.find(params[:id])
+      raise ActiveRecord::RecordNotFound unless @cash_out.store_id == current_store.id
+    end
+
+    def resolve_card
+      return if @card_number.blank?
+
+      @gift_card = GiftCards::Lookup.by_number(@card_number)
+      @eligibility = GiftCards::CashOutEligibility.call(@gift_card) if @gift_card
+    end
+  end
+end

--- a/app/controllers/pos/homes_controller.rb
+++ b/app/controllers/pos/homes_controller.rb
@@ -8,6 +8,7 @@ module Pos
         Pos::OpenGate.for(store: current_store, register: @preferred_register, actor: current_user)
       end
       @open_session = cashier_target_session
+      @session_totals = Pos::SessionTotals.for(@open_session) if @open_session
     end
   end
 end

--- a/app/javascript/controllers/register_workspace_controller.js
+++ b/app/javascript/controllers/register_workspace_controller.js
@@ -29,6 +29,8 @@ export default class extends Controller {
     "giftCardNumberField",
     "cardNumberInput",
     "issuanceCardNumber",
+    "cashOutForm",
+    "cashOutCardInput",
     "destinationModeInput",
     "referenceLabel",
     "removeTenderInput",
@@ -174,7 +176,8 @@ export default class extends Controller {
     settlement: String,
     refundRemaining: Number,
     paymentRemaining: Number,
-    transactionsUrl: String
+    transactionsUrl: String,
+    cashOutAllowed: Boolean
   }
 
   connect() {
@@ -1537,6 +1540,13 @@ export default class extends Controller {
         this.prefillRemaining()
         this.enableReadyActions()
         return
+      }
+      if (this.cashOutAllowedValue && !this.hasCommercialContent() && this.remainingCents() === 0) {
+        if (this.hasCashOutFormTarget && this.hasCashOutCardInputTarget) {
+          this.cashOutCardInputTarget.value = scanned
+          this.cashOutFormTarget.requestSubmit()
+          return
+        }
       }
       this.showFeedback(result.masked_number ? `Gift card ${result.masked_number}` : "Gift card on file")
       this.enableReadyActions()

--- a/app/models/gift_card.rb
+++ b/app/models/gift_card.rb
@@ -12,6 +12,7 @@ class GiftCard < ApplicationRecord
   belongs_to :replaced_by, class_name: "GiftCard", optional: true
   has_one :replaced_from, class_name: "GiftCard", foreign_key: :replaced_by_id, inverse_of: :replaced_by,
           dependent: :restrict_with_exception
+  has_many :gift_card_cash_outs, dependent: :restrict_with_exception
 
   validates :number, :number_digest, :number_prefix, :number_last_four, :status, :activated_at, presence: true
   validates :status, inclusion: { in: STATUSES }

--- a/app/models/gift_card_cash_out.rb
+++ b/app/models/gift_card_cash_out.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class GiftCardCashOut < ApplicationRecord
+  include UuidV7PrimaryKey
+
+  belongs_to :gift_card
+  belongs_to :stored_value_account
+  belongs_to :register
+  belongs_to :pos_session
+  belongs_to :store
+  belongs_to :performed_by, class_name: "User"
+  belongs_to :approved_by, class_name: "User", optional: true
+  belongs_to :physical_cash_confirmed_by, class_name: "User", optional: true
+  belongs_to :stored_value_operation, optional: true
+  belongs_to :reversal_of, class_name: "GiftCardCashOut", optional: true
+  has_one :reversed_by, class_name: "GiftCardCashOut", foreign_key: :reversal_of_id, inverse_of: :reversal_of,
+          dependent: :restrict_with_exception
+  has_one :pos_controlled_action, dependent: :restrict_with_exception
+
+  validates :amount_cents, :business_date, :posted_at, presence: true
+  validates :amount_cents, numericality: { only_integer: true, greater_than: 0 }
+
+  scope :originals, -> { where(reversal_of_id: nil) }
+  scope :reversals, -> { where.not(reversal_of_id: nil) }
+
+  def reversal?
+    reversal_of_id.present?
+  end
+
+  def reversed?
+    reversed_by.present?
+  end
+
+  def readonly?
+    super || persisted?
+  end
+end

--- a/app/models/pos_controlled_action.rb
+++ b/app/models/pos_controlled_action.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 class PosControlledAction < ApplicationRecord
-  ACTION_TYPES = %w[price_override line_discount tax_class_override unlinked_return post_void].freeze
+  ACTION_TYPES = %w[price_override line_discount tax_class_override unlinked_return post_void gift_card_cash_out].freeze
   POLICY_RESULTS = %w[direct approval_required].freeze
   POLICY_VERSION = "phase6_permission_tier_v1"
   FINGERPRINT_SCHEMA_VERSION = "v1"
 
-  belongs_to :pos_transaction
+  belongs_to :pos_transaction, optional: true
   belongs_to :pos_transaction_line, optional: true
+  belongs_to :gift_card_cash_out, optional: true
   belongs_to :performed_by_user, class_name: "User"
   belongs_to :approved_by_user, class_name: "User", optional: true
 
@@ -20,7 +21,7 @@ class PosControlledAction < ApplicationRecord
   validate :approver_matches_policy
 
   def readonly?
-    super || (persisted? && pos_transaction&.commercially_immutable?)
+    super || (persisted? && (pos_transaction&.commercially_immutable? || gift_card_cash_out_id.present?))
   end
 
   private

--- a/app/models/pos_session.rb
+++ b/app/models/pos_session.rb
@@ -8,6 +8,7 @@ class PosSession < ApplicationRecord
   belongs_to :reporting_period, class_name: "PosReportingPeriod"
   belongs_to :cashier_user, class_name: "User"
   has_many :pos_transactions, dependent: :restrict_with_exception
+  has_many :gift_card_cash_outs, dependent: :restrict_with_exception
 
   validates :status, :opened_at, presence: true
   validates :status, inclusion: { in: STATUSES }

--- a/app/services/admin/navigation_catalog.rb
+++ b/app/services/admin/navigation_catalog.rb
@@ -93,11 +93,12 @@ module Admin
             key: :pos_operations,
             label: "POS operations",
             destinations: [
-              dest(:pos, "POS", :pos_path, permission: "pos.transact", requires_store: true, controllers: %w[pos/homes pos/enters pos/workspaces pos/preferred_registers pos/active_sessions pos/session_closes pos/register_closes pos/closed_sessions pos/x_reports pos/reports pos/reporting_period_zs pos/reporting_period_finalizations pos/return_items pos/post_voids pos/completed_transactions]),
+              dest(:pos, "POS", :pos_path, permission: "pos.transact", requires_store: true, controllers: %w[pos/homes pos/enters pos/workspaces pos/preferred_registers pos/active_sessions pos/session_closes pos/register_closes pos/closed_sessions pos/x_reports pos/reports pos/reporting_period_zs pos/reporting_period_finalizations pos/return_items pos/post_voids pos/completed_transactions pos/cash_outs]),
               dest(:pos_transactions, "Transactions", :pos_transactions_path, permission: "pos.transact", requires_store: true, controllers: %w[pos/transactions]),
               dest(:tender_types, "Tender types", :admin_tender_types_path, permission: "pos.manage_tender_types", controllers: %w[admin/tender_types]),
               dest(:gift_card_programs, "Gift-card programs", :admin_gift_card_programs_path, permission: "gift_cards.manage_programs", controllers: %w[admin/gift_card_programs]),
-              dest(:gift_cards, "Gift cards", :inquiry_admin_gift_cards_path, permission: "gift_cards.view", controllers: %w[admin/gift_cards admin/gift_card_adjustments])
+              dest(:gift_cards, "Gift cards", :inquiry_admin_gift_cards_path, permission: "gift_cards.view", controllers: %w[admin/gift_cards admin/gift_card_adjustments]),
+              dest(:stored_value_report, "Stored-value reporting", :admin_stored_value_report_path, permission: "stored_value.view_activity", controllers: %w[admin/stored_value_reports])
             ]
           ),
           Group.new(

--- a/app/services/gift_cards/cash_out.rb
+++ b/app/services/gift_cards/cash_out.rb
@@ -1,0 +1,211 @@
+# frozen_string_literal: true
+
+module GiftCards
+  class CashOut
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(
+      gift_card:,
+      session:,
+      actor:,
+      source_id:,
+      idempotency_key:,
+      customer_requested: false,
+      approver_username: nil,
+      approver_password: nil,
+      reason_code: "gift_card_cash_out",
+      reason_note: nil
+    )
+      @gift_card = gift_card
+      @session = session
+      @actor = actor
+      @source_id = source_id
+      @idempotency_key = idempotency_key
+      @customer_requested = ActiveModel::Type::Boolean.new.cast(customer_requested)
+      @approver_username = approver_username
+      @approver_password = approver_password
+      @reason_code = reason_code.to_s
+      @reason_note = reason_note.to_s.strip.presence
+    end
+
+    def call
+      unless Authorization::PermissionEvaluator.allowed?(
+        user: @actor,
+        permission_key: "gift_cards.cash_out",
+        store: @session.store
+      )
+        raise GiftCards::Error, "not authorized to cash out gift cards"
+      end
+      raise GiftCards::Error, "session is not open" unless @session.open?
+      working = @session.pos_transactions.working.first
+      if working && Pos::Support.commercial_content?(working)
+        raise GiftCards::Error, "complete or cancel the current transaction before cash-out"
+      end
+
+      eligibility = CashOutEligibility.call(@gift_card)
+      raise GiftCards::Error, eligibility.reason unless eligibility.eligible
+      if eligibility.requires_request_confirmation && !@customer_requested
+        raise GiftCards::Error, "cash-out requires confirmation that the customer requested it"
+      end
+
+      payload = { gift_card_id: @gift_card.id, amount_cents: eligibility.amount_cents }
+      op = Idempotency::OperationService.begin!(
+        source_id: @source_id,
+        operation_type: "gift_card_cash_out",
+        idempotency_key: @idempotency_key,
+        payload: payload
+      )
+      if op.replayed
+        return GiftCardCashOut.find(op.operation.result_id) if op.operation.result_id
+
+        raise GiftCards::Error, "idempotent replay missing result"
+      end
+
+      begin
+        result = nil
+        GiftCard.transaction do
+          session = PosSession.lock.find(@session.id)
+          Pos::Support.require_active_context!(session.store, session.register)
+          Pos::Support.require_session_cashier!(@actor, session)
+          raise GiftCards::Error, "session is not open" unless session.open?
+          card = GiftCard.lock.find(@gift_card.id)
+          account = StoredValueAccount.lock.find(card.stored_value_account_id)
+          eligibility = CashOutEligibility.call(card)
+          raise GiftCards::Error, eligibility.reason unless eligibility.eligible
+          if eligibility.requires_request_confirmation && !@customer_requested
+            raise GiftCards::Error, "cash-out requires confirmation that the customer requested it"
+          end
+
+          amount = eligibility.amount_cents
+          approver = authenticate_approver!(session) if eligibility.approval_required
+          cash_out_id = SecureRandom.uuid_v7
+          occurred_at = Time.current
+          operation = StoredValue::Post.call(
+            operation_type: "cash_out",
+            store: session.store,
+            performed_by: @actor,
+            source_id: cash_out_id,
+            idempotency_key: Pos::Support.nested_stored_value_idempotency_key(cash_out_id, "cash_out", card.id),
+            entries: [ { account: account, amount_cents: -amount } ],
+            business_date: session.reporting_period.business_date,
+            occurred_at: occurred_at,
+            pos_session: session,
+            reason_code: @reason_code,
+            reason_name_snapshot: "Gift-card cash-out"
+          )
+          account.reload.close_zero!(at: occurred_at)
+          card.update!(status: "closed", closed_at: occurred_at)
+
+          cash_out = GiftCardCashOut.create!(
+            id: cash_out_id,
+            gift_card: card,
+            stored_value_account: account,
+            amount_cents: amount,
+            register: session.register,
+            pos_session: session,
+            store: session.store,
+            business_date: session.reporting_period.business_date,
+            program_policy_snapshot: policy_snapshot(card.gift_card_program),
+            performed_by: @actor,
+            approved_by: approver,
+            stored_value_operation: operation,
+            posted_at: occurred_at
+          )
+          record_controlled_action!(cash_out, eligibility, approver)
+          Audit::Recorder.record!(
+            action: "gift_cards.cash_out",
+            outcome: "succeeded",
+            actor_user: @actor,
+            store: session.store,
+            register: session.register,
+            subject: cash_out,
+            after_values: {
+              gift_card_id: card.id,
+              amount_cents: amount,
+              number_last_four: card.number_last_four
+            }
+          )
+          Idempotency::OperationService.complete!(
+            op.operation,
+            result_type: "GiftCardCashOut",
+            result_id: cash_out.id
+          )
+          result = cash_out
+        end
+        result
+      rescue GiftCards::Error, Pos::Denied, StoredValue::Error, ActiveRecord::RecordInvalid => e
+        Idempotency::OperationService.fail!(op.operation, message: e.message)
+        raise GiftCards::Error, e.message
+      end
+    end
+
+    private
+
+    def authenticate_approver!(session)
+      Pos::AuthenticateApprover.call(
+        username: @approver_username,
+        password: @approver_password,
+        store: session.store,
+        action_type: "gift_card_cash_out",
+        performer: @actor,
+        permission_key: "gift_cards.cash_out"
+      )
+    rescue Pos::Denied => e
+      Audit::Recorder.record!(
+        action: "gift_cards.cash_out",
+        outcome: "denied",
+        actor_user: @actor,
+        store: session.store,
+        register: session.register,
+        subject: @gift_card,
+        reason_code: "approval_denied",
+        metadata: { message: e.message }
+      )
+      raise GiftCards::Error, e.message
+    end
+
+    def record_controlled_action!(cash_out, eligibility, approver)
+      policy = eligibility.approval_required ? "approval_required" : "direct"
+      material = {
+        "gift_card_id" => cash_out.gift_card_id.to_s,
+        "amount_cents" => cash_out.amount_cents,
+        "pos_session_id" => cash_out.pos_session_id.to_s
+      }
+      fingerprint = Pos::ControlledActionFingerprint.call(
+        action_type: "gift_card_cash_out",
+        cash_out_id: cash_out.id,
+        material_values: material,
+        reason_code: @reason_code,
+        reason_note: @reason_note
+      )
+      PosControlledAction.create!(
+        action_type: "gift_card_cash_out",
+        gift_card_cash_out: cash_out,
+        performed_by_user: @actor,
+        performed_by_name_snapshot: @actor.display_name,
+        approved_by_user: approver,
+        approved_by_name_snapshot: approver&.display_name,
+        reason_code: @reason_code,
+        reason_name_snapshot: "Gift-card cash-out",
+        reason_note: @reason_note,
+        policy_result: policy,
+        policy_version: PosControlledAction::POLICY_VERSION,
+        fingerprint_schema_version: PosControlledAction::FINGERPRINT_SCHEMA_VERSION,
+        action_fingerprint: fingerprint,
+        material_values: material,
+        executed_at: cash_out.posted_at
+      )
+    end
+
+    def policy_snapshot(program)
+      {
+        "cash_out_policy" => program.cash_out_policy,
+        "cash_out_threshold_cents" => program.cash_out_threshold_cents,
+        "cash_out_threshold_inclusive" => program.cash_out_threshold_inclusive,
+        "cash_out_approval_required" => program.cash_out_approval_required
+      }
+    end
+  end
+end

--- a/app/services/gift_cards/cash_out_eligibility.rb
+++ b/app/services/gift_cards/cash_out_eligibility.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module GiftCards
+  class CashOutEligibility
+    Result = Struct.new(:eligible, :amount_cents, :reason, :requires_request_confirmation, :approval_required, keyword_init: true)
+
+    def self.call(gift_card)
+      new(gift_card).call
+    end
+
+    def initialize(gift_card)
+      @gift_card = gift_card
+    end
+
+    def call
+      program = @gift_card.gift_card_program
+      balance = @gift_card.stored_value_account.balance_cents
+      if program.cash_out_policy == "prohibited"
+        return denied("cash-out is prohibited for this program")
+      end
+      unless @gift_card.active? && @gift_card.stored_value_account.active?
+        return denied("gift card is not available for cash-out")
+      end
+      unless balance.positive?
+        return denied("gift card has no remaining balance")
+      end
+      unless threshold_met?(program, balance)
+        return denied("remaining balance is above the cash-out threshold")
+      end
+
+      Result.new(
+        eligible: true,
+        amount_cents: balance,
+        reason: nil,
+        requires_request_confirmation: program.cash_out_policy == "required_on_request_when_eligible",
+        approval_required: program.cash_out_approval_required
+      )
+    end
+
+    private
+
+    def denied(reason)
+      Result.new(
+        eligible: false,
+        amount_cents: 0,
+        reason: reason,
+        requires_request_confirmation: false,
+        approval_required: false
+      )
+    end
+
+    def threshold_met?(program, balance)
+      threshold = program.cash_out_threshold_cents
+      return true if threshold.blank?
+
+      program.cash_out_threshold_inclusive? ? balance <= threshold : balance < threshold
+    end
+  end
+end

--- a/app/services/gift_cards/print_recovery.rb
+++ b/app/services/gift_cards/print_recovery.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module GiftCards
+  class PrintRecovery
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(gift_card:, actor:, store:, reason:)
+      @gift_card = gift_card
+      @actor = actor
+      @store = store
+      @reason = reason.to_s.strip
+    end
+
+    def call
+      raise GiftCards::Error, "a recovery reason is required" if @reason.blank?
+      unless @gift_card.gift_card_program.system_generated?
+        raise GiftCards::Error, "print recovery applies only to system-generated cards"
+      end
+      unless Authorization::PermissionEvaluator.allowed?(
+        user: @actor,
+        permission_key: "gift_cards.view",
+        store: @store
+      )
+        raise GiftCards::Error, "not authorized to recover a gift-card print"
+      end
+
+      Audit::Recorder.record!(
+        action: "gift_cards.print_recovery",
+        outcome: "succeeded",
+        actor_user: @actor,
+        store: @store,
+        subject: @gift_card,
+        reason_text: @reason,
+        after_values: {
+          gift_card_id: @gift_card.id,
+          number_last_four: @gift_card.number_last_four
+        }
+      )
+      @gift_card.number
+    end
+  end
+end

--- a/app/services/gift_cards/reverse_cash_out.rb
+++ b/app/services/gift_cards/reverse_cash_out.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+module GiftCards
+  class ReverseCashOut
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(
+      cash_out:,
+      session:,
+      actor:,
+      source_id:,
+      idempotency_key:,
+      physical_cash_returned:,
+      approver_username: nil,
+      approver_password: nil
+    )
+      @cash_out = cash_out
+      @session = session
+      @actor = actor
+      @source_id = source_id
+      @idempotency_key = idempotency_key
+      @physical_cash_returned = ActiveModel::Type::Boolean.new.cast(physical_cash_returned)
+      @approver_username = approver_username
+      @approver_password = approver_password
+    end
+
+    def call
+      unless Authorization::PermissionEvaluator.allowed?(
+        user: @actor,
+        permission_key: "gift_cards.cash_out",
+        store: @session.store
+      )
+        raise GiftCards::Error, "not authorized to reverse gift-card cash-out"
+      end
+      unless @physical_cash_returned
+        raise GiftCards::Error, "reversal requires confirmation that the original cash has physically returned"
+      end
+      raise GiftCards::Error, "only an original cash-out can be reversed" if @cash_out.reversal?
+
+      payload = { cash_out_id: @cash_out.id, pos_session_id: @session.id }
+      op = Idempotency::OperationService.begin!(
+        source_id: @source_id,
+        operation_type: "gift_card_cash_out_reverse",
+        idempotency_key: @idempotency_key,
+        payload: payload
+      )
+      if op.replayed
+        return GiftCardCashOut.find(op.operation.result_id) if op.operation.result_id
+
+        raise GiftCards::Error, "idempotent replay missing result"
+      end
+
+      begin
+        result = nil
+        GiftCard.transaction do
+          session = PosSession.lock.find(@session.id)
+          Pos::Support.require_active_context!(session.store, session.register)
+          Pos::Support.require_session_cashier!(@actor, session)
+          raise GiftCards::Error, "session is not open" unless session.open?
+          original = GiftCardCashOut.lock.find(@cash_out.id)
+          raise GiftCards::Error, "only an original cash-out can be reversed" if original.reversal?
+          raise GiftCards::Error, "cash-out has already been reversed" if GiftCardCashOut.exists?(reversal_of_id: original.id)
+
+          card = GiftCard.lock.find(original.gift_card_id)
+          account = StoredValueAccount.lock.find(original.stored_value_account_id)
+          raise GiftCards::Error, "gift-card account is not closed from this cash-out" unless account.closed? && account.balance_cents.zero?
+
+          approver = nil
+          if card.gift_card_program.cash_out_approval_required
+            approver = Pos::AuthenticateApprover.call(
+              username: @approver_username,
+              password: @approver_password,
+              store: session.store,
+              action_type: "gift_card_cash_out",
+              performer: @actor,
+              permission_key: "gift_cards.cash_out"
+            )
+          end
+
+          reversal_id = SecureRandom.uuid_v7
+          occurred_at = Time.current
+          original_entry = original.stored_value_operation.stored_value_entries.sole
+          account.update!(status: "active", closed_at: nil)
+          operation = StoredValue::Post.call(
+            operation_type: "reverse",
+            store: session.store,
+            performed_by: @actor,
+            source_id: reversal_id,
+            idempotency_key: Pos::Support.nested_stored_value_idempotency_key(reversal_id, "reverse", original.id),
+            entries: [ { account: account, amount_cents: original.amount_cents } ],
+            business_date: session.reporting_period.business_date,
+            occurred_at: occurred_at,
+            pos_session: session,
+            reversal_of: original.stored_value_operation,
+            reversal_entry_map: { 0 => original_entry },
+            reason_code: "gift_card_cash_out_reverse",
+            reason_name_snapshot: "Gift-card cash-out reversal"
+          )
+          card.update!(status: "active", closed_at: nil)
+
+          reversal = GiftCardCashOut.create!(
+            id: reversal_id,
+            gift_card: card,
+            stored_value_account: account,
+            amount_cents: original.amount_cents,
+            register: session.register,
+            pos_session: session,
+            store: session.store,
+            business_date: session.reporting_period.business_date,
+            program_policy_snapshot: original.program_policy_snapshot,
+            performed_by: @actor,
+            approved_by: approver,
+            stored_value_operation: operation,
+            reversal_of: original,
+            physical_cash_confirmed: true,
+            physical_cash_confirmed_by: @actor,
+            posted_at: occurred_at
+          )
+          Audit::Recorder.record!(
+            action: "gift_cards.cash_out_reversed",
+            outcome: "succeeded",
+            actor_user: @actor,
+            store: session.store,
+            register: session.register,
+            subject: reversal,
+            after_values: {
+              original_cash_out_id: original.id,
+              amount_cents: original.amount_cents,
+              number_last_four: card.number_last_four,
+              physical_cash_confirmed: true
+            }
+          )
+          Idempotency::OperationService.complete!(
+            op.operation,
+            result_type: "GiftCardCashOut",
+            result_id: reversal.id
+          )
+          result = reversal
+        end
+        result
+      rescue GiftCards::Error, Pos::Denied, StoredValue::Error, ActiveRecord::RecordInvalid => e
+        Idempotency::OperationService.fail!(op.operation, message: e.message)
+        raise GiftCards::Error, e.message
+      end
+    end
+  end
+end

--- a/app/services/pos/authenticate_approver.rb
+++ b/app/services/pos/authenticate_approver.rb
@@ -6,12 +6,13 @@ module Pos
       new(**attrs).call
     end
 
-    def initialize(username:, password:, store:, action_type:, performer:)
+    def initialize(username:, password:, store:, action_type:, performer:, permission_key: nil)
       @username = username.to_s.strip
       @password = password
       @store = store
       @action_type = action_type
       @performer = performer
+      @permission_key = permission_key.presence || "pos.#{action_type}.approve"
     end
 
     def call
@@ -25,7 +26,7 @@ module Pos
 
       unless Authorization::PermissionEvaluator.allowed?(
         user: user,
-        permission_key: "pos.#{@action_type}.approve",
+        permission_key: @permission_key,
         store: @store
       )
         raise Pos::Denied, "approver is not authorized at this store"

--- a/app/services/pos/controlled_action_fingerprint.rb
+++ b/app/services/pos/controlled_action_fingerprint.rb
@@ -8,10 +8,11 @@ module Pos
       new(**attrs).call
     end
 
-    def initialize(action_type:, transaction_id:, material_values:, reason_code:, reason_note: nil, line_id: nil)
+    def initialize(action_type:, material_values:, reason_code:, reason_note: nil, transaction_id: nil, line_id: nil, cash_out_id: nil)
       @action_type = action_type
       @transaction_id = transaction_id
       @line_id = line_id
+      @cash_out_id = cash_out_id
       @material_values = material_values
       @reason_code = reason_code
       @reason_note = reason_note
@@ -20,11 +21,12 @@ module Pos
     def call
       payload = {
         "action_type" => @action_type,
-        "transaction_id" => @transaction_id.to_s,
         "material_values" => @material_values,
         "reason_code" => @reason_code,
         "fingerprint_schema_version" => SCHEMA_VERSION
       }
+      payload["transaction_id"] = @transaction_id.to_s if @transaction_id.present?
+      payload["cash_out_id"] = @cash_out_id.to_s if @cash_out_id.present?
       payload["line_id"] = @line_id.to_s if @line_id.present?
       payload["reason_note"] = @reason_note.to_s if @reason_code == "other"
       Idempotency::CanonicalJson.hash(payload)

--- a/app/services/pos/customer_receipt.rb
+++ b/app/services/pos/customer_receipt.rb
@@ -12,12 +12,13 @@ module Pos
     )
     TaxGroup = Struct.new(:letter, :name, :rate_percent, :basis_cents, :tax_cents, keyword_init: true)
     TenderLine = Struct.new(:label, :amount_cents, :presented_cents, :change_cents, keyword_init: true)
+    RemainingBalanceNote = Struct.new(:label, :masked_card, :balance_cents, keyword_init: true)
 
     def self.build(transaction)
       new(transaction).tap(&:prepare!)
     end
 
-    attr_reader :transaction, :error, :lines, :tax_groups, :tenders
+    attr_reader :transaction, :error, :lines, :tax_groups, :tenders, :remaining_balance_notes
 
     def initialize(transaction)
       @transaction = transaction
@@ -26,6 +27,7 @@ module Pos
       @lines = []
       @tax_groups = []
       @tenders = []
+      @remaining_balance_notes = []
       @indicator_by_key = {}
     end
 
@@ -38,6 +40,7 @@ module Pos
       assign_tax_groups!
       @lines = customer_lines
       @tenders = customer_tenders
+      @remaining_balance_notes = remaining_balance_notes_for_print
       verify_total!
       self
     end
@@ -316,6 +319,32 @@ module Pos
 
     def pos_cash_payment?(tender)
       tender.cash? && tender.direction == "payment"
+    end
+
+    def remaining_balance_notes_for_print
+      notes = []
+      @transaction.pos_stored_value_issuances.ordered.each do |issuance|
+        card = issuance.gift_card
+        next unless card
+
+        notes << RemainingBalanceNote.new(
+          label: "Remaining balance",
+          masked_card: issuance.masked_card_snapshot.presence || card.masked_number,
+          balance_cents: card.balance_cents
+        )
+      end
+      @transaction.pos_tenders.ordered.each do |tender|
+        detail = tender.stored_value_tender_detail
+        card = detail&.gift_card
+        next unless card
+
+        notes << RemainingBalanceNote.new(
+          label: "Remaining balance",
+          masked_card: detail.masked_card_snapshot.presence || card.masked_number,
+          balance_cents: card.balance_cents
+        )
+      end
+      notes
     end
 
     def verify_total!

--- a/app/services/pos/operator_report.rb
+++ b/app/services/pos/operator_report.rb
@@ -21,10 +21,25 @@ module Pos
     end
 
     def groups
-      [ sales_group, returns_group, post_void_group, net_group, tenders_group, cash_group ]
+      [ sales_group, stored_value_group, returns_group, post_void_group, net_group, tenders_group, cash_group ]
     end
 
     private
+
+    def stored_value_group
+      Group.new(title: "Stored value", rows: [
+        money_row("Gift-card issuance", @totals.stored_value_issuance_cents),
+        money_row("Store-credit payments", @totals.store_credit_payment_cents),
+        money_row("Trade-credit payments", @totals.trade_credit_payment_cents),
+        money_row("Gift-card payments", @totals.gift_card_payment_cents),
+        money_row("Refund to original gift card", @totals.gift_card_existing_refund_cents),
+        money_row("Refund to new gift card", @totals.gift_card_new_refund_cents),
+        money_row("Refund to store credit", @totals.store_credit_refund_destination_cents),
+        count_row("Gift-card cash-outs", @totals.gift_card_cash_out_count),
+        money_row("Gift-card cash-outs", @totals.gift_card_cash_out_cents),
+        money_row("Gift-card cash-out reversals", @totals.gift_card_cash_out_reversal_cents)
+      ])
+    end
 
     def sales_group
       Group.new(title: "Sales", rows: [
@@ -81,6 +96,8 @@ module Pos
           money_row("Opening float", @session.opening_float_cents),
           money_row("Cash payments", @totals.cash_payment_cents),
           money_row("Cash refunds", @totals.cash_refund_cents),
+          money_row("Gift-card cash-outs", @totals.gift_card_cash_out_cents),
+          money_row("Gift-card cash-out reversals", @totals.gift_card_cash_out_reversal_cents),
           signed_row("Expected Cash", @totals.expected_cash_cents)
         ]
       when :session
@@ -88,6 +105,8 @@ module Pos
           money_row("Opening float", @session.opening_float_cents),
           money_row("Cash payments", @totals.cash_payment_cents),
           money_row("Cash refunds", @totals.cash_refund_cents),
+          money_row("Gift-card cash-outs", @totals.gift_card_cash_out_cents),
+          money_row("Gift-card cash-out reversals", @totals.gift_card_cash_out_reversal_cents),
           signed_row("Expected closing Cash", @session.closing_expected_cash_cents),
           money_row("Counted Cash", @session.closing_count_cents),
           signed_row("Variance", @session.closing_variance_cents)
@@ -98,6 +117,8 @@ module Pos
           money_row("Opening floats total", @totals.opening_float_cents_sum),
           money_row("Cash payments", @totals.cash_payment_cents),
           money_row("Cash refunds", @totals.cash_refund_cents),
+          money_row("Gift-card cash-outs", @totals.gift_card_cash_out_cents),
+          money_row("Gift-card cash-out reversals", @totals.gift_card_cash_out_reversal_cents),
           signed_row("Expected closing Cash", @totals.closing_expected_cash_cents_sum),
           money_row("Counted closing Cash", @totals.closing_count_cents_sum),
           signed_row("Closing variance", @totals.closing_variance_cents_sum)

--- a/app/services/pos/period_totals.rb
+++ b/app/services/pos/period_totals.rb
@@ -108,6 +108,55 @@ module Pos
       snapshot_or(:finalized_other_refund_cents) { category_refund_cents("other") }
     end
 
+    def stored_value_issuance_cents
+      snapshot_or(:finalized_stored_value_issuance_cents) { commercial_transactions.sum(:stored_value_issuance_cents) }
+    end
+
+    def stored_value_payment_cents
+      snapshot_or(:finalized_stored_value_payment_cents) { category_payment_cents("stored_value") }
+    end
+
+    def stored_value_refund_cents
+      snapshot_or(:finalized_stored_value_refund_cents) { category_refund_cents("stored_value") }
+    end
+
+    def gift_card_cash_out_cents
+      snapshot_or(:finalized_gift_card_cash_out_cents) { period_cash_outs.originals.sum(:amount_cents) }
+    end
+
+    def gift_card_cash_out_reversal_cents
+      snapshot_or(:finalized_gift_card_cash_out_reversal_cents) { period_cash_outs.reversals.sum(:amount_cents) }
+    end
+
+    def gift_card_cash_out_count
+      period_cash_outs.originals.count
+    end
+
+    def store_credit_payment_cents
+      type_tender_cents("store_credit", "payment")
+    end
+
+    def trade_credit_payment_cents
+      type_tender_cents("trade_credit", "payment")
+    end
+
+    def gift_card_payment_cents
+      type_tender_cents("gift_card", "payment")
+    end
+
+    def gift_card_existing_refund_cents
+      refund_destination_cents("existing_account", tender_type: "gift_card")
+    end
+
+    def gift_card_new_refund_cents
+      refund_destination_cents("new_gift_card")
+    end
+
+    def store_credit_refund_destination_cents
+      refund_destination_cents("customer_store_credit") +
+        refund_destination_cents("existing_account", tender_type: "store_credit")
+    end
+
     def session_count
       snapshot_or(:finalized_session_count) { closed_sessions.count }
     end
@@ -148,6 +197,11 @@ module Pos
         finalized_card_refund_cents: card_refund_cents,
         finalized_check_refund_cents: check_refund_cents,
         finalized_other_refund_cents: other_refund_cents,
+        finalized_stored_value_issuance_cents: stored_value_issuance_cents,
+        finalized_stored_value_payment_cents: stored_value_payment_cents,
+        finalized_stored_value_refund_cents: stored_value_refund_cents,
+        finalized_gift_card_cash_out_cents: gift_card_cash_out_cents,
+        finalized_gift_card_cash_out_reversal_cents: gift_card_cash_out_reversal_cents,
         finalized_post_void_transaction_count: post_void_transaction_count,
         finalized_post_void_merchandise_cents: post_void_merchandise_cents,
         finalized_post_void_discount_cents: post_void_discount_cents,
@@ -184,6 +238,22 @@ module Pos
                .sum(:amount_cents)
     end
 
+    def type_tender_cents(tender_type, direction)
+      PosTender.joins(:pos_transaction)
+               .where(pos_transactions: { reporting_period_id: @period.id, status: "completed" })
+               .where(tender_type: tender_type, direction: direction)
+               .sum(:amount_cents)
+    end
+
+    def refund_destination_cents(destination_mode, tender_type: nil)
+      relation = PosTender.joins(:pos_transaction, :stored_value_tender_detail)
+                          .where(pos_transactions: { reporting_period_id: @period.id, status: "completed" })
+                          .where(direction: "refund")
+                          .where(pos_stored_value_tender_details: { destination_mode: destination_mode })
+      relation = relation.where(tender_type: tender_type) if tender_type
+      relation.sum(:amount_cents)
+    end
+
     def completed_transactions
       @period.pos_transactions.completed
     end
@@ -202,6 +272,10 @@ module Pos
 
     def closed_sessions
       @period.pos_sessions.closed
+    end
+
+    def period_cash_outs
+      GiftCardCashOut.joins(:pos_session).where(pos_sessions: { reporting_period_id: @period.id })
     end
   end
 end

--- a/app/services/pos/session_totals.rb
+++ b/app/services/pos/session_totals.rb
@@ -121,7 +121,57 @@ module Pos
     def expected_cash_cents
       return @session.closing_expected_cash_cents if @session.closed?
 
-      @session.opening_float_cents + cash_payment_cents - cash_refund_cents
+      @session.opening_float_cents + cash_payment_cents - cash_refund_cents -
+        gift_card_cash_out_cents + gift_card_cash_out_reversal_cents
+    end
+
+    def stored_value_issuance_cents
+      commercial_transactions.sum(:stored_value_issuance_cents)
+    end
+
+    def stored_value_payment_cents
+      category_payment_cents("stored_value")
+    end
+
+    def stored_value_refund_cents
+      category_refund_cents("stored_value")
+    end
+
+    def gift_card_cash_out_cents
+      GiftCardCashOut.originals.where(pos_session_id: @session.id).sum(:amount_cents)
+    end
+
+    def gift_card_cash_out_reversal_cents
+      GiftCardCashOut.reversals.where(pos_session_id: @session.id).sum(:amount_cents)
+    end
+
+    def gift_card_cash_out_count
+      GiftCardCashOut.originals.where(pos_session_id: @session.id).count
+    end
+
+    def store_credit_payment_cents
+      type_tender_cents("store_credit", "payment")
+    end
+
+    def trade_credit_payment_cents
+      type_tender_cents("trade_credit", "payment")
+    end
+
+    def gift_card_payment_cents
+      type_tender_cents("gift_card", "payment")
+    end
+
+    def gift_card_existing_refund_cents
+      refund_destination_cents("existing_account", tender_type: "gift_card")
+    end
+
+    def gift_card_new_refund_cents
+      refund_destination_cents("new_gift_card")
+    end
+
+    def store_credit_refund_destination_cents
+      refund_destination_cents("customer_store_credit") +
+        refund_destination_cents("existing_account", tender_type: "store_credit")
     end
 
     def closing_count_cents
@@ -147,6 +197,22 @@ module Pos
                .where(pos_transactions: { pos_session_id: @session.id, status: "completed" })
                .where(behavioral_category: category, direction: direction)
                .sum(:amount_cents)
+    end
+
+    def type_tender_cents(tender_type, direction)
+      PosTender.joins(:pos_transaction)
+               .where(pos_transactions: { pos_session_id: @session.id, status: "completed" })
+               .where(tender_type: tender_type, direction: direction)
+               .sum(:amount_cents)
+    end
+
+    def refund_destination_cents(destination_mode, tender_type: nil)
+      relation = PosTender.joins(:pos_transaction, :stored_value_tender_detail)
+                          .where(pos_transactions: { pos_session_id: @session.id, status: "completed" })
+                          .where(direction: "refund")
+                          .where(pos_stored_value_tender_details: { destination_mode: destination_mode })
+      relation = relation.where(tender_type: tender_type) if tender_type
+      relation.sum(:amount_cents)
     end
 
     def completed_transactions

--- a/app/views/admin/gift_cards/print_recovery.html.erb
+++ b/app/views/admin/gift_cards/print_recovery.html.erb
@@ -1,0 +1,27 @@
+<% content_for :title, "Recover gift-card print" %>
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Gift cards", path: admin_gift_cards_path },
+  { name: @gift_card.masked_number, path: admin_gift_card_path(@gift_card) },
+  { name: "Print recovery" }
+] %>
+<%= render "shared/page_header", title: "Recover print for #{@gift_card.masked_number}" %>
+<p>Exceptional recovery of a system-generated credential. Ordinary receipts stay masked. This is not a general reveal screen.</p>
+<% if @recovered_number.present? %>
+  <section class="pos-first-print">
+    <h2>Recovered number</h2>
+    <p><%= @recovered_number %></p>
+    <p class="muted">Print now. This page is the only delivery of the full number.</p>
+  </section>
+<% else %>
+  <%= form_with url: print_recovery_admin_gift_card_path(@gift_card), method: :post, class: "form" do |form| %>
+    <div class="form-field">
+      <%= label_tag :reason, "Reason" %>
+      <%= text_field_tag :reason, params[:reason], required: true, autocomplete: "off" %>
+    </div>
+    <div class="actions">
+      <%= action_submit(form, "Recover print", style: :solid, intent: :brand) %>
+      <%= action_link_to("Cancel", admin_gift_card_path(@gift_card), style: :ghost, intent: :neutral) %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/admin/gift_cards/show.html.erb
+++ b/app/views/admin/gift_cards/show.html.erb
@@ -17,6 +17,9 @@
 <% if !@gift_card.replaced? && !@gift_card.closed? && effective_permissions.include?("gift_cards.associate_customer") %>
   <% actions << action_link_to("Associate customer", associate_admin_gift_card_path(@gift_card), style: :outline, intent: :neutral) %>
 <% end %>
+<% if @gift_card.gift_card_program.system_generated? && effective_permissions.include?("gift_cards.view") %>
+  <% actions << action_link_to("Recover print", print_recovery_admin_gift_card_path(@gift_card), style: :outline, intent: :neutral) %>
+<% end %>
 <% if !@gift_card.replaced? && !@gift_card.closed? && effective_permissions.include?("stored_value.adjust") %>
   <% actions << action_link_to("Adjust", new_admin_gift_card_stored_value_adjustment_path(@gift_card), style: :outline, intent: :neutral) %>
 <% end %>

--- a/app/views/admin/stored_value_reports/show.html.erb
+++ b/app/views/admin/stored_value_reports/show.html.erb
@@ -1,0 +1,22 @@
+<% content_for :title, "Stored-value reporting" %>
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Stored-value reporting" }
+] %>
+<%= render "shared/page_header", title: "Stored-value reporting" %>
+<h2 class="section__title">Outstanding liability</h2>
+<p class="muted">Open account balances by type. Store is attribution of activity only; these totals are organization-wide.</p>
+<%= render "shared/data_table",
+      headers: ["Account type", "Open accounts", "Balance"],
+      rows: @liability_rows.map { |type, count, cents| [ type, count, format_money_cents(cents) ] } %>
+<h2 class="section__title">Recent gift-card cash-outs</h2>
+<% cash_out_rows = @cash_outs.map { |cash_out|
+     [
+       cash_out.gift_card.masked_number,
+       format_money_cents(cash_out.amount_cents),
+       cash_out.register.admin_label,
+       cash_out.business_date.iso8601,
+       cash_out.reversal? ? "Reversal" : (cash_out.reversed? ? "Reversed" : "Posted")
+     ]
+   } %>
+<%= render "shared/data_table", headers: ["Card", "Amount", "Register", "Business date", "Status"], rows: cash_out_rows %>

--- a/app/views/pos/cash_outs/new.html.erb
+++ b/app/views/pos/cash_outs/new.html.erb
@@ -1,0 +1,59 @@
+<% content_for :title, "Gift-card cash-out" %>
+
+<main class="pos-history">
+  <%= render "pos/shared/report_nav" %>
+  <h1>Gift-card cash-out</h1>
+  <p>Pays the full eligible remaining balance from this open Register session. This is not a tender and not a paid-out.</p>
+
+  <% if @error.present? %>
+    <p class="pos-enter__alert" role="alert"><%= @error %></p>
+  <% end %>
+
+  <%= form_with url: lookup_pos_cash_outs_path, method: :post, local: true, class: "pos-return-items" do %>
+    <div class="form-field">
+      <%= label_tag :card_number, "Gift-card number" %>
+      <%= password_field_tag :card_number, nil, id: "card_number", autocomplete: "off", autofocus: true %>
+    </div>
+    <div class="actions">
+      <%= submit_tag "Look up", class: "btn" %>
+    </div>
+  <% end %>
+
+  <% if @gift_card && @eligibility %>
+    <dl class="pos-history__header">
+      <div><dt>Card</dt><dd><%= @gift_card.masked_number %></dd></div>
+      <div><dt>Program</dt><dd><%= @gift_card.gift_card_program.name %></dd></div>
+      <div><dt>Balance</dt><dd><%= format_money_cents(@gift_card.balance_cents) %></dd></div>
+      <div><dt>Eligible</dt><dd><%= @eligibility.eligible ? "Yes" : @eligibility.reason %></dd></div>
+    </dl>
+    <% if @eligibility.eligible %>
+      <%= form_with url: pos_cash_outs_path, method: :post, local: true, class: "pos-return-items" do %>
+        <%= hidden_field_tag :card_number, @card_number %>
+        <%= hidden_field_tag :source_id, SecureRandom.uuid_v7 %>
+        <%= hidden_field_tag :idempotency_key, SecureRandom.uuid_v7 %>
+        <% if @eligibility.requires_request_confirmation %>
+          <div class="form-field">
+            <label>
+              <%= check_box_tag :customer_requested, "1", false, id: "customer_requested" %>
+              Customer requested this cash-out
+            </label>
+          </div>
+        <% end %>
+        <% if @eligibility.approval_required %>
+          <div class="form-field">
+            <%= label_tag :approver_username, "Approver username" %>
+            <%= text_field_tag :approver_username, params[:approver_username], id: "approver_username", autocomplete: "off" %>
+          </div>
+          <div class="form-field">
+            <%= label_tag :approver_password, "Approver password" %>
+            <%= password_field_tag :approver_password, nil, id: "approver_password", autocomplete: "off" %>
+          </div>
+        <% end %>
+        <div class="actions">
+          <%= submit_tag "Cash out #{format_money_cents(@eligibility.amount_cents)}", class: "btn" %>
+          <%= link_to "POS Home", pos_path, class: "btn btn--ghost" %>
+        </div>
+      <% end %>
+    <% end %>
+  <% end %>
+</main>

--- a/app/views/pos/cash_outs/show.html.erb
+++ b/app/views/pos/cash_outs/show.html.erb
@@ -1,0 +1,50 @@
+<% content_for :title, "Gift-card cash-out" %>
+
+<main class="pos-receipt" data-controller="pos-receipt">
+  <div class="pos-receipt__screen">
+    <h1 tabindex="-1" autofocus><%= @cash_out.reversal? ? "Cash-out reversed" : "Cash-out complete" %></h1>
+    <% if notice.present? %>
+      <p role="status"><%= notice %></p>
+    <% end %>
+    <% if @error.present? %>
+      <p class="pos-enter__alert" role="alert"><%= @error %></p>
+    <% end %>
+    <dl class="pos-receipt__totals">
+      <div><dt>Card</dt><dd><%= @cash_out.gift_card.masked_number %></dd></div>
+      <div><dt>Amount</dt><dd><%= format_money_cents(@cash_out.amount_cents) %></dd></div>
+      <div><dt>Register</dt><dd><%= @cash_out.register.admin_label %></dd></div>
+      <div><dt>Business date</dt><dd><%= @cash_out.business_date.iso8601 %></dd></div>
+      <div><dt>Remaining balance</dt><dd><%= format_money_cents(@cash_out.gift_card.balance_cents) %></dd></div>
+    </dl>
+  </div>
+
+  <div class="pos-receipt__actions pos-no-print">
+    <%= action_button("Print", style: :solid, intent: :brand, data: { action: "pos-receipt#print" }) %>
+    <%= action_link_to("POS Home", pos_path, style: :outline, intent: :neutral) %>
+    <% if !@cash_out.reversal? && !@cash_out.reversed? && cashier_target_session %>
+      <%= form_with url: reverse_pos_cash_out_path(@cash_out), method: :post, local: true, class: "pos-return-items" do %>
+        <%= hidden_field_tag :source_id, SecureRandom.uuid_v7 %>
+        <%= hidden_field_tag :idempotency_key, SecureRandom.uuid_v7 %>
+        <div class="form-field">
+          <label>
+            <%= check_box_tag :physical_cash_returned, "1", false, id: "physical_cash_returned" %>
+            Original cash has physically returned to this open Register
+          </label>
+        </div>
+        <% if @cash_out.gift_card.gift_card_program.cash_out_approval_required? %>
+          <div class="form-field">
+            <%= label_tag :approver_username, "Approver username" %>
+            <%= text_field_tag :approver_username, params[:approver_username], id: "approver_username", autocomplete: "off" %>
+          </div>
+          <div class="form-field">
+            <%= label_tag :approver_password, "Approver password" %>
+            <%= password_field_tag :approver_password, nil, id: "approver_password", autocomplete: "off" %>
+          </div>
+        <% end %>
+        <div class="actions">
+          <%= submit_tag "Reverse cash-out", class: "btn" %>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+</main>

--- a/app/views/pos/homes/show.html.erb
+++ b/app/views/pos/homes/show.html.erb
@@ -38,6 +38,16 @@
         <% end %>
       </dd>
     </div>
+    <% if @open_session && @session_totals %>
+      <div>
+        <dt>Expected cash</dt>
+        <dd><%= format_money_cents(@session_totals.expected_cash_cents) %></dd>
+      </div>
+      <div>
+        <dt>Gift-card cash-outs</dt>
+        <dd><%= format_money_cents(@session_totals.gift_card_cash_out_cents) %></dd>
+      </div>
+    <% end %>
   </dl>
 
   <nav class="pos-home__actions" aria-label="POS Home">
@@ -48,6 +58,9 @@
     <% end %>
     <%= link_to "Transactions", pos_transactions_path, class: "btn btn--secondary" %>
     <%= link_to "X Report", pos_x_report_path, class: "btn btn--secondary" %>
+    <% if @open_session && Authorization::PermissionEvaluator.allowed?(user: current_user, permission_key: "gift_cards.cash_out", store: current_store) %>
+      <%= link_to "Gift-card cash-out", new_pos_cash_out_path, class: "btn btn--secondary" %>
+    <% end %>
     <% if can_view_other_sessions? %>
       <%= link_to "Active Sessions", pos_active_sessions_path, class: "btn btn--secondary" %>
     <% end %>

--- a/app/views/pos/receipts/_print.html.erb
+++ b/app/views/pos/receipts/_print.html.erb
@@ -121,6 +121,9 @@
           <% end %>
         <% end %>
       <% end %>
+      <% receipt.remaining_balance_notes.each do |note| %>
+        <div><dt><%= note.label %> <%= note.masked_card %></dt><dd><%= pos_print_amount(note.balance_cents) %></dd></div>
+      <% end %>
     </dl>
 
     <% unless receipt.post_void_reversal? %>

--- a/app/views/pos/workspaces/_surface.html.erb
+++ b/app/views/pos/workspaces/_surface.html.erb
@@ -389,15 +389,12 @@
       <div class="pos-actions__group pos-actions__group--escape" role="group" aria-label="Cancel transaction">
         <%= action_button "Cancel (F9)", style: :outline, intent: :danger, size: :large, disabled: true,
               data: { action: "register-workspace#openOverlay", register_workspace_target: "cancelButton" } %>
-        <% if effective_permissions.include?("gift_cards.cash_out") %>
-          <%= action_link_to "Cash out", new_pos_cash_out_path, style: :outline, intent: :neutral, size: :large %>
-        <% end %>
       </div>
     </div>
 
     <% if effective_permissions.include?("gift_cards.cash_out") %>
       <%= form_with url: lookup_pos_cash_outs_path, method: :post, local: true, html: { class: "pos-hidden", data: { register_workspace_target: "cashOutForm" } } do %>
-        <%= password_field_tag :card_number, nil, autocomplete: "off", data: { register_workspace_target: "cashOutCardInput" } %>
+        <%= hidden_field_tag :card_number, nil, data: { register_workspace_target: "cashOutCardInput" } %>
       <% end %>
     <% end %>
 

--- a/app/views/pos/workspaces/_surface.html.erb
+++ b/app/views/pos/workspaces/_surface.html.erb
@@ -69,6 +69,7 @@
      data-register-workspace-settlement-value="<%= settlement_direction %>"
      data-register-workspace-refund-remaining-value="<%= remaining_refund_cents %>"
      data-register-workspace-payment-remaining-value="<%= remaining_payment_cents %>"
+     data-register-workspace-cash-out-allowed-value="<%= effective_permissions.include?("gift_cards.cash_out") ? "true" : "false" %>"
      data-register-workspace-transactions-url-value="<%= pos_transactions_path %>"
      data-register-workspace-policies-value="<%= h((@control_policies || {}).to_json) %>"
      data-register-workspace-reasons-value="<%= h(Pos::ControlledActionReasons::CATALOGS.to_json) %>"
@@ -388,8 +389,17 @@
       <div class="pos-actions__group pos-actions__group--escape" role="group" aria-label="Cancel transaction">
         <%= action_button "Cancel (F9)", style: :outline, intent: :danger, size: :large, disabled: true,
               data: { action: "register-workspace#openOverlay", register_workspace_target: "cancelButton" } %>
+        <% if effective_permissions.include?("gift_cards.cash_out") %>
+          <%= action_link_to "Cash out", new_pos_cash_out_path, style: :outline, intent: :neutral, size: :large %>
+        <% end %>
       </div>
     </div>
+
+    <% if effective_permissions.include?("gift_cards.cash_out") %>
+      <%= form_with url: lookup_pos_cash_outs_path, method: :post, local: true, html: { class: "pos-hidden", data: { register_workspace_target: "cashOutForm" } } do %>
+        <%= password_field_tag :card_number, nil, autocomplete: "off", data: { register_workspace_target: "cashOutCardInput" } %>
+      <% end %>
+    <% end %>
 
     <%= form_with url: pos_register_merchandise_path(register_scope), method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "merchandiseForm", turbo: true } } do %>
       <%= hidden_field_tag :register_id, @register.id %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -129,9 +129,12 @@ Rails.application.routes.draw do
         post :replace, action: :create_replacement
         get :associate
         patch :associate, action: :update_association
+        get :print_recovery
+        post :print_recovery, action: :create_print_recovery
       end
       resources :stored_value_adjustments, only: %i[new create], controller: "gift_card_adjustments"
     end
+    resource :stored_value_report, only: :show
     resources :customer_requests, only: %i[index show new create] do
       collection do
         get :customer_lookup
@@ -195,6 +198,10 @@ Rails.application.routes.draw do
     resources :transactions, only: %i[index show]
     get "register/enter", to: "enters#show", as: :register_enter
     post "register/enter", to: "enters#create"
+    resources :cash_outs, only: %i[new create show] do
+      collection { post :lookup }
+      member { post :reverse }
+    end
     get "register", to: "workspaces#show", as: :register_workspace
     get "register/merchandise_search", to: "workspaces#search", as: :register_merchandise_search
     get "register/merchandise_resolve", to: "workspaces#resolve", as: :register_merchandise_resolve

--- a/db/migrate/20260826050000_create_phase10_gift_card_cash_outs.rb
+++ b/db/migrate/20260826050000_create_phase10_gift_card_cash_outs.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+class CreatePhase10GiftCardCashOuts < ActiveRecord::Migration[8.1]
+  def change
+    create_uuid_table :gift_card_cash_outs do |t|
+      t.uuid :gift_card_id, null: false
+      t.uuid :stored_value_account_id, null: false
+      t.bigint :amount_cents, null: false
+      t.uuid :register_id, null: false
+      t.uuid :pos_session_id, null: false
+      t.uuid :store_id, null: false
+      t.date :business_date, null: false
+      t.jsonb :program_policy_snapshot, null: false, default: {}
+      t.uuid :performed_by_id, null: false
+      t.uuid :approved_by_id
+      t.uuid :stored_value_operation_id
+      t.uuid :reversal_of_id
+      t.boolean :physical_cash_confirmed, null: false, default: false
+      t.uuid :physical_cash_confirmed_by_id
+      t.timestamptz :posted_at, null: false
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+    add_index :gift_card_cash_outs, :gift_card_id
+    add_index :gift_card_cash_outs, :stored_value_account_id
+    add_index :gift_card_cash_outs, :register_id
+    add_index :gift_card_cash_outs, :pos_session_id
+    add_index :gift_card_cash_outs, :store_id
+    add_index :gift_card_cash_outs, :stored_value_operation_id, unique: true,
+              where: "stored_value_operation_id IS NOT NULL",
+              name: "index_gift_card_cash_outs_on_operation"
+    add_index :gift_card_cash_outs, :reversal_of_id, unique: true,
+              where: "reversal_of_id IS NOT NULL"
+    add_foreign_key :gift_card_cash_outs, :gift_cards
+    add_foreign_key :gift_card_cash_outs, :stored_value_accounts
+    add_foreign_key :gift_card_cash_outs, :registers
+    add_foreign_key :gift_card_cash_outs, :pos_sessions
+    add_foreign_key :gift_card_cash_outs, :stores
+    add_foreign_key :gift_card_cash_outs, :users, column: :performed_by_id
+    add_foreign_key :gift_card_cash_outs, :users, column: :approved_by_id
+    add_foreign_key :gift_card_cash_outs, :users, column: :physical_cash_confirmed_by_id
+    add_foreign_key :gift_card_cash_outs, :stored_value_operations
+    add_foreign_key :gift_card_cash_outs, :gift_card_cash_outs, column: :reversal_of_id
+    add_check_constraint :gift_card_cash_outs,
+                         "amount_cents > 0",
+                         name: "gift_card_cash_outs_amount_positive"
+    add_check_constraint :gift_card_cash_outs,
+                         "reversal_of_id IS NULL AND physical_cash_confirmed = FALSE AND physical_cash_confirmed_by_id IS NULL OR reversal_of_id IS NOT NULL AND physical_cash_confirmed = TRUE AND physical_cash_confirmed_by_id IS NOT NULL",
+                         name: "gift_card_cash_outs_physical_cash_on_reversal"
+
+    add_column :pos_controlled_actions, :gift_card_cash_out_id, :uuid
+    add_index :pos_controlled_actions, :gift_card_cash_out_id, unique: true,
+              where: "gift_card_cash_out_id IS NOT NULL",
+              name: "index_pos_controlled_actions_on_cash_out"
+    add_foreign_key :pos_controlled_actions, :gift_card_cash_outs
+    change_column_null :pos_controlled_actions, :pos_transaction_id, true
+
+    remove_check_constraint :pos_controlled_actions, name: "pos_controlled_actions_type_valid"
+    add_check_constraint :pos_controlled_actions,
+                         "action_type IN ('price_override', 'line_discount', 'tax_class_override', 'unlinked_return', 'post_void', 'gift_card_cash_out')",
+                         name: "pos_controlled_actions_type_valid"
+
+    remove_check_constraint :pos_controlled_actions, name: "pos_controlled_actions_line_scope"
+    add_check_constraint :pos_controlled_actions,
+                         <<~SQL.squish,
+                           (action_type = 'post_void' AND pos_transaction_line_id IS NULL AND pos_transaction_id IS NOT NULL AND gift_card_cash_out_id IS NULL)
+                           OR (action_type = 'gift_card_cash_out' AND pos_transaction_line_id IS NULL AND pos_transaction_id IS NULL AND gift_card_cash_out_id IS NOT NULL)
+                           OR (action_type NOT IN ('post_void', 'gift_card_cash_out') AND pos_transaction_line_id IS NOT NULL AND pos_transaction_id IS NOT NULL AND gift_card_cash_out_id IS NULL)
+                         SQL
+                         name: "pos_controlled_actions_line_scope"
+
+    add_column :pos_reporting_periods, :finalized_stored_value_issuance_cents, :bigint
+    add_column :pos_reporting_periods, :finalized_stored_value_payment_cents, :bigint
+    add_column :pos_reporting_periods, :finalized_stored_value_refund_cents, :bigint
+    add_column :pos_reporting_periods, :finalized_gift_card_cash_out_cents, :bigint
+    add_column :pos_reporting_periods, :finalized_gift_card_cash_out_reversal_cents, :bigint
+    add_check_constraint :pos_reporting_periods,
+                         "finalized_stored_value_issuance_cents IS NULL OR finalized_stored_value_issuance_cents >= 0",
+                         name: "pos_reporting_periods_finalized_sv_issuance_nonnegative"
+    add_check_constraint :pos_reporting_periods,
+                         "finalized_stored_value_payment_cents IS NULL OR finalized_stored_value_payment_cents >= 0",
+                         name: "pos_reporting_periods_finalized_sv_payment_nonnegative"
+    add_check_constraint :pos_reporting_periods,
+                         "finalized_stored_value_refund_cents IS NULL OR finalized_stored_value_refund_cents >= 0",
+                         name: "pos_reporting_periods_finalized_sv_refund_nonnegative"
+    add_check_constraint :pos_reporting_periods,
+                         "finalized_gift_card_cash_out_cents IS NULL OR finalized_gift_card_cash_out_cents >= 0",
+                         name: "pos_reporting_periods_finalized_gc_cash_out_nonnegative"
+    add_check_constraint :pos_reporting_periods,
+                         "finalized_gift_card_cash_out_reversal_cents IS NULL OR finalized_gift_card_cash_out_reversal_cents >= 0",
+                         name: "pos_reporting_periods_finalized_gc_cash_out_rev_nonnegative"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_26_040000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_26_050000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -220,6 +220,35 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_040000) do
     t.index ["sales_returns_gl_account_id"], name: "index_departments_on_sales_returns_gl_account_id"
     t.index ["sales_revenue_gl_account_id"], name: "index_departments_on_sales_revenue_gl_account_id"
     t.check_constraint "code::text ~ '^[a-z0-9]+(_[a-z0-9]+)*$'::text", name: "departments_code_format"
+  end
+
+  create_table "gift_card_cash_outs", id: :uuid, default: nil, force: :cascade do |t|
+    t.bigint "amount_cents", null: false
+    t.uuid "approved_by_id"
+    t.date "business_date", null: false
+    t.timestamptz "created_at", null: false
+    t.uuid "gift_card_id", null: false
+    t.uuid "performed_by_id", null: false
+    t.boolean "physical_cash_confirmed", default: false, null: false
+    t.uuid "physical_cash_confirmed_by_id"
+    t.uuid "pos_session_id", null: false
+    t.timestamptz "posted_at", null: false
+    t.jsonb "program_policy_snapshot", default: {}, null: false
+    t.uuid "register_id", null: false
+    t.uuid "reversal_of_id"
+    t.uuid "store_id", null: false
+    t.uuid "stored_value_account_id", null: false
+    t.uuid "stored_value_operation_id"
+    t.timestamptz "updated_at", null: false
+    t.index ["gift_card_id"], name: "index_gift_card_cash_outs_on_gift_card_id"
+    t.index ["pos_session_id"], name: "index_gift_card_cash_outs_on_pos_session_id"
+    t.index ["register_id"], name: "index_gift_card_cash_outs_on_register_id"
+    t.index ["reversal_of_id"], name: "index_gift_card_cash_outs_on_reversal_of_id", unique: true, where: "(reversal_of_id IS NOT NULL)"
+    t.index ["store_id"], name: "index_gift_card_cash_outs_on_store_id"
+    t.index ["stored_value_account_id"], name: "index_gift_card_cash_outs_on_stored_value_account_id"
+    t.index ["stored_value_operation_id"], name: "index_gift_card_cash_outs_on_operation", unique: true, where: "(stored_value_operation_id IS NOT NULL)"
+    t.check_constraint "amount_cents > 0", name: "gift_card_cash_outs_amount_positive"
+    t.check_constraint "reversal_of_id IS NULL AND physical_cash_confirmed = false AND physical_cash_confirmed_by_id IS NULL OR reversal_of_id IS NOT NULL AND physical_cash_confirmed = true AND physical_cash_confirmed_by_id IS NOT NULL", name: "gift_card_cash_outs_physical_cash_on_reversal"
   end
 
   create_table "gift_card_programs", id: :uuid, default: nil, force: :cascade do |t|
@@ -590,25 +619,27 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_040000) do
     t.timestamptz "created_at", null: false
     t.timestamptz "executed_at", null: false
     t.string "fingerprint_schema_version", null: false
+    t.uuid "gift_card_cash_out_id"
     t.jsonb "material_values", default: {}, null: false
     t.string "performed_by_name_snapshot", null: false
     t.uuid "performed_by_user_id", null: false
     t.string "policy_result", null: false
     t.string "policy_version", null: false
-    t.uuid "pos_transaction_id", null: false
+    t.uuid "pos_transaction_id"
     t.uuid "pos_transaction_line_id"
     t.string "reason_code", null: false
     t.string "reason_name_snapshot", null: false
     t.text "reason_note"
     t.timestamptz "updated_at", null: false
     t.index ["approved_by_user_id"], name: "index_pos_controlled_actions_on_approved_by_user_id"
+    t.index ["gift_card_cash_out_id"], name: "index_pos_controlled_actions_on_cash_out", unique: true, where: "(gift_card_cash_out_id IS NOT NULL)"
     t.index ["performed_by_user_id"], name: "index_pos_controlled_actions_on_performed_by_user_id"
     t.index ["pos_transaction_id", "action_type"], name: "index_pos_controlled_actions_one_post_void", unique: true, where: "((action_type)::text = 'post_void'::text)"
     t.index ["pos_transaction_id"], name: "index_pos_controlled_actions_on_pos_transaction_id"
     t.index ["pos_transaction_line_id", "action_type"], name: "index_pos_controlled_actions_effective_line", unique: true, where: "(pos_transaction_line_id IS NOT NULL)"
     t.index ["pos_transaction_line_id"], name: "index_pos_controlled_actions_on_pos_transaction_line_id"
-    t.check_constraint "action_type::text = 'post_void'::text AND pos_transaction_line_id IS NULL OR action_type::text <> 'post_void'::text AND pos_transaction_line_id IS NOT NULL", name: "pos_controlled_actions_line_scope"
-    t.check_constraint "action_type::text = ANY (ARRAY['price_override'::character varying::text, 'line_discount'::character varying::text, 'tax_class_override'::character varying::text, 'unlinked_return'::character varying::text, 'post_void'::character varying::text])", name: "pos_controlled_actions_type_valid"
+    t.check_constraint "action_type::text = 'post_void'::text AND pos_transaction_line_id IS NULL AND pos_transaction_id IS NOT NULL AND gift_card_cash_out_id IS NULL OR action_type::text = 'gift_card_cash_out'::text AND pos_transaction_line_id IS NULL AND pos_transaction_id IS NULL AND gift_card_cash_out_id IS NOT NULL OR (action_type::text <> ALL (ARRAY['post_void'::character varying, 'gift_card_cash_out'::character varying]::text[])) AND pos_transaction_line_id IS NOT NULL AND pos_transaction_id IS NOT NULL AND gift_card_cash_out_id IS NULL", name: "pos_controlled_actions_line_scope"
+    t.check_constraint "action_type::text = ANY (ARRAY['price_override'::character varying, 'line_discount'::character varying, 'tax_class_override'::character varying, 'unlinked_return'::character varying, 'post_void'::character varying, 'gift_card_cash_out'::character varying]::text[])", name: "pos_controlled_actions_type_valid"
     t.check_constraint "approved_by_user_id IS NULL OR approved_by_user_id <> performed_by_user_id", name: "pos_controlled_actions_approver_not_performer"
     t.check_constraint "policy_result::text = 'approval_required'::text AND approved_by_user_id IS NOT NULL AND approved_by_name_snapshot IS NOT NULL OR policy_result::text = 'direct'::text AND approved_by_user_id IS NULL AND approved_by_name_snapshot IS NULL", name: "pos_controlled_actions_approver_matches_policy"
     t.check_constraint "policy_result::text = ANY (ARRAY['direct'::character varying::text, 'approval_required'::character varying::text])", name: "pos_controlled_actions_policy_valid"
@@ -676,6 +707,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_040000) do
     t.bigint "finalized_closing_expected_cash_cents_sum"
     t.bigint "finalized_closing_variance_cents_sum"
     t.bigint "finalized_discount_cents"
+    t.bigint "finalized_gift_card_cash_out_cents"
+    t.bigint "finalized_gift_card_cash_out_reversal_cents"
     t.bigint "finalized_net_cents"
     t.bigint "finalized_opening_float_cents_sum"
     t.bigint "finalized_other_payment_cents"
@@ -690,6 +723,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_040000) do
     t.bigint "finalized_return_tax_cents"
     t.bigint "finalized_return_total_cents"
     t.integer "finalized_session_count"
+    t.bigint "finalized_stored_value_issuance_cents"
+    t.bigint "finalized_stored_value_payment_cents"
+    t.bigint "finalized_stored_value_refund_cents"
     t.bigint "finalized_subtotal_cents"
     t.bigint "finalized_tax_cents"
     t.bigint "finalized_total_cents"
@@ -713,6 +749,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_040000) do
     t.check_constraint "finalized_closing_count_cents_sum IS NULL OR finalized_closing_count_cents_sum >= 0", name: "pos_reporting_periods_finalized_closing_count_sum_nonnegative"
     t.check_constraint "finalized_closing_variance_cents_sum IS NULL OR finalized_closing_variance_cents_sum = (finalized_closing_count_cents_sum - finalized_closing_expected_cash_cents_sum)", name: "pos_reporting_periods_finalized_variance_matches_sums"
     t.check_constraint "finalized_discount_cents IS NULL OR finalized_discount_cents >= 0", name: "pos_reporting_periods_finalized_discount_nonnegative"
+    t.check_constraint "finalized_gift_card_cash_out_cents IS NULL OR finalized_gift_card_cash_out_cents >= 0", name: "pos_reporting_periods_finalized_gc_cash_out_nonnegative"
+    t.check_constraint "finalized_gift_card_cash_out_reversal_cents IS NULL OR finalized_gift_card_cash_out_reversal_cents >= 0", name: "pos_reporting_periods_finalized_gc_cash_out_rev_nonnegative"
     t.check_constraint "finalized_opening_float_cents_sum IS NULL OR finalized_opening_float_cents_sum >= 0", name: "pos_reporting_periods_finalized_opening_float_sum_nonnegative"
     t.check_constraint "finalized_other_payment_cents IS NULL OR finalized_other_payment_cents >= 0", name: "pos_reporting_periods_finalized_other_payment_nonnegative"
     t.check_constraint "finalized_other_refund_cents IS NULL OR finalized_other_refund_cents >= 0", name: "pos_reporting_periods_finalized_other_refund_cents_nonnegative"
@@ -722,6 +760,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_040000) do
     t.check_constraint "finalized_return_tax_cents IS NULL OR finalized_return_tax_cents >= 0", name: "pos_reporting_periods_finalized_return_tax_cents_nonnegative"
     t.check_constraint "finalized_return_total_cents IS NULL OR finalized_return_total_cents >= 0", name: "pos_reporting_periods_finalized_return_total_cents_nonnegative"
     t.check_constraint "finalized_session_count IS NULL OR finalized_session_count >= 0", name: "pos_reporting_periods_finalized_session_count_nonnegative"
+    t.check_constraint "finalized_stored_value_issuance_cents IS NULL OR finalized_stored_value_issuance_cents >= 0", name: "pos_reporting_periods_finalized_sv_issuance_nonnegative"
+    t.check_constraint "finalized_stored_value_payment_cents IS NULL OR finalized_stored_value_payment_cents >= 0", name: "pos_reporting_periods_finalized_sv_payment_nonnegative"
+    t.check_constraint "finalized_stored_value_refund_cents IS NULL OR finalized_stored_value_refund_cents >= 0", name: "pos_reporting_periods_finalized_sv_refund_nonnegative"
     t.check_constraint "finalized_subtotal_cents IS NULL OR finalized_subtotal_cents >= 0", name: "pos_reporting_periods_finalized_subtotal_nonnegative"
     t.check_constraint "finalized_tax_cents IS NULL OR finalized_tax_cents >= 0", name: "pos_reporting_periods_finalized_tax_nonnegative"
     t.check_constraint "finalized_total_cents IS NULL OR finalized_total_cents >= 0", name: "pos_reporting_periods_finalized_total_nonnegative"
@@ -1665,6 +1706,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_040000) do
   add_foreign_key "departments", "gl_accounts", column: "receiving_clearing_gl_account_id"
   add_foreign_key "departments", "gl_accounts", column: "sales_returns_gl_account_id"
   add_foreign_key "departments", "gl_accounts", column: "sales_revenue_gl_account_id"
+  add_foreign_key "gift_card_cash_outs", "gift_card_cash_outs", column: "reversal_of_id"
+  add_foreign_key "gift_card_cash_outs", "gift_cards"
+  add_foreign_key "gift_card_cash_outs", "pos_sessions"
+  add_foreign_key "gift_card_cash_outs", "registers"
+  add_foreign_key "gift_card_cash_outs", "stored_value_accounts"
+  add_foreign_key "gift_card_cash_outs", "stored_value_operations"
+  add_foreign_key "gift_card_cash_outs", "stores"
+  add_foreign_key "gift_card_cash_outs", "users", column: "approved_by_id"
+  add_foreign_key "gift_card_cash_outs", "users", column: "performed_by_id"
+  add_foreign_key "gift_card_cash_outs", "users", column: "physical_cash_confirmed_by_id"
   add_foreign_key "gift_card_replacements", "gift_card_replacements", column: "reversal_of_id"
   add_foreign_key "gift_card_replacements", "gift_cards", column: "original_gift_card_id"
   add_foreign_key "gift_card_replacements", "gift_cards", column: "replacement_gift_card_id"
@@ -1709,6 +1760,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_040000) do
   add_foreign_key "orders", "stores", on_delete: :restrict
   add_foreign_key "orders", "suppliers", on_delete: :restrict
   add_foreign_key "orders", "users", column: "cancelled_by_id", on_delete: :restrict
+  add_foreign_key "pos_controlled_actions", "gift_card_cash_outs"
   add_foreign_key "pos_controlled_actions", "pos_transaction_lines"
   add_foreign_key "pos_controlled_actions", "pos_transactions"
   add_foreign_key "pos_controlled_actions", "users", column: "approved_by_user_id"

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,7 +44,7 @@ This directory contains the project’s technical authority, development guidanc
 | [Phase 7.1 purchasing polish](planning/phase7.1-purchasing-polish/README.md) | Complete on `main` (7.1.1–7.1.3); 7.1.4 deferred |
 | [Phase 8 customer foundation](planning/phase8-customer-foundation/README.md) | Complete on `main` (PR #42); [ADR-023](adr/ADR-023-customer-merge.md) |
 | [Phase 9 catalog enrichment](planning/phase9-catalog-enrichment/README.md) | Implemented; [ADR-024](adr/ADR-024-bibliographic-data-authority.md) |
-| [Phase 10 stored value](planning/phase10-stored-value/README.md) | Proposed; [ADR-025](adr/ADR-025-domain-owned-operational-ledgers.md), [ADR-026](adr/ADR-026-gift-card-number-protection.md) |
+| [Phase 10 stored value](planning/phase10-stored-value/README.md) | Slices 10.1–10.5 on `main`; milestone open until the manual test plan; [ADR-025](adr/ADR-025-domain-owned-operational-ledgers.md), [ADR-026](adr/ADR-026-gift-card-number-protection.md) |
 | [Canonical roadmap](planning/roadmap.md) | Implemented milestones, forward phases 10–14, UDS, Terminal program |
 | [Planning packets](planning/README.md) | Phase and UX packet index |
 | [UX design system](planning/ux-design-system/README.md) | Warm Parchment UDS-1–3 operationally complete; UDS-4.0–4.2 and UDS-5 on `main` |

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -30,7 +30,7 @@ An early outline in this file numbered Phase 8 as buyback and Phase 9 as financi
 
 | Packet | Status |
 |---|---|
-| [Phase 10 — Stored value](phase10-stored-value/README.md) | **Proposed**; [ADR-025](../adr/ADR-025-domain-owned-operational-ledgers.md), [ADR-026](../adr/ADR-026-gift-card-number-protection.md) |
+| [Phase 10 — Stored value](phase10-stored-value/README.md) | Slices 10.1–10.5 on `main`; milestone open until the [manual test plan](phase10-stored-value/phase10-manual-test-plan.md); [ADR-025](../adr/ADR-025-domain-owned-operational-ledgers.md), [ADR-026](../adr/ADR-026-gift-card-number-protection.md) |
 
 ## Cross-phase UX
 

--- a/docs/planning/phase10-stored-value/README.md
+++ b/docs/planning/phase10-stored-value/README.md
@@ -1,6 +1,6 @@
 # Phase 10 — Stored value
 
-Status: **Proposed**. After Phase 8 customer identity. Authority: this packet plus [ADR-025](../../adr/ADR-025-domain-owned-operational-ledgers.md) and [ADR-026](../../adr/ADR-026-gift-card-number-protection.md). GitHub tracker: [milestone 5](https://github.com/BankEncore/ShelfSense-v1/milestone/5).
+Status: **Proposed** — slices 10.1–10.5 implement on `main`; [milestone 5](https://github.com/BankEncore/ShelfSense-v1/milestone/5) stays open until the [manual test plan](phase10-manual-test-plan.md) is executed. After Phase 8 customer identity. Authority: this packet plus [ADR-025](../../adr/ADR-025-domain-owned-operational-ledgers.md) and [ADR-026](../../adr/ADR-026-gift-card-number-protection.md). GitHub tracker: [milestone 5](https://github.com/BankEncore/ShelfSense-v1/milestone/5).
 
 The draft [phase-10-stored-value-spec.md](../../drafts/phase-10-stored-value-spec.md) is **superseded**. Do not implement from it.
 

--- a/docs/planning/phase10-stored-value/phase10-implementation-plan.md
+++ b/docs/planning/phase10-stored-value/phase10-implementation-plan.md
@@ -53,7 +53,7 @@ Issue branches PR **directly to `main`**. There is no `phase-10-stored-value` in
 | 10.2 Customer store/trade credit | Complete (issue [#60](https://github.com/BankEncore/ShelfSense-v1/issues/60)) |
 | 10.3 Gift-card programs and instruments | Complete (issue [#61](https://github.com/BankEncore/ShelfSense-v1/issues/61)) |
 | 10.4 POS issuance, tenders, refund destinations, post-void | Complete (issue [#62](https://github.com/BankEncore/ShelfSense-v1/issues/62)) |
-| 10.5 Cash-out, closeout, print, nav | Not started |
+| 10.5 Cash-out, closeout, print, nav | Complete (issue [#63](https://github.com/BankEncore/ShelfSense-v1/issues/63)); Phase 10 milestone remains open until the [manual test plan](phase10-manual-test-plan.md) is executed |
 
 ## Integration notes
 

--- a/docs/planning/phase10-stored-value/phase10-plan.md
+++ b/docs/planning/phase10-stored-value/phase10-plan.md
@@ -1,6 +1,6 @@
 # Phase 10 — Stored value plan
 
-Status: **Proposed**.
+Status: **Proposed**. Implementation slices 10.1–10.5 land on `main`; the Phase 10 milestone stays open until the [manual test plan](phase10-manual-test-plan.md) is executed.
 
 ## Goal
 

--- a/docs/planning/phase10-stored-value/phase10-schema.md
+++ b/docs/planning/phase10-stored-value/phase10-schema.md
@@ -227,6 +227,9 @@ Do not persist plaintext numbers in logs or public columns. Lifecycle starts at 
 | `performed_by_id` | uuid | Required |
 | `approved_by_id` | uuid, nullable | When `cash_out_approval_required` |
 | `stored_value_operation_id` | uuid, nullable | Unique when present |
+| `reversal_of_id` | uuid, nullable | Unique when present |
+| `physical_cash_confirmed` | boolean | Required true on reversal rows; false on originals |
+| `physical_cash_confirmed_by_id` | uuid, nullable | Required on reversal |
 | `posted_at` | timestamptz | Required |
 | timestamps | timestamptz | Required |
 

--- a/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/receipt-presentation.md
+++ b/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/receipt-presentation.md
@@ -892,6 +892,8 @@ A reprint may differ from the original physical paper in Store legal name, addre
 
 No reprint table. **No reprint audit** — 6.3 stands (`window.print` stays client-side). This contract does not add print-attempt persistence.
 
+Phase 10: ordinary POS reprints stay masked. Full generated gift-card numbers appear only on controlled first print, complete-retry of that outcome, or exceptional print recovery with a reason (`GiftCards::PrintRecovery`). Gift-card cash-out has its own receipt (masked number, amount, remaining balance); it is not a tender line.
+
 ---
 
 ## 25. Post-voided original receipts
@@ -946,6 +948,10 @@ commit immutable facts
         ↓
 render/print receipt
 ```
+
+Phase 10 cash-out commits `gift_card_cash_outs` then renders/prints a cash-out receipt. Print recovery after a failed first print does not reopen the stored-value fact.
+
+---
 
 Never print then commit. Printer or browser printing failure does not reopen, cancel, or reverse the transaction, release the receipt identity, or rerun tax or settlement.
 

--- a/docs/planning/roadmap.md
+++ b/docs/planning/roadmap.md
@@ -192,7 +192,7 @@ The external lookup boundary returns **normalized candidate data**; the Product 
 
 ## Phase 10 — Stored value
 
-**Status:** Proposed. **After Phase 8** (customer identity foundation). Planning packet: [phase10-stored-value/](phase10-stored-value/README.md). Policy: [ADR-025](../adr/ADR-025-domain-owned-operational-ledgers.md), [ADR-026](../adr/ADR-026-gift-card-number-protection.md).
+**Status:** Implementation slices 10.1–10.5 land on `main`. Phase 10 is **not Complete** until the [manual test plan](phase10-stored-value/phase10-manual-test-plan.md) is executed. Planning packet: [phase10-stored-value/](phase10-stored-value/README.md). Policy: [ADR-025](../adr/ADR-025-domain-owned-operational-ledgers.md), [ADR-026](../adr/ADR-026-gift-card-number-protection.md).
 
 Stored-value redemption is **online-authorized** until a bounded offline mechanism exists ([ADR-005](../adr/ADR-005-terminal-originated-operations.md)). There is **no** universal operational financial-event table; each domain keeps its own immutable facts. Cross-domain accounting/export is Phase 14.
 
@@ -376,7 +376,7 @@ The following remain out of scope until a planning packet and ADR review justify
 | UDS-5 — Administrative composition | **Complete** on `main` (PR #57; [uds-5-plan.md](ux-design-system/uds-5-plan.md)) |
 | Phase 8 — Customer foundation (MVP) | **Complete** on `main` (PR #42) |
 | Phase 9 — Catalog and bibliographic enrichment | **Implemented**; Phase 10 unblocked but not primary |
-| Phase 10 — Stored value | After Phase 8 (unblocked; packet [phase10-stored-value](phase10-stored-value/README.md); not the primary stream) |
+| Phase 10 — Stored value | Slices 10.1–10.5 land on `main`; milestone remains open until the [manual test plan](phase10-stored-value/phase10-manual-test-plan.md) |
 | Phase 11 — Cash accountability completion | After Phase 10 stored-value and Register integration |
 | Phase 12 — Used buyback | After 8–11 (payout after 10–11) |
 | Phase 13 — Customer workspace | After activity sources exist |
@@ -391,7 +391,7 @@ The following remain out of scope until a planning packet and ADR review justify
 
 | Document | Relationship |
 |---|---|
-| [Phase 10 stored value](phase10-stored-value/README.md) | Proposed stored-value packet; [ADR-025](../adr/ADR-025-domain-owned-operational-ledgers.md) |
+| [Phase 10 stored value](phase10-stored-value/README.md) | Slices 10.1–10.5 on `main`; milestone open until manual gate; [ADR-025](../adr/ADR-025-domain-owned-operational-ledgers.md) |
 | [Phase planning packets](phase1-operational-foundation/phase1-plan.md) | Authoritative detail per implemented phase |
 | [Phase 7.1 purchasing closeout](phase7.1-purchasing-polish/README.md) | Phase 7 operability finish; [coordination with UDS-4](phase7.1-purchasing-polish/phase7.1-uds-coordination.md) |
 | [UDS-4 plan](ux-design-system/uds-4-plan.md) | Grouped navigation and cross-cutting adoption |

--- a/test/services/admin/navigation_view_model_test.rb
+++ b/test/services/admin/navigation_view_model_test.rb
@@ -33,6 +33,7 @@ class Admin::NavigationViewModelTest < ActiveSupport::TestCase
     assert nav.groups.find { |g| g.key == :pos_operations }.destinations.any? { |d| d.key == :pos }
     assert nav.groups.find { |g| g.key == :pos_operations }.destinations.any? { |d| d.key == :gift_cards }
     assert nav.groups.find { |g| g.key == :pos_operations }.destinations.any? { |d| d.key == :gift_card_programs }
+    assert nav.groups.find { |g| g.key == :pos_operations }.destinations.any? { |d| d.key == :stored_value_report }
 
     assert nav.groups.find { |g| g.key == :merchandise }.current
     assert_equal :products, nav.current_destination.key

--- a/test/services/gift_cards/cash_out_test.rb
+++ b/test/services/gift_cards/cash_out_test.rb
@@ -1,0 +1,224 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class GiftCardsCashOutTest < ActiveSupport::TestCase
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    @approver = create_store_manager("cash_out_approver")
+    GiftCards::Programs.seed!
+    StoredValue::AdjustmentReasons.seed!
+    @program = GiftCardProgram.find_by!(code: "generated")
+    @context = pos_open_context(store: @store, actor: @actor, opening_float_cents: 10_000)
+    @session = @context[:session]
+  end
+
+  test "cashes out the full eligible balance and reduces expected cash" do
+    card = funded_card(500)
+    before = Pos::SessionTotals.for(@session).expected_cash_cents
+
+    cash_out = GiftCards::CashOut.call(
+      gift_card: card,
+      session: @session,
+      actor: @actor,
+      source_id: SecureRandom.uuid_v7,
+      idempotency_key: SecureRandom.uuid_v7
+    )
+
+    assert_equal 500, cash_out.amount_cents
+    assert_equal @session.register_id, cash_out.register_id
+    assert_equal 0, card.stored_value_account.reload.balance_cents
+    assert card.reload.closed?
+    assert_equal "cash_out", cash_out.stored_value_operation.operation_type
+    assert_equal before - 500, Pos::SessionTotals.for(@session.reload).expected_cash_cents
+    assert OutboxMessage.exists?(event_type: "stored_value.cash_out_completed")
+    assert PosControlledAction.exists?(action_type: "gift_card_cash_out", gift_card_cash_out_id: cash_out.id)
+    groups = Pos::OperatorReport.session(totals: Pos::SessionTotals.for(@session), session: @session, kind: :x)
+    stored_value = groups.find { |group| group.title == "Stored value" }
+    cash = groups.find { |group| group.title == "Cash custody" }
+    assert_equal 500, stored_value.rows.find { |row| row.label == "Gift-card cash-outs" && row.format != :count }.cents
+    assert_equal 500, cash.rows.find { |row| row.label == "Gift-card cash-outs" }.cents
+  end
+
+  test "associates cannot cash out" do
+    card = funded_card(500)
+    associate = User.create!(
+      username: "cash_out_assoc",
+      display_name: "Associate",
+      password: "correct-horse-battery",
+      password_confirmation: "correct-horse-battery"
+    )
+    RoleAssignment.create!(
+      user: associate,
+      role: Role.find_by!(key: "associate"),
+      store: @store,
+      assigned_by: @actor,
+      effective_at: Time.current
+    )
+
+    error = assert_raises(GiftCards::Error) do
+      GiftCards::CashOut.call(
+        gift_card: card,
+        session: @session,
+        actor: associate,
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+    end
+    assert_match(/not authorized/, error.message)
+    assert_equal 500, card.stored_value_account.reload.balance_cents
+  end
+
+  test "required_on_request_when_eligible does not pay out without confirmation" do
+    @program.update!(cash_out_policy: "required_on_request_when_eligible")
+    card = funded_card(400)
+    error = assert_raises(GiftCards::Error) do
+      GiftCards::CashOut.call(
+        gift_card: card,
+        session: @session,
+        actor: @actor,
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+    end
+    assert_match(/customer requested/, error.message)
+
+    cash_out = GiftCards::CashOut.call(
+      gift_card: card,
+      session: @session,
+      actor: @actor,
+      source_id: SecureRandom.uuid_v7,
+      idempotency_key: SecureRandom.uuid_v7,
+      customer_requested: true
+    )
+    assert_equal 400, cash_out.amount_cents
+  end
+
+  test "cash_out_approval_required uses PosControlledAction second user" do
+    @program.update!(cash_out_approval_required: true)
+    card = funded_card(250)
+    error = assert_raises(GiftCards::Error) do
+      GiftCards::CashOut.call(
+        gift_card: card,
+        session: @session,
+        actor: @actor,
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+    end
+    assert_match(/approver/, error.message)
+
+    cash_out = GiftCards::CashOut.call(
+      gift_card: card,
+      session: @session,
+      actor: @actor,
+      source_id: SecureRandom.uuid_v7,
+      idempotency_key: SecureRandom.uuid_v7,
+      approver_username: @approver.username,
+      approver_password: "correct-horse-battery"
+    )
+    action = cash_out.pos_controlled_action
+    assert_equal "approval_required", action.policy_result
+    assert_equal @approver.id, action.approved_by_user_id
+  end
+
+  test "reversal requires physical cash confirmation and credits the reversing session" do
+    card = funded_card(500)
+    original = GiftCards::CashOut.call(
+      gift_card: card,
+      session: @session,
+      actor: @actor,
+      source_id: SecureRandom.uuid_v7,
+      idempotency_key: SecureRandom.uuid_v7
+    )
+    after_cash_out = Pos::SessionTotals.for(@session.reload).expected_cash_cents
+
+    error = assert_raises(GiftCards::Error) do
+      GiftCards::ReverseCashOut.call(
+        cash_out: original,
+        session: @session,
+        actor: @actor,
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7,
+        physical_cash_returned: false
+      )
+    end
+    assert_match(/physically returned/, error.message)
+
+    reversal = GiftCards::ReverseCashOut.call(
+      cash_out: original,
+      session: @session,
+      actor: @actor,
+      source_id: SecureRandom.uuid_v7,
+      idempotency_key: SecureRandom.uuid_v7,
+      physical_cash_returned: true
+    )
+    assert reversal.reversal?
+    assert_equal original.id, reversal.reversal_of_id
+    assert_equal 500, card.stored_value_account.reload.balance_cents
+    assert card.reload.active?
+    assert_equal after_cash_out + 500, Pos::SessionTotals.for(@session.reload).expected_cash_cents
+  end
+
+  test "closed session expected cash stays on the snapshot after a later cash-out reverse" do
+    card = funded_card(500)
+    GiftCards::CashOut.call(
+      gift_card: card,
+      session: @session,
+      actor: @actor,
+      source_id: SecureRandom.uuid_v7,
+      idempotency_key: SecureRandom.uuid_v7
+    )
+    closed = Pos::CloseSession.call(
+      session: @session,
+      actor: @actor,
+      expected_lock_version: @session.lock_version,
+      closing_count_cents: 9_500
+    )
+    snapshot = closed.closing_expected_cash_cents
+    assert_equal 9_500, snapshot
+    assert_equal snapshot, Pos::SessionTotals.for(closed).expected_cash_cents
+  end
+
+  test "print recovery returns the number with a reason and does not put it in audit" do
+    card = funded_card(200)
+    number = GiftCards::PrintRecovery.call(
+      gift_card: card,
+      actor: @actor,
+      store: @store,
+      reason: "printer jammed after first print"
+    )
+    assert_equal card.number, number
+    event = AuditEvent.where(action: "gift_cards.print_recovery").order(:created_at).last
+    assert_equal "succeeded", event.outcome
+    refute event.after_values.values.any? { |value| value.to_s.include?(card.number) }
+    assert_equal card.number_last_four, event.after_values["number_last_four"]
+  end
+
+  private
+
+  def funded_card(amount_cents)
+    card = GiftCards::ProvisionInstrument.call(program: @program, store: @store)
+    GiftCards::Fund.call(gift_card: card, amount_cents: amount_cents, store: @store, performed_by: @actor)
+    card
+  end
+
+  def create_store_manager(username)
+    user = User.create!(
+      username: username,
+      display_name: username.titleize,
+      password: "correct-horse-battery",
+      password_confirmation: "correct-horse-battery"
+    )
+    RoleAssignment.create!(
+      user: user,
+      role: Role.find_by!(key: "store_manager"),
+      store: @store,
+      assigned_by: @actor,
+      effective_at: Time.current
+    )
+    user
+  end
+end

--- a/test/services/pos/stored_value_completion_test.rb
+++ b/test/services/pos/stored_value_completion_test.rb
@@ -65,7 +65,11 @@ class PosStoredValueCompletionTest < ActiveSupport::TestCase
     assert_equal 1, credentials.size
     assert_equal card.number, credentials.first.number
     Pos::CompletedTransactionFacts.new(result.operation.envelope).verify!
-    assert_equal result.transaction.signed_net_cents, Pos::CustomerReceipt.build(result.transaction).signed_net_cents
+    receipt = Pos::CustomerReceipt.build(result.transaction)
+    assert_equal result.transaction.signed_net_cents, receipt.signed_net_cents
+    note = receipt.remaining_balance_notes.sole
+    assert_equal card.masked_number, note.masked_card
+    assert_equal 2500, note.balance_cents
   end
 
   test "gift-card redeem posts a negative redeem and rejects same-ticket issuance" do

--- a/test/system/pos_mixed_return_test.rb
+++ b/test/system/pos_mixed_return_test.rb
@@ -103,6 +103,9 @@ class PosMixedReturnTest < ApplicationSystemTestCase
     assert_selector "tr.is-selected[data-direction='return']"
     send_keys :f5
     assert_no_selector "#pos_control_overlay", visible: true
+    assert_selector "#pos_other_overlay", visible: true
+    send_keys :escape
+    assert_no_selector "#pos_other_overlay", visible: true
     send_keys :f6
     assert_no_selector "#pos_control_overlay", visible: true
     send_keys :f7


### PR DESCRIPTION
## Summary
- Gift-card cash-out pays the full eligible remaining balance from an open Register session (`gift_cards.cash_out`). It is not a tender or paid-out. Program `cash_out_approval_required` reuses `PosControlledAction` with a second user who also holds `gift_cards.cash_out`.
- Expected cash is `float + cash payments − cash refunds − completed cash-outs + cash-out reversals`. Reversal requires confirmation that cash physically returned to an open Register; the reversing session gets the positive expected-cash effect. Closed-session snapshots stay immutable.
- Idle Register gift-card scans POST into cash-out lookup (card number never in the query string). Exceptional print recovery is reason-gated and audits last four only. Customer receipts print remaining gift-card balance (masked). X/Z stored-value rows include issuance, tenders by type, refund destinations, and cash-outs. Stored-value reporting is in `Admin::NavigationCatalog`.

## Verification
- `./dev/rails-docker bin/rails test` (1066 runs, 0 failures, 1 skip)
- `./dev/rails-docker bin/rubocop`
- `./dev/rails-docker bin/brakeman --no-pager`
- `./dev/rails-docker bin/bundler-audit`

## Documentation and migrations
- `db/migrate/20260826050000_create_phase10_gift_card_cash_outs.rb` (reversible `change`)
- `db/schema.rb` regenerated
- Slice 10.5 marked Complete in phase10-implementation-plan.md
- Roadmap/packet: slices 10.1–10.5 land on `main`; Phase 10 milestone remains open until the [manual test plan](docs/planning/phase10-stored-value/phase10-manual-test-plan.md) is executed

Closes #63

Made with [Cursor](https://cursor.com)