### PR TITLE
Close stored-value first-print, refund, and Register operability gaps

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -2233,20 +2233,77 @@ input[type="submit"]:disabled,
     font-family: var(--font-receipt);
     font-weight: 700;
     color: #000;
-    font-size: 11pt;
+    font-size: 10pt;
     line-height: 1.25;
     text-align: center;
   }
 
+  .pos-gift-card-voucher p {
+    margin: 0;
+  }
+
+  .pos-gift-card-voucher__card {
+    padding-bottom: 10mm;
+  }
+
+  .pos-gift-card-voucher__card + .pos-gift-card-voucher__card {
+    break-before: page;
+    page-break-before: always;
+  }
+
+  .pos-gift-card-voucher__store {
+    margin-bottom: 0.9em;
+  }
+
+  .pos-gift-card-voucher__legal-name {
+    font-size: 11pt;
+  }
+
+  .pos-gift-card-voucher__issued {
+    margin: 0.6em 0 1.1em;
+  }
+
+  .pos-gift-card-voucher__amount {
+    font-size: 22pt;
+    line-height: 1.05;
+    margin: 0.9em 0 0.25em;
+  }
+
   .pos-gift-card-voucher__title {
-    font-size: 14pt;
-    letter-spacing: 0.08em;
+    font-size: 16pt;
+    margin: 0 0 1.1em;
+  }
+
+  .pos-gift-card-voucher__barcode {
+    margin: 0.4em 0 1.1em;
+  }
+
+  .pos-gift-card-voucher__barcode svg {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    height: 48px;
+    margin: 0 auto 0.35em;
   }
 
   .pos-gift-card-voucher__number {
-    font-size: 13pt;
-    word-break: break-all;
-    margin: 8px 0;
+    font-size: 10pt;
+    word-break: break-word;
+  }
+
+  .pos-gift-card-voucher .pos-gift-card-voucher__footer {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    font-size: 9pt;
+    line-height: 1.3;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    overflow: visible;
+    text-align: center;
+    margin: 1.2em 0 0;
+    color: #000;
   }
 
   .pos-receipt__print p,

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1579,6 +1579,20 @@ input[type="submit"]:disabled,
   margin-top: var(--space-3);
 }
 
+.pos-customer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  align-items: center;
+}
+
+.pos-customer__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+}
+
 .pos-issuance-form,
 .pos-customer-form {
   display: flex;
@@ -2181,6 +2195,19 @@ input[type="submit"]:disabled,
     display: block !important;
   }
 
+  body:not(.is-printing-voucher) .pos-gift-card-voucher {
+    display: none !important;
+  }
+
+  body.is-printing-voucher .pos-receipt__print,
+  body.is-printing-voucher .pos-report-print {
+    display: none !important;
+  }
+
+  body.is-printing-voucher .pos-gift-card-voucher {
+    display: block !important;
+  }
+
   .pos-body,
   .pos-receipt,
   .pos-report-print {
@@ -2200,6 +2227,26 @@ input[type="submit"]:disabled,
     font-variant-numeric: tabular-nums;
     -webkit-print-color-adjust: exact;
     print-color-adjust: exact;
+  }
+
+  .pos-gift-card-voucher {
+    font-family: var(--font-receipt);
+    font-weight: 700;
+    color: #000;
+    font-size: 11pt;
+    line-height: 1.25;
+    text-align: center;
+  }
+
+  .pos-gift-card-voucher__title {
+    font-size: 14pt;
+    letter-spacing: 0.08em;
+  }
+
+  .pos-gift-card-voucher__number {
+    font-size: 13pt;
+    word-break: break-all;
+    margin: 8px 0;
   }
 
   .pos-receipt__print p,

--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -27,15 +27,11 @@ module Admin
       if Authorization::PermissionEvaluator.allowed?(user: current_user, permission_key: "stored_value.view_activity", store: current_store)
         @stored_value_accounts = @customer.stored_value_accounts
                                           .where(account_type: StoredValueAccount::CUSTOMER_OWNED_TYPES)
-                                          .where.not(status: "closed").order(:account_type)
-        @stored_value_entries = StoredValueEntry.joins(:stored_value_account)
-                                                .where(stored_value_accounts: {
-                                                  customer_id: @customer.id,
-                                                  account_type: StoredValueAccount::CUSTOMER_OWNED_TYPES
-                                                })
-                                                .includes(:stored_value_operation, :stored_value_account)
-                                                .order(created_at: :desc)
-                                                .limit(25)
+                                          .order(:account_type, :opened_at)
+        pages = params[:activity_page].is_a?(ActionController::Parameters) ? params[:activity_page] : {}
+        @stored_value_activities = @stored_value_accounts.index_with do |account|
+          StoredValue::AccountActivity.call(account: account, page: pages[account.id])
+        end
       end
       if Authorization::PermissionEvaluator.allowed?(user: current_user, permission_key: "gift_cards.view", store: current_store)
         @associated_gift_cards = @customer.gift_cards.includes(:gift_card_program, :stored_value_account).order(:created_at)

--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -30,7 +30,12 @@ module Admin
                                           .order(:account_type, :opened_at)
         pages = params[:activity_page].is_a?(ActionController::Parameters) ? params[:activity_page] : {}
         @stored_value_activities = @stored_value_accounts.index_with do |account|
-          StoredValue::AccountActivity.call(account: account, page: pages[account.id])
+          StoredValue::AccountActivity.call(
+            account: account,
+            actor: current_user,
+            permission_key: "stored_value.view_activity",
+            page: pages[account.id]
+          )
         end
       end
       if Authorization::PermissionEvaluator.allowed?(user: current_user, permission_key: "gift_cards.view", store: current_store)

--- a/app/controllers/admin/gift_cards_controller.rb
+++ b/app/controllers/admin/gift_cards_controller.rb
@@ -2,31 +2,61 @@
 
 module Admin
   class GiftCardsController < BaseController
-    before_action -> { require_permission!("gift_cards.view") }, only: %i[index show inquiry resolve_inquiry print_recovery create_print_recovery]
+    before_action -> { require_permission!("gift_cards.view") }, only: %i[index show inquiry resolve_inquiry]
+    before_action -> { require_permission!("gift_cards.recover_print") }, only: %i[print_recovery create_print_recovery]
     before_action -> { require_permission!("gift_cards.suspend") }, only: %i[suspend reinstate]
-    before_action -> { require_permission!("gift_cards.replace") }, only: %i[replace create_replacement]
+    before_action -> { require_permission!("gift_cards.replace") }, only: %i[replace create_replacement credential]
     before_action -> { require_permission!("gift_cards.associate_customer") }, only: %i[associate update_association]
-    before_action :set_gift_card, only: %i[show suspend reinstate replace create_replacement associate update_association print_recovery create_print_recovery]
+    before_action :set_gift_card, only: %i[show suspend reinstate replace create_replacement associate update_association print_recovery create_print_recovery credential]
 
     def index
       @gift_cards = GiftCard.includes(:gift_card_program, :stored_value_account, :customer).admin_ordered.limit(100)
     end
 
-    def show; end
+    def show
+      @activity = StoredValue::AccountActivity.call(account: @gift_card.stored_value_account, page: params[:page])
+    end
 
     def inquiry; end
 
     def resolve_inquiry
-      card = GiftCards::Resolver.call(raw_number: params[:card_number], actor: current_user, store: current_store)
-      Audit::Recorder.record!(
-        action: "gift_cards.inquiry",
-        outcome: "succeeded",
-        actor_user: current_user,
-        store: current_store,
-        subject: card,
-        after_values: { number_last_four: card.number_last_four, status: card.status }
+      if params[:card_number].present?
+        card = GiftCards::Resolver.call(raw_number: params[:card_number], actor: current_user, store: current_store)
+        Audit::Recorder.record!(
+          action: "gift_cards.inquiry",
+          outcome: "succeeded",
+          actor_user: current_user,
+          store: current_store,
+          subject: card,
+          after_values: { number_last_four: card.number_last_four, status: card.status }
+        )
+        redirect_to admin_gift_card_path(card)
+        return
+      end
+
+      if params[:number_prefix].blank? && params[:number_last_four].blank?
+        flash.now[:alert] = "Enter a card number or prefix and last four."
+        render :inquiry, status: :unprocessable_entity
+        return
+      end
+
+      result = GiftCards::AdminInquiry.call(
+        prefix: params[:number_prefix],
+        last_four: params[:number_last_four],
+        actor: current_user,
+        store: current_store
       )
-      redirect_to admin_gift_card_path(card)
+      case result.status
+      when :found
+        redirect_to admin_gift_card_path(result.card)
+      when :ambiguous
+        @candidates = result.candidates
+        flash.now[:alert] = "Several cards share that prefix and last four. Choose a masked candidate."
+        render :inquiry, status: :unprocessable_entity
+      else
+        flash.now[:alert] = GiftCards::GENERIC_INQUIRY_FAILURE
+        render :inquiry, status: :unprocessable_entity
+      end
     rescue GiftCards::Error => e
       flash.now[:alert] = e.message
       render :inquiry, status: :unprocessable_entity
@@ -70,7 +100,12 @@ module Admin
         number: params[:card_number],
         notes: params[:notes]
       )
-      redirect_to admin_gift_card_path(replacement.replacement_gift_card), notice: "Gift card replaced."
+      new_card = replacement.replacement_gift_card
+      if new_card.gift_card_program.system_generated?
+        redirect_to credential_admin_gift_card_path(new_card), notice: "Gift card replaced. Print the new credential once."
+      else
+        redirect_to admin_gift_card_path(new_card), notice: "Gift card replaced."
+      end
     rescue GiftCards::Error, StoredValue::Error => e
       flash.now[:alert] = e.message
       render :replace, status: :unprocessable_entity
@@ -81,6 +116,11 @@ module Admin
     end
 
     def print_recovery; end
+
+    def credential
+      @gift_card_credentials = GiftCards::ReplacementFirstPrint.call(@gift_card)
+      redirect_to admin_gift_card_path(@gift_card) if @gift_card_credentials.empty?
+    end
 
     def create_print_recovery
       @recovered_number = GiftCards::PrintRecovery.call(

--- a/app/controllers/admin/gift_cards_controller.rb
+++ b/app/controllers/admin/gift_cards_controller.rb
@@ -14,7 +14,12 @@ module Admin
     end
 
     def show
-      @activity = StoredValue::AccountActivity.call(account: @gift_card.stored_value_account, page: params[:page])
+      @activity = StoredValue::AccountActivity.call(
+        account: @gift_card.stored_value_account,
+        actor: current_user,
+        permission_key: "gift_cards.view",
+        page: params[:page]
+      )
     end
 
     def inquiry; end
@@ -119,7 +124,11 @@ module Admin
 
     def credential
       @gift_card_credentials = GiftCards::ReplacementFirstPrint.call(@gift_card)
-      redirect_to admin_gift_card_path(@gift_card) if @gift_card_credentials.empty?
+      if @gift_card_credentials.empty?
+        redirect_to admin_gift_card_path(@gift_card)
+      else
+        forbid_credential_caching!
+      end
     end
 
     def create_print_recovery
@@ -129,6 +138,7 @@ module Admin
         store: operational_store,
         reason: params[:reason]
       )
+      forbid_credential_caching! if @recovered_number.present?
       render :print_recovery
     rescue GiftCards::Error => e
       flash.now[:alert] = e.message

--- a/app/controllers/admin/system_settings_controller.rb
+++ b/app/controllers/admin/system_settings_controller.rb
@@ -18,7 +18,7 @@ module Admin
         @settings = SystemSettings.current
         before = @settings.attributes.slice(
           "organization_name", "legal_name", "default_timezone", "default_country_code",
-          "default_receipt_header", "default_receipt_footer",
+          "default_receipt_header", "default_receipt_footer", "gift_card_voucher_footer",
           "stored_value_adjust_credit_approval_threshold_cents"
         )
         if @settings.update(settings_params)
@@ -45,7 +45,8 @@ module Admin
         :organization_name, :legal_name, :base_currency_code, :default_timezone,
         :default_country_code, :default_region_code, :fiscal_year_start_month,
         :default_supplier_cancellation_days, :default_customer_reservation_expiration_days,
-        :default_receipt_header, :default_receipt_footer, :stored_value_adjust_credit_approval_threshold_cents, :lock_version
+        :default_receipt_header, :default_receipt_footer, :gift_card_voucher_footer,
+        :stored_value_adjust_credit_approval_threshold_cents, :lock_version
       )
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,4 +6,10 @@ class ApplicationController < ActionController::Base
 
   allow_browser versions: :modern unless Rails.env.test?
   before_action :require_authentication
+
+  private
+
+  def forbid_credential_caching!
+    response.headers["Cache-Control"] = "no-store"
+  end
 end

--- a/app/controllers/pos/completed_transactions_controller.rb
+++ b/app/controllers/pos/completed_transactions_controller.rb
@@ -13,6 +13,7 @@ module Pos
       @period = @transaction.reporting_period
       @tenders = @transaction.pos_tenders.ordered
       @tender = @tenders.find { |tender| tender.cash? && tender.direction == "payment" }
+      @transaction.customer
       @transaction.pos_transaction_lines.includes(
         :pos_controlled_actions,
         original_transaction_line: :pos_transaction,
@@ -20,6 +21,7 @@ module Pos
       ).load
       @transaction.post_void_of
       @transaction.post_void
+      @gift_card_credentials = Pos::FirstPrint.call(@transaction)
       session[:pos_register_id] = @register.id
     rescue Pos::Denied
       raise ActiveRecord::RecordNotFound

--- a/app/controllers/pos/completed_transactions_controller.rb
+++ b/app/controllers/pos/completed_transactions_controller.rb
@@ -22,6 +22,7 @@ module Pos
       @transaction.post_void_of
       @transaction.post_void
       @gift_card_credentials = Pos::FirstPrint.call(@transaction)
+      forbid_credential_caching! if Array(@gift_card_credentials).any?
       session[:pos_register_id] = @register.id
     rescue Pos::Denied
       raise ActiveRecord::RecordNotFound

--- a/app/controllers/pos/transactions_controller.rb
+++ b/app/controllers/pos/transactions_controller.rb
@@ -20,6 +20,7 @@ module Pos
                                      :post_void_of,
                                      :post_void,
                                      :pos_controlled_actions,
+                                     :customer,
                                      pos_transaction_lines: [
                                        :pos_line_tax_components,
                                        :pos_controlled_actions,

--- a/app/controllers/pos/workspaces_controller.rb
+++ b/app/controllers/pos/workspaces_controller.rb
@@ -388,12 +388,25 @@ module Pos
 
     def attach_customer
       rescue_workspace(error_mode: "sale_entry") do
-        customer = Customer.find(params.require(:customer_id))
+        customer = Customer.find_by(id: params.require(:customer_id))
         Pos::AttachCustomer.call(
           transaction: @transaction,
           actor: current_user,
           expected_lock_version: expected_lock_version,
           customer: customer
+        )
+        @transaction.reload
+        @ui_mode = "sale_entry"
+        respond_workspace
+      end
+    end
+
+    def detach_customer
+      rescue_workspace(error_mode: "sale_entry") do
+        Pos::DetachCustomer.call(
+          transaction: @transaction,
+          actor: current_user,
+          expected_lock_version: expected_lock_version
         )
         @transaction.reload
         @ui_mode = "sale_entry"

--- a/app/javascript/controllers/pos_receipt_controller.js
+++ b/app/javascript/controllers/pos_receipt_controller.js
@@ -9,6 +9,22 @@ export default class extends Controller {
 
   async print(event) {
     event.preventDefault()
+    document.body.classList.remove("is-printing-voucher")
+    await this.prepareFonts()
+    window.print()
+  }
+
+  async printVoucher(event) {
+    event.preventDefault()
+    document.body.classList.add("is-printing-voucher")
+    const cleanup = () => document.body.classList.remove("is-printing-voucher")
+    window.addEventListener("afterprint", cleanup, { once: true })
+    await this.prepareFonts()
+    window.print()
+    window.setTimeout(cleanup, 1000)
+  }
+
+  async prepareFonts() {
     if (document.fonts && document.fonts.load) {
       try {
         await document.fonts.load('700 12px "Inconsolata"')
@@ -17,6 +33,5 @@ export default class extends Controller {
         // Print with the stack fallback if the local face is unavailable.
       }
     }
-    window.print()
   }
 }

--- a/app/javascript/controllers/register_workspace_controller.js
+++ b/app/javascript/controllers/register_workspace_controller.js
@@ -123,6 +123,13 @@ export default class extends Controller {
     "pickupQueryLabel",
     "pickupForm",
     "pickupRequestInput",
+    "attachCustomerButton",
+    "attachCustomerForm",
+    "attachCustomerIdInput",
+    "customerOverlay",
+    "customerList",
+    "customerQueryField",
+    "customerQueryLabel",
     "productOverlay",
     "productList",
     "variantOverlay",
@@ -171,6 +178,7 @@ export default class extends Controller {
     resolveUrl: String,
     searchUrl: String,
     pickupSearchUrl: String,
+    customerSearchUrl: String,
     pickupAllowed: Boolean,
     openPriceUrl: String,
     settlement: String,
@@ -199,6 +207,9 @@ export default class extends Controller {
     }
     this.enableReadyActions()
     this.restoreFocus()
+    if (this.hasFeedbackTarget && /customer is required/i.test(this.feedbackTarget.textContent || "")) {
+      this.openCustomerOverlay()
+    }
   }
 
   disconnect() {
@@ -277,6 +288,11 @@ export default class extends Controller {
 
     if (this.pickupOverlayOpen()) {
       this.onPickupOverlayKeydown(event, key)
+      return
+    }
+
+    if (this.customerOverlayOpen()) {
+      this.onCustomerOverlayKeydown(event, key)
       return
     }
 
@@ -1079,6 +1095,90 @@ export default class extends Controller {
     if (!this.hasPickupFormTarget || !this.hasPickupRequestInputTarget) return
     this.pickupRequestInputTarget.value = selected.dataset.requestId
     this.pickupFormTarget.requestSubmit()
+  }
+
+  openCustomerOverlay() {
+    if (!this.hasCustomerOverlayTarget) return
+    this.customerResultsReady = false
+    if (this.hasCustomerQueryFieldTarget) this.customerQueryFieldTarget.value = ""
+    if (this.hasCustomerListTarget) this.customerListTarget.replaceChildren()
+    if (this.hasCustomerQueryLabelTarget) this.customerQueryLabelTarget.textContent = ""
+    this.showOverlay(this.customerOverlayTarget, this.hasCustomerQueryFieldTarget && this.customerQueryFieldTarget)
+  }
+
+  closeCustomerOverlay() {
+    this.hideOverlay(this.hasCustomerOverlayTarget && this.customerOverlayTarget)
+  }
+
+  onCustomerOverlayKeydown(event, key) {
+    if (key === "Escape") {
+      event.preventDefault()
+      this.closeCustomerOverlay()
+      return
+    }
+    if (key === "ArrowUp" || key === "ArrowDown") {
+      event.preventDefault()
+      this.movePickerList(this.customerListTarget, key === "ArrowUp" ? -1 : 1)
+      return
+    }
+    if (key !== "Enter") return
+    event.preventDefault()
+    const inField = event.target === this.customerQueryFieldTarget
+    if (inField && !this.customerResultsReady) {
+      this.runCustomerSearch()
+      return
+    }
+    if (inField && this.customerListTarget.querySelectorAll("li").length === 0) {
+      this.runCustomerSearch()
+      return
+    }
+    this.selectHighlightedCustomer()
+  }
+
+  async runCustomerSearch() {
+    const query = this.hasCustomerQueryFieldTarget ? this.customerQueryFieldTarget.value.trim() : ""
+    if (!query) {
+      this.renderCustomerResults([])
+      if (this.hasCustomerQueryLabelTarget) this.customerQueryLabelTarget.textContent = "Enter a search."
+      return
+    }
+    const url = new URL(this.customerSearchUrlValue, window.location.origin)
+    url.searchParams.set("q", query)
+    try {
+      const response = await fetch(url, { headers: { Accept: "application/json" } })
+      const payload = await response.json()
+      if (!response.ok) throw new Error(payload.error || "customer search failed")
+      this.renderCustomerResults(payload.results || [])
+    } catch (_error) {
+      this.renderCustomerResults([])
+      if (this.hasCustomerQueryLabelTarget) this.customerQueryLabelTarget.textContent = "Search failed."
+    }
+  }
+
+  renderCustomerResults(rows) {
+    if (!this.hasCustomerListTarget) return
+    this.customerListTarget.replaceChildren()
+    this.customerResultsReady = true
+    if (this.hasCustomerQueryLabelTarget) {
+      this.customerQueryLabelTarget.textContent = rows.length === 0 ? "No matching customers." : ""
+    }
+    rows.forEach((row, index) => {
+      const item = document.createElement("li")
+      item.setAttribute("role", "option")
+      item.className = index === 0 ? "is-selected" : ""
+      item.dataset.customerId = row.id
+      item.textContent = row.label
+      this.customerListTarget.append(item)
+    })
+  }
+
+  selectHighlightedCustomer() {
+    const selected = this.hasCustomerListTarget && this.customerListTarget.querySelector("li.is-selected")
+    if (!selected) return
+    this.closeCustomerOverlay()
+    if (!this.hasAttachCustomerFormTarget || !this.hasAttachCustomerIdInputTarget) return
+    this.attachCustomerIdInputTarget.value = selected.dataset.customerId
+    this.attachCustomerFormTarget.requestSubmit()
   }
 
   openProductPicker(products) {
@@ -2013,6 +2113,7 @@ export default class extends Controller {
       this.hasOtherOverlayTarget && this.otherOverlayTarget,
       this.hasSearchOverlayTarget && this.searchOverlayTarget,
       this.hasPickupOverlayTarget && this.pickupOverlayTarget,
+      this.hasCustomerOverlayTarget && this.customerOverlayTarget,
       this.hasOverlayTarget && this.overlayTarget
     ]
     return overlays.find((el) => el && !el.hidden) || null
@@ -2115,6 +2216,10 @@ export default class extends Controller {
 
   pickupOverlayOpen() {
     return this.hasPickupOverlayTarget && !this.pickupOverlayTarget.hidden
+  }
+
+  customerOverlayOpen() {
+    return this.hasCustomerOverlayTarget && !this.customerOverlayTarget.hidden
   }
 
   productOverlayOpen() {

--- a/app/models/gift_card.rb
+++ b/app/models/gift_card.rb
@@ -12,6 +12,7 @@ class GiftCard < ApplicationRecord
   belongs_to :replaced_by, class_name: "GiftCard", optional: true
   has_one :replaced_from, class_name: "GiftCard", foreign_key: :replaced_by_id, inverse_of: :replaced_by,
           dependent: :restrict_with_exception
+  has_one :credential_delivery, class_name: "PosGiftCardCredentialDelivery", dependent: :restrict_with_exception
   has_many :gift_card_cash_outs, dependent: :restrict_with_exception
 
   validates :number, :number_digest, :number_prefix, :number_last_four, :status, :activated_at, presence: true
@@ -19,6 +20,7 @@ class GiftCard < ApplicationRecord
   validates :number_digest, uniqueness: true
   validates :number_last_four, length: { is: 4 }
   validate :customer_must_be_canonical_when_present
+  validate :number_identity_consistent
   validate :number_identity_immutable, on: :update
   before_validation :assign_number_identity, on: :create
 
@@ -67,9 +69,25 @@ class GiftCard < ApplicationRecord
     errors.add(:customer_id, "must be an active canonical customer")
   end
 
+  def number_identity_consistent
+    normalized = GiftCards::Number.normalize(number)
+    return if normalized.blank?
+
+    errors.add(:number_digest, "must match the card number") unless number_digest == GiftCards::Number.digest(normalized)
+    errors.add(:number_last_four, "must match the card number") unless number_last_four == GiftCards::Number.last_four(normalized)
+    return if gift_card_program.blank?
+
+    errors.add(:number_prefix, "must match the program prefix") unless number_prefix == gift_card_program.prefix
+  end
+
   def number_identity_immutable
     %i[number_digest number_prefix number_last_four gift_card_program_id stored_value_account_id].each do |attr|
       errors.add(attr, "cannot change after issue") if will_save_change_to_attribute?(attr)
     end
+    persisted_digest = number_digest_in_database
+    return if persisted_digest.blank? || number.blank?
+    return if GiftCards::Number.digest(GiftCards::Number.normalize(number)) == persisted_digest
+
+    errors.add(:number, "cannot change after issue")
   end
 end

--- a/app/models/pos_gift_card_credential_delivery.rb
+++ b/app/models/pos_gift_card_credential_delivery.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class PosGiftCardCredentialDelivery < ApplicationRecord
+  include UuidV7PrimaryKey
+
+  belongs_to :pos_transaction, optional: true
+  belongs_to :gift_card, optional: true
+
+  validates :delivered_at, presence: true
+  validate :exactly_one_subject
+
+  private
+
+  def exactly_one_subject
+    if pos_transaction_id.present? == gift_card_id.present?
+      errors.add(:base, "delivery must key to a POS transaction or a gift card, not both")
+    end
+  end
+end

--- a/app/models/pos_transaction.rb
+++ b/app/models/pos_transaction.rb
@@ -15,6 +15,7 @@ class PosTransaction < ApplicationRecord
   has_many :pos_controlled_actions, dependent: :destroy
   has_many :pos_tenders, -> { ordered }, dependent: :destroy
   has_many :pos_stored_value_issuances, -> { ordered }, dependent: :destroy
+  has_one :gift_card_credential_delivery, class_name: "PosGiftCardCredentialDelivery", dependent: :restrict_with_exception
   has_many :pos_operations, dependent: :restrict_with_exception
 
   validates :status, :currency_code, presence: true

--- a/app/models/system_settings.rb
+++ b/app/models/system_settings.rb
@@ -13,7 +13,8 @@ class SystemSettings < ApplicationRecord
             numericality: { only_integer: true, greater_than: 0 }
   validates :stored_value_adjust_credit_approval_threshold_cents,
             numericality: { only_integer: true, greater_than_or_equal_to: 0 }
-  validates :default_receipt_header, :default_receipt_footer, length: { maximum: Store::RECEIPT_MESSAGE_LIMIT }
+  validates :default_receipt_header, :default_receipt_footer, :gift_card_voucher_footer,
+            length: { maximum: Store::RECEIPT_MESSAGE_LIMIT }
   validate :singleton_row
   before_validation :normalize_receipt_messages
 
@@ -33,11 +34,22 @@ class SystemSettings < ApplicationRecord
     initialized_at.present?
   end
 
+  def printed_gift_card_voucher_footer
+    text = gift_card_voucher_footer.presence
+    return if text.blank?
+
+    replacement = legal_name.presence
+    return text if replacement.blank?
+
+    text.gsub("{organization legal name}", replacement)
+  end
+
   private
 
   def normalize_receipt_messages
     self.default_receipt_header = default_receipt_header&.strip
     self.default_receipt_footer = default_receipt_footer&.strip
+    self.gift_card_voucher_footer = gift_card_voucher_footer&.strip
   end
 
   def singleton_row

--- a/app/services/authorization/permission_catalog.rb
+++ b/app/services/authorization/permission_catalog.rb
@@ -131,7 +131,8 @@ module Authorization
       { key: "gift_cards.suspend", group_key: "gift_cards", name: "Suspend or reinstate gift cards", scope_type: "either" },
       { key: "gift_cards.replace", group_key: "gift_cards", name: "Replace gift cards", scope_type: "either" },
       { key: "gift_cards.associate_customer", group_key: "gift_cards", name: "Associate gift cards with customers", scope_type: "either" },
-      { key: "gift_cards.cash_out", group_key: "gift_cards", name: "Cash out gift cards", scope_type: "either" }
+      { key: "gift_cards.cash_out", group_key: "gift_cards", name: "Cash out gift cards", scope_type: "either" },
+      { key: "gift_cards.recover_print", group_key: "gift_cards", name: "Recover gift-card print", scope_type: "either" }
     ].freeze
 
     PHASE9_PERMISSIONS = [
@@ -177,6 +178,7 @@ module Authorization
       gift_cards.replace
       gift_cards.associate_customer
       gift_cards.cash_out
+      gift_cards.recover_print
     ].freeze
 
     STORE_MANAGER_PHASE3 = %w[

--- a/app/services/gift_cards/admin_inquiry.rb
+++ b/app/services/gift_cards/admin_inquiry.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+module GiftCards
+  class AdminInquiry
+    Result = Data.define(:status, :card, :candidates)
+
+    Candidate = Data.define(
+      :id, :masked_number, :status, :program_name, :balance_cents, :activated_at
+    )
+
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(prefix:, last_four:, actor:, store: nil)
+      @prefix = prefix.to_s.strip
+      @last_four = last_four.to_s.strip
+      @actor = actor
+      @store = store
+    end
+
+    def call
+      enforce_throttle!
+      unless valid_fragments?
+        record_failure!
+        return Result.new(status: :not_found, card: nil, candidates: [])
+      end
+
+      cards = GiftCard.where(number_prefix: @prefix, number_last_four: @last_four)
+                      .includes(:gift_card_program, :stored_value_account)
+                      .admin_ordered
+                      .to_a
+
+      case cards.size
+      when 0
+        record_failure!
+        Result.new(status: :not_found, card: nil, candidates: [])
+      when 1
+        card = cards.first
+        record_success!(card, extra: { number_last_four: card.number_last_four, status: card.status })
+        Result.new(status: :found, card: card, candidates: [])
+      else
+        candidates = cards.map { |card| candidate_for(card) }
+        record_success!(
+          nil,
+          extra: {
+            match_count: cards.size,
+            gift_card_ids: cards.map(&:id),
+            number_last_four: @last_four
+          }
+        )
+        Result.new(status: :ambiguous, card: nil, candidates: candidates)
+      end
+    end
+
+    private
+
+    def valid_fragments?
+      @prefix.match?(/\A\d+\z/) && @last_four.match?(/\A\d{4}\z/)
+    end
+
+    def candidate_for(card)
+      Candidate.new(
+        id: card.id,
+        masked_number: card.masked_number,
+        status: card.status,
+        program_name: card.gift_card_program.name,
+        balance_cents: card.balance_cents,
+        activated_at: card.activated_at
+      )
+    end
+
+    def enforce_throttle!
+      failures = AuditEvent.where(action: "gift_cards.inquiry", outcome: "failed", actor_user_id: @actor&.id)
+                           .where("occurred_at > ?", GiftCards::Resolver::FAILURE_WINDOW.ago)
+                           .count
+      return if failures < GiftCards::Resolver::FAILURE_LIMIT
+
+      raise GiftCards::Error, GENERIC_INQUIRY_FAILURE
+    end
+
+    def record_failure!
+      Audit::Recorder.record!(
+        action: "gift_cards.inquiry",
+        outcome: "failed",
+        actor_user: @actor,
+        store: @store,
+        reason_text: GENERIC_INQUIRY_FAILURE
+      )
+    end
+
+    def record_success!(card, extra:)
+      Audit::Recorder.record!(
+        action: "gift_cards.inquiry",
+        outcome: "succeeded",
+        actor_user: @actor,
+        store: @store,
+        subject: card,
+        after_values: extra
+      )
+    end
+  end
+end

--- a/app/services/gift_cards/maximum_balance.rb
+++ b/app/services/gift_cards/maximum_balance.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module GiftCards
+  module MaximumBalance
+    module_function
+
+    def assert!(account:, next_balance_cents:)
+      return unless account.account_type == "gift_card"
+
+      card = account.gift_card
+      return if card.blank?
+
+      maximum = card.gift_card_program.maximum_balance_cents
+      return if maximum.blank?
+      return if Integer(next_balance_cents) <= maximum
+
+      raise StoredValue::Error, "credit would exceed the program maximum balance"
+    end
+  end
+end

--- a/app/services/gift_cards/number.rb
+++ b/app/services/gift_cards/number.rb
@@ -21,6 +21,16 @@ module GiftCards
       normalized.to_s[-4, 4]
     end
 
+    def present(raw, prefix:)
+      digits = normalize(raw)
+      prefix = prefix.to_s
+      return digits if prefix.blank? || !digits.start_with?(prefix) || digits.length <= prefix.length
+
+      check = digits[-1]
+      body = digits[prefix.length...-1]
+      [ prefix, *body.scan(/.{1,4}/), check ].compact_blank.join(" ")
+    end
+
     def generate(program)
       prefix = program.prefix
       length = program.number_length

--- a/app/services/gift_cards/print_recovery.rb
+++ b/app/services/gift_cards/print_recovery.rb
@@ -20,7 +20,7 @@ module GiftCards
       end
       unless Authorization::PermissionEvaluator.allowed?(
         user: @actor,
-        permission_key: "gift_cards.view",
+        permission_key: "gift_cards.recover_print",
         store: @store
       )
         raise GiftCards::Error, "not authorized to recover a gift-card print"

--- a/app/services/gift_cards/replacement_first_print.rb
+++ b/app/services/gift_cards/replacement_first_print.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module GiftCards
+  class ReplacementFirstPrint
+    Credential = Pos::FirstPrint::Credential
+
+    def self.call(gift_card)
+      new(gift_card).call
+    end
+
+    def initialize(gift_card)
+      @gift_card = gift_card
+    end
+
+    def call
+      return [] unless @gift_card.gift_card_program.system_generated?
+
+      credentials = []
+      GiftCard.transaction do
+        card = GiftCard.lock.find(@gift_card.id)
+        if PosGiftCardCredentialDelivery.exists?(gift_card_id: card.id)
+          return []
+        end
+
+        credentials = [
+          Credential.new(
+            kind: "replacement",
+            masked_number: card.masked_number,
+            number: card.number,
+            amount_cents: card.balance_cents,
+            program_name: card.gift_card_program.name
+          )
+        ]
+        PosGiftCardCredentialDelivery.create!(
+          gift_card: card,
+          delivered_at: Time.current
+        )
+      end
+      credentials
+    end
+  end
+end

--- a/app/services/gift_cards/replacement_first_print.rb
+++ b/app/services/gift_cards/replacement_first_print.rb
@@ -14,6 +14,7 @@ module GiftCards
 
     def call
       return [] unless @gift_card.gift_card_program.system_generated?
+      return [] unless GiftCardReplacement.exists?(replacement_gift_card_id: @gift_card.id)
 
       credentials = []
       GiftCard.transaction do
@@ -27,8 +28,11 @@ module GiftCards
             kind: "replacement",
             masked_number: card.masked_number,
             number: card.number,
+            number_prefix: card.number_prefix,
             amount_cents: card.balance_cents,
-            program_name: card.gift_card_program.name
+            program_name: card.gift_card_program.name,
+            store: card.activated_store,
+            issued_at: card.activated_at
           )
         ]
         PosGiftCardCredentialDelivery.create!(

--- a/app/services/pos/add_stored_value_refund_tender.rb
+++ b/app/services/pos/add_stored_value_refund_tender.rb
@@ -46,6 +46,7 @@ module Pos
         raise Pos::Error, "amount is greater than remaining refund" if @amount_cents > remaining
 
         detail_attrs = build_detail_attrs!(transaction)
+        assert_refund_capacity!(transaction, detail_attrs)
         tender = transaction.pos_tenders.new(
           direction: "refund",
           tender_number: Pos::Support.next_tender_number(transaction),
@@ -87,6 +88,7 @@ module Pos
         unless original_gift_card_accounts(transaction).include?(card.stored_value_account_id)
           raise Pos::Error, "presented gift card does not match the original tender"
         end
+        assert_gift_card_credit_within_maximum!(card)
         { destination_mode: "existing_account", stored_value_account: card.stored_value_account, gift_card: card, masked_card_snapshot: card.masked_number }
       when "trade_credit"
         raise Pos::Error, "trade credit is not a generic refund destination" unless @tender_type.allows_original_tender_refund?
@@ -127,6 +129,9 @@ module Pos
       program = @gift_card_program || GiftCards::Lookup.program_for(@card_number)
       raise Pos::Error, "gift-card program is required" if program.blank?
       raise Pos::Error, "gift-card program is not active" unless program.active?
+      if program.maximum_balance_cents.present? && @amount_cents > program.maximum_balance_cents
+        raise Pos::Error, "credit would exceed the program maximum balance"
+      end
 
       attrs = { destination_mode: "new_gift_card", gift_card_program: program }
       if program.manual_external?
@@ -144,6 +149,31 @@ module Pos
         raise Pos::Error, "system-generated refund cards cannot take a card number"
       end
       attrs
+    end
+
+    def assert_refund_capacity!(transaction, detail_attrs)
+      remaining = Pos::StoredValueRefundCapacity.remaining_cents(
+        transaction: transaction,
+        tender_type: @tender_type,
+        destination_mode: @destination_mode,
+        account_id: detail_attrs[:stored_value_account]&.id || detail_attrs[:stored_value_account_id]
+      )
+      return if remaining.nil?
+
+      kind = @tender_type.stored_value_account_type == "trade_credit" ? "trade-credit-funded" : "gift-card-funded"
+      if remaining <= 0
+        raise Pos::Error, "#{@destination_mode == 'new_gift_card' ? 'new gift card' : @tender_type.name.downcase} cannot receive this refund"
+      end
+      raise Pos::Error, "refund exceeds remaining #{kind} amount" if @amount_cents > remaining
+    end
+
+    def assert_gift_card_credit_within_maximum!(card)
+      GiftCards::MaximumBalance.assert!(
+        account: card.stored_value_account,
+        next_balance_cents: card.stored_value_account.balance_cents + @amount_cents
+      )
+    rescue StoredValue::Error => e
+      raise Pos::Error, e.message
     end
 
     def original_gift_card_funded?(transaction)

--- a/app/services/pos/complete_stored_value.rb
+++ b/app/services/pos/complete_stored_value.rb
@@ -20,6 +20,7 @@ module Pos
       end
 
       require_customer!(tenders)
+      Pos::StoredValueRefundCapacity.assert_working_allocation!(@transaction)
       issuances.each { |issuance| post_issuance!(issuance) }
       tenders.each { |tender| post_tender!(tender) }
     rescue StoredValue::Error, GiftCards::Error => e

--- a/app/services/pos/complete_transaction.rb
+++ b/app/services/pos/complete_transaction.rb
@@ -22,27 +22,31 @@ module Pos
         "stored_value_issuance_cents" => transaction.stored_value_issuance_cents.to_i,
         "customer_id" => transaction.customer_id&.to_s,
         "issuances" => transaction.pos_stored_value_issuances.ordered.map { |issuance|
-          {
+          payload_issuance = {
             "issuance_id" => issuance.id.to_s,
             "issuance_type" => issuance.issuance_type,
             "amount_cents" => issuance.amount_cents,
             "gift_card_program_id" => issuance.gift_card_program_id&.to_s,
-            "gift_card_id" => issuance.gift_card_id&.to_s,
             "number_authority" => issuance.number_authority
           }
+          payload_issuance["gift_card_id"] = issuance.gift_card_id.to_s if issuance.reload_issuance? && issuance.gift_card_id.present?
+          payload_issuance
         },
         "stored_value_tenders" => transaction.pos_tenders.ordered.select(&:stored_value?).map { |tender|
           detail = tender.stored_value_tender_detail
-          {
+          payload_tender = {
             "tender_id" => tender.id.to_s,
             "tender_type" => tender.tender_type,
             "direction" => tender.direction,
             "amount_cents" => tender.amount_cents,
             "destination_mode" => detail&.destination_mode,
             "stored_value_account_id" => detail&.stored_value_account_id&.to_s,
-            "gift_card_id" => detail&.gift_card_id&.to_s,
             "gift_card_program_id" => detail&.gift_card_program_id&.to_s
           }
+          if detail&.existing_account? && detail.gift_card_id.present?
+            payload_tender["gift_card_id"] = detail.gift_card_id.to_s
+          end
+          payload_tender
         }
       }
       payload = payload.compact
@@ -206,6 +210,9 @@ module Pos
 
       originals = PosTransactionLine.lock.where(id: original_ids).order(:id).to_a
       raise Pos::Error, "original sale line is missing" if originals.size != original_ids.size
+
+      original_transaction_ids = originals.map(&:pos_transaction_id).uniq.sort
+      PosTransaction.where(id: original_transaction_ids).lock.order(:id).to_a
 
       originals.each do |original|
         remaining = Pos::Returnability.remaining_quantity(original)

--- a/app/services/pos/customer_receipt.rb
+++ b/app/services/pos/customer_receipt.rb
@@ -97,6 +97,10 @@ module Pos
       Pos::Code128.svg(compact_reference)
     end
 
+    def customer_name
+      @transaction.customer&.display_name
+    end
+
     def cashier_name
       @transaction.cashier_name_snapshot.presence || "Not captured"
     end

--- a/app/services/pos/detach_customer.rb
+++ b/app/services/pos/detach_customer.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Pos
+  class DetachCustomer
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(transaction:, actor:, expected_lock_version:)
+      @transaction = transaction
+      @actor = actor
+      @expected_lock_version = expected_lock_version
+    end
+
+    def call
+      Pos::Support.authorize!(@actor, @transaction.store)
+      Pos::Support.require_active_context!(@transaction.store, @transaction.register)
+      Pos::Support.require_transaction_cashier!(@actor, @transaction)
+
+      PosTransaction.transaction do
+        transaction = Pos::Support.lock_working_transaction!(@transaction, @expected_lock_version)
+        transaction.update!(customer: nil)
+        Pos::Support.touch_working_transaction!(transaction)
+        transaction
+      end
+    end
+  end
+end

--- a/app/services/pos/first_print.rb
+++ b/app/services/pos/first_print.rb
@@ -14,8 +14,30 @@ module Pos
 
     def call
       credentials = []
+      PosTransaction.transaction do
+        PosTransaction.lock.find(@transaction.id)
+        if PosGiftCardCredentialDelivery.exists?(pos_transaction_id: @transaction.id)
+          return []
+        end
+
+        credentials = decrypt_undelivered_credentials
+        if credentials.any?
+          PosGiftCardCredentialDelivery.create!(
+            pos_transaction: @transaction,
+            delivered_at: Time.current
+          )
+        end
+      end
+      credentials
+    end
+
+    private
+
+    def decrypt_undelivered_credentials
+      credentials = []
       @transaction.pos_stored_value_issuances.ordered.each do |issuance|
-        next unless issuance.system_generated?
+        next unless issuance.activation? && issuance.system_generated?
+
         card = issuance.gift_card
         next if card.blank?
 

--- a/app/services/pos/first_print.rb
+++ b/app/services/pos/first_print.rb
@@ -2,7 +2,38 @@
 
 module Pos
   class FirstPrint
-    Credential = Struct.new(:kind, :masked_number, :number, :amount_cents, :program_name, keyword_init: true)
+    Credential = Struct.new(
+      :kind, :masked_number, :number, :number_prefix, :amount_cents, :program_name, :store, :issued_at,
+      keyword_init: true
+    ) do
+      def presented_number
+        GiftCards::Number.present(number, prefix: number_prefix)
+      end
+
+      def legal_name
+        store&.legal_name
+      end
+
+      def address_lines
+        return [] if store.blank?
+
+        lines = []
+        lines << store.street_address_1.presence
+        lines << store.street_address_2.presence
+        locality = [ store.city.presence, store.region_code.presence ].compact.join(", ")
+        locality = [ locality.presence, store.postal_code.presence ].compact.join(" ")
+        lines << locality.presence
+        lines << store.phone.presence
+        lines.compact
+      end
+
+      def issued_at_label
+        return if issued_at.blank? || store.blank?
+
+        zone = ActiveSupport::TimeZone[store.timezone] || ActiveSupport::TimeZone["UTC"]
+        issued_at.in_time_zone(zone).strftime("%-d %b %y %-l:%M%P")
+      end
+    end
 
     def self.call(transaction)
       new(transaction).call
@@ -19,6 +50,8 @@ module Pos
         if PosGiftCardCredentialDelivery.exists?(pos_transaction_id: @transaction.id)
           return []
         end
+        session = PosSession.lock.find(@transaction.pos_session_id)
+        return [] unless session.open?
 
         credentials = decrypt_undelivered_credentials
         if credentials.any?
@@ -41,13 +74,7 @@ module Pos
         card = issuance.gift_card
         next if card.blank?
 
-        credentials << Credential.new(
-          kind: issuance.issuance_type,
-          masked_number: card.masked_number,
-          number: card.number,
-          amount_cents: issuance.amount_cents,
-          program_name: card.gift_card_program.name
-        )
+        credentials << credential_for(card, kind: issuance.issuance_type, amount_cents: issuance.amount_cents)
       end
       @transaction.pos_tenders.ordered.each do |tender|
         detail = tender.stored_value_tender_detail
@@ -56,15 +83,22 @@ module Pos
         card = detail.gift_card
         next unless card&.gift_card_program&.system_generated?
 
-        credentials << Credential.new(
-          kind: "refund_gift_card",
-          masked_number: card.masked_number,
-          number: card.number,
-          amount_cents: tender.amount_cents,
-          program_name: card.gift_card_program.name
-        )
+        credentials << credential_for(card, kind: "refund_gift_card", amount_cents: tender.amount_cents)
       end
       credentials
+    end
+
+    def credential_for(card, kind:, amount_cents:)
+      Credential.new(
+        kind: kind,
+        masked_number: card.masked_number,
+        number: card.number,
+        number_prefix: card.number_prefix,
+        amount_cents: amount_cents,
+        program_name: card.gift_card_program.name,
+        store: @transaction.store,
+        issued_at: @transaction.completed_at
+      )
     end
   end
 end

--- a/app/services/pos/stored_value_refund_capacity.rb
+++ b/app/services/pos/stored_value_refund_capacity.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+module Pos
+  class StoredValueRefundCapacity
+    def self.remaining_cents(transaction:, tender_type:, destination_mode:, account_id: nil)
+      new(transaction).remaining_cents(
+        tender_type: tender_type,
+        destination_mode: destination_mode,
+        account_id: account_id
+      )
+    end
+
+    def self.assert_working_allocation!(transaction)
+      new(transaction, include_working: false).assert_allocation!(refund_stored_value_tenders(transaction))
+    end
+
+    def self.refund_stored_value_tenders(transaction)
+      transaction.pos_tenders.ordered.select { |tender| tender.stored_value? && tender.direction == "refund" }
+    end
+
+    def initialize(transaction, include_working: true)
+      @transaction = transaction
+      @include_working = include_working
+    end
+
+    def remaining_cents(tender_type:, destination_mode:, account_id: nil)
+      code = tender_type.respond_to?(:code) ? tender_type.code : tender_type.to_s
+      case code
+      when "gift_card"
+        pool = gift_card_pool
+        allowed_from_pool(pool, destination_mode: destination_mode, account_id: account_id)
+      when "trade_credit"
+        pool = trade_credit_pool
+        allowed_from_pool(pool, destination_mode: "existing_account", account_id: account_id)
+      else
+        nil
+      end
+    end
+
+    def assert_allocation!(tenders)
+      gift = gift_card_pool
+      trade = trade_credit_pool
+      tenders.each do |tender|
+        detail = tender.stored_value_tender_detail
+        next if detail.blank?
+
+        case tender.tender_type
+        when "gift_card"
+          allowed = allowed_from_pool(gift, destination_mode: detail.destination_mode, account_id: detail.stored_value_account_id)
+          if tender.amount_cents > allowed
+            raise Pos::Error, "refund exceeds remaining gift-card-funded amount"
+          end
+
+          gift[:total] -= tender.amount_cents
+          consume_account!(gift, detail.stored_value_account_id, tender.amount_cents) if detail.existing_account?
+        when "trade_credit"
+          allowed = allowed_from_pool(trade, destination_mode: "existing_account", account_id: detail.stored_value_account_id)
+          if tender.amount_cents > allowed
+            raise Pos::Error, "refund exceeds remaining trade-credit-funded amount"
+          end
+
+          trade[:total] -= tender.amount_cents
+          consume_account!(trade, detail.stored_value_account_id, tender.amount_cents)
+        end
+      end
+    end
+
+    private
+
+    def allowed_from_pool(pool, destination_mode:, account_id:)
+      if destination_mode == "new_gift_card"
+        pool[:total]
+      else
+        [ pool[:by_account].fetch(account_id, 0), pool[:total] ].min
+      end
+    end
+
+    def consume_account!(pool, account_id, amount_cents)
+      return if account_id.blank?
+
+      pool[:by_account][account_id] = pool[:by_account].fetch(account_id, 0) - amount_cents
+    end
+
+    def gift_card_pool
+      pool_for("gift_card")
+    end
+
+    def trade_credit_pool
+      pool_for("trade_credit")
+    end
+
+    def pool_for(tender_code)
+      funded_by_account = Hash.new(0)
+      payment_tenders(tender_code).each do |tender|
+        account_id = tender.stored_value_tender_detail&.stored_value_account_id
+        next if account_id.blank?
+
+        funded_by_account[account_id] += tender.amount_cents
+      end
+
+      consumed_by_account = Hash.new(0)
+      consumed_total = 0
+      refund_tenders(tender_code).each do |tender|
+        detail = tender.stored_value_tender_detail
+        next if detail.blank?
+
+        consumed_total += tender.amount_cents
+        consumed_by_account[detail.stored_value_account_id] += tender.amount_cents if detail.existing_account?
+      end
+
+      remaining_by_account = {}
+      funded_by_account.each do |account_id, funded|
+        remaining_by_account[account_id] = [ funded - consumed_by_account[account_id], 0 ].max
+      end
+
+      {
+        total: [ funded_by_account.values.sum - consumed_total, 0 ].max,
+        by_account: remaining_by_account
+      }
+    end
+
+    def payment_tenders(tender_code)
+      ids = active_original_transaction_ids
+      return PosTender.none if ids.empty?
+
+      PosTender.where(pos_transaction_id: ids, tender_type: tender_code, direction: "payment")
+               .includes(:stored_value_tender_detail)
+    end
+
+    def refund_tenders(tender_code)
+      tenders = PosTender.where(pos_transaction_id: completed_refund_transaction_ids, tender_type: tender_code, direction: "refund")
+                         .includes(:stored_value_tender_detail)
+                         .to_a
+      tenders.concat(working_refund_tenders(tender_code)) if @include_working
+      tenders
+    end
+
+    def working_refund_tenders(tender_code)
+      self.class.refund_stored_value_tenders(@transaction).select { |tender| tender.tender_type == tender_code }
+    end
+
+    def active_original_transaction_ids
+      commercially_active(original_transaction_ids)
+    end
+
+    def original_transaction_ids
+      original_line_ids = @transaction.pos_transaction_lines.filter_map(&:original_transaction_line_id)
+      return [] if original_line_ids.empty?
+
+      PosTransactionLine.where(id: original_line_ids).distinct.pluck(:pos_transaction_id)
+    end
+
+    def completed_refund_transaction_ids
+      original_ids = active_original_transaction_ids
+      return [] if original_ids.empty?
+
+      original_line_ids = PosTransactionLine.where(pos_transaction_id: original_ids).pluck(:id)
+      refund_ids = PosTransactionLine.where(original_transaction_line_id: original_line_ids)
+                                     .where.not(pos_transaction_id: @transaction.id)
+                                     .distinct
+                                     .pluck(:pos_transaction_id)
+      commercially_active(
+        PosTransaction.completed.where(id: refund_ids, post_void_of_transaction_id: nil).pluck(:id)
+      )
+    end
+
+    def commercially_active(ids)
+      ids = Array(ids).uniq
+      return [] if ids.empty?
+
+      voided = PosTransaction.completed.where(post_void_of_transaction_id: ids).pluck(:post_void_of_transaction_id)
+      ids - voided
+    end
+  end
+end

--- a/app/services/stored_value/account_activity.rb
+++ b/app/services/stored_value/account_activity.rb
@@ -3,38 +3,52 @@
 module StoredValue
   class AccountActivity
     PER_PAGE = 25
+    ANOTHER_STORE_LABEL = "Another store"
 
     Result = Struct.new(
-      :account, :entries, :page, :per_page, :total_count, :total_pages, :pos_transactions_by_operation_id,
+      :account, :entries, :rows, :page, :per_page, :total_count, :total_pages, :pos_transactions_by_operation_id,
       keyword_init: true
+    )
+    Row = Struct.new(
+      :business_date, :store_label, :operation_label, :amount_cents, :balance_after_cents,
+      :actor_reason, :pos_transaction, :redacted, keyword_init: true
     )
 
     def self.call(**attrs)
       new(**attrs).call
     end
 
-    def initialize(account:, page: 1)
+    def initialize(account:, actor:, permission_key:, page: 1)
       @account = account
+      @actor = actor
+      @permission_key = permission_key
       @requested_page = page
     end
 
     def call
       scope = @account.stored_value_entries
-                      .includes(stored_value_operation: [ :store, :performed_by ])
-                      .order(created_at: :desc, entry_sequence: :desc)
-      total_count = scope.count
+                      .joins(:stored_value_operation)
+                      .preload(stored_value_operation: [ :store, :performed_by, :reversal_of, :reversed_by ])
+                      .order(
+                        StoredValueOperation.arel_table[:occurred_at].desc,
+                        StoredValueOperation.arel_table[:id].desc,
+                        StoredValueEntry.arel_table[:entry_sequence].desc
+                      )
+      total_count = @account.stored_value_entries.count
       total_pages = [ (total_count.to_f / PER_PAGE).ceil, 1 ].max
       page = parse_page(total_pages)
       entries = scope.offset((page - 1) * PER_PAGE).limit(PER_PAGE).to_a
+      pos_transactions = pos_transactions_for(entries)
 
       Result.new(
         account: @account,
         entries: entries,
+        rows: entries.map { |entry| build_row(entry, pos_transactions) },
         page: page,
         per_page: PER_PAGE,
         total_count: total_count,
         total_pages: total_pages,
-        pos_transactions_by_operation_id: pos_transactions_for(entries)
+        pos_transactions_by_operation_id: pos_transactions
       )
     end
 
@@ -62,6 +76,87 @@ module StoredValue
         map[detail.stored_value_operation_id] ||= detail.pos_tender.pos_transaction
       end
       map
+    end
+
+    def build_row(entry, pos_transactions)
+      operation = entry.stored_value_operation
+      authorized = store_authorized?(operation.store)
+      actor_reason = [
+        operation.reason_name_snapshot.presence || operation.reason_code.presence,
+        operation.performed_by&.display_name
+      ].compact.join(" · ")
+
+      Row.new(
+        business_date: operation.business_date,
+        store_label: authorized ? operation.store.admin_label : ANOTHER_STORE_LABEL,
+        operation_label: operation_label(entry),
+        amount_cents: entry.amount_cents,
+        balance_after_cents: entry.balance_after_cents,
+        actor_reason: authorized ? actor_reason.presence : nil,
+        pos_transaction: authorized ? pos_transactions[operation.id] : nil,
+        redacted: !authorized
+      )
+    end
+
+    def store_authorized?(store)
+      Authorization::PermissionEvaluator.allowed?(
+        user: @actor,
+        permission_key: @permission_key,
+        store: store
+      )
+    end
+
+    def operation_label(entry)
+      operation = entry.stored_value_operation
+      label = base_operation_label(entry)
+      return label if operation.reverse?
+      return "#{label} (reversed)" if operation.reversed?
+
+      label
+    end
+
+    def base_operation_label(entry)
+      operation = entry.stored_value_operation
+      case operation.operation_type
+      when "transfer"
+        entry.amount_cents.positive? ? "Transfer in" : "Transfer out"
+      when "adjust"
+        entry.amount_cents.positive? ? "Credit adjustment" : "Debit adjustment"
+      when "reverse"
+        reversal_label(operation)
+      when "activate"
+        "Activate"
+      when "reload"
+        "Reload"
+      when "redeem"
+        "Redeem"
+      when "refund"
+        "Refund"
+      when "cash_out"
+        "Cash-out"
+      when "issue"
+        "Issue"
+      else
+        operation.operation_type.humanize
+      end
+    end
+
+    def reversal_label(operation)
+      original_type = operation.reversal_of&.operation_type
+      case original_type
+      when "cash_out"
+        "Cash-out reversal"
+      when "activate", "reload", "redeem", "refund"
+        "Post-void reversal"
+      when "adjust"
+        "Adjustment reversal"
+      when "transfer"
+        "Transfer reversal"
+      when nil
+        "Reversal"
+      else
+        "Reversal of #{original_type.tr('_', ' ')}"
+      end
     end
   end
 end

--- a/app/services/stored_value/account_activity.rb
+++ b/app/services/stored_value/account_activity.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module StoredValue
+  class AccountActivity
+    PER_PAGE = 25
+
+    Result = Struct.new(
+      :account, :entries, :page, :per_page, :total_count, :total_pages, :pos_transactions_by_operation_id,
+      keyword_init: true
+    )
+
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(account:, page: 1)
+      @account = account
+      @requested_page = page
+    end
+
+    def call
+      scope = @account.stored_value_entries
+                      .includes(stored_value_operation: [ :store, :performed_by ])
+                      .order(created_at: :desc, entry_sequence: :desc)
+      total_count = scope.count
+      total_pages = [ (total_count.to_f / PER_PAGE).ceil, 1 ].max
+      page = parse_page(total_pages)
+      entries = scope.offset((page - 1) * PER_PAGE).limit(PER_PAGE).to_a
+
+      Result.new(
+        account: @account,
+        entries: entries,
+        page: page,
+        per_page: PER_PAGE,
+        total_count: total_count,
+        total_pages: total_pages,
+        pos_transactions_by_operation_id: pos_transactions_for(entries)
+      )
+    end
+
+    private
+
+    def parse_page(total_pages)
+      value = Integer(@requested_page)
+      value = 1 if value < 1
+      [ value, total_pages ].min
+    rescue ArgumentError, TypeError
+      1
+    end
+
+    def pos_transactions_for(entries)
+      op_ids = entries.map(&:stored_value_operation_id)
+      return {} if op_ids.empty?
+
+      map = {}
+      PosStoredValueIssuance.where(stored_value_operation_id: op_ids).includes(:pos_transaction).find_each do |issuance|
+        map[issuance.stored_value_operation_id] = issuance.pos_transaction
+      end
+      PosStoredValueTenderDetail.where(stored_value_operation_id: op_ids)
+                                .includes(pos_tender: :pos_transaction)
+                                .find_each do |detail|
+        map[detail.stored_value_operation_id] ||= detail.pos_tender.pos_transaction
+      end
+      map
+    end
+  end
+end

--- a/app/services/stored_value/post.rb
+++ b/app/services/stored_value/post.rb
@@ -80,6 +80,9 @@ module StoredValue
 
             next_balance = account.balance_cents + amount
             raise Error, "balance cannot be negative" if next_balance.negative?
+            if amount.positive? && @reversal_of.blank?
+              GiftCards::MaximumBalance.assert!(account: account, next_balance_cents: next_balance)
+            end
 
             account.apply_posted_balance!(next_balance)
             posted << {

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -97,7 +97,7 @@
     <% if @stored_value_accounts.any? %>
       <% rows = @stored_value_accounts.map { |account|
            actions = []
-           if effective_permissions.include?("stored_value.adjust") && @customer.active?
+           if effective_permissions.include?("stored_value.adjust") && @customer.active? && account.active?
              actions << action_link_to("Adjust", new_admin_customer_stored_value_adjustment_path(@customer, stored_value_account_id: account.id), style: :outline, intent: :neutral)
            end
            [
@@ -109,7 +109,7 @@
          } %>
       <%= render "shared/data_table", headers: ["Type", "Balance", "Status", ""], rows: rows %>
     <% else %>
-      <%= render "shared/empty_state", title: "No open stored-value accounts", body: "Store credit and trade credit are created when value is posted." %>
+      <%= render "shared/empty_state", title: "No stored-value accounts", body: "Store credit and trade credit are created when value is posted." %>
     <% end %>
     <% if effective_permissions.include?("stored_value.adjust") && @customer.canonical? && @customer.active? %>
       <div class="actions">
@@ -125,19 +125,21 @@
   </section>
 <% end %>
 
-<% if @stored_value_entries&.any? %>
-  <section class="section">
-    <h2 class="section__title">Recent stored-value activity</h2>
-    <% rows = @stored_value_entries.map { |entry|
-         [
-           entry.stored_value_operation.operation_type.humanize,
-           entry.stored_value_account.account_type.humanize,
-           format_money_cents(entry.amount_cents),
-           format_money_cents(entry.balance_after_cents)
-         ]
-       } %>
-    <%= render "shared/data_table", headers: ["Operation", "Account", "Amount", "Balance after"], rows: rows %>
-  </section>
+<% if @stored_value_activities.present? %>
+  <% @stored_value_activities.each do |account, activity| %>
+    <section class="section">
+      <h2 class="section__title"><%= account.account_type.humanize %> activity</h2>
+      <%= render "admin/stored_value/account_activity",
+            activity: activity,
+            show_card: false,
+            page_path: ->(page) {
+              other = (@stored_value_activities.keys - [account]).to_h { |other_account|
+                [other_account.id, @stored_value_activities[other_account].page]
+              }
+              admin_customer_path(@customer, activity_page: other.merge(account.id => page))
+            } %>
+    </section>
+  <% end %>
 <% end %>
 
 <% if @associated_gift_cards %>

--- a/app/views/admin/gift_cards/credential.html.erb
+++ b/app/views/admin/gift_cards/credential.html.erb
@@ -1,0 +1,34 @@
+<% content_for :title, "Print replacement gift card" %>
+<%= render "shared/breadcrumbs", crumbs: [
+  { name: "Home", path: root_path },
+  { name: "Gift cards", path: admin_gift_cards_path },
+  { name: @gift_card.masked_number, path: admin_gift_card_path(@gift_card) },
+  { name: "New credential" }
+] %>
+
+<main class="pos-receipt" data-controller="pos-receipt" data-action="keydown@document->pos-receipt#onKeydown">
+  <div class="pos-receipt__screen">
+    <%= render "shared/page_header", title: "Print the new gift card once" %>
+    <p>Ordinary receipts stay masked. This page discloses the new number once.</p>
+    <section class="pos-first-print">
+      <h2>Gift card credentials</h2>
+      <ul>
+        <% Array(@gift_card_credentials).each do |credential| %>
+          <li>
+            <%= credential.kind.humanize %>
+            · <%= credential.program_name %>
+            · <%= format_money_cents(credential.amount_cents) %>
+            · <%= credential.number %>
+          </li>
+        <% end %>
+      </ul>
+    </section>
+  </div>
+
+  <%= render "pos/receipts/gift_card_voucher", credentials: @gift_card_credentials %>
+
+  <div class="pos-receipt__actions pos-no-print">
+    <%= action_button("Print gift card", style: :solid, intent: :brand, data: { action: "pos-receipt#printVoucher" }) %>
+    <%= action_link_to("Gift card", admin_gift_card_path(@gift_card), style: :outline, intent: :neutral) %>
+  </div>
+</main>

--- a/app/views/admin/gift_cards/index.html.erb
+++ b/app/views/admin/gift_cards/index.html.erb
@@ -6,7 +6,7 @@
 <%= render "shared/page_header",
       title: "Gift cards",
       actions: action_link_to("Inquire", inquiry_admin_gift_cards_path, style: :solid, intent: :brand) %>
-<p class="muted">Inquiry is exact-match only. Lists show prefix and last four, never the full number.</p>
+<p class="muted">Inquiry accepts an exact number or prefix + last four. Lists show prefix and last four, never the full number.</p>
 <% rows = @gift_cards.map { |card|
      [
        link_to(card.masked_number, admin_gift_card_path(card)),

--- a/app/views/admin/gift_cards/inquiry.html.erb
+++ b/app/views/admin/gift_cards/inquiry.html.erb
@@ -5,12 +5,37 @@
   { name: "Inquiry" }
 ] %>
 <%= render "shared/page_header", title: "Inquire by number" %>
+<p class="muted">Exact number uses digest lookup. Prefix and last four are an administrative history path, not a redemption path. Lists stay masked.</p>
 <%= form_with url: inquiry_admin_gift_cards_path, method: :post, class: "form" do |form| %>
   <div class="form-field">
     <%= label_tag :card_number, "Card number" %>
     <%= password_field_tag :card_number, nil, autocomplete: "off" %>
   </div>
+  <div class="form-field">
+    <%= label_tag :number_prefix, "Prefix" %>
+    <%= text_field_tag :number_prefix, params[:number_prefix], autocomplete: "off", inputmode: "numeric" %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :number_last_four, "Last four" %>
+    <%= text_field_tag :number_last_four, params[:number_last_four], autocomplete: "off", inputmode: "numeric", maxlength: 4 %>
+  </div>
   <div class="actions">
     <%= action_submit(form, "Look up", style: :solid, intent: :brand) %>
   </div>
+<% end %>
+
+<% if @candidates.present? %>
+  <section class="section">
+    <h2 class="section__title">Matching cards</h2>
+    <% rows = @candidates.map { |candidate|
+         [
+           link_to(candidate.masked_number, admin_gift_card_path(candidate.id)),
+           candidate.program_name,
+           candidate.status.humanize,
+           format_money_cents(candidate.balance_cents),
+           candidate.activated_at.to_date.iso8601
+         ]
+       } %>
+    <%= render "shared/data_table", headers: ["Card", "Program", "Status", "Balance", "Activated"], rows: rows %>
+  </section>
 <% end %>

--- a/app/views/admin/gift_cards/print_recovery.html.erb
+++ b/app/views/admin/gift_cards/print_recovery.html.erb
@@ -12,8 +12,11 @@
        kind: "print_recovery",
        masked_number: @gift_card.masked_number,
        number: @recovered_number,
+       number_prefix: @gift_card.number_prefix,
        amount_cents: @gift_card.balance_cents,
-       program_name: @gift_card.gift_card_program.name
+       program_name: @gift_card.gift_card_program.name,
+       store: @gift_card.activated_store,
+       issued_at: @gift_card.activated_at
      )] %>
   <main class="pos-receipt" data-controller="pos-receipt">
     <section class="pos-first-print pos-receipt__screen">

--- a/app/views/admin/gift_cards/print_recovery.html.erb
+++ b/app/views/admin/gift_cards/print_recovery.html.erb
@@ -8,11 +8,25 @@
 <%= render "shared/page_header", title: "Recover print for #{@gift_card.masked_number}" %>
 <p>Exceptional recovery of a system-generated credential. Ordinary receipts stay masked. This is not a general reveal screen.</p>
 <% if @recovered_number.present? %>
-  <section class="pos-first-print">
-    <h2>Recovered number</h2>
-    <p><%= @recovered_number %></p>
-    <p class="muted">Print now. This page is the only delivery of the full number.</p>
-  </section>
+  <% recovered = [Pos::FirstPrint::Credential.new(
+       kind: "print_recovery",
+       masked_number: @gift_card.masked_number,
+       number: @recovered_number,
+       amount_cents: @gift_card.balance_cents,
+       program_name: @gift_card.gift_card_program.name
+     )] %>
+  <main class="pos-receipt" data-controller="pos-receipt">
+    <section class="pos-first-print pos-receipt__screen">
+      <h2>Recovered number</h2>
+      <p><%= @recovered_number %></p>
+      <p class="muted">Print the gift card now. This page is the only delivery of the full number.</p>
+    </section>
+    <%= render "pos/receipts/gift_card_voucher", credentials: recovered %>
+    <div class="actions pos-no-print">
+      <%= action_button("Print gift card", style: :solid, intent: :brand, data: { action: "pos-receipt#printVoucher" }) %>
+      <%= action_link_to("Gift card", admin_gift_card_path(@gift_card), style: :outline, intent: :neutral) %>
+    </div>
+  </main>
 <% else %>
   <%= form_with url: print_recovery_admin_gift_card_path(@gift_card), method: :post, class: "form" do |form| %>
     <div class="form-field">

--- a/app/views/admin/gift_cards/show.html.erb
+++ b/app/views/admin/gift_cards/show.html.erb
@@ -17,7 +17,7 @@
 <% if !@gift_card.replaced? && !@gift_card.closed? && effective_permissions.include?("gift_cards.associate_customer") %>
   <% actions << action_link_to("Associate customer", associate_admin_gift_card_path(@gift_card), style: :outline, intent: :neutral) %>
 <% end %>
-<% if @gift_card.gift_card_program.system_generated? && effective_permissions.include?("gift_cards.view") %>
+<% if @gift_card.gift_card_program.system_generated? && effective_permissions.include?("gift_cards.recover_print") %>
   <% actions << action_link_to("Recover print", print_recovery_admin_gift_card_path(@gift_card), style: :outline, intent: :neutral) %>
 <% end %>
 <% if !@gift_card.replaced? && !@gift_card.closed? && effective_permissions.include?("stored_value.adjust") %>
@@ -31,3 +31,11 @@
       ["Customer", (@gift_card.customer ? link_to(@gift_card.customer.admin_label, admin_customer_path(@gift_card.customer)) : "None")],
       ["Activated store", @gift_card.activated_store.admin_label]
     ] %>
+
+<section class="section">
+  <h2 class="section__title">Account activity</h2>
+  <%= render "admin/stored_value/account_activity",
+        activity: @activity,
+        show_card: true,
+        page_path: ->(page) { admin_gift_card_path(@gift_card, page: page) } %>
+</section>

--- a/app/views/admin/stored_value/_account_activity.html.erb
+++ b/app/views/admin/stored_value/_account_activity.html.erb
@@ -1,0 +1,43 @@
+<%#
+  locals: activity:, show_card: false, page_param: :page, page_path:
+%>
+<% activity = local_assigns.fetch(:activity) %>
+<% show_card = local_assigns.fetch(:show_card, false) %>
+<% page_path = local_assigns.fetch(:page_path) %>
+<% if activity.total_count.zero? %>
+  <%= render "shared/empty_state", title: "No stored-value activity", body: "Posted operations for this account will appear here." %>
+<% else %>
+  <% headers = ["Business date", "Store", "Operation", "Amount", "Balance after", "Actor / reason", "POS"] %>
+  <% headers.insert(3, "Card") if show_card %>
+  <% rows = activity.entries.map { |entry|
+       operation = entry.stored_value_operation
+       pos_transaction = activity.pos_transactions_by_operation_id[operation.id]
+       reason = [operation.reason_name_snapshot.presence || operation.reason_code.presence, operation.performed_by&.display_name].compact.join(" · ")
+       row = [
+         operation.business_date.iso8601,
+         operation.store.admin_label,
+         operation.operation_type.humanize,
+         format_signed_money_cents(entry.amount_cents),
+         format_money_cents(entry.balance_after_cents),
+         reason.presence || missing_value,
+         (pos_transaction_cross_link(pos_transaction, label: pos_transaction.transaction_reference) if pos_transaction)
+       ]
+       if show_card
+         card = activity.account.gift_card
+         row.insert(3, card&.masked_number || missing_value)
+       end
+       row
+     } %>
+  <%= render "shared/data_table", headers: headers, rows: rows %>
+  <% if activity.total_pages > 1 %>
+    <nav class="pagination" aria-label="Stored-value activity pages">
+      <span class="muted">Page <%= activity.page %> of <%= activity.total_pages %> · <%= activity.total_count %> total</span>
+      <% if activity.page > 1 %>
+        <%= action_link_to("Previous", page_path.call(activity.page - 1), style: :ghost, intent: :neutral) %>
+      <% end %>
+      <% if activity.page < activity.total_pages %>
+        <%= action_link_to("Next", page_path.call(activity.page + 1), style: :ghost, intent: :neutral) %>
+      <% end %>
+    </nav>
+  <% end %>
+<% end %>

--- a/app/views/admin/stored_value/_account_activity.html.erb
+++ b/app/views/admin/stored_value/_account_activity.html.erb
@@ -9,24 +9,21 @@
 <% else %>
   <% headers = ["Business date", "Store", "Operation", "Amount", "Balance after", "Actor / reason", "POS"] %>
   <% headers.insert(3, "Card") if show_card %>
-  <% rows = activity.entries.map { |entry|
-       operation = entry.stored_value_operation
-       pos_transaction = activity.pos_transactions_by_operation_id[operation.id]
-       reason = [operation.reason_name_snapshot.presence || operation.reason_code.presence, operation.performed_by&.display_name].compact.join(" · ")
-       row = [
-         operation.business_date.iso8601,
-         operation.store.admin_label,
-         operation.operation_type.humanize,
-         format_signed_money_cents(entry.amount_cents),
-         format_money_cents(entry.balance_after_cents),
-         reason.presence || missing_value,
-         (pos_transaction_cross_link(pos_transaction, label: pos_transaction.transaction_reference) if pos_transaction)
+  <% rows = activity.rows.map { |row|
+       table_row = [
+         row.business_date.iso8601,
+         row.store_label,
+         row.operation_label,
+         format_signed_money_cents(row.amount_cents),
+         format_money_cents(row.balance_after_cents),
+         row.actor_reason.presence || missing_value,
+         (pos_transaction_cross_link(row.pos_transaction, label: row.pos_transaction.transaction_reference) if row.pos_transaction)
        ]
        if show_card
          card = activity.account.gift_card
-         row.insert(3, card&.masked_number || missing_value)
+         table_row.insert(3, card&.masked_number || missing_value)
        end
-       row
+       table_row
      } %>
   <%= render "shared/data_table", headers: headers, rows: rows %>
   <% if activity.total_pages > 1 %>

--- a/app/views/admin/system_settings/edit.html.erb
+++ b/app/views/admin/system_settings/edit.html.erb
@@ -20,5 +20,10 @@
     <%= form.text_area :default_receipt_footer, maxlength: Store::RECEIPT_MESSAGE_LIMIT %>
   </p>
   <p class="muted">Used by Stores configured to inherit. Receipt messages are plain text and automatically wrap to receipt width. A blank System value means there is no organization default message.</p>
+  <p>
+    <%= form.label :gift_card_voucher_footer, "Gift card voucher footer" %>
+    <%= form.text_area :gift_card_voucher_footer, maxlength: Store::RECEIPT_MESSAGE_LIMIT %>
+  </p>
+  <p class="muted">Printed at the bottom of every gift-card voucher. Plain text wraps to 80 mm. Leave blank to omit a footer. The token {organization legal name} is replaced with this organization's legal name.</p>
   <p><%= action_submit(form, "Save", style: :solid, intent: :brand) %></p>
 <% end %>

--- a/app/views/admin/system_settings/show.html.erb
+++ b/app/views/admin/system_settings/show.html.erb
@@ -5,6 +5,7 @@
   <dt>Legal name</dt><dd><%= @settings.legal_name %></dd>
   <dt>Currency</dt><dd><%= @settings.base_currency_code %></dd>
   <dt>Stored-value credit approval threshold</dt><dd><%= @settings.stored_value_adjust_credit_approval_threshold_cents %> cents</dd>
+  <dt>Gift card voucher footer</dt><dd><%= @settings.gift_card_voucher_footer.presence || "Not set" %></dd>
   <dt>Timezone</dt><dd><%= @settings.default_timezone %></dd>
   <dt>Country</dt><dd><%= @settings.default_country_code %></dd>
 </dl>

--- a/app/views/pos/completed_transactions/show.html.erb
+++ b/app/views/pos/completed_transactions/show.html.erb
@@ -13,13 +13,16 @@
 
     <h1 tabindex="-1" autofocus>Transaction complete</h1>
     <p class="pos-receipt__ref"><%= @transaction.transaction_reference %></p>
+    <% if @transaction.customer %>
+      <p class="pos-customer">Customer · <%= @transaction.customer.display_name %></p>
+    <% end %>
     <%= render "pos/receipts/post_void_banner", transaction: @transaction, linked: true %>
 
-    <% credentials = Pos::FirstPrint.call(@transaction) %>
+    <% credentials = Array(@gift_card_credentials) %>
     <% if credentials.any? %>
-      <section class="pos-first-print" data-controller="pos-receipt">
+      <section class="pos-first-print">
         <h2>Gift card credentials</h2>
-        <p>Print these numbers now. Ordinary receipts stay masked.</p>
+        <p>Print the gift card now. Ordinary receipts stay masked.</p>
         <ul>
           <% credentials.each do |credential| %>
             <li>
@@ -80,6 +83,7 @@
   </div>
 
   <%= render "pos/receipts/print", transaction: @transaction, tenders: @tenders, reprint: false %>
+  <%= render "pos/receipts/gift_card_voucher", credentials: @gift_card_credentials %>
 
   <div class="pos-receipt__actions pos-no-print">
     <% receipt = Pos::CustomerReceipt.build(@transaction) %>
@@ -87,6 +91,9 @@
       <%= action_button("Print receipt", style: :solid, intent: :brand, data: { action: "pos-receipt#print" }) %>
     <% else %>
       <p class="pos-enter__alert" role="alert"><%= receipt.error %></p>
+    <% end %>
+    <% if Array(@gift_card_credentials).any? %>
+      <%= action_button("Print gift card", style: :solid, intent: :brand, data: { action: "pos-receipt#printVoucher" }) %>
     <% end %>
     <%= action_link_to("Transactions", pos_transactions_path, style: :outline, intent: :neutral) %>
     <span class="pos-receipt__new">

--- a/app/views/pos/receipts/_gift_card_voucher.html.erb
+++ b/app/views/pos/receipts/_gift_card_voucher.html.erb
@@ -2,15 +2,31 @@
   locals: credentials:
 %>
 <% credentials = Array(local_assigns[:credentials]) %>
+<% footer = SystemSettings.current.printed_gift_card_voucher_footer %>
 <% if credentials.any? %>
   <section class="pos-gift-card-voucher pos-print-only" aria-hidden="true">
     <% credentials.each do |credential| %>
       <div class="pos-gift-card-voucher__card">
-        <p class="pos-gift-card-voucher__title">GIFT CARD</p>
-        <p><%= credential.program_name %></p>
-        <p><%= format_money_cents(credential.amount_cents) %></p>
-        <p class="pos-gift-card-voucher__number"><%= credential.number %></p>
-        <p class="pos-gift-card-voucher__kind"><%= credential.kind.to_s.humanize %></p>
+        <% if credential.legal_name.present? %>
+          <div class="pos-gift-card-voucher__store">
+            <p class="pos-gift-card-voucher__legal-name"><%= credential.legal_name %></p>
+            <% credential.address_lines.each do |line| %>
+              <p><%= line %></p>
+            <% end %>
+          </div>
+        <% end %>
+        <% if credential.issued_at_label.present? %>
+          <p class="pos-gift-card-voucher__issued">Issued: <%= credential.issued_at_label %></p>
+        <% end %>
+        <p class="pos-gift-card-voucher__amount"><%= format_money_cents(credential.amount_cents) %></p>
+        <p class="pos-gift-card-voucher__title">Gift Card</p>
+        <div class="pos-gift-card-voucher__barcode">
+          <%= pos_code128_svg(GiftCards::Number.normalize(credential.number)) %>
+          <p class="pos-gift-card-voucher__number"><%= credential.presented_number %></p>
+        </div>
+        <% if footer.present? %>
+          <p class="pos-receipt__message pos-gift-card-voucher__footer"><%= footer %></p>
+        <% end %>
       </div>
     <% end %>
   </section>

--- a/app/views/pos/receipts/_gift_card_voucher.html.erb
+++ b/app/views/pos/receipts/_gift_card_voucher.html.erb
@@ -1,0 +1,17 @@
+<%#
+  locals: credentials:
+%>
+<% credentials = Array(local_assigns[:credentials]) %>
+<% if credentials.any? %>
+  <section class="pos-gift-card-voucher pos-print-only" aria-hidden="true">
+    <% credentials.each do |credential| %>
+      <div class="pos-gift-card-voucher__card">
+        <p class="pos-gift-card-voucher__title">GIFT CARD</p>
+        <p><%= credential.program_name %></p>
+        <p><%= format_money_cents(credential.amount_cents) %></p>
+        <p class="pos-gift-card-voucher__number"><%= credential.number %></p>
+        <p class="pos-gift-card-voucher__kind"><%= credential.kind.to_s.humanize %></p>
+      </div>
+    <% end %>
+  </section>
+<% end %>

--- a/app/views/pos/receipts/_print.html.erb
+++ b/app/views/pos/receipts/_print.html.erb
@@ -33,6 +33,9 @@
       <p><%= receipt.completed_at_label %></p>
       <p class="pos-receipt__print-header"><%= receipt.identity_header %></p>
       <p>Cashier: <%= receipt.cashier_name %></p>
+      <% if receipt.customer_name.present? %>
+        <p>Customer: <%= receipt.customer_name %></p>
+      <% end %>
     </div>
 
     <div class="pos-receipt__print-lines">

--- a/app/views/pos/transactions/show.html.erb
+++ b/app/views/pos/transactions/show.html.erb
@@ -11,6 +11,9 @@
       <div><dt>Completed</dt><dd><%= format_store_timestamp(@transaction.completed_at, @transaction.store) %></dd></div>
       <div><dt>Register</dt><dd><%= pos_padded_register_snapshot(@transaction.register_number_snapshot) %></dd></div>
       <div><dt>Cashier</dt><dd><%= pos_cashier_name(@transaction) %></dd></div>
+      <% if @transaction.customer %>
+        <div><dt>Customer</dt><dd><%= @transaction.customer.display_name %></dd></div>
+      <% end %>
     </dl>
 
     <dl class="pos-history__header">

--- a/app/views/pos/workspaces/_surface.html.erb
+++ b/app/views/pos/workspaces/_surface.html.erb
@@ -79,6 +79,7 @@
      data-register-workspace-resolve-url-value="<%= pos_register_merchandise_resolve_path(register_scope) %>"
      data-register-workspace-search-url-value="<%= pos_register_merchandise_search_path(register_scope) %>"
      data-register-workspace-pickup-search-url-value="<%= pos_register_pickup_search_path(register_scope) %>"
+     data-register-workspace-customer-search-url-value="<%= pos_register_customer_search_path(register_scope) %>"
      data-register-workspace-pickup-allowed-value="<%= @pickup_allowed ? "true" : "false" %>"
      data-register-workspace-open-price-url-value="<%= pos_register_open_price_path(register_scope) %>"
      data-action="turbo:submit-end->register-workspace#onSubmitEnd">
@@ -239,17 +240,25 @@
           </section>
         <% end %>
         <% if @transaction.customer %>
-          <p class="pos-customer">Customer · <%= @transaction.customer.display_name %></p>
+          <div class="pos-customer">
+            <p>Customer · <%= @transaction.customer.display_name %></p>
+            <% if @ui_mode == "sale_entry" %>
+              <div class="pos-customer__actions">
+                <%= action_button "Change", style: :outline, intent: :neutral, size: :standard,
+                      data: { action: "register-workspace#openCustomerOverlay", register_workspace_target: "attachCustomerButton" } %>
+                <%= form_with url: pos_register_detach_customer_path(register_scope), method: :post, class: "pos-customer-form" do %>
+                  <%= hidden_field_tag :register_id, @register.id %>
+                  <%= hidden_field_tag :lock_version, @transaction.lock_version %>
+                  <%= submit_tag "Clear", class: "btn btn--outline" %>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
         <% elsif @ui_mode == "sale_entry" %>
-          <%= form_with url: pos_register_attach_customer_path(register_scope), method: :post, class: "pos-customer-form" do %>
-            <%= hidden_field_tag :register_id, @register.id %>
-            <%= hidden_field_tag :lock_version, @transaction.lock_version %>
-            <label>
-              Customer id
-              <input name="customer_id" autocomplete="off">
-            </label>
-            <%= submit_tag "Attach customer", class: "btn btn--outline" %>
-          <% end %>
+          <div class="pos-customer">
+            <%= action_button "Attach customer", style: :outline, intent: :neutral, size: :standard,
+                  data: { action: "register-workspace#openCustomerOverlay", register_workspace_target: "attachCustomerButton" } %>
+          </div>
         <% end %>
       </div>
 
@@ -412,6 +421,12 @@
       <%= hidden_field_tag :register_id, @register.id %>
       <%= hidden_field_tag :lock_version, @transaction.lock_version %>
       <%= hidden_field_tag :customer_request_id, "", data: { register_workspace_target: "pickupRequestInput" } %>
+    <% end %>
+
+    <%= form_with url: pos_register_attach_customer_path(register_scope), method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "attachCustomerForm", turbo: true } } do %>
+      <%= hidden_field_tag :register_id, @register.id %>
+      <%= hidden_field_tag :lock_version, @transaction.lock_version %>
+      <%= hidden_field_tag :customer_id, "", data: { register_workspace_target: "attachCustomerIdInput" } %>
     <% end %>
 
     <%= form_with url: pos_register_quantity_path(register_scope), method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "quantityForm", turbo: true } } do %>
@@ -690,6 +705,27 @@
       <p class="muted">Enter searches, then Enter selects the highlighted available request. Esc cancels.</p>
       <%= action_button "Cancel (Esc)", style: :outline, intent: :neutral, size: :standard,
             data: { action: "register-workspace#closePickupOverlay" } %>
+    </div>
+  </div>
+
+  <div class="pos-overlay"
+       id="pos_customer_overlay"
+       hidden
+       data-register-workspace-target="customerOverlay"
+       role="dialog"
+       aria-modal="true"
+       aria-labelledby="pos-customer-title">
+    <div class="pos-overlay__panel">
+      <h2 id="pos-customer-title">Attach customer</h2>
+      <label class="field">
+        <span>Name, email, or phone</span>
+        <input type="text" autocomplete="off" data-register-workspace-target="customerQueryField">
+      </label>
+      <p class="muted" data-register-workspace-target="customerQueryLabel"></p>
+      <ul class="pos-picker" role="listbox" aria-labelledby="pos-customer-title" data-register-workspace-target="customerList"></ul>
+      <p class="muted">Enter searches, then Enter selects the highlighted customer. Esc cancels.</p>
+      <%= action_button "Cancel (Esc)", style: :outline, intent: :neutral, size: :standard,
+            data: { action: "register-workspace#closeCustomerOverlay" } %>
     </div>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,6 +127,7 @@ Rails.application.routes.draw do
         post :reinstate
         get :replace
         post :replace, action: :create_replacement
+        get :credential
         get :associate
         patch :associate, action: :update_association
         get :print_recovery
@@ -222,6 +223,7 @@ Rails.application.routes.draw do
     post "register/stored_value_issuance", to: "workspaces#stored_value_issuance"
     post "register/remove_stored_value_issuance", to: "workspaces#remove_stored_value_issuance"
     post "register/attach_customer", to: "workspaces#attach_customer"
+    post "register/detach_customer", to: "workspaces#detach_customer"
     get "register/customer_search", to: "workspaces#customer_search", as: :register_customer_search
     post "register/remove_tender", to: "workspaces#remove_tender"
     post "register/continue", to: "workspaces#continue"

--- a/db/migrate/20260826060000_add_pos_gift_card_credential_deliveries.rb
+++ b/db/migrate/20260826060000_add_pos_gift_card_credential_deliveries.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddPosGiftCardCredentialDeliveries < ActiveRecord::Migration[8.1]
+  def change
+    create_uuid_table :pos_gift_card_credential_deliveries do |t|
+      t.uuid :pos_transaction_id, null: false
+      t.timestamptz :delivered_at, null: false
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+    add_index :pos_gift_card_credential_deliveries, :pos_transaction_id, unique: true,
+              name: "index_pos_gc_credential_deliveries_on_transaction"
+    add_foreign_key :pos_gift_card_credential_deliveries, :pos_transactions
+  end
+end

--- a/db/migrate/20260826070000_add_gift_card_admin_inquiry_and_replacement_deliveries.rb
+++ b/db/migrate/20260826070000_add_gift_card_admin_inquiry_and_replacement_deliveries.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class AddGiftCardAdminInquiryAndReplacementDeliveries < ActiveRecord::Migration[8.1]
+  def change
+    add_index :gift_cards, [ :number_prefix, :number_last_four ],
+              name: "index_gift_cards_on_prefix_and_last_four"
+
+    change_column_null :pos_gift_card_credential_deliveries, :pos_transaction_id, true
+    add_column :pos_gift_card_credential_deliveries, :gift_card_id, :uuid
+    add_index :pos_gift_card_credential_deliveries, :gift_card_id, unique: true,
+              where: "gift_card_id IS NOT NULL",
+              name: "index_pos_gc_credential_deliveries_on_gift_card"
+    add_foreign_key :pos_gift_card_credential_deliveries, :gift_cards
+    add_check_constraint :pos_gift_card_credential_deliveries,
+                         "(pos_transaction_id IS NOT NULL AND gift_card_id IS NULL) OR (pos_transaction_id IS NULL AND gift_card_id IS NOT NULL)",
+                         name: "pos_gc_credential_deliveries_one_subject"
+  end
+end

--- a/db/migrate/20260826080000_add_gift_card_voucher_footer_to_system_settings.rb
+++ b/db/migrate/20260826080000_add_gift_card_voucher_footer_to_system_settings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddGiftCardVoucherFooterToSystemSettings < ActiveRecord::Migration[8.1]
+  def change
+    add_column :system_settings, :gift_card_voucher_footer, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_26_070000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_26_080000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -1603,6 +1603,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_070000) do
     t.integer "default_supplier_cancellation_days", limit: 2, default: 20, null: false
     t.string "default_timezone", null: false
     t.integer "fiscal_year_start_month", limit: 2, default: 1, null: false
+    t.text "gift_card_voucher_footer"
     t.timestamptz "initialized_at"
     t.string "legal_name"
     t.integer "lock_version", default: 0, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_26_050000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_26_070000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -320,6 +320,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_050000) do
     t.index ["customer_id"], name: "index_gift_cards_on_customer_id"
     t.index ["gift_card_program_id"], name: "index_gift_cards_on_gift_card_program_id"
     t.index ["number_digest"], name: "index_gift_cards_on_number_digest", unique: true
+    t.index ["number_prefix", "number_last_four"], name: "index_gift_cards_on_prefix_and_last_four"
     t.index ["stored_value_account_id"], name: "index_gift_cards_on_stored_value_account_id", unique: true
     t.check_constraint "char_length(number_last_four::text) = 4", name: "gift_cards_last_four_length"
     t.check_constraint "status::text = ANY (ARRAY['active'::character varying, 'suspended'::character varying, 'replaced'::character varying, 'closed'::character varying]::text[])", name: "gift_cards_status_valid"
@@ -643,6 +644,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_050000) do
     t.check_constraint "approved_by_user_id IS NULL OR approved_by_user_id <> performed_by_user_id", name: "pos_controlled_actions_approver_not_performer"
     t.check_constraint "policy_result::text = 'approval_required'::text AND approved_by_user_id IS NOT NULL AND approved_by_name_snapshot IS NOT NULL OR policy_result::text = 'direct'::text AND approved_by_user_id IS NULL AND approved_by_name_snapshot IS NULL", name: "pos_controlled_actions_approver_matches_policy"
     t.check_constraint "policy_result::text = ANY (ARRAY['direct'::character varying::text, 'approval_required'::character varying::text])", name: "pos_controlled_actions_policy_valid"
+  end
+
+  create_table "pos_gift_card_credential_deliveries", id: :uuid, default: nil, force: :cascade do |t|
+    t.timestamptz "created_at", null: false
+    t.timestamptz "delivered_at", null: false
+    t.uuid "gift_card_id"
+    t.uuid "pos_transaction_id"
+    t.timestamptz "updated_at", null: false
+    t.index ["gift_card_id"], name: "index_pos_gc_credential_deliveries_on_gift_card", unique: true, where: "(gift_card_id IS NOT NULL)"
+    t.index ["pos_transaction_id"], name: "index_pos_gc_credential_deliveries_on_transaction", unique: true
+    t.check_constraint "pos_transaction_id IS NOT NULL AND gift_card_id IS NULL OR pos_transaction_id IS NULL AND gift_card_id IS NOT NULL", name: "pos_gc_credential_deliveries_one_subject"
   end
 
   create_table "pos_line_tax_components", id: :uuid, default: nil, force: :cascade do |t|
@@ -1765,6 +1777,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_050000) do
   add_foreign_key "pos_controlled_actions", "pos_transactions"
   add_foreign_key "pos_controlled_actions", "users", column: "approved_by_user_id"
   add_foreign_key "pos_controlled_actions", "users", column: "performed_by_user_id"
+  add_foreign_key "pos_gift_card_credential_deliveries", "gift_cards"
+  add_foreign_key "pos_gift_card_credential_deliveries", "pos_transactions"
   add_foreign_key "pos_line_tax_components", "pos_transaction_lines"
   add_foreign_key "pos_line_tax_components", "store_taxes"
   add_foreign_key "pos_operations", "pos_transactions"

--- a/docs/adr/ADR-026-gift-card-number-protection.md
+++ b/docs/adr/ADR-026-gift-card-number-protection.md
@@ -16,9 +16,9 @@ Digest-only storage cannot satisfy complete-retry print. Custom ciphertext envel
 
 1. **ShelfSense stores the normalized gift-card number through Rails Active Record Encryption using nondeterministic encryption.** A separate keyed HMAC digest provides exact lookup and uniqueness. Prefix and last four digits are stored for ordinary display.
 2. **Active Record Encryption keys are configured through the standard Rails credentials/environment mechanism.** ShelfSense does not implement custom ciphertext envelopes, IV handling, per-row key identifiers, or application-specific key-rotation metadata. Future rotation uses Rails-supported encryption schemes. HMAC secret is separate from Active Record Encryption keys. Do not commit production keys, plaintext numbers, or decryptable fixtures. Docker/CI test keys are documented and distinct from production.
-3. **Lookup is exact-match on the digest.** No prefix search, autocomplete, or unmasked lists. Failed lookup uses a generic error. Repeated failures are throttled and audited without recording the submitted number.
+3. **Operational lookup is exact-match on the digest.** Redeem, reload, cash-out, original-card refund possession, and Register scan routing have no prefix search, autocomplete, or unmasked lists. Failed lookup uses a generic error. Repeated failures are throttled and audited without recording the submitted number. Administrative history inquiry by stored `number_prefix` + `number_last_four` is [ADR-027](ADR-027-admin-gift-card-prefix-last-four-inquiry.md); it is not a redemption path.
 4. **The completed POS envelope never contains the full number.** Command payload for system-generated cards expresses “generate a number from program X.” The envelope snapshots masked identity and Core foreign keys. Decrypt for the controlled activation/refund-card print channel and for idempotent complete-retry of that first print.
-5. **Full-number decryption is limited to controlled first-print, idempotent completion retry, and narrowly authorized print-recovery or replacement services.** Phase 10 does not provide a general administrative reveal screen. Audit records card identity by ID and last four only.
+5. **Full-number decryption is limited to controlled first-print until that delivery is acknowledged, idempotent completion retry before acknowledgment, and narrowly authorized print-recovery or replacement services.** After first-print delivery is recorded, later completed-transaction views stay masked. Phase 10 does not provide a general administrative reveal screen. Audit records card identity by ID and last four only.
 6. **Outbox, URLs, logs, exceptions, screenshots, and support dumps never include the full number or ciphertext that tests could treat as a credential.** Tests use the documented test key and synthetic numbers.
 
 Working manual activation and new refund cards may persist `pending_card_number` with `encrypts :pending_card_number` on the working POS row. No gift-card row exists until completion.
@@ -28,8 +28,8 @@ PIN/access codes remain out of Phase 10. Offline number pools remain a future AD
 ## Consequences
 
 - Gift-card rows carry `number` (`encrypts :number`), `number_digest`, `number_prefix`, and `number_last_four` as specified in [phase10-gift-card-numbering.md](../planning/phase10-stored-value/phase10-gift-card-numbering.md). There is no `number_ciphertext`, `encryption_key_id`, or `gift_cards.reveal_number` permission.
-- First-print after commit and complete-retry can recover the number; abandoned working transactions never persist a gift-card liability.
-- Lost physical cards are recovered through print-recovery or replacement, not a general reveal UI.
+- First-print after commit and complete-retry can recover the number until that delivery is acknowledged; abandoned working transactions never persist a gift-card liability.
+- Subsequent completed-transaction views stay masked. Lost physical cards are recovered through print-recovery (`gift_cards.recover_print`) or replacement, not a general reveal UI.
 - CI and local Docker must configure Active Record encryption keys; document them in development guidance when implementation lands.
 
 ## Related documentation
@@ -39,3 +39,4 @@ PIN/access codes remain out of Phase 10. Offline number pools remain a future AD
 - [ADR-008](ADR-008-audit-events.md)
 - [ADR-009](ADR-009-concurrency-and-idempotency.md)
 - [ADR-020](ADR-020-pos-operation-envelope-and-core-facts.md)
+- [ADR-027](ADR-027-admin-gift-card-prefix-last-four-inquiry.md)

--- a/docs/adr/ADR-027-admin-gift-card-prefix-last-four-inquiry.md
+++ b/docs/adr/ADR-027-admin-gift-card-prefix-last-four-inquiry.md
@@ -1,0 +1,40 @@
+# ADR-027: Admin gift-card inquiry by prefix and last four
+
+- **Status:** Accepted
+- **Date:** 2026-08-26
+- **Accepted:** 2026-08-26
+
+## Context
+
+[ADR-026](ADR-026-gift-card-number-protection.md) §3 requires gift-card lookup to be exact-match on the HMAC digest: no prefix search, autocomplete, or unmasked lists. That rule is the correct possession test for redemption, reload, cash-out, and original-card refund.
+
+Staff who already have `gift_cards.view` often have only the printed prefix and last four from a receipt, envelope, or card face. Those snapshots are stored on `gift_cards` for ordinary display, but there is no authorized query path. Using prefix + last four as a **redemption** path would weaken bearer-credential protection. Using it only as an **administrative history inquiry** does not prove possession and must not feed Register scan routing.
+
+## Decision
+
+1. **Operational use stays exact digest.** POS `GiftCards::Lookup.by_number`, Register scan routing, redeem, reload, cash-out, and original-card refund possession continue to resolve only by HMAC digest of the normalized full number. Prefix + last four is not proof of possession. Do not add `gift_cards.reveal_number`.
+
+2. **Admin/management inquiry may resolve by `number_prefix` + `number_last_four`.** This is a history/find path for staff with `gift_cards.view`. The inquiry form accepts an exact number **or** prefix + last four. The exact-number path remains digest lookup (`GiftCards::Resolver`).
+
+3. **Match handling:**
+   - **Unique match:** open the card show (masked).
+   - **Two or more matches:** show a short **masked** candidate list (status, program, balance, activated-at) and let staff pick. Do not show full numbers.
+   - **Zero matches:** generic failure, same wording as digest miss. Do not distinguish missing vs ineligible.
+
+4. **Abuse controls match ADR-026.** Failed inquiries are throttled and audited without recording submitted digits. Successful and ambiguous inquiries audit card IDs and last four only. Lists, URLs, and flash never contain the full number.
+
+5. **Index.** A non-unique composite index on `gift_cards (number_prefix, number_last_four)` supports the inquiry. Collisions are expected and are a product path, not a uniqueness violation.
+
+ADR-026 §3 is refined: exact digest for operational use; admin history may use prefix + last four.
+
+## Consequences
+
+- Register and POS completion code must not call the prefix + last-four inquiry service.
+- Candidate lists are a disclosure of which cards share a face fragment; they remain masked and are not a reveal channel.
+- Print, recover-print, and replacement credential vouchers are unchanged by this decision ([ADR-026](ADR-026-gift-card-number-protection.md) §4–5).
+
+## Related documentation
+
+- [ADR-026](ADR-026-gift-card-number-protection.md)
+- [Phase 10 gift-card numbering](../planning/phase10-stored-value/phase10-gift-card-numbering.md)
+- [Phase 10 authorization](../planning/phase10-stored-value/phase10-authorization.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,6 +38,7 @@ These ADRs capture the architecture decisions reached during the ShelfSense offl
 | [ADR-024](ADR-024-bibliographic-data-authority.md) | External bibliographic data is non-authoritative | Accepted |
 | [ADR-025](ADR-025-domain-owned-operational-ledgers.md) | Domain-owned operational ledgers (no universal financial-event table) | Accepted |
 | [ADR-026](ADR-026-gift-card-number-protection.md) | Gift-card number protection | Accepted |
+| [ADR-027](ADR-027-admin-gift-card-prefix-last-four-inquiry.md) | Admin gift-card inquiry by prefix and last four | Accepted |
 
 ## Governing principle
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -97,7 +97,7 @@ Gift-card numbers use Rails Active Record Encryption plus a separate HMAC digest
 | `ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT` | Rails key-derivation salt |
 | `GIFT_CARD_NUMBER_HMAC_KEY` | HMAC-SHA256 lookup digest (not an Active Record Encryption key) |
 
-Production must set all four from the deployment environment. Do not commit production keys, plaintext gift-card numbers, or decryptable fixtures. Tests generate synthetic numbers and encrypt them with the test keys. Existing installations need `shelfsense:seed_permissions` (and `GiftCards::Programs.seed!`) after this slice.
+Production must set all four from the deployment environment. Do not commit production keys, plaintext gift-card numbers, or decryptable fixtures. Tests generate synthetic numbers and encrypt them with the test keys. Existing installations need `shelfsense:seed_permissions` after this slice so permissions, gift-card programs, and the three protected stored-value tender types (`store_credit`, `trade_credit`, `gift_card`) exist.
 
 Do not commit production credentials. Production values must come from the deployment environment. The ERB in `config/database.yml` must not use strict `ENV.fetch` calls without defaults for production-only variables, because Rails evaluates the entire file before selecting an environment; strict production lookups would also break development and CI startup.
 

--- a/docs/planning/phase1-operational-foundation/phase1-schema.md
+++ b/docs/planning/phase1-operational-foundation/phase1-schema.md
@@ -29,6 +29,7 @@ One row representing installation-wide configuration.
 | `default_customer_reservation_expiration_days` | smallint | null: false; default `7`; check `>= 0` | Default for customer reservations |
 | `default_receipt_header` | text | max 500 after trim | Organization default; inherit target |
 | `default_receipt_footer` | text | max 500 after trim | Organization default; inherit target |
+| `gift_card_voucher_footer` | text | max 500 after trim | Organization gift-card voucher terms; blank omits the footer ([phase10-schema.md](../phase10-stored-value/phase10-schema.md) §13) |
 | `stored_value_adjust_credit_approval_threshold_cents` | bigint | null: false; default `5000`; check `>= 0` | Credits at or above this amount require second-user approval; all debits require second-user approval ([phase10-schema.md](../phase10-stored-value/phase10-schema.md) §13) |
 | `initialized_at` | timestamptz |  | Set only as the final successful bootstrap step; null means install incomplete / retryable |
 | `lock_version` | integer | null: false; default `0` | Optimistic concurrency |

--- a/docs/planning/phase10-stored-value/README.md
+++ b/docs/planning/phase10-stored-value/README.md
@@ -1,6 +1,6 @@
 # Phase 10 — Stored value
 
-Status: **Proposed** — slices 10.1–10.5 implement on `main`; [milestone 5](https://github.com/BankEncore/ShelfSense-v1/milestone/5) stays open until the [manual test plan](phase10-manual-test-plan.md) is executed. After Phase 8 customer identity. Authority: this packet plus [ADR-025](../../adr/ADR-025-domain-owned-operational-ledgers.md) and [ADR-026](../../adr/ADR-026-gift-card-number-protection.md). GitHub tracker: [milestone 5](https://github.com/BankEncore/ShelfSense-v1/milestone/5).
+Status: **Proposed** — slices 10.1–10.5 implement on `main`; [milestone 5](https://github.com/BankEncore/ShelfSense-v1/milestone/5) stays open until the [manual test plan](phase10-manual-test-plan.md) is executed. After Phase 8 customer identity. Authority: this packet plus [ADR-025](../../adr/ADR-025-domain-owned-operational-ledgers.md), [ADR-026](../../adr/ADR-026-gift-card-number-protection.md), and [ADR-027](../../adr/ADR-027-admin-gift-card-prefix-last-four-inquiry.md). GitHub tracker: [milestone 5](https://github.com/BankEncore/ShelfSense-v1/milestone/5).
 
 The draft [phase-10-stored-value-spec.md](../../drafts/phase-10-stored-value-spec.md) is **superseded**. Do not implement from it.
 

--- a/docs/planning/phase10-stored-value/phase10-account-transfers-and-adjustments.md
+++ b/docs/planning/phase10-stored-value/phase10-account-transfers-and-adjustments.md
@@ -55,7 +55,7 @@ Eligible accounts: store credit, trade credit, and gift-card accounts that pass 
 | Suspended gift card | Elevated administrative adjustment only |
 | Replaced gift card | Block; use the replacement account |
 | Closed gift card | Block ordinary adjustment |
-| Positive adjustment | Must respect program `maximum_balance_cents` |
+| Positive adjustment | Must respect program `maximum_balance_cents`. `StoredValue::Post` rechecks under the account lock for every non-reversal gift-card credit. |
 | Negative adjustment | Cannot overdraw |
 
 Reasons come from `stored_value_adjustment_reasons`. Do not seed `opening_balance` as an ordinary reason. Snapshot `reason_code` / `reason_name_snapshot` on the posted adjustment.
@@ -70,7 +70,13 @@ Reasons come from `stored_value_adjustment_reasons`. Do not seed `opening_balanc
 | Known bad posted operation | `reverse` |
 | Move value between same-type accounts | `transfer` |
 
-## 4. Outbox
+## 4. Account activity (read model)
+
+Staff with `stored_value.view_activity` see per-account history on customer show for store credit and trade credit, including closed accounts. Staff with `gift_cards.view` see the same table on gift-card show for that instrument’s account.
+
+Columns: store, business date, operation type, signed amount, balance-after, actor and reason snapshot when present, and a POS transaction reference when the operation is attributable to a completed POS issuance, tender, or related source row. Gift-card identity stays masked. This is UI over `stored_value_entries`; it is not a second ledger.
+
+## 5. Outbox
 
 - `stored_value.transferred`
 - `stored_value.adjusted`

--- a/docs/planning/phase10-stored-value/phase10-account-transfers-and-adjustments.md
+++ b/docs/planning/phase10-stored-value/phase10-account-transfers-and-adjustments.md
@@ -74,7 +74,13 @@ Reasons come from `stored_value_adjustment_reasons`. Do not seed `opening_balanc
 
 Staff with `stored_value.view_activity` see per-account history on customer show for store credit and trade credit, including closed accounts. Staff with `gift_cards.view` see the same table on gift-card show for that instrument’s account.
 
-Columns: store, business date, operation type, signed amount, balance-after, actor and reason snapshot when present, and a POS transaction reference when the operation is attributable to a completed POS issuance, tender, or related source row. Gift-card identity stays masked. This is UI over `stored_value_entries`; it is not a second ledger.
+Columns: store, business date, operation label, signed amount, balance-after, actor and reason snapshot when present, and a POS transaction reference when the operation is attributable to a completed POS issuance, tender, or related source row. Gift-card identity stays masked. This is UI over `stored_value_entries`; it is not a second ledger.
+
+Order entries by `stored_value_operations.occurred_at DESC`, `stored_value_operations.id DESC`, `stored_value_entries.entry_sequence DESC`.
+
+Operation labels distinguish transfer in vs out, credit vs debit adjustment, cash-out reversal, post-void reversal, and mark reversed originals.
+
+Store-scoped viewers keep every row so the running balance remains explainable. Unauthorized stores are labeled `Another store`. Actor, reason, and POS transaction links for those rows are omitted. Global assignments see store identity and provenance for every row.
 
 ## 5. Outbox
 

--- a/docs/planning/phase10-stored-value/phase10-authorization.md
+++ b/docs/planning/phase10-stored-value/phase10-authorization.md
@@ -31,9 +31,9 @@ Do **not** add `gift_cards.activate`, `gift_cards.reload`, `gift_cards.redeem`, 
 | Refund destinations (original card, new refund card, store credit) | `pos.transact` |
 | Gift-card cash-out | `gift_cards.cash_out` **and** open session |
 | Balance inquiry at Register (masked) | `pos.transact` |
-| Immediate first print after complete | `pos.transact` (same completion, until delivery is recorded); **Print gift card** voucher, not Print receipt |
-| Controlled print-recovery / replacement print | `gift_cards.recover_print` (reason required); replacement first-print voucher uses `gift_cards.replace`. Store managers may be granted `gift_cards.recover_print`. |
-| Admin/customer activity | `stored_value.view_activity` (customer-owned accounts); `gift_cards.view` (gift-card account ledger) |
+| Immediate first print after complete | `pos.transact` (same completion, originating session still open, until delivery is recorded); **Print gift card** voucher, not Print receipt |
+| Controlled print-recovery / replacement print | `gift_cards.recover_print` (reason required); replacement first-print voucher uses `gift_cards.replace` and only for a `GiftCardReplacement` new card. Store managers may be granted `gift_cards.recover_print`. |
+| Admin/customer activity | `stored_value.view_activity` (customer-owned accounts); `gift_cards.view` (gift-card account ledger). Store-scoped viewers see other stores’ amounts with store labeled `Another store`; actor, reason, and POS links are omitted. |
 | Manual adjust | `stored_value.adjust` |
 | Administrative transfer / consolidation | `stored_value.transfer` |
 | Adjustment reason catalog | `stored_value.manage_adjustment_reasons` |
@@ -63,7 +63,7 @@ Store-scoped `pos.transact` authorizes using an organization-wide customer credi
 |---|---|
 | `system_administrator` | Entire Phase 10 catalog |
 | `store_manager` | `stored_value.view_activity`, `stored_value.adjust`, `stored_value.transfer`, `gift_cards.view`, `gift_cards.suspend`, `gift_cards.replace`, `gift_cards.associate_customer`, `gift_cards.cash_out`, `gift_cards.recover_print` (not `gift_cards.manage_programs`, not `stored_value.manage_adjustment_reasons`) |
-| `associate` | No new keys. Existing `pos.transact` covers ordinary SV at the Register including first print until delivery is recorded. No cash-out, adjust, transfer, program manage, or print recovery. |
+| `associate` | No new keys. Existing `pos.transact` covers ordinary SV at the Register including first print while the originating session is open until delivery is recorded. No cash-out, adjust, transfer, program manage, or print recovery. |
 
 `gift_cards.manage_programs` and `stored_value.manage_adjustment_reasons` require a **global** assignment.
 

--- a/docs/planning/phase10-stored-value/phase10-authorization.md
+++ b/docs/planning/phase10-stored-value/phase10-authorization.md
@@ -13,13 +13,14 @@ Phase 1–9 keys are unchanged except where this document adds grants to seeded 
 | `stored_value.transfer` | either | stored_value | Same-type administrative transfer and consolidation |
 | `stored_value.manage_adjustment_reasons` | global | stored_value | Catalog of adjustment reasons |
 | `gift_cards.manage_programs` | global | gift_cards | Create/update gift-card programs |
-| `gift_cards.view` | either | gift_cards | Inquiry (masked) |
+| `gift_cards.view` | either | gift_cards | Inquiry (masked), including admin prefix + last-four history |
 | `gift_cards.suspend` | either | gift_cards | Suspend / reinstate instrument |
 | `gift_cards.replace` | either | gift_cards | Replacement / controlled transfer of remaining balance |
 | `gift_cards.associate_customer` | either | gift_cards | Set or clear optional customer association |
 | `gift_cards.cash_out` | either | gift_cards | Register cash-out of eligible gift-card balance |
+| `gift_cards.recover_print` | either | gift_cards | Exceptional recovery of a system-generated credential (reason required) |
 
-Do **not** add `gift_cards.activate`, `gift_cards.reload`, `gift_cards.redeem`, `stored_value.redeem_customer_credit`, or `gift_cards.reveal_number`. Ordinary Register actions use `pos.transact`. Full-number decryption is a controlled print/recovery service, not a general plaintext-view permission.
+Do **not** add `gift_cards.activate`, `gift_cards.reload`, `gift_cards.redeem`, `stored_value.redeem_customer_credit`, or `gift_cards.reveal_number`. Ordinary Register actions use `pos.transact`. Full-number decryption after first-print delivery uses `gift_cards.recover_print`, not a general plaintext-view permission.
 
 ## Register vs administrative
 
@@ -30,9 +31,9 @@ Do **not** add `gift_cards.activate`, `gift_cards.reload`, `gift_cards.redeem`, 
 | Refund destinations (original card, new refund card, store credit) | `pos.transact` |
 | Gift-card cash-out | `gift_cards.cash_out` **and** open session |
 | Balance inquiry at Register (masked) | `pos.transact` |
-| Immediate first print after complete | `pos.transact` (same completion) |
-| Controlled print-recovery / replacement print | Narrow service authorization (not a general reveal key); store managers may be permitted narrowly |
-| Admin/customer activity | `stored_value.view_activity` |
+| Immediate first print after complete | `pos.transact` (same completion, until delivery is recorded); **Print gift card** voucher, not Print receipt |
+| Controlled print-recovery / replacement print | `gift_cards.recover_print` (reason required); replacement first-print voucher uses `gift_cards.replace`. Store managers may be granted `gift_cards.recover_print`. |
+| Admin/customer activity | `stored_value.view_activity` (customer-owned accounts); `gift_cards.view` (gift-card account ledger) |
 | Manual adjust | `stored_value.adjust` |
 | Administrative transfer / consolidation | `stored_value.transfer` |
 | Adjustment reason catalog | `stored_value.manage_adjustment_reasons` |
@@ -45,7 +46,7 @@ Store-scoped `pos.transact` authorizes using an organization-wide customer credi
 | `stored_value.transfer` | Yes | Yes, store-scoped | No |
 | `stored_value.adjust` | Yes | Yes, store-scoped | No |
 | `stored_value.manage_adjustment_reasons` | Yes | No | No |
-| Controlled credential reprint | Through POS recovery/replacement service | Narrowly permitted | Immediate first print only |
+| `gift_cards.recover_print` | Yes | Yes, store-scoped | No |
 
 ## Second-user and Register controlled actions
 
@@ -61,8 +62,8 @@ Store-scoped `pos.transact` authorizes using an organization-wide customer credi
 | Role | Phase 10 additions |
 |---|---|
 | `system_administrator` | Entire Phase 10 catalog |
-| `store_manager` | `stored_value.view_activity`, `stored_value.adjust`, `stored_value.transfer`, `gift_cards.view`, `gift_cards.suspend`, `gift_cards.replace`, `gift_cards.associate_customer`, `gift_cards.cash_out` (not `gift_cards.manage_programs`, not `stored_value.manage_adjustment_reasons`) |
-| `associate` | No new keys. Existing `pos.transact` covers ordinary SV at the Register including first print. No cash-out, adjust, transfer, or program manage. |
+| `store_manager` | `stored_value.view_activity`, `stored_value.adjust`, `stored_value.transfer`, `gift_cards.view`, `gift_cards.suspend`, `gift_cards.replace`, `gift_cards.associate_customer`, `gift_cards.cash_out`, `gift_cards.recover_print` (not `gift_cards.manage_programs`, not `stored_value.manage_adjustment_reasons`) |
+| `associate` | No new keys. Existing `pos.transact` covers ordinary SV at the Register including first print until delivery is recorded. No cash-out, adjust, transfer, program manage, or print recovery. |
 
 `gift_cards.manage_programs` and `stored_value.manage_adjustment_reasons` require a **global** assignment.
 
@@ -74,7 +75,7 @@ Deactivate-with-balance: `customers.manage` remains the lifecycle permission; th
 
 | Kind | Contents |
 |---|---|
-| Production baseline | Permission keys; system-protected tender types `store_credit`, `trade_credit`, `gift_card`; at least two gift-card programs; adjustment-reason seed without `opening_balance` |
+| Production baseline | Permission keys including `gift_cards.recover_print`; system-protected tender types `store_credit`, `trade_credit`, `gift_card`; at least two gift-card programs; adjustment-reason seed without `opening_balance` |
 | Bootstrap / demo | Example program names/prefixes only if needed for operability |
 | Test fixtures | Synthetic numbers encrypted with the documented Rails test encryption keys |
 

--- a/docs/planning/phase10-stored-value/phase10-gift-card-numbering.md
+++ b/docs/planning/phase10-stored-value/phase10-gift-card-numbering.md
@@ -67,19 +67,36 @@ If the number must be printed **before** payment, that is out of Phase 10 (would
 
 ## 5. Print and recovery
 
-The **credential voucher** is a distinct 80mm print from the customer receipt. Ordinary **Print receipt** (including history reprint) stays masked. Explicit **Print gift card** prints the decrypted number only when first-print delivery has not yet been recorded: undelivered completed POS activation or new refund card, complete-retry before delivery, system-generated replacement of a card, or `gift_cards.recover_print`. Reloads of an existing number do not first-print. Manual/external replacements that already have a physical number do not need generated-credential print.
+The **credential voucher** is a distinct 80mm print from the customer receipt. Ordinary **Print receipt** (including history reprint) stays masked. Explicit **Print gift card** prints the decrypted number only when first-print delivery has not yet been recorded **and** the originating POS session is still open: undelivered completed POS activation or new refund card, or complete-retry of that outcome before delivery while the session remains open. After the session closes, recovery requires `gift_cards.recover_print` plus a reason. System-generated replacement of a card uses the replacement credential route only for a card that is the `replacement_gift_card` on a `GiftCardReplacement`. Reloads of an existing number do not first-print. Manual/external replacements that already have a physical number do not need generated-credential print.
 
-On-screen completed-transaction copy may list undelivered credentials. The voucher HTML is **not** inside `.pos-receipt__screen` (print CSS hides that block). After delivery, **Print gift card** is gone; recover-print is the exceptional path.
+On-screen completed-transaction copy may list undelivered credentials. The voucher HTML is **not** inside `.pos-receipt__screen` (print CSS hides that block). After delivery, **Print gift card** is gone; recover-print is the exceptional path. Responses that include a full number send `Cache-Control: no-store`.
+
+Printed voucher order, centered on 80 mm:
+
+```text
+Store legal name
+address and phone (omit blank lines)
+Issued: {completed_at in the Store timezone, same format as receipts}
+{amount}
+Gift Card
+[Code 128 of the normalized number]
+PPP RRRR RRRR RRRR RRRR C
+{system_settings.gift_card_voucher_footer, when present}
+```
+
+The human-readable number is the space-separated grouping from §1 (strip separators before lookup). Do not print a hyphenated form, per-digit spacing, program name, or issuance kind on the voucher. Barcode payload is the normalized digits. One slip per credential, with a page break between cards.
+
+The voucher footer is organization configuration (`system_settings.gift_card_voucher_footer`): plain text, 500-character limit after trim. Blank omits the footer. The token `{organization legal name}` is replaced with `system_settings.legal_name` when that name is present. Store receipt header/footer messages are not used on this slip.
 
 | Channel | Full number |
 |---|---|
 | Credential voucher (undelivered first print) | Yes |
-| Idempotent retry of same completion before delivery is recorded | Yes |
+| Idempotent retry of same completion before delivery, originating session still open | Yes |
 | Ordinary Print receipt / later completed-transaction view / history / envelope | No |
 | Controlled print-recovery service (`gift_cards.recover_print` + reason) | Only with reason and appropriate authority |
-| System-generated replacement | Print new credential voucher once; do not reveal old |
+| System-generated replacement | Print new credential voucher once for the replacement card only; do not reveal old; do not use this route for ordinary POS cards |
 
-First-print delivery is mutable processing state (`pos_gift_card_credential_deliveries`), not an edit of the completed POS fact. POS completions key delivery by transaction. System-generated replacements key delivery by the new gift card. The first successful first-print call records delivery. After that, print recovery or another replacement is the path to a credential.
+First-print delivery is mutable processing state (`pos_gift_card_credential_deliveries`), not an edit of the completed POS fact. POS completions key delivery by transaction. System-generated replacements key delivery by the new gift card. `Pos::FirstPrint` decrypts only while the originating session is open and no delivery row exists; the first successful first-print call then records delivery. After session close, or after delivery, print recovery or another replacement is the path to a credential.
 
 Print failure after commit does not reopen the transaction ([receipt-presentation.md](../phase4-6-point-of-sale/phase6-pos-mvp/receipt-presentation.md)). Recovery is the print-recovery service or replacement—not a general reveal screen and not unused-instrument return (deferred).
 

--- a/docs/planning/phase10-stored-value/phase10-gift-card-numbering.md
+++ b/docs/planning/phase10-stored-value/phase10-gift-card-numbering.md
@@ -1,6 +1,6 @@
 # Phase 10 — Gift-card numbering and scan routing
 
-Status: **Proposed**. Policy: [ADR-026](../../adr/ADR-026-gift-card-number-protection.md).
+Status: **Proposed**. Policy: [ADR-026](../../adr/ADR-026-gift-card-number-protection.md), [ADR-027](../../adr/ADR-027-admin-gift-card-prefix-last-four-inquiry.md).
 
 ### Actually locked
 
@@ -8,13 +8,13 @@ Status: **Proposed**. Policy: [ADR-026](../../adr/ADR-026-gift-card-number-prote
 20-digit dedicated namespace; not identifier_registry
 PPP + body + Luhn check digit
 system_generated vs manual_external programs
-exact digest lookup; throttle; generic failure
+exact digest lookup for operational use; admin history may use prefix+last-four ([ADR-027](../../adr/ADR-027-admin-gift-card-prefix-last-four-inquiry.md)); throttle; generic failure
 GiftCard encrypts :number using default nondeterministic Active Record Encryption
 PosStoredValueIssuance encrypts :pending_card_number
 PosStoredValueTenderDetail encrypts :pending_card_number
 HMAC digest remains the exact lookup and uniqueness key
 generate at completion; no reservation table
-ordinary reprint masked; no general reveal permission
+ordinary reprint masked; dedicated credential voucher for first print and system-generated replacement; no general reveal permission
 scan: gift-card shape before merchandise lookup (Register integration is 10.4; 10.3 uses the resolver for admin inquiry only)
 ```
 
@@ -53,9 +53,9 @@ Unknown numbers cannot be redeemed, reloaded, inquired, replaced, or cashed out.
 | Prefix, last four | Fixtures with production keys or plaintext production-like numbers |
 | Pending working numbers via `encrypts :pending_card_number` | Ciphertext in exception messages; custom `encryption_key_id` columns |
 
-Lookup: compute digest of normalized input; equality on `number_digest`. Repeated encrypted writes must not rely on ciphertext equality. Active Record Encryption keys use the standard Rails credentials/environment mechanism. HMAC secret is separate. Docker/CI uses documented test keys.
+Operational lookup: compute digest of normalized input; equality on `number_digest`. Repeated encrypted writes must not rely on ciphertext equality. Active Record Encryption keys use the standard Rails credentials/environment mechanism. HMAC secret is separate. Docker/CI uses documented test keys. Admin history inquiry may also match `number_prefix` + `number_last_four` ([ADR-027](../../adr/ADR-027-admin-gift-card-prefix-last-four-inquiry.md)); that path is not used for POS redeem, reload, cash-out, or original-card refund.
 
-Number identity on `gift_cards` is immutable after insert.
+Number identity on `gift_cards` is immutable after insert, including the encrypted `number` attribute. Normalized number, digest, prefix, and last four must agree.
 
 ## 4. Generation timing and pending identity
 
@@ -67,13 +67,19 @@ If the number must be printed **before** payment, that is out of Phase 10 (would
 
 ## 5. Print and recovery
 
+The **credential voucher** is a distinct 80mm print from the customer receipt. Ordinary **Print receipt** (including history reprint) stays masked. Explicit **Print gift card** prints the decrypted number only when first-print delivery has not yet been recorded: undelivered completed POS activation or new refund card, complete-retry before delivery, system-generated replacement of a card, or `gift_cards.recover_print`. Reloads of an existing number do not first-print. Manual/external replacements that already have a physical number do not need generated-credential print.
+
+On-screen completed-transaction copy may list undelivered credentials. The voucher HTML is **not** inside `.pos-receipt__screen` (print CSS hides that block). After delivery, **Print gift card** is gone; recover-print is the exceptional path.
+
 | Channel | Full number |
 |---|---|
-| Controlled first print | Yes |
-| Idempotent retry of same completion | Yes |
-| Ordinary reprint / history / envelope | No |
-| Controlled print-recovery service | Only with reason and appropriate authority |
-| Replacement | Print new credential; do not reveal old |
+| Credential voucher (undelivered first print) | Yes |
+| Idempotent retry of same completion before delivery is recorded | Yes |
+| Ordinary Print receipt / later completed-transaction view / history / envelope | No |
+| Controlled print-recovery service (`gift_cards.recover_print` + reason) | Only with reason and appropriate authority |
+| System-generated replacement | Print new credential voucher once; do not reveal old |
+
+First-print delivery is mutable processing state (`pos_gift_card_credential_deliveries`), not an edit of the completed POS fact. POS completions key delivery by transaction. System-generated replacements key delivery by the new gift card. The first successful first-print call records delivery. After that, print recovery or another replacement is the path to a credential.
 
 Print failure after commit does not reopen the transaction ([receipt-presentation.md](../phase4-6-point-of-sale/phase6-pos-mvp/receipt-presentation.md)). Recovery is the print-recovery service or replacement—not a general reveal screen and not unused-instrument return (deferred).
 
@@ -81,7 +87,7 @@ Audit records card identity by ID and last four only.
 
 ## 6. Inquiry and abuse
 
-Exact match only. Generic failure (do not distinguish missing vs suspended unless the operator already has `gift_cards.view` and a successful digest hit). Throttle and audit repeated failures **without** storing the submitted number.
+Operational lookup is exact digest only. Admin/management inquiry may use prefix + last four per [ADR-027](../../adr/ADR-027-admin-gift-card-prefix-last-four-inquiry.md). Generic failure (do not distinguish missing vs suspended unless the operator already has `gift_cards.view` and a successful digest hit). Ambiguous prefix + last-four matches show a short masked candidate list. Throttle and audit repeated failures **without** storing the submitted number. Successful and ambiguous admin inquiries audit IDs and last four only.
 
 No PIN in Phase 10.
 

--- a/docs/planning/phase10-stored-value/phase10-manual-test-plan.md
+++ b/docs/planning/phase10-stored-value/phase10-manual-test-plan.md
@@ -7,8 +7,8 @@ Do not treat this as a substitute for CI.
 ## 1. Register — issuance and tenders
 
 1. Activate a manual-number card with merchandise in one ticket; amount due = merchandise + tax + issuance; receipt shows issuance separately; last four only on reprint.
-2. Activate a system-generated card; on-screen list and **Print gift card** voucher show the full number; **Print receipt** is masked; refresh or reopen the completed-transaction page is masked; reprint is masked.
-3. Kill the client after complete before print; retry complete; first-print path still available without a second liability; after the first successful first print, recovery requires `gift_cards.recover_print`.
+2. Activate a system-generated card; on-screen list and **Print gift card** voucher show the full number (space-separated grouping under the barcode); **Print receipt** is masked; refresh or reopen the completed-transaction page is masked; reprint is masked. Store identity and `Issued:` print on the voucher; the organization gift-card footer prints only when `system_settings.gift_card_voucher_footer` is set.
+3. Kill the client after complete before print; while the originating session is open, retry complete or reopen the completed-transaction page to first-print without a second liability; after session close, or after the first successful first print, recovery requires `gift_cards.recover_print`.
 4. Reload an existing card; remaining balance increases only after complete; abandon working ticket has no effect.
 5. Redeem gift card partial + cash; split SV tenders on two cards.
 6. Attach customer via Register search (not UUID paste); change or clear on a working ticket; redeem store credit; refuse merged or inactive customer; pickup does not auto-attach.
@@ -69,6 +69,7 @@ Do not treat this as a substitute for CI.
 5. Ordinary reprint masked.
 6. Controlled retry prints original credential.
 7. Print recovery requires reason and `gift_cards.recover_print`; no general reveal screen.
+8. Organization gift-card voucher footer can be set, changed, and cleared under System settings; blank omits the footer on the next voucher print.
 
 ## 7. Admin, merge, security
 

--- a/docs/planning/phase10-stored-value/phase10-manual-test-plan.md
+++ b/docs/planning/phase10-stored-value/phase10-manual-test-plan.md
@@ -7,11 +7,11 @@ Do not treat this as a substitute for CI.
 ## 1. Register — issuance and tenders
 
 1. Activate a manual-number card with merchandise in one ticket; amount due = merchandise + tax + issuance; receipt shows issuance separately; last four only on reprint.
-2. Activate a system-generated card; first print shows full number; reprint is masked.
-3. Kill the client after complete before print; retry complete; first-print path still available without a second liability.
+2. Activate a system-generated card; on-screen list and **Print gift card** voucher show the full number; **Print receipt** is masked; refresh or reopen the completed-transaction page is masked; reprint is masked.
+3. Kill the client after complete before print; retry complete; first-print path still available without a second liability; after the first successful first print, recovery requires `gift_cards.recover_print`.
 4. Reload an existing card; remaining balance increases only after complete; abandon working ticket has no effect.
 5. Redeem gift card partial + cash; split SV tenders on two cards.
-6. Attach customer; redeem store credit; refuse merged or inactive customer.
+6. Attach customer via Register search (not UUID paste); change or clear on a working ticket; redeem store credit; refuse merged or inactive customer; pickup does not auto-attach.
 7. Redeem trade credit issued by admin adjust.
 8. Attempt activate + redeem in one ticket — blocked.
 9. Attempt reload + redeem in one ticket — blocked.
@@ -21,8 +21,8 @@ Do not treat this as a substitute for CI.
 
 1. Original gift card present and matching — refund original; remaining on that card increases.
 2. Wrong gift card presented — blocked; masked history is not sufficient.
-3. Original gift card unavailable → new generated refund card; first print shows full number; not an issuance; `stored_value_issuance_cents` unchanged.
-4. Original unavailable → manually numbered refund card.
+3. Original gift card unavailable → new generated refund card; first print shows full number; not an issuance; `stored_value_issuance_cents` unchanged; amount cannot exceed remaining gift-card-funded portion.
+4. Original unavailable → manually numbered refund card, still capped at remaining gift-card-funded portion.
 5. Original unavailable → customer store credit (customer required).
 6. New refund card complete retry creates only one instrument/liability.
 7. Trade credit is not offered as a generic destination.
@@ -68,14 +68,14 @@ Do not treat this as a substitute for CI.
 4. Logs/audit/outbox/envelope omit full number.
 5. Ordinary reprint masked.
 6. Controlled retry prints original credential.
-7. Print recovery requires reason and authority; no general reveal screen.
+7. Print recovery requires reason and `gift_cards.recover_print`; no general reveal screen.
 
 ## 7. Admin, merge, security
 
-1. Customer show balances require `stored_value.view_activity`.
+1. Customer show balances require `stored_value.view_activity`; per-account history paginates; closed accounts remain in history; gift-card show lists masked entries.
 2. Deactivate customer with nonzero store credit — warn/block.
 3. Gift-card association follows merge; balance stays on the instrument.
-4. Failed inquiry throttle; lists never show full numbers.
+4. Failed inquiry throttle; lists never show full numbers. Prefix + last-four unique match opens the card; collisions show a masked candidate list; POS redeem with prefix + last four does not resolve.
 5. Lookup code colliding with program prefix cannot be saved.
 
 ## 8. Navigation and UDS

--- a/docs/planning/phase10-stored-value/phase10-pos-issuance-and-tenders.md
+++ b/docs/planning/phase10-stored-value/phase10-pos-issuance-and-tenders.md
@@ -76,7 +76,11 @@ Register basket: distinct issuance section (UDS-3 hierarchy), not a merchandise 
 
 ## 4. Customer on the transaction
 
-`pos_transactions.customer_id` is new and optional.
+`pos_transactions.customer_id` is optional. Gift-card-only tickets do not require a customer.
+
+Cashiers attach a customer through operational Register search (`Customers::Search` mode `:operational` and `GET register/customer_search`), not by pasting a UUID. Working tickets may change or clear the customer with the same lock and cashier rules as attach. Pickup remains a request allocation and does **not** set `customer_id` unless a later packet decides otherwise. Creating a customer from the Register is out of this slice.
+
+The attached customer name appears on the completed-transaction screen and on the customer receipt header. It is not a CRM dump.
 
 At completion, if any tender is store/trade credit or destination mode is `customer_store_credit`:
 
@@ -84,7 +88,7 @@ At completion, if any tender is store/trade credit or destination mode is `custo
 - Each such tender’s account belongs to that customer
 - Revalidate customer and accounts under lock
 
-Gift-card payment tenders and new-refund-card destinations do not require a transaction customer.
+Gift-card payment tenders and new-refund-card destinations do not require a transaction customer. If store/trade tender is attempted with no customer, the server still rejects; the Register surfaces the customer-search overlay.
 
 ## 5. Tender types
 
@@ -104,9 +108,9 @@ Inside the existing complete transaction (inventory, tax, envelope, outbox):
 8. Build envelope from persisted Core (masked numbers only).
 9. Commit atomically. Failure rolls back POS and SV.
 
-Command payload includes expected signed_net, issuance cents, tender plan, destination modes, and “generate from program X” — not the resulting number.
+Command payload includes expected signed_net, issuance cents, tender plan, destination modes, and “generate from program X” — not the resulting number or generated `gift_card_id` on activations and new refund cards.
 
-Complete-retry (ADR-009): same command hash returns stored envelope **and** may decrypt for the controlled first-print channel. The public envelope still has last four only.
+Complete-retry (ADR-009): same command hash returns stored envelope **and** may decrypt for the controlled first-print channel until delivery is recorded. The public envelope still has last four only. After first-print delivery, later views stay masked.
 
 ## 7. Envelope vs Core
 

--- a/docs/planning/phase10-stored-value/phase10-pos-issuance-and-tenders.md
+++ b/docs/planning/phase10-stored-value/phase10-pos-issuance-and-tenders.md
@@ -110,7 +110,7 @@ Inside the existing complete transaction (inventory, tax, envelope, outbox):
 
 Command payload includes expected signed_net, issuance cents, tender plan, destination modes, and “generate from program X” — not the resulting number or generated `gift_card_id` on activations and new refund cards.
 
-Complete-retry (ADR-009): same command hash returns stored envelope **and** may decrypt for the controlled first-print channel until delivery is recorded. The public envelope still has last four only. After first-print delivery, later views stay masked.
+Complete-retry (ADR-009): same command hash returns stored envelope **and** may decrypt for the controlled first-print channel until delivery is recorded **and** the originating session is still open. The public envelope still has last four only. After first-print delivery, or after the session closes, later views stay masked; recovery uses `gift_cards.recover_print`.
 
 ## 7. Envelope vs Core
 

--- a/docs/planning/phase10-stored-value/phase10-refund-post-void.md
+++ b/docs/planning/phase10-stored-value/phase10-refund-post-void.md
@@ -28,9 +28,9 @@ For an amount originally paid by gift card:
 4. Never create trade credit.
 5. Do not convert the amount directly to cash except through a separately eligible gift-card cash-out after refund completion.
 
-A new gift card is not a generic destination for arbitrary refund value. It is permitted as a substitute bearer instrument for value originally paid by gift card.
+A new gift card is not a generic destination for arbitrary refund value. It is permitted as a substitute bearer instrument for value originally paid by gift card. Original-card, new-card, and original-trade-credit allocations are capped at the remaining funded portion: original payments of that stored-value type on the linked original transactions, minus completed (non-post-voided) refunds already sent to those destinations. Completion locks the original transactions and revalidates the cap.
 
-Trade-credit-funded portions may return to the **original** trade-credit account (`allows_original_tender_refund`). Trade credit is not a generic leftover destination.
+Trade-credit-funded portions may return to the **original** trade-credit account (`allows_original_tender_refund`), still capped at the remaining trade-credit-funded portion. Trade credit is not a generic leftover destination.
 
 Store credit may receive leftover refund value (`allows_generic_refund_destination`) when a customer is attached.
 

--- a/docs/planning/phase10-stored-value/phase10-reporting-closeout.md
+++ b/docs/planning/phase10-stored-value/phase10-reporting-closeout.md
@@ -78,4 +78,4 @@ No GL export status.
 
 ## 5. Print
 
-See [phase10-gift-card-numbering.md](phase10-gift-card-numbering.md) and [receipt-presentation.md](../phase4-6-point-of-sale/phase6-pos-mvp/receipt-presentation.md). Customer paper: issuance, redemption, remaining balance (masked), refund destinations, cash-out. Full number only on controlled first print, complete-retry, or print recovery.
+See [phase10-gift-card-numbering.md](phase10-gift-card-numbering.md) and [receipt-presentation.md](../phase4-6-point-of-sale/phase6-pos-mvp/receipt-presentation.md). Customer paper: issuance, redemption, remaining balance (masked), refund destinations, cash-out. Full number only on controlled first print while the originating session is open, complete-retry of that outcome before delivery, or print recovery.

--- a/docs/planning/phase10-stored-value/phase10-schema.md
+++ b/docs/planning/phase10-stored-value/phase10-schema.md
@@ -384,7 +384,7 @@ Mutable first-print delivery state, kept off the commercially immutable `pos_tra
 | `delivered_at` | timestamptz | Required; set when first print discloses a generated credential |
 | timestamps | timestamptz | Required |
 
-Exactly one of `pos_transaction_id` or `gift_card_id` is set. Presence means later views for that subject stay masked. Idempotent complete-retry may still first-print until the POS transaction delivery row exists. Replacement vouchers stamp the new gift card, not a second reveal of the old number.
+Exactly one of `pos_transaction_id` or `gift_card_id` is set. Presence means later views for that subject stay masked. `Pos::FirstPrint` decrypts only while the originating POS session is open and no delivery row exists. Idempotent complete-retry may still first-print until that delivery row exists **and** the session remains open. After session close, `gift_cards.recover_print` is required. Replacement vouchers require a `GiftCardReplacement` for that new card and stamp the new gift card, not a second reveal of the old number.
 
 Composite index on `gift_cards (number_prefix, number_last_four)` supports admin history inquiry ([ADR-027](../../adr/ADR-027-admin-gift-card-prefix-last-four-inquiry.md)). It is not unique.
 
@@ -407,6 +407,7 @@ These are integration messages, not `financial_events` rows.
 ## 13. System settings
 
 - Manual-adjustment approval threshold (organization): `system_settings.stored_value_adjust_credit_approval_threshold_cents` (default 5000). Credits at or above require second user; all debit adjustments require second user.
+- Gift-card voucher footer (organization): `system_settings.gift_card_voucher_footer` (text, max 500 after trim). Printed on every credential voucher; blank omits the footer. `{organization legal name}` is replaced with `system_settings.legal_name`. Plain text wrapping; not a per-Store inherit/custom/none message.
 - Do not put gift-card cash-out threshold here (program-level).
 
 ## 14. Idempotency

--- a/docs/planning/phase10-stored-value/phase10-schema.md
+++ b/docs/planning/phase10-stored-value/phase10-schema.md
@@ -207,7 +207,7 @@ Seed at least one `system_generated` and one `manual_external` program with non-
 encrypts :number
 ```
 
-Default nondeterministic Active Record Encryption. No caller-selected encryption scheme. No custom per-row key ID. HMAC secret is separate from Active Record Encryption keys. Number identity is immutable after insert.
+Default nondeterministic Active Record Encryption. No caller-selected encryption scheme. No custom per-row key ID. HMAC secret is separate from Active Record Encryption keys. Number identity is immutable after insert, including the encrypted `number` attribute. Digest, prefix, and last four must agree with the normalized number.
 
 Do not persist plaintext numbers in logs or public columns. Lifecycle starts at `active` when activation or refund-card creation completes. No preregistration table. No working-transaction reservation table in Phase 10.
 
@@ -371,6 +371,22 @@ Rules:
 - Trade credit as a **generic** refund destination is prohibited (original-tender refund to the original trade account remains allowed).
 - Completed detail retains account/card and masked snapshots.
 - New refund card does not increase `stored_value_issuance_cents`.
+
+### 11.6 `pos_gift_card_credential_deliveries`
+
+Mutable first-print delivery state, kept off the commercially immutable `pos_transactions` row ([ADR-013](../../adr/ADR-013-append-only-facts.md)).
+
+| Column | Type | Contract |
+|---|---|---|
+| `id` | uuid | UUIDv7 PK |
+| `pos_transaction_id` | uuid, nullable | Unique when present; POS first-print subject |
+| `gift_card_id` | uuid, nullable | Unique when present; system-generated replacement first-print subject |
+| `delivered_at` | timestamptz | Required; set when first print discloses a generated credential |
+| timestamps | timestamptz | Required |
+
+Exactly one of `pos_transaction_id` or `gift_card_id` is set. Presence means later views for that subject stay masked. Idempotent complete-retry may still first-print until the POS transaction delivery row exists. Replacement vouchers stamp the new gift card, not a second reveal of the old number.
+
+Composite index on `gift_cards (number_prefix, number_last_four)` supports admin history inquiry ([ADR-027](../../adr/ADR-027-admin-gift-card-prefix-last-four-inquiry.md)). It is not unique.
 
 ## 12. Outbox
 

--- a/docs/planning/phase10-stored-value/phase10-user-stories.md
+++ b/docs/planning/phase10-stored-value/phase10-user-stories.md
@@ -169,8 +169,9 @@ GitHub-issue-ready stories. Keep 10.4 issuance and signed-net in the same implem
 - DB signed-net identity includes `stored_value_issuance_cents`
 - Envelope golden files updated; Core FKs on source rows
 - Working manual activation uses encrypted pending identity; `gift_card_id` null until complete
-- Controlled first print after generated-card activation and generated refund cards; complete-retry reprints that outcome; ordinary receipts stay masked
+- Controlled first print after generated-card activation and generated refund cards while the originating session is open; after session close, `gift_cards.recover_print`; complete-retry reprints that outcome only before delivery and while the session is open; ordinary receipts stay masked
 - Credential voucher is a distinct 80mm print from the customer receipt; **Print receipt** never includes the full number; **Print gift card** is the first-print channel until delivery is recorded
+- Voucher paper: Store identity, issued timestamp, amount, `Gift Card`, Code 128, space-separated number; organization `gift_card_voucher_footer` when set
 - Register gift-card scan routing (sale, activation, reload, redeem, refund)
 - Every new POS transaction snapshots `system_settings.base_currency_code`
 

--- a/docs/planning/phase10-stored-value/phase10-user-stories.md
+++ b/docs/planning/phase10-stored-value/phase10-user-stories.md
@@ -93,8 +93,16 @@ GitHub-issue-ready stories. Keep 10.4 issuance and signed-net in the same implem
 ### US-10.2.5 — Customer activity
 
 **As** staff with `stored_value.view_activity`  
-**I want** balances and recent operations on customer show  
-**So that** I can explain the account without seeing gift-card full numbers.
+**I want** balances and per-account ledger history on customer show  
+**So that** I can explain store and trade credit without seeing gift-card full numbers.
+
+**Acceptance:**
+
+- Open balances remain on customer show; closed customer-owned accounts stay visible in history
+- Each store-credit and trade-credit account has paginated activity (store, business date, operation type, amount, balance-after, actor/reason when present, POS reference when attributable)
+- Gift-card show uses `gift_cards.view` for the same table on that card’s account
+- No plaintext gift-card numbers; gift-card rows stay masked
+- Policy: [phase10-account-transfers-and-adjustments.md](phase10-account-transfers-and-adjustments.md)
 
 ### US-10.2.6 — Transfer customer credit
 
@@ -139,6 +147,14 @@ GitHub-issue-ready stories. Keep 10.4 issuance and signed-net in the same implem
 **I want** masked inquiry, suspend/reinstate, replacement, and optional customer association  
 **So that** bearer cards can be administered without changing ledger ownership rules.
 
+**Acceptance:**
+
+- Exact-number inquiry remains digest lookup
+- Admin history may inquire by prefix + last four ([ADR-027](../../adr/ADR-027-admin-gift-card-prefix-last-four-inquiry.md)): unique match opens the card; collisions show a short masked candidate list; zero matches use the generic failure
+- POS redeem, reload, cash-out, and original-card refund stay exact digest
+- Replacement of a system-generated card lands on a one-shot credential voucher for the **new** number; the old number is not revealed
+- Manual/external replacements that already have a physical number do not print a generated credential
+
 ## 10.4 — POS commercial
 
 ### US-10.4.1 — Issuance child and signed-net
@@ -154,6 +170,7 @@ GitHub-issue-ready stories. Keep 10.4 issuance and signed-net in the same implem
 - Envelope golden files updated; Core FKs on source rows
 - Working manual activation uses encrypted pending identity; `gift_card_id` null until complete
 - Controlled first print after generated-card activation and generated refund cards; complete-retry reprints that outcome; ordinary receipts stay masked
+- Credential voucher is a distinct 80mm print from the customer receipt; **Print receipt** never includes the full number; **Print gift card** is the first-print channel until delivery is recorded
 - Register gift-card scan routing (sale, activation, reload, redeem, refund)
 - Every new POS transaction snapshots `system_settings.base_currency_code`
 
@@ -166,6 +183,7 @@ GitHub-issue-ready stories. Keep 10.4 issuance and signed-net in the same implem
 **Acceptance:**
 
 - Customer required and revalidated for store/trade
+- Cashiers attach, change, or clear the customer via operational search on working tickets; gift-card-only tickets do not require a customer; pickup does not auto-attach
 - Multiple SV tenders allowed; lock UUID order
 - Same-transaction activate/reload + redeem forbidden
 - One detail row per stored-value tender
@@ -224,7 +242,11 @@ GitHub-issue-ready stories. Keep 10.4 issuance and signed-net in the same implem
 **I want** controlled print recovery of a generated credential with a reason  
 **So that** a failed first print can be recovered without a general reveal screen.
 
-First print of generated activation and refund cards ships in 10.4. This slice adds exceptional recovery, cash-out receipts, and X/Z print polish.
+**Acceptance:**
+
+- Requires `gift_cards.recover_print` and a reason
+- Audits last four only; does not write the number
+- `gift_cards.view` alone is not sufficient
 
 ### US-10.5.4 — Cash-out and reporting navigation
 

--- a/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/receipt-presentation.md
+++ b/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/receipt-presentation.md
@@ -892,7 +892,7 @@ A reprint may differ from the original physical paper in Store legal name, addre
 
 No reprint table. **No reprint audit** — 6.3 stands (`window.print` stays client-side). This contract does not add print-attempt persistence.
 
-Phase 10: ordinary POS reprints stay masked. Full generated gift-card numbers appear only on controlled first print, complete-retry of that outcome, or exceptional print recovery with a reason (`GiftCards::PrintRecovery`). Gift-card cash-out has its own receipt (masked number, amount, remaining balance); it is not a tender line.
+Phase 10: ordinary POS reprints stay masked. Full generated gift-card numbers appear only on the dedicated **credential voucher** (controlled first print, complete-retry of that outcome before delivery, system-generated replacement voucher, or exceptional print recovery with a reason (`GiftCards::PrintRecovery`)). **Print receipt** never includes the full number. Gift-card cash-out has its own receipt (masked number, amount, remaining balance); it is not a tender line.
 
 ---
 
@@ -949,7 +949,7 @@ commit immutable facts
 render/print receipt
 ```
 
-Phase 10 cash-out commits `gift_card_cash_outs` then renders/prints a cash-out receipt. Print recovery after a failed first print does not reopen the stored-value fact.
+Phase 10 cash-out commits `gift_card_cash_outs` then renders/prints a cash-out receipt. Gift-card credential vouchers are a separate print from the customer receipt; they use the same 80mm browser print CSS. Print recovery after a failed first print does not reopen the stored-value fact.
 
 ---
 

--- a/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/receipt-presentation.md
+++ b/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/receipt-presentation.md
@@ -892,7 +892,9 @@ A reprint may differ from the original physical paper in Store legal name, addre
 
 No reprint table. **No reprint audit** — 6.3 stands (`window.print` stays client-side). This contract does not add print-attempt persistence.
 
-Phase 10: ordinary POS reprints stay masked. Full generated gift-card numbers appear only on the dedicated **credential voucher** (controlled first print, complete-retry of that outcome before delivery, system-generated replacement voucher, or exceptional print recovery with a reason (`GiftCards::PrintRecovery`)). **Print receipt** never includes the full number. Gift-card cash-out has its own receipt (masked number, amount, remaining balance); it is not a tender line.
+Phase 10: ordinary POS reprints stay masked. Full generated gift-card numbers appear only on the dedicated **credential voucher** (controlled first print while the originating session is open, complete-retry of that outcome before delivery while the session remains open, system-generated replacement voucher, or exceptional print recovery with a reason (`GiftCards::PrintRecovery`)). **Print receipt** never includes the full number. Gift-card cash-out has its own receipt (masked number, amount, remaining balance); it is not a tender line.
+
+The credential voucher is a separate 80 mm slip from the customer receipt. Layout: current Store identity (`stores.legal_name`, address, phone), `Issued:` timestamp, amount, the title `Gift Card`, Code 128 of the normalized number, the space-separated presentation from [phase10-gift-card-numbering.md](../../phase10-stored-value/phase10-gift-card-numbering.md) §1, then `system_settings.gift_card_voucher_footer` when that organization setting is present. The footer is plain text with the same 500-character limit as receipt messages; it is not inherited per Store. `{organization legal name}` is replaced with the organization legal name. Blank omits the footer.
 
 ---
 
@@ -949,7 +951,7 @@ commit immutable facts
 render/print receipt
 ```
 
-Phase 10 cash-out commits `gift_card_cash_outs` then renders/prints a cash-out receipt. Gift-card credential vouchers are a separate print from the customer receipt; they use the same 80mm browser print CSS. Print recovery after a failed first print does not reopen the stored-value fact.
+Phase 10 cash-out commits `gift_card_cash_outs` then renders/prints a cash-out receipt. Gift-card credential vouchers are a separate print from the customer receipt; they use the same 80mm browser print CSS and the voucher layout in [phase10-gift-card-numbering.md](../../phase10-stored-value/phase10-gift-card-numbering.md) §5. Print recovery after a failed first print does not reopen the stored-value fact.
 
 ---
 
@@ -1067,7 +1069,7 @@ Add database CHECK constraints for the mode enums. Where practical, add database
 
 Receipt configuration remains ordinary mutable administrative configuration.
 
-Changes to Store legal name/address/phone, Store receipt mode, Store receipt custom text, and System default receipt header/footer should use the existing configuration audit conventions.
+Changes to Store legal name/address/phone, Store receipt mode, Store receipt custom text, System default receipt header/footer, and `system_settings.gift_card_voucher_footer` should use the existing configuration audit conventions.
 
 Rendering or reprinting a receipt does not modify completed commercial facts and does not create a reprint audit event.
 

--- a/lib/tasks/shelfsense.rake
+++ b/lib/tasks/shelfsense.rake
@@ -40,7 +40,7 @@ namespace :shelfsense do
     puts "Administrator: #{result[:administrator].username}"
   end
 
-  desc "Idempotently seed permissions and system role grants from PermissionCatalog"
+  desc "Idempotently seed permissions, system role grants, catalogs, and protected tender types"
   task seed_permissions: :environment do
     granted_by = User.system_actors.order(:created_at).first
     abort "No system actor found. Bootstrap the installation first." if granted_by.nil?
@@ -51,11 +51,13 @@ namespace :shelfsense do
     SubjectSchemes::Catalog.seed!
     StoredValue::AdjustmentReasons.seed!
     GiftCards::Programs.seed!
+    Pos::TenderTypes.seed!
     after = Role.find_by!(key: "system_administrator").permissions.pluck(:key)
 
     added = after - before
     puts "Permission catalog seeded."
     puts "Permissions: #{Permission.count}"
+    puts "Tender types: #{TenderType.order(:code).pluck(:code).join(', ')}"
     puts "system_administrator grants: #{after.size}"
     puts "Newly granted to system_administrator: #{added.sort.join(', ')}" if added.any?
   end

--- a/test/integration/gift_cards_admin_test.rb
+++ b/test/integration/gift_cards_admin_test.rb
@@ -60,14 +60,68 @@ class GiftCardsAdminTest < ActionDispatch::IntegrationTest
     new_card = original.reload.replaced_by
     assert_redirected_to credential_admin_gift_card_path(new_card)
     follow_redirect!
+    voucher = css_select(".pos-gift-card-voucher").first
+    presented = GiftCards::Number.present(new_card.number, prefix: new_card.number_prefix)
+    assert voucher
+    assert_includes voucher.text, @store.legal_name
+    assert_includes voucher.text, "Gift Card"
+    assert_includes voucher.text, presented
     assert_includes response.body, new_card.number
     refute_includes response.body, old_number
+    assert_match(/no-store/, response.headers["Cache-Control"].to_s)
+    assert css_select(".pos-gift-card-voucher svg[aria-label='#{new_card.number}']").any?
+    assert_empty css_select(".pos-gift-card-voucher__footer")
     assert_match "Print gift card", response.body
 
     get credential_admin_gift_card_path(new_card)
     assert_redirected_to admin_gift_card_path(new_card)
     follow_redirect!
     refute_includes response.body, new_card.number
+  end
+
+  test "replacement credential route does not reveal a POS or provisioned card" do
+    card = GiftCards::ProvisionInstrument.call(program: @program, store: @store)
+    GiftCards::Fund.call(gift_card: card, amount_cents: 250, store: @store, performed_by: @admin)
+
+    get credential_admin_gift_card_path(card)
+    assert_redirected_to admin_gift_card_path(card)
+    follow_redirect!
+    refute_includes response.body, card.number
+    assert_includes response.body, card.masked_number
+  end
+
+  test "print recovery sets Cache-Control no-store when the number is disclosed" do
+    card = GiftCards::ProvisionInstrument.call(program: @program, store: @store)
+    GiftCards::Fund.call(gift_card: card, amount_cents: 150, store: @store, performed_by: @admin)
+
+    post print_recovery_admin_gift_card_path(card), params: { reason: "printer jammed" }
+    assert_response :success
+    assert_includes response.body, card.number
+    assert_match(/no-store/, response.headers["Cache-Control"].to_s)
+  end
+
+  test "store-scoped activity redacts another store's identity" do
+    other = Store.create!(
+      store_number: 92,
+      code: "gc_east",
+      name: "East Gift Store",
+      legal_name: "East Gift LLC",
+      timezone: "America/New_York",
+      country_code: "US"
+    )
+    card = GiftCards::ProvisionInstrument.call(program: @program, store: @store)
+    GiftCards::Fund.call(gift_card: card, amount_cents: 200, store: @store, performed_by: @admin)
+    GiftCards::Fund.call(gift_card: card, amount_cents: 75, store: other, performed_by: @admin)
+    manager = pos_store_manager(store: @store, assigned_by: @admin, username: "gc_activity_mgr")
+
+    delete session_path
+    sign_in_as("gc_activity_mgr")
+    post store_selection_path, params: { store_id: @store.id }
+    get admin_gift_card_path(card)
+    assert_response :success
+    assert_includes response.body, "Another store"
+    refute_includes response.body, other.admin_label
+    assert_includes response.body, @store.admin_label
   end
 
   private

--- a/test/integration/gift_cards_admin_test.rb
+++ b/test/integration/gift_cards_admin_test.rb
@@ -9,51 +9,84 @@ class GiftCardsAdminTest < ActionDispatch::IntegrationTest
     @store = @bootstrap[:store]
     GiftCards::Programs.seed!
     @program = GiftCardProgram.find_by!(code: "generated")
-  end
-
-  test "inquiry finds a masked card and never renders the full number" do
-    number = GiftCards::Number.generate(@program)
-    card = GiftCards::ProvisionInstrument.call(program: @program, store: @store, number: number)
-    GiftCards::Fund.call(gift_card: card, amount_cents: 150, store: @store, performed_by: @admin)
-
     sign_in_as("admin")
-    get inquiry_admin_gift_cards_path
-    assert_response :success
-
-    post inquiry_admin_gift_cards_path, params: { card_number: number }
-    assert_redirected_to admin_gift_card_path(card)
-    follow_redirect!
-    assert_response :success
-    assert_includes response.body, card.masked_number
-    assert_not_includes response.body, number
-    get admin_products_path
-    assert_includes response.body, inquiry_admin_gift_cards_path
-    assert_includes response.body, admin_gift_card_programs_path
   end
 
-  test "associates cannot inquire gift cards" do
-    associate = User.create!(
-      username: "gc_associate",
-      display_name: "GC Associate",
-      password: "correct-horse-battery",
-      password_confirmation: "correct-horse-battery"
-    )
-    RoleAssignment.create!(
-      user: associate,
-      role: Role.find_by!(key: "associate"),
-      store: @store,
-      assigned_by: @admin,
-      effective_at: Time.current
-    )
-    sign_in_as("gc_associate")
-    post store_selection_path, params: { store_id: @store.id }
-    get inquiry_admin_gift_cards_path
-    assert_redirected_to root_path
+  test "gift-card show lists masked activity after activate" do
+    card = GiftCards::ProvisionInstrument.call(program: @program, store: @store)
+    GiftCards::Fund.call(gift_card: card, amount_cents: 300, store: @store, performed_by: @admin)
+
+    get admin_gift_card_path(card)
+    assert_response :success
+    assert_includes response.body, "Account activity"
+    assert_includes response.body, "Activate"
+    assert_includes response.body, card.masked_number
+    refute_includes response.body, card.number
+  end
+
+  test "prefix last-four inquiry unique hit redirects and collisions stay masked" do
+    first = numbered_card("3131")
+    second = numbered_card("3131")
+    GiftCards::Fund.call(gift_card: first, amount_cents: 100, store: @store, performed_by: @admin)
+
+    post inquiry_admin_gift_cards_path, params: { number_prefix: first.number_prefix, number_last_four: "3131" }
+    assert_response :unprocessable_entity
+    assert_includes response.body, first.masked_number
+    assert_includes response.body, second.masked_number
+    refute_includes response.body, first.number
+    refute_includes response.body, second.number
+
+    unique = numbered_card("6262")
+    post inquiry_admin_gift_cards_path, params: { number_prefix: unique.number_prefix, number_last_four: "6262" }
+    assert_redirected_to admin_gift_card_path(unique)
+  end
+
+  test "exact inquiry still uses digest lookup" do
+    card = GiftCards::ProvisionInstrument.call(program: @program, store: @store)
+    post inquiry_admin_gift_cards_path, params: { card_number: card.number }
+    assert_redirected_to admin_gift_card_path(card)
+  end
+
+  test "system-generated replacement lands on a one-shot credential voucher" do
+    original = GiftCards::ProvisionInstrument.call(program: @program, store: @store)
+    GiftCards::Fund.call(gift_card: original, amount_cents: 500, store: @store, performed_by: @admin)
+    old_number = original.number
+
+    post replace_admin_gift_card_path(original), params: {
+      reason_code: "lost",
+      notes: "print new card",
+      idempotency_key: SecureRandom.uuid_v7
+    }
+    new_card = original.reload.replaced_by
+    assert_redirected_to credential_admin_gift_card_path(new_card)
+    follow_redirect!
+    assert_includes response.body, new_card.number
+    refute_includes response.body, old_number
+    assert_match "Print gift card", response.body
+
+    get credential_admin_gift_card_path(new_card)
+    assert_redirected_to admin_gift_card_path(new_card)
+    follow_redirect!
+    refute_includes response.body, new_card.number
   end
 
   private
 
   def sign_in_as(username)
     post session_path, params: { session: { username: username, password: "correct-horse-battery" } }
+  end
+
+  def numbered_card(last_four)
+    prefix = @program.prefix
+    body_length = @program.number_length - prefix.length - 1
+    50_000.times do |index|
+      body = format("%0#{body_length}d", index)
+      number = "#{prefix}#{body}#{GiftCards::Luhn.check_digit("#{prefix}#{body}")}"
+      next unless number.end_with?(last_four)
+      next if GiftCard.exists?(number_digest: GiftCards::Number.digest(number))
+
+      return GiftCards::ProvisionInstrument.call(program: @program, store: @store, number: number)
+    end
+    raise "unable to allocate a number ending in #{last_four}"
   end
 end

--- a/test/integration/pos_customer_attach_test.rb
+++ b/test/integration/pos_customer_attach_test.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PosCustomerAttachTest < ActionDispatch::IntegrationTest
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    @tax = tax_class(code: "physical_book", name: "Physical book")
+    StoreTaxes::Create.call(
+      store: @store,
+      actor: @actor,
+      name: "Illinois State",
+      rate_percent: "5.000",
+      calculation_order: 1,
+      applies_by_tax_class_id: { @tax.id => true }
+    )
+    @variant = pos_sellable_variant(actor: @actor, tax_class: @tax)
+    open_quantity_stock(store: @store, variant: @variant, actor: @actor, quantity: 5)
+    @register = Register.create!(store: @store, register_number: 1, name: "Front")
+    @customer = Customer.create!(display_name: "Attachable Reader", email: "attachable@example.com")
+    sign_in_as("admin")
+  end
+
+  test "search attach and detach a customer on a working ticket" do
+    post pos_register_enter_path, params: enter_params
+    follow_redirect!
+    transaction = PosTransaction.working.find_by!(register: @register)
+
+    get pos_register_customer_search_path, params: { register_id: @register.id, q: "Attachable" }
+    assert_response :success
+    payload = JSON.parse(response.body)
+    assert_equal @customer.id, payload.fetch("results").first.fetch("id")
+
+    post pos_register_attach_customer_path, params: {
+      register_id: @register.id,
+      lock_version: transaction.lock_version,
+      customer_id: @customer.id
+    }
+    assert_response :success
+    assert_equal @customer.id, transaction.reload.customer_id
+    assert_match "Attachable Reader", response.body
+
+    post pos_register_detach_customer_path, params: {
+      register_id: @register.id,
+      lock_version: transaction.lock_version
+    }
+    assert_response :success
+    assert_nil transaction.reload.customer_id
+  end
+
+  test "customer search omits inactive customers and attach rejects them" do
+    inactive = Customer.create!(display_name: "Inactive Attach", email: "inactive.attach@example.com", active: false)
+    post pos_register_enter_path, params: enter_params
+    follow_redirect!
+    transaction = PosTransaction.working.find_by!(register: @register)
+
+    get pos_register_customer_search_path, params: { register_id: @register.id, q: "Inactive Attach" }
+    payload = JSON.parse(response.body)
+    assert_empty payload.fetch("results")
+
+    post pos_register_attach_customer_path, params: {
+      register_id: @register.id,
+      lock_version: transaction.lock_version,
+      customer_id: inactive.id
+    }
+    assert_match(/active canonical customer/, response.body)
+    assert_nil transaction.reload.customer_id
+  end
+
+  test "completed ticket and receipt show the attached customer name" do
+    post pos_register_enter_path, params: enter_params
+    follow_redirect!
+    transaction = PosTransaction.working.find_by!(register: @register)
+    post pos_register_merchandise_path, params: { identifier: @variant.sku, lock_version: transaction.lock_version }
+    post pos_register_attach_customer_path, params: {
+      register_id: @register.id,
+      lock_version: transaction.reload.lock_version,
+      customer_id: @customer.id
+    }
+    post pos_register_tender_path, params: { tender_amount: "25.00", lock_version: transaction.reload.lock_version }
+    operation_id = css_select("input[name='completion_operation_id']").first["value"]
+    post pos_transaction_complete_path(transaction), params: {
+      completion_operation_id: operation_id,
+      lock_version: transaction.reload.lock_version,
+      expected_total_cents: transaction.total_cents,
+      expected_signed_net_cents: transaction.signed_net_cents,
+      amount_presented_cents: 2500
+    }
+    follow_redirect!
+    assert_match "Customer · Attachable Reader", response.body
+    assert_match "Customer: Attachable Reader", response.body
+
+    receipt = Pos::CustomerReceipt.build(transaction.reload)
+    assert_equal "Attachable Reader", receipt.customer_name
+  end
+
+  test "store-credit tender still requires an attached customer" do
+    Pos::TenderTypes.seed!
+    account = StoredValue::OpenAccount.call(account_type: "store_credit", customer: @customer)
+    StoredValue::Post.call(
+      operation_type: "issue",
+      store: @store,
+      performed_by: @actor,
+      source_id: account.id,
+      idempotency_key: SecureRandom.uuid_v7,
+      entries: [ { account: account, amount_cents: 5000 } ]
+    )
+    post pos_register_enter_path, params: enter_params
+    follow_redirect!
+    transaction = PosTransaction.working.find_by!(register: @register)
+    post pos_register_merchandise_path, params: { identifier: @variant.sku, lock_version: transaction.lock_version }
+    store_credit = TenderType.find_by!(code: "store_credit")
+    post pos_register_tender_path, params: {
+      tender_amount: "5.00",
+      lock_version: transaction.reload.lock_version,
+      tender_type_id: store_credit.id
+    }
+    assert_match(/customer is required/, response.body)
+  end
+
+  private
+
+  def sign_in_as(username)
+    post session_path, params: { session: { username: username, password: "correct-horse-battery" } }
+  end
+
+  def enter_params
+    {
+      register_id: @register.id,
+      opening_float: "50.00",
+      confirmed_business_date: BusinessDate.for_store(@store).iso8601
+    }
+  end
+end

--- a/test/integration/pos_gift_card_voucher_test.rb
+++ b/test/integration/pos_gift_card_voucher_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PosGiftCardVoucherTest < ActionDispatch::IntegrationTest
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    @tax = tax_class(code: "physical_book", name: "Physical book")
+    StoreTaxes::Create.call(
+      store: @store,
+      actor: @actor,
+      name: "Illinois State",
+      rate_percent: "5.000",
+      calculation_order: 1,
+      applies_by_tax_class_id: { @tax.id => true }
+    )
+    @register = Register.create!(store: @store, register_number: 1, name: "Front")
+    GiftCards::Programs.seed!
+    Pos::TenderTypes.seed!
+    @program = GiftCardProgram.find_by!(code: "generated")
+    sign_in_as("admin")
+  end
+
+  test "first completed view prints a voucher once and ordinary receipt stays masked" do
+    post pos_register_enter_path, params: enter_params
+    follow_redirect!
+    transaction = PosTransaction.working.find_by!(register: @register)
+    post pos_register_stored_value_issuance_path, params: {
+      register_id: @register.id,
+      lock_version: transaction.lock_version,
+      issuance_type: "activation",
+      gift_card_program_id: @program.id,
+      issuance_amount: "10.00"
+    }
+    post pos_register_tender_path, params: { tender_amount: "10.00", lock_version: transaction.reload.lock_version }
+    operation_id = css_select("input[name='completion_operation_id']").first["value"]
+    post pos_transaction_complete_path(transaction), params: {
+      completion_operation_id: operation_id,
+      lock_version: transaction.reload.lock_version,
+      expected_total_cents: transaction.total_cents,
+      expected_signed_net_cents: transaction.signed_net_cents,
+      amount_presented_cents: 1000
+    }
+    follow_redirect!
+    card = transaction.reload.pos_stored_value_issuances.sole.gift_card
+    voucher = css_select(".pos-gift-card-voucher").first
+    receipt = css_select(".pos-receipt__print").first
+    assert voucher
+    assert_includes voucher.text, card.number
+    assert_match "Print gift card", response.body
+    refute_includes receipt.text, card.number
+    assert_includes receipt.text, card.masked_number
+
+    get pos_completed_transaction_path(transaction)
+    assert_response :success
+    refute_includes response.body, card.number
+    assert_no_match "Print gift card", response.body
+
+    get pos_transaction_path(transaction)
+    assert_response :success
+    refute_includes response.body, card.number
+  end
+
+  private
+
+  def sign_in_as(username)
+    post session_path, params: { session: { username: username, password: "correct-horse-battery" } }
+  end
+
+  def enter_params
+    {
+      register_id: @register.id,
+      opening_float: "50.00",
+      confirmed_business_date: BusinessDate.for_store(@store).iso8601
+    }
+  end
+end

--- a/test/integration/pos_gift_card_voucher_test.rb
+++ b/test/integration/pos_gift_card_voucher_test.rb
@@ -20,6 +20,14 @@ class PosGiftCardVoucherTest < ActionDispatch::IntegrationTest
     GiftCards::Programs.seed!
     Pos::TenderTypes.seed!
     @program = GiftCardProgram.find_by!(code: "generated")
+    @store.update!(
+      street_address_1: "1234 Any Street",
+      city: "Any Town",
+      region_code: "MI",
+      postal_code: "99999",
+      phone: "586-555-9999"
+    )
+    SystemSettings.current.update!(gift_card_voucher_footer: "Redeemable at Example Books LLC.\nTreat this voucher like cash.")
     sign_in_as("admin")
   end
 
@@ -45,13 +53,33 @@ class PosGiftCardVoucherTest < ActionDispatch::IntegrationTest
     }
     follow_redirect!
     card = transaction.reload.pos_stored_value_issuances.sole.gift_card
+    presented = GiftCards::Number.present(card.number, prefix: card.number_prefix)
     voucher = css_select(".pos-gift-card-voucher").first
     receipt = css_select(".pos-receipt__print").first
     assert voucher
-    assert_includes voucher.text, card.number
+    assert_includes voucher.text, @store.legal_name
+    assert_includes voucher.text, "1234 Any Street"
+    assert_includes voucher.text, "Issued:"
+    assert_includes voucher.text, "$10.00"
+    assert_includes voucher.text, "Gift Card"
+    assert_includes voucher.text, presented
+    refute_includes voucher.text, card.number
+    barcode = css_select(".pos-gift-card-voucher svg").first
+    assert barcode
+    assert_equal card.number, barcode["aria-label"]
+    assert_includes voucher.to_html, card.number
+    assert_includes voucher.text, "Redeemable at Example Books LLC."
+    assert_includes voucher.text, "Treat this voucher like cash."
+    refute_includes voucher.text, "Store generated"
+    refute_includes voucher.text, "Activation"
     assert_match "Print gift card", response.body
+    assert_match(/no-store/, response.headers["Cache-Control"].to_s)
     refute_includes receipt.text, card.number
+    refute_includes receipt.text, presented
+    refute_includes receipt.text, "Treat this voucher like cash."
     assert_includes receipt.text, card.masked_number
+    receipt_svgs = css_select(".pos-receipt__print svg")
+    refute receipt_svgs.any? { |svg| svg["aria-label"] == card.number }
 
     get pos_completed_transaction_path(transaction)
     assert_response :success

--- a/test/integration/stored_value_customer_credit_test.rb
+++ b/test/integration/stored_value_customer_credit_test.rb
@@ -29,6 +29,8 @@ class StoredValueCustomerCreditTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "Stored value"
     assert_includes response.body, "Store credit"
     assert_includes response.body, format_cents(125)
+    assert_includes response.body, "Store credit activity"
+    assert_includes response.body, "Issue"
   end
 
   test "customer show hides stored-value balances without view_activity" do
@@ -39,6 +41,34 @@ class StoredValueCustomerCreditTest < ActionDispatch::IntegrationTest
     get admin_customer_path(@customer)
     assert_response :success
     assert_not_includes response.body, "Stored value"
+  end
+
+  test "closed store-credit accounts remain in activity history" do
+    account = StoredValue::OpenAccount.call(account_type: "store_credit", customer: @customer)
+    StoredValue::Post.call(
+      operation_type: "issue",
+      store: @store,
+      performed_by: @admin,
+      source_id: account.id,
+      idempotency_key: SecureRandom.uuid_v7,
+      entries: [ { account: account, amount_cents: 50 } ]
+    )
+    StoredValue::Post.call(
+      operation_type: "adjust",
+      store: @store,
+      performed_by: @admin,
+      source_id: account.id,
+      idempotency_key: SecureRandom.uuid_v7,
+      entries: [ { account: account.reload, amount_cents: -50 } ]
+    )
+    account.reload.close_zero!
+
+    sign_in_as("admin")
+    get admin_customer_path(@customer)
+    assert_response :success
+    assert_includes response.body, "Closed"
+    assert_includes response.body, "Store credit activity"
+    assert_includes response.body, "Adjust"
   end
 
   test "opening the adjust form does not create an account" do

--- a/test/integration/stored_value_customer_credit_test.rb
+++ b/test/integration/stored_value_customer_credit_test.rb
@@ -68,7 +68,7 @@ class StoredValueCustomerCreditTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes response.body, "Closed"
     assert_includes response.body, "Store credit activity"
-    assert_includes response.body, "Adjust"
+    assert_includes response.body, "Debit adjustment"
   end
 
   test "opening the adjust form does not create an account" do

--- a/test/models/system_settings_validation_test.rb
+++ b/test/models/system_settings_validation_test.rb
@@ -10,4 +10,28 @@ class SystemSettingsValidationTest < ActiveSupport::TestCase
     assert_not settings.valid?
     assert settings.errors[:default_customer_reservation_expiration_days].any?
   end
+
+  test "gift card voucher footer is limited like receipt messages" do
+    actor_user
+    settings = SystemSettings.current
+    settings.gift_card_voucher_footer = "x" * (Store::RECEIPT_MESSAGE_LIMIT + 1)
+    assert_not settings.valid?
+    assert settings.errors[:gift_card_voucher_footer].any?
+
+    settings.gift_card_voucher_footer = "  Treat this voucher like cash.  "
+    assert settings.valid?
+    settings.save!
+    assert_equal "Treat this voucher like cash.", settings.reload.gift_card_voucher_footer
+  end
+
+  test "printed gift card voucher footer substitutes organization legal name" do
+    actor_user
+    settings = SystemSettings.current
+    settings.update!(
+      legal_name: "Example Books LLC",
+      gift_card_voucher_footer: "Redeemable at {organization legal name}. Treat this voucher like cash."
+    )
+    assert_equal "Redeemable at Example Books LLC. Treat this voucher like cash.",
+                 settings.printed_gift_card_voucher_footer
+  end
 end

--- a/test/services/gift_cards/admin_inquiry_test.rb
+++ b/test/services/gift_cards/admin_inquiry_test.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GiftCards
+  class AdminInquiryTest < ActiveSupport::TestCase
+    setup do
+      @bootstrap = bootstrap!
+      @store = @bootstrap[:store]
+      @actor = @bootstrap[:administrator]
+      GiftCards::Programs.seed!
+      @program = GiftCardProgram.find_by!(code: "generated")
+    end
+
+    test "unique prefix and last four opens the card and POS lookup stays digest-only" do
+      card = numbered_card(last_four: "4242")
+      GiftCards::Fund.call(gift_card: card, amount_cents: 250, store: @store, performed_by: @actor)
+
+      result = GiftCards::AdminInquiry.call(
+        prefix: card.number_prefix,
+        last_four: "4242",
+        actor: @actor,
+        store: @store
+      )
+      assert_equal :found, result.status
+      assert_equal card.id, result.card.id
+
+      assert_nil GiftCards::Lookup.by_number("#{card.number_prefix}4242")
+      assert_nil GiftCards::Lookup.by_number("4242")
+      assert_equal card.id, GiftCards::Lookup.by_number(card.number).id
+    end
+
+    test "collisions return a masked candidate list without full numbers" do
+      first = numbered_card(last_four: "7777")
+      second = numbered_card(last_four: "7777")
+      GiftCards::Fund.call(gift_card: first, amount_cents: 100, store: @store, performed_by: @actor)
+      GiftCards::Fund.call(gift_card: second, amount_cents: 200, store: @store, performed_by: @actor)
+
+      result = GiftCards::AdminInquiry.call(
+        prefix: first.number_prefix,
+        last_four: "7777",
+        actor: @actor,
+        store: @store
+      )
+      assert_equal :ambiguous, result.status
+      assert_equal 2, result.candidates.size
+      masked = result.candidates.map(&:masked_number)
+      assert_includes masked, first.masked_number
+      assert_includes masked, second.masked_number
+      refute_includes result.candidates.map(&:inspect).join, first.number
+      event = AuditEvent.where(action: "gift_cards.inquiry", outcome: "succeeded").order(:created_at).last
+      refute_includes event.attributes.to_json, first.number
+      refute_includes event.after_values.to_s, first.number
+    end
+
+    test "zero matches and submitted digits stay out of the audit" do
+      result = GiftCards::AdminInquiry.call(
+        prefix: "801",
+        last_four: "0001",
+        actor: @actor,
+        store: @store
+      )
+      assert_equal :not_found, result.status
+      event = AuditEvent.where(action: "gift_cards.inquiry", outcome: "failed").order(:created_at).last
+      refute_includes event.attributes.to_json, "0001"
+      refute_includes event.attributes.to_json, "801"
+    end
+
+    test "throttle matches resolver after repeated failures" do
+      GiftCards::Resolver::FAILURE_LIMIT.times do
+        GiftCards::AdminInquiry.call(prefix: "801", last_four: "0002", actor: @actor, store: @store)
+      end
+      error = assert_raises(GiftCards::Error) do
+        GiftCards::AdminInquiry.call(prefix: "801", last_four: "0002", actor: @actor, store: @store)
+      end
+      assert_equal GiftCards::GENERIC_INQUIRY_FAILURE, error.message
+    end
+
+    private
+
+    def numbered_card(last_four:)
+      prefix = @program.prefix
+      body_length = @program.number_length - prefix.length - 1
+      50_000.times do |index|
+        body = format("%0#{body_length}d", index)
+        number = "#{prefix}#{body}#{GiftCards::Luhn.check_digit("#{prefix}#{body}")}"
+        next unless number.end_with?(last_four)
+        next if GiftCard.exists?(number_digest: GiftCards::Number.digest(number))
+
+        return GiftCards::ProvisionInstrument.call(program: @program, store: @store, number: number)
+      end
+      raise "unable to allocate a #{prefix} number ending in #{last_four}"
+    end
+  end
+end

--- a/test/services/gift_cards/cash_out_test.rb
+++ b/test/services/gift_cards/cash_out_test.rb
@@ -197,6 +197,29 @@ class GiftCardsCashOutTest < ActiveSupport::TestCase
     assert_equal card.number_last_four, event.after_values["number_last_four"]
   end
 
+  test "print recovery requires recover_print and not merely view" do
+    card = funded_card(200)
+    associate = pos_transacting_user(store: @store, assigned_by: @actor, username: "gc_associate")
+    error = assert_raises(GiftCards::Error) do
+      GiftCards::PrintRecovery.call(
+        gift_card: card,
+        actor: associate,
+        store: @store,
+        reason: "printer jammed"
+      )
+    end
+    assert_match(/not authorized/, error.message)
+
+    manager = create_store_manager("gc_print_mgr")
+    recovered = GiftCards::PrintRecovery.call(
+      gift_card: card,
+      actor: manager,
+      store: @store,
+      reason: "printer jammed"
+    )
+    assert_equal card.number, recovered
+  end
+
   private
 
   def funded_card(amount_cents)

--- a/test/services/gift_cards/instruments_test.rb
+++ b/test/services/gift_cards/instruments_test.rb
@@ -51,6 +51,19 @@ module GiftCards
       refute_includes event.attributes.to_json, "80100000000000000000"
     end
 
+    test "number identity cannot be rewritten after issue" do
+      card = GiftCards::ProvisionInstrument.call(program: @program, store: @store)
+      original = card.number
+      other = GiftCards::Number.generate(@program)
+
+      error = assert_raises(ActiveRecord::RecordInvalid) { card.update!(number: other) }
+      assert_match(/cannot change after issue/, error.message)
+      assert_equal original, card.reload.number
+
+      GiftCards::Suspend.call(gift_card: card, actor: @actor, store: @store)
+      assert card.reload.suspended?
+    end
+
     test "suspend and reinstate keep the ledger account in sync" do
       card = GiftCards::ProvisionInstrument.call(program: @program, store: @store)
       GiftCards::Suspend.call(gift_card: card, actor: @actor, store: @store)

--- a/test/services/gift_cards/number_test.rb
+++ b/test/services/gift_cards/number_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GiftCards
+  class NumberTest < ActiveSupport::TestCase
+    test "present groups prefix, four-digit body blocks, and check digit" do
+      assert_equal "801 6592 9340 5700 4387 9",
+                   GiftCards::Number.present("80165929340570043879", prefix: "801")
+      assert_equal "801 6592 9340 5700 4387 9",
+                   GiftCards::Number.present("801-6592-9340-5700-4387-9", prefix: "801")
+    end
+
+    test "present keeps a longer prefix intact" do
+      assert_equal "80 1659 2934 0570 0438 7",
+                   GiftCards::Number.present("8016592934057004387", prefix: "80")
+    end
+  end
+end

--- a/test/services/gift_cards/replacement_first_print_test.rb
+++ b/test/services/gift_cards/replacement_first_print_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module GiftCards
+  class ReplacementFirstPrintTest < ActiveSupport::TestCase
+    setup do
+      @bootstrap = bootstrap!
+      @store = @bootstrap[:store]
+      @actor = @bootstrap[:administrator]
+      GiftCards::Programs.seed!
+      @program = GiftCardProgram.find_by!(code: "generated")
+    end
+
+    test "prints the new number once and does not reveal the old number" do
+      original = GiftCards::ProvisionInstrument.call(program: @program, store: @store)
+      GiftCards::Fund.call(gift_card: original, amount_cents: 400, store: @store, performed_by: @actor)
+      old_number = original.number
+
+      replacement = GiftCards::Replace.call(
+        gift_card: original,
+        performed_by: @actor,
+        store: @store,
+        source_id: original.id,
+        idempotency_key: SecureRandom.uuid_v7,
+        reason_code: "lost",
+        reason_name_snapshot: "Lost card"
+      )
+      new_card = replacement.replacement_gift_card
+
+      credentials = GiftCards::ReplacementFirstPrint.call(new_card)
+      assert_equal 1, credentials.size
+      assert_equal new_card.number, credentials.first.number
+      refute_equal old_number, credentials.first.number
+      assert_equal [], GiftCards::ReplacementFirstPrint.call(new_card)
+      assert PosGiftCardCredentialDelivery.exists?(gift_card_id: new_card.id)
+    end
+  end
+end

--- a/test/services/gift_cards/replacement_first_print_test.rb
+++ b/test/services/gift_cards/replacement_first_print_test.rb
@@ -31,9 +31,20 @@ module GiftCards
       credentials = GiftCards::ReplacementFirstPrint.call(new_card)
       assert_equal 1, credentials.size
       assert_equal new_card.number, credentials.first.number
+      assert_equal @store, credentials.first.store
+      assert_equal GiftCards::Number.present(new_card.number, prefix: new_card.number_prefix),
+                   credentials.first.presented_number
       refute_equal old_number, credentials.first.number
       assert_equal [], GiftCards::ReplacementFirstPrint.call(new_card)
       assert PosGiftCardCredentialDelivery.exists?(gift_card_id: new_card.id)
+    end
+
+    test "does not decrypt a system-generated card that was not created by replacement" do
+      card = GiftCards::ProvisionInstrument.call(program: @program, store: @store)
+      GiftCards::Fund.call(gift_card: card, amount_cents: 250, store: @store, performed_by: @actor)
+
+      assert_equal [], GiftCards::ReplacementFirstPrint.call(card)
+      refute PosGiftCardCredentialDelivery.exists?(gift_card_id: card.id)
     end
   end
 end

--- a/test/services/pos/attach_customer_test.rb
+++ b/test/services/pos/attach_customer_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PosAttachCustomerTest < ActiveSupport::TestCase
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    @context = pos_open_context(store: @store, actor: @actor, opening_float_cents: 10_000)
+    @customer = Customer.create!(display_name: "Register Customer", email: "register.customer@example.com")
+  end
+
+  test "attaches an active canonical customer and detach clears it" do
+    transaction = Pos::StartTransaction.call(session: @context[:session], actor: @actor)
+
+    Pos::AttachCustomer.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      customer: @customer
+    )
+    assert_equal @customer.id, transaction.reload.customer_id
+
+    Pos::DetachCustomer.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version
+    )
+    assert_nil transaction.reload.customer_id
+  end
+
+  test "rejects inactive and merged customers" do
+    transaction = Pos::StartTransaction.call(session: @context[:session], actor: @actor)
+    inactive = Customer.create!(display_name: "Inactive Register", email: "inactive.reg@example.com", active: false)
+    error = assert_raises(Pos::Error) do
+      Pos::AttachCustomer.call(
+        transaction: transaction,
+        actor: @actor,
+        expected_lock_version: transaction.lock_version,
+        customer: inactive
+      )
+    end
+    assert_match(/active canonical customer/, error.message)
+
+    survivor = Customer.create!(display_name: "Survivor Register", email: "surv.reg@example.com")
+    source = Customer.create!(display_name: "Source Register", email: "src.reg@example.com")
+    Customers::MergeCustomers.call(
+      source: source,
+      survivor: survivor,
+      actor: @actor,
+      reason: "dup",
+      idempotency_key: SecureRandom.uuid_v7,
+      store: @store
+    )
+    error = assert_raises(Pos::Error) do
+      Pos::AttachCustomer.call(
+        transaction: transaction,
+        actor: @actor,
+        expected_lock_version: transaction.lock_version,
+        customer: source.reload
+      )
+    end
+    assert_match(/active canonical customer/, error.message)
+  end
+end

--- a/test/services/pos/stored_value_completion_test.rb
+++ b/test/services/pos/stored_value_completion_test.rb
@@ -74,6 +74,42 @@ class PosStoredValueCompletionTest < ActiveSupport::TestCase
     assert_equal 2500, note.balance_cents
   end
 
+  test "first print does not decrypt after the originating session is closed" do
+    transaction = Pos::StartTransaction.call(session: @context[:session], actor: @actor)
+    Pos::AddStoredValueIssuance.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      issuance_type: "activation",
+      amount_cents: 1200,
+      gift_card_program: @program
+    )
+    Pos::TenderCash.call(
+      transaction: transaction.reload,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      amount_presented_cents: 1200
+    )
+    result = complete_current!(transaction.reload)
+    card = result.transaction.pos_stored_value_issuances.sole.gift_card
+    Pos::CloseSession.call(
+      session: @context[:session],
+      actor: @actor,
+      expected_lock_version: @context[:session].lock_version,
+      closing_count_cents: 11_200
+    )
+
+    assert_equal [], Pos::FirstPrint.call(result.transaction)
+    refute PosGiftCardCredentialDelivery.exists?(pos_transaction_id: result.transaction.id)
+    recovered = GiftCards::PrintRecovery.call(
+      gift_card: card,
+      actor: @actor,
+      store: @store,
+      reason: "session closed before voucher print"
+    )
+    assert_equal card.number, recovered
+  end
+
   test "gift-card redeem posts a negative redeem and rejects same-ticket issuance" do
     card = GiftCards::ProvisionInstrument.call(program: @program, store: @store)
     GiftCards::Fund.call(gift_card: card, amount_cents: 5000, store: @store, performed_by: @actor)

--- a/test/services/pos/stored_value_completion_test.rb
+++ b/test/services/pos/stored_value_completion_test.rb
@@ -64,6 +64,8 @@ class PosStoredValueCompletionTest < ActiveSupport::TestCase
     credentials = Pos::FirstPrint.call(result.transaction)
     assert_equal 1, credentials.size
     assert_equal card.number, credentials.first.number
+    assert_equal [], Pos::FirstPrint.call(result.transaction)
+    assert PosGiftCardCredentialDelivery.exists?(pos_transaction_id: result.transaction.id)
     Pos::CompletedTransactionFacts.new(result.operation.envelope).verify!
     receipt = Pos::CustomerReceipt.build(result.transaction)
     assert_equal result.transaction.signed_net_cents, receipt.signed_net_cents
@@ -339,6 +341,170 @@ class PosStoredValueCompletionTest < ActiveSupport::TestCase
     assert_match(/downstream stored-value activity/, error.message)
   end
 
+  test "complete-retry can still first-print until delivery is recorded" do
+    transaction = Pos::StartTransaction.call(session: @context[:session], actor: @actor)
+    Pos::AddStoredValueIssuance.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      issuance_type: "activation",
+      amount_cents: 2500,
+      gift_card_program: @program
+    )
+    Pos::TenderCash.call(
+      transaction: transaction.reload,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      amount_presented_cents: 2500
+    )
+    operation_id = SecureRandom.uuid_v7
+    transaction.reload
+    complete_attrs = {
+      transaction: transaction,
+      actor: @actor,
+      operation_id: operation_id,
+      expected_lock_version: transaction.lock_version,
+      expected_total_cents: transaction.total_cents,
+      expected_signed_net_cents: transaction.signed_net_cents
+    }
+    first = Pos::CompleteTransaction.call(**complete_attrs)
+    replay = Pos::CompleteTransaction.call(**complete_attrs)
+    card = first.transaction.pos_stored_value_issuances.sole.gift_card
+    credentials = Pos::FirstPrint.call(replay.transaction)
+    assert_equal card.number, credentials.sole.number
+  end
+
+  test "new refund gift card cannot exceed remaining gift-card-funded amount" do
+    card = GiftCards::ProvisionInstrument.call(program: @program, store: @store)
+    GiftCards::Fund.call(gift_card: card, amount_cents: 5000, store: @store, performed_by: @actor)
+    sale = mixed_gift_card_and_cash_sale(card: card, gift_cents: 100)
+
+    refund_txn = start_linked_return(sale)
+    error = assert_raises(Pos::Error) do
+      Pos::AddStoredValueRefundTender.call(
+        transaction: refund_txn,
+        actor: @actor,
+        expected_lock_version: refund_txn.lock_version,
+        tender_type: @gift_card_type,
+        amount_cents: -refund_txn.signed_net_cents,
+        destination_mode: "new_gift_card",
+        gift_card_program: @program
+      )
+    end
+    assert_match(/gift-card-funded/, error.message)
+
+    Pos::AddStoredValueRefundTender.call(
+      transaction: refund_txn.reload,
+      actor: @actor,
+      expected_lock_version: refund_txn.lock_version,
+      tender_type: @gift_card_type,
+      amount_cents: 100,
+      destination_mode: "new_gift_card",
+      gift_card_program: @program
+    )
+    Pos::AddRefundTender.call(
+      transaction: refund_txn.reload,
+      actor: @actor,
+      expected_lock_version: refund_txn.lock_version,
+      tender_type: @cash,
+      amount_cents: Pos::Support.remaining_refund_cents(refund_txn)
+    )
+    refund = complete_current!(refund_txn.reload, expected_signed_net_cents: refund_txn.signed_net_cents).transaction
+    assert_equal 100, refund.pos_tenders.find { |tender| tender.tender_type == "gift_card" }.amount_cents
+  end
+
+  test "trade-credit refund cannot exceed the original trade-credit-funded portion" do
+    customer = Customer.create!(display_name: "Mixed Trade", email: "mixed.trade@example.com")
+    account = StoredValue::EnsureCustomerAccount.call(customer: customer, account_type: "trade_credit")
+    StoredValue::Adjust.call(
+      account: account,
+      direction: "credit",
+      amount_cents: 3000,
+      reason: StoredValueAdjustmentReason.find_by!(code: "goodwill"),
+      store: @store,
+      performed_by: @actor,
+      source_id: SecureRandom.uuid_v7,
+      idempotency_key: SecureRandom.uuid_v7
+    )
+
+    transaction = start_sale
+    Pos::AttachCustomer.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      customer: customer
+    )
+    Pos::AddStoredValueTender.call(
+      transaction: transaction.reload,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      tender_type: @trade_credit_type,
+      amount_cents: 100
+    )
+    Pos::TenderCash.call(
+      transaction: transaction.reload,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      amount_presented_cents: Pos::Support.remaining_payment_cents(transaction)
+    )
+    sale = complete_current!(transaction.reload).transaction
+
+    refund_txn = start_linked_return(sale)
+    Pos::AttachCustomer.call(
+      transaction: refund_txn,
+      actor: @actor,
+      expected_lock_version: refund_txn.lock_version,
+      customer: customer
+    )
+    error = assert_raises(Pos::Error) do
+      Pos::AddStoredValueRefundTender.call(
+        transaction: refund_txn.reload,
+        actor: @actor,
+        expected_lock_version: refund_txn.lock_version,
+        tender_type: @trade_credit_type,
+        amount_cents: -refund_txn.signed_net_cents,
+        destination_mode: "existing_account"
+      )
+    end
+    assert_match(/trade-credit-funded/, error.message)
+  end
+
+  test "completion rechecks gift-card maximum after two working reloads" do
+    @program.update!(maximum_balance_cents: 1000)
+    card = GiftCards::ProvisionInstrument.call(program: @program, store: @store)
+    GiftCards::Fund.call(gift_card: card, amount_cents: 400, store: @store, performed_by: @actor)
+
+    first = build_reload_ticket(card, 400, session: @context[:session])
+    other = pos_open_context(store: @store, actor: @actor, opening_float_cents: 10_000)
+    second = build_reload_ticket(card, 400, session: other[:session])
+
+    complete_current!(first.reload)
+    error = assert_raises(Pos::Error) { complete_current!(second.reload) }
+    assert_match(/maximum balance/, error.message)
+    assert_equal 800, card.stored_value_account.reload.balance_cents
+  end
+
+  test "new refund gift card cannot exceed the program maximum balance" do
+    card = GiftCards::ProvisionInstrument.call(program: @program, store: @store)
+    GiftCards::Fund.call(gift_card: card, amount_cents: 5000, store: @store, performed_by: @actor)
+    @program.update!(maximum_balance_cents: 50)
+    sale = mixed_gift_card_and_cash_sale(card: card, gift_cents: 100)
+
+    refund_txn = start_linked_return(sale)
+    error = assert_raises(Pos::Error) do
+      Pos::AddStoredValueRefundTender.call(
+        transaction: refund_txn,
+        actor: @actor,
+        expected_lock_version: refund_txn.lock_version,
+        tender_type: @gift_card_type,
+        amount_cents: 100,
+        destination_mode: "new_gift_card",
+        gift_card_program: @program
+      )
+    end
+    assert_match(/maximum balance/, error.message)
+  end
+
   test "v2 completed envelopes remain acceptable after the v3 signed-net rewrite" do
     payload = JSON.parse(File.read(Rails.root.join("test/fixtures/files/pos/completed_pos_operation_v2/cash_sale.json")))
     assert_equal 2, payload.fetch("schema_version")
@@ -354,6 +520,57 @@ class PosStoredValueCompletionTest < ActiveSupport::TestCase
       actor: @actor,
       expected_lock_version: transaction.lock_version,
       identifier: @variant.sku
+    )
+    transaction.reload
+  end
+
+  def mixed_gift_card_and_cash_sale(card:, gift_cents:)
+    transaction = start_sale
+    Pos::AddStoredValueTender.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      tender_type: @gift_card_type,
+      amount_cents: gift_cents,
+      card_number: card.number
+    )
+    Pos::TenderCash.call(
+      transaction: transaction.reload,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      amount_presented_cents: Pos::Support.remaining_payment_cents(transaction)
+    )
+    complete_current!(transaction.reload).transaction
+  end
+
+  def start_linked_return(sale)
+    refund_txn = Pos::StartTransaction.call(session: @context[:session], actor: @actor)
+    Pos::AddLinkedReturnLine.call(
+      transaction: refund_txn,
+      actor: @actor,
+      expected_lock_version: refund_txn.lock_version,
+      original_line: sale.pos_transaction_lines.first,
+      quantity: 1,
+      reason_code: "changed_mind"
+    )
+    refund_txn.reload
+  end
+
+  def build_reload_ticket(card, amount_cents, session:)
+    transaction = Pos::StartTransaction.call(session: session, actor: @actor)
+    Pos::AddStoredValueIssuance.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      issuance_type: "reload",
+      amount_cents: amount_cents,
+      card_number: card.number
+    )
+    Pos::TenderCash.call(
+      transaction: transaction.reload,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      amount_presented_cents: amount_cents
     )
     transaction.reload
   end

--- a/test/services/pos/tender_types_test.rb
+++ b/test/services/pos/tender_types_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Pos::TenderTypesTest < ActiveSupport::TestCase
+  test "seed creates protected stored-value tenders and is idempotent" do
+    Pos::TenderTypes.seed!
+
+    %w[store_credit trade_credit gift_card].each do |code|
+      type = TenderType.find_by!(code: code)
+      assert type.system_protected?
+      assert type.active?
+      assert_equal "stored_value", type.behavioral_category
+      assert_equal code, type.stored_value_account_type
+      assert type.allows_refund?
+    end
+
+    store_credit = TenderType.find_by!(code: "store_credit")
+    trade_credit = TenderType.find_by!(code: "trade_credit")
+    gift_card = TenderType.find_by!(code: "gift_card")
+    assert store_credit.allows_generic_refund_destination?
+    assert_not trade_credit.allows_generic_refund_destination?
+    assert gift_card.allows_refund_instrument_replacement?
+
+    snapshot = TenderType.order(:code).pluck(:code, :behavioral_category, :stored_value_account_type)
+    Pos::TenderTypes.seed!
+    assert_equal snapshot, TenderType.order(:code).pluck(:code, :behavioral_category, :stored_value_account_type)
+  end
+end

--- a/test/services/stored_value/account_activity_test.rb
+++ b/test/services/stored_value/account_activity_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module StoredValue
+  class AccountActivityTest < ActiveSupport::TestCase
+    setup do
+      @bootstrap = bootstrap!
+      @store = @bootstrap[:store]
+      @actor = @bootstrap[:administrator]
+      @customer = Customer.create!(display_name: "Ledger Customer", email: "ledger@example.com")
+      @account = StoredValue::OpenAccount.call(account_type: "store_credit", customer: @customer)
+    end
+
+    test "paginates entries newest first and includes closed accounts" do
+      26.times do |index|
+        StoredValue::Post.call(
+          operation_type: "issue",
+          store: @store,
+          performed_by: @actor,
+          source_id: @account.id,
+          idempotency_key: SecureRandom.uuid_v7,
+          entries: [ { account: @account.reload, amount_cents: 1 } ],
+          notes: "row #{index}"
+        )
+      end
+
+      page1 = StoredValue::AccountActivity.call(account: @account, page: 1)
+      assert_equal 25, page1.entries.size
+      assert_equal 26, page1.total_count
+      assert_equal 2, page1.total_pages
+
+      page2 = StoredValue::AccountActivity.call(account: @account, page: 2)
+      assert_equal 1, page2.entries.size
+      assert_equal "issue", page2.entries.first.stored_value_operation.operation_type
+    end
+  end
+end

--- a/test/services/stored_value/account_activity_test.rb
+++ b/test/services/stored_value/account_activity_test.rb
@@ -20,19 +20,186 @@ module StoredValue
           performed_by: @actor,
           source_id: @account.id,
           idempotency_key: SecureRandom.uuid_v7,
-          entries: [ { account: @account.reload, amount_cents: 1 } ],
-          notes: "row #{index}"
+          entries: [ { account: @account.reload, amount_cents: 1 } ]
         )
       end
 
-      page1 = StoredValue::AccountActivity.call(account: @account, page: 1)
+      page1 = activity(page: 1)
       assert_equal 25, page1.entries.size
       assert_equal 26, page1.total_count
       assert_equal 2, page1.total_pages
 
-      page2 = StoredValue::AccountActivity.call(account: @account, page: 2)
+      page2 = activity(page: 2)
       assert_equal 1, page2.entries.size
       assert_equal "issue", page2.entries.first.stored_value_operation.operation_type
+    end
+
+    test "orders by operation occurred_at then operation id then entry sequence" do
+      first = StoredValue::Post.call(
+        operation_type: "issue",
+        store: @store,
+        performed_by: @actor,
+        source_id: @account.id,
+        idempotency_key: SecureRandom.uuid_v7,
+        occurred_at: Time.utc(2026, 8, 1, 12, 0, 0),
+        entries: [ { account: @account.reload, amount_cents: 10 } ]
+      )
+      second = StoredValue::Post.call(
+        operation_type: "issue",
+        store: @store,
+        performed_by: @actor,
+        source_id: @account.id,
+        idempotency_key: SecureRandom.uuid_v7,
+        occurred_at: Time.utc(2026, 8, 2, 12, 0, 0),
+        entries: [ { account: @account.reload, amount_cents: 20 } ]
+      )
+
+      result = activity
+      assert_equal [ second.id, first.id ], result.entries.map { |entry| entry.stored_value_operation_id }
+    end
+
+    test "labels transfer direction, adjustment sign, reversals, and reversed originals" do
+      other = Customer.create!(display_name: "Transfer Destination", email: "ledger.dest@example.com")
+      destination = StoredValue::OpenAccount.call(account_type: "store_credit", customer: other)
+      StoredValue::Post.call(
+        operation_type: "issue",
+        store: @store,
+        performed_by: @actor,
+        source_id: @account.id,
+        idempotency_key: SecureRandom.uuid_v7,
+        entries: [ { account: @account.reload, amount_cents: 400 } ]
+      )
+      StoredValue::Post.call(
+        operation_type: "adjust",
+        store: @store,
+        performed_by: @actor,
+        source_id: @account.id,
+        idempotency_key: SecureRandom.uuid_v7,
+        entries: [ { account: @account.reload, amount_cents: 50 } ]
+      )
+      StoredValue::Post.call(
+        operation_type: "adjust",
+        store: @store,
+        performed_by: @actor,
+        source_id: @account.id,
+        idempotency_key: SecureRandom.uuid_v7,
+        entries: [ { account: @account.reload, amount_cents: -25 } ]
+      )
+      StoredValue::Post.call(
+        operation_type: "transfer",
+        store: @store,
+        performed_by: @actor,
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7,
+        entries: [
+          { account: @account.reload, amount_cents: -100 },
+          { account: destination, amount_cents: 100 }
+        ]
+      )
+      cash_out = StoredValue::Post.call(
+        operation_type: "cash_out",
+        store: @store,
+        performed_by: @actor,
+        source_id: @account.id,
+        idempotency_key: SecureRandom.uuid_v7,
+        entries: [ { account: @account.reload, amount_cents: -40 } ]
+      )
+      StoredValue::Reverse.call(
+        operation: cash_out,
+        performed_by: @actor,
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+      activate = StoredValue::Post.call(
+        operation_type: "activate",
+        store: @store,
+        performed_by: @actor,
+        source_id: @account.id,
+        idempotency_key: SecureRandom.uuid_v7,
+        entries: [ { account: @account.reload, amount_cents: 15 } ]
+      )
+      StoredValue::Reverse.call(
+        operation: activate,
+        performed_by: @actor,
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+
+      labels = activity.rows.to_h { |row| [ row.operation_label, row.amount_cents ] }
+      assert_equal(-100, labels["Transfer out"])
+      assert_equal 50, labels["Credit adjustment"]
+      assert_equal(-25, labels["Debit adjustment"])
+      assert_equal 40, labels["Cash-out reversal"]
+      assert_equal(-15, labels["Post-void reversal"])
+      assert_equal 15, labels["Activate (reversed)"]
+    end
+
+    test "store-scoped viewers see other-store amounts without actor or POS identity" do
+      other = Store.create!(
+        store_number: 91,
+        code: "sv_other",
+        name: "East Ledger Store",
+        legal_name: "East Ledger LLC",
+        timezone: "America/New_York",
+        country_code: "US"
+      )
+      StoredValue::Post.call(
+        operation_type: "issue",
+        store: @store,
+        performed_by: @actor,
+        source_id: @account.id,
+        idempotency_key: SecureRandom.uuid_v7,
+        reason_code: "home_issue",
+        reason_name_snapshot: "Home store issue",
+        entries: [ { account: @account.reload, amount_cents: 80 } ]
+      )
+      StoredValue::Post.call(
+        operation_type: "issue",
+        store: other,
+        performed_by: @actor,
+        source_id: @account.id,
+        idempotency_key: SecureRandom.uuid_v7,
+        reason_code: "east_issue",
+        reason_name_snapshot: "East store issue",
+        entries: [ { account: @account.reload, amount_cents: 45 } ]
+      )
+      manager = pos_store_manager(store: @store, assigned_by: @actor, username: "sv_activity_mgr")
+
+      scoped = StoredValue::AccountActivity.call(
+        account: @account,
+        actor: manager,
+        permission_key: "stored_value.view_activity"
+      )
+      by_amount = scoped.rows.index_by(&:amount_cents)
+      home = by_amount.fetch(80)
+      remote = by_amount.fetch(45)
+
+      assert_equal @store.admin_label, home.store_label
+      assert_includes home.actor_reason, @actor.display_name
+      refute home.redacted
+
+      assert_equal "Another store", remote.store_label
+      assert_nil remote.actor_reason
+      assert_nil remote.pos_transaction
+      assert remote.redacted
+      refute_includes scoped.rows.map(&:actor_reason).compact.join, "East store issue"
+
+      global = activity
+      remote_global = global.rows.find { |row| row.amount_cents == 45 }
+      assert_equal other.admin_label, remote_global.store_label
+      assert_includes remote_global.actor_reason, "East store issue"
+      refute remote_global.redacted
+    end
+
+    private
+
+    def activity(page: 1, actor: @actor, permission_key: "stored_value.view_activity")
+      StoredValue::AccountActivity.call(
+        account: @account,
+        actor: actor,
+        permission_key: permission_key,
+        page: page
+      )
     end
   end
 end

--- a/test/services/stored_value/post_test.rb
+++ b/test/services/stored_value/post_test.rb
@@ -140,6 +140,27 @@ module StoredValue
       assert_equal 7, @account.reload.balance_cents
     end
 
+    test "gift-card credits cannot exceed the program maximum while the account is locked" do
+      GiftCards::Programs.seed!
+      program = GiftCardProgram.find_by!(code: "generated")
+      program.update!(maximum_balance_cents: 1000)
+      card = GiftCards::ProvisionInstrument.call(program: program, store: @store)
+      GiftCards::Fund.call(gift_card: card, amount_cents: 800, store: @store, performed_by: @actor)
+
+      error = assert_raises(StoredValue::Error) do
+        StoredValue::Post.call(
+          operation_type: "reload",
+          store: @store,
+          performed_by: @actor,
+          source_id: SecureRandom.uuid_v7,
+          idempotency_key: SecureRandom.uuid_v7,
+          entries: [ { account: card.stored_value_account, amount_cents: 300 } ]
+        )
+      end
+      assert_match(/maximum balance/, error.message)
+      assert_equal 800, card.stored_value_account.reload.balance_cents
+    end
+
     test "seeded phase 10 permissions grant store managers but not associates the exceptional keys" do
       Authorization::PermissionCatalog.seed!(granted_by: @actor)
       manager = Role.find_by!(key: "store_manager")
@@ -153,6 +174,9 @@ module StoredValue
       assert_not associate.permissions.exists?(key: "stored_value.adjust")
       assert admin.permissions.exists?(key: "gift_cards.manage_programs")
       assert_not Permission.exists?(key: "gift_cards.reveal_number")
+      assert Permission.exists?(key: "gift_cards.recover_print")
+      assert manager.permissions.exists?(key: "gift_cards.recover_print")
+      assert_not associate.permissions.exists?(key: "gift_cards.recover_print")
     end
 
     test "currency is snapshotted from system settings and is not caller-selectable" do

--- a/test/system/pos_register_workspace_test.rb
+++ b/test/system/pos_register_workspace_test.rb
@@ -679,6 +679,20 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     assert_selector "#pos_return_chooser", visible: true
   end
 
+  test "cashier attaches a customer from operational search overlay" do
+    Customer.create!(display_name: "Overlay Customer", email: "overlay.customer@example.com")
+    open_register
+    click_on "Attach customer"
+    assert_selector "#pos_customer_overlay", visible: true
+    field = find("[data-register-workspace-target='customerQueryField']")
+    field.fill_in with: "Overlay Customer"
+    field.send_keys :enter
+    assert_selector "#pos_customer_overlay li", text: "Overlay Customer", wait: 10
+    field.send_keys :enter
+    assert_no_selector "#pos_customer_overlay", visible: true, wait: 10
+    assert_text "Customer · Overlay Customer"
+  end
+
   private
 
   test "gift-card shaped scan does not add merchandise" do


### PR DESCRIPTION
## Summary
- Record first-print delivery off the completed POS row, cap original-card / new-card / trade-credit refunds, and re-check gift-card maximum balance under the account lock. Gift-card numbers stay immutable after issue; print recovery uses `gift_cards.recover_print`.
- Cashiers attach, change, or clear a customer from Register operational search (pickup still does not set `customer_id`). Customer show and gift-card show get per-account paginated ledger history with masked identity.
- **Print gift card** is a dedicated 80mm credential voucher (store identity, issued time, amount, Code 128, grouped number); ordinary **Print receipt** stays masked. Organization `gift_card_voucher_footer` supports `{organization legal name}`. System-generated replacement lands on a one-shot new-credential screen and requires a `GiftCardReplacement`.
- POS first print decrypts only while the originating session is open and does not stamp delivery after close. Store-scoped activity keeps other-store amounts, labels the store `Another store`, and omits actor, reason, and POS links. Responses that include a full number send `Cache-Control: no-store`.
- Accept [ADR-027](https://github.com/BankEncore/ShelfSense-v1/blob/70-stored-value-policy-enforcement/docs/adr/ADR-027-admin-gift-card-prefix-last-four-inquiry.md): admin inquiry may resolve by prefix + last four (unique hit, masked collision list, generic miss). POS redeem/reload/cash-out remain exact digest.

## Verification
- `./dev/rails-docker bin/rails test` focused on stored-value completion, gift-card admin/inquiry/replacement, customer attach, voucher HTML/barcode, account activity, cash-out, instruments, numbering, system settings, and `test/models/pos_schema_test.rb`
- `./dev/rails-docker bin/rails test test/system/pos_register_workspace_test.rb -n test_cashier_attaches_a_customer_from_operational_search_overlay`
- `./dev/rails-docker bin/rubocop` on touched Ruby files
- Full `./dev/rails-docker bin/ci` was not run in this change
- Browser `window.print` of the voucher vs receipt was not exercised; voucher HTML vs masked receipt is covered by integration tests

## Documentation and migrations
- Phase 10 packet, receipt-presentation §27, ADR-026 §3, ADR-027 Accepted
- `20260826060000_add_pos_gift_card_credential_deliveries` — first-print delivery keyed by POS transaction
- `20260826070000_add_gift_card_admin_inquiry_and_replacement_deliveries` — prefix+last-four index; delivery may key by gift card for replacement vouchers (XOR check)
- `20260826080000_add_gift_card_voucher_footer_to_system_settings` — nullable organization voucher footer. Rollback: reverse the third migration, then the second, then the first; no data backfill