### PR TITLE
Record Phase 10 as implemented after the manual test plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ShelfSense is an inventory, purchasing, customer-service, and point-of-sale syst
 
 ## Project status
 
-The operational foundation through **Phase 9** is implemented on `main`, including:
+The operational foundation through **Phase 10** is implemented on `main`, including:
 
 - Organization, stores, users, scoped authorization, and audit
 - Merchandise, identifiers, classification, pricing, and inventory valuation
@@ -12,9 +12,10 @@ The operational foundation through **Phase 9** is implemented on `main`, includi
 - Suppliers, customer requests, reservations, purchase orders, receiving, and corrections
 - Customer identity, contact lookup, duplicate suggestions, and merge
 - Catalog and bibliographic enrichment with reviewed external-data apply
+- Store credit, trade credit, and gift cards
 - The Warm Parchment UX foundation, grouped administrative navigation, ActionButtonHelper adoption on reference and non-purchasing screens, and UDS-5 administrative composition (compact nav and Product reference family)
 
-Forward domain work is sequenced in the [canonical roadmap](docs/planning/roadmap.md). Phase 10 stored-value slices 10.1–10.5 land on `main`; the milestone stays open until the [manual test plan](docs/planning/phase10-stored-value/phase10-manual-test-plan.md) is executed. Later phases cover cash accountability, used buyback, customer-service expansion, and financial/reporting closeout.
+Forward domain work is sequenced in the [canonical roadmap](docs/planning/roadmap.md). Later phases cover cash accountability, used buyback, customer-service expansion, and financial/reporting closeout.
 
 ## Technology
 
@@ -97,6 +98,7 @@ Named domains for ownership. `buyback` and `reports` are reserved for later phas
 | `merchandise` | Catalog, variants, classification, pricing, inventory units, and inventory |
 | `purchasing` | Suppliers, orders, purchase orders, receiving, and supplier-facing workflows |
 | `pos` | Sales, returns, tenders, sessions, business dates, and Register operation |
+| `stored_value` | Store credit, trade credit, gift-card instruments, and their ledger |
 | `buyback` | Acquisition and valuation of used merchandise from customers (Phase 12) |
 | `reports` | Operational, financial, and analytical reporting (Phase 14 closeout) |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,8 +44,8 @@ This directory contains the project’s technical authority, development guidanc
 | [Phase 7.1 purchasing polish](planning/phase7.1-purchasing-polish/README.md) | Complete on `main` (7.1.1–7.1.3); 7.1.4 deferred |
 | [Phase 8 customer foundation](planning/phase8-customer-foundation/README.md) | Complete on `main` (PR #42); [ADR-023](adr/ADR-023-customer-merge.md) |
 | [Phase 9 catalog enrichment](planning/phase9-catalog-enrichment/README.md) | Implemented; [ADR-024](adr/ADR-024-bibliographic-data-authority.md) |
-| [Phase 10 stored value](planning/phase10-stored-value/README.md) | Slices 10.1–10.5 on `main`; milestone open until the manual test plan; [ADR-025](adr/ADR-025-domain-owned-operational-ledgers.md), [ADR-026](adr/ADR-026-gift-card-number-protection.md) |
-| [Canonical roadmap](planning/roadmap.md) | Implemented milestones, forward phases 10–14, UDS, Terminal program |
+| [Phase 10 stored value](planning/phase10-stored-value/README.md) | Implemented on `main`; [ADR-025](adr/ADR-025-domain-owned-operational-ledgers.md), [ADR-026](adr/ADR-026-gift-card-number-protection.md), [ADR-027](adr/ADR-027-admin-gift-card-prefix-last-four-inquiry.md) |
+| [Canonical roadmap](planning/roadmap.md) | Implemented milestones, forward phases 11–14, UDS, Terminal program |
 | [Planning packets](planning/README.md) | Phase and UX packet index |
 | [UX design system](planning/ux-design-system/README.md) | Warm Parchment UDS-1–3 operationally complete; UDS-4.0–4.2 and UDS-5 on `main` |
 | [POS Phases 4–6 plan](planning/phase4-6-point-of-sale/spec.md) | Multi-phase POS sequencing (foundation → cash register → MVP); §6 deferred to the Phase 6 packet |

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -8,7 +8,7 @@ An early outline in this file numbered Phase 8 as buyback and Phase 9 as financi
 
 | Document | Purpose |
 |---|---|
-| [roadmap.md](roadmap.md) | Implemented milestones, forward phases 10–14, UDS, Terminal program, explicit deferrals |
+| [roadmap.md](roadmap.md) | Implemented milestones, forward phases 11–14, UDS, Terminal program, explicit deferrals |
 
 ## Implemented domain packets
 
@@ -25,12 +25,11 @@ An early outline in this file numbered Phase 8 as buyback and Phase 9 as financi
 | [Phase 7.1 — Purchasing polish](phase7.1-purchasing-polish/README.md) | Complete on `main` (7.1.1–7.1.3; 7.1.4 deferred) |
 | [Phase 8 — Customer foundation](phase8-customer-foundation/README.md) | Complete on `main` |
 | [Phase 9 catalog enrichment](phase9-catalog-enrichment/README.md) | Implemented; persistence in [phase9-remediation.md](phase9-catalog-enrichment/phase9-remediation.md) |
+| [Phase 10 — Stored value](phase10-stored-value/README.md) | Implemented on `main`; [ADR-025](../adr/ADR-025-domain-owned-operational-ledgers.md), [ADR-026](../adr/ADR-026-gift-card-number-protection.md), [ADR-027](../adr/ADR-027-admin-gift-card-prefix-last-four-inquiry.md) |
 
 ## Proposed domain packets
 
-| Packet | Status |
-|---|---|
-| [Phase 10 — Stored value](phase10-stored-value/README.md) | Slices 10.1–10.5 on `main`; milestone open until the [manual test plan](phase10-stored-value/phase10-manual-test-plan.md); [ADR-025](../adr/ADR-025-domain-owned-operational-ledgers.md), [ADR-026](../adr/ADR-026-gift-card-number-protection.md) |
+Phases 11–14 and the Terminal program are sequenced in [roadmap.md](roadmap.md). They do not yet have planning packets.
 
 ## Cross-phase UX
 

--- a/docs/planning/phase10-stored-value/README.md
+++ b/docs/planning/phase10-stored-value/README.md
@@ -1,6 +1,6 @@
 # Phase 10 — Stored value
 
-Status: **Proposed** — slices 10.1–10.5 implement on `main`; [milestone 5](https://github.com/BankEncore/ShelfSense-v1/milestone/5) stays open until the [manual test plan](phase10-manual-test-plan.md) is executed. After Phase 8 customer identity. Authority: this packet plus [ADR-025](../../adr/ADR-025-domain-owned-operational-ledgers.md), [ADR-026](../../adr/ADR-026-gift-card-number-protection.md), and [ADR-027](../../adr/ADR-027-admin-gift-card-prefix-last-four-inquiry.md). GitHub tracker: [milestone 5](https://github.com/BankEncore/ShelfSense-v1/milestone/5).
+Status: **Implemented** on `main` (August 2026). Manual test plan executed. After Phase 8 customer identity. Authority: this packet plus [ADR-025](../../adr/ADR-025-domain-owned-operational-ledgers.md), [ADR-026](../../adr/ADR-026-gift-card-number-protection.md), and [ADR-027](../../adr/ADR-027-admin-gift-card-prefix-last-four-inquiry.md). GitHub tracker: [milestone 5](https://github.com/BankEncore/ShelfSense-v1/milestone/5).
 
 The draft [phase-10-stored-value-spec.md](../../drafts/phase-10-stored-value-spec.md) is **superseded**. Do not implement from it.
 

--- a/docs/planning/phase10-stored-value/phase10-account-transfers-and-adjustments.md
+++ b/docs/planning/phase10-stored-value/phase10-account-transfers-and-adjustments.md
@@ -1,6 +1,6 @@
 # Phase 10 — Account transfers and adjustments
 
-Status: **Proposed**. Administrative same-type movement and manual ledger corrections. POS refund destinations remain [phase10-refund-post-void.md](phase10-refund-post-void.md). Schema: [phase10-schema.md](phase10-schema.md). Authorization: [phase10-authorization.md](phase10-authorization.md).
+Status: **Accepted**. Administrative same-type movement and manual ledger corrections. POS refund destinations remain [phase10-refund-post-void.md](phase10-refund-post-void.md). Schema: [phase10-schema.md](phase10-schema.md). Authorization: [phase10-authorization.md](phase10-authorization.md).
 
 ### Actually locked
 

--- a/docs/planning/phase10-stored-value/phase10-authorization.md
+++ b/docs/planning/phase10-stored-value/phase10-authorization.md
@@ -1,6 +1,6 @@
 # Phase 10 — Authorization contract
 
-Status: **Proposed**. Keys are seeded in `Authorization::PermissionCatalog`. The UI must not invent permission semantics. Controllers and services remain the authorization boundary.
+Status: **Accepted**. Keys are seeded in `Authorization::PermissionCatalog`. The UI must not invent permission semantics. Controllers and services remain the authorization boundary.
 
 Phase 1–9 keys are unchanged except where this document adds grants to seeded roles.
 

--- a/docs/planning/phase10-stored-value/phase10-gift-card-numbering.md
+++ b/docs/planning/phase10-stored-value/phase10-gift-card-numbering.md
@@ -1,6 +1,6 @@
 # Phase 10 — Gift-card numbering and scan routing
 
-Status: **Proposed**. Policy: [ADR-026](../../adr/ADR-026-gift-card-number-protection.md), [ADR-027](../../adr/ADR-027-admin-gift-card-prefix-last-four-inquiry.md).
+Status: **Accepted**. Policy: [ADR-026](../../adr/ADR-026-gift-card-number-protection.md), [ADR-027](../../adr/ADR-027-admin-gift-card-prefix-last-four-inquiry.md).
 
 ### Actually locked
 

--- a/docs/planning/phase10-stored-value/phase10-implementation-plan.md
+++ b/docs/planning/phase10-stored-value/phase10-implementation-plan.md
@@ -1,10 +1,10 @@
 # Phase 10 — Implementation plan
 
-Status: **Proposed** (not started). Living file: update slice status when work lands.
+Status: **Complete** on `main` (August 2026). Manual test plan executed.
 
 GitHub tracker: [milestone Phase 10](https://github.com/BankEncore/ShelfSense-v1/milestone/5) — [#58](https://github.com/BankEncore/ShelfSense-v1/issues/58) packet, [#59](https://github.com/BankEncore/ShelfSense-v1/issues/59) 10.1, [#60](https://github.com/BankEncore/ShelfSense-v1/issues/60) 10.2, [#61](https://github.com/BankEncore/ShelfSense-v1/issues/61) 10.3, [#62](https://github.com/BankEncore/ShelfSense-v1/issues/62) 10.4, [#63](https://github.com/BankEncore/ShelfSense-v1/issues/63) 10.5.
 
-Authority: [phase10-plan.md](phase10-plan.md), [phase10-schema.md](phase10-schema.md), [ADR-025](../../adr/ADR-025-domain-owned-operational-ledgers.md), [ADR-026](../../adr/ADR-026-gift-card-number-protection.md).
+Authority: [phase10-plan.md](phase10-plan.md), [phase10-schema.md](phase10-schema.md), [ADR-025](../../adr/ADR-025-domain-owned-operational-ledgers.md), [ADR-026](../../adr/ADR-026-gift-card-number-protection.md), [ADR-027](../../adr/ADR-027-admin-gift-card-prefix-last-four-inquiry.md).
 
 ## Merge policy
 
@@ -53,7 +53,8 @@ Issue branches PR **directly to `main`**. There is no `phase-10-stored-value` in
 | 10.2 Customer store/trade credit | Complete (issue [#60](https://github.com/BankEncore/ShelfSense-v1/issues/60)) |
 | 10.3 Gift-card programs and instruments | Complete (issue [#61](https://github.com/BankEncore/ShelfSense-v1/issues/61)) |
 | 10.4 POS issuance, tenders, refund destinations, post-void | Complete (issue [#62](https://github.com/BankEncore/ShelfSense-v1/issues/62)) |
-| 10.5 Cash-out, closeout, print, nav | Complete (issue [#63](https://github.com/BankEncore/ShelfSense-v1/issues/63)); Phase 10 milestone remains open until the [manual test plan](phase10-manual-test-plan.md) is executed |
+| 10.5 Cash-out, closeout, print, nav | Complete (issue [#63](https://github.com/BankEncore/ShelfSense-v1/issues/63)) |
+| Manual test plan | Executed (August 2026) |
 
 ## Integration notes
 

--- a/docs/planning/phase10-stored-value/phase10-manual-test-plan.md
+++ b/docs/planning/phase10-stored-value/phase10-manual-test-plan.md
@@ -1,6 +1,6 @@
 # Phase 10 — Manual test plan
 
-Status: **Proposed**. Complements automated tests in [phase10-user-stories.md](phase10-user-stories.md). Register and print checks need a browser; admin checks use current UDS screens once they exist.
+Status: **Executed** (August 2026). Complements automated tests in [phase10-user-stories.md](phase10-user-stories.md).
 
 Do not treat this as a substitute for CI.
 

--- a/docs/planning/phase10-stored-value/phase10-plan.md
+++ b/docs/planning/phase10-stored-value/phase10-plan.md
@@ -1,6 +1,6 @@
 # Phase 10 — Stored value plan
 
-Status: **Proposed**. Implementation slices 10.1–10.5 land on `main`; the Phase 10 milestone stays open until the [manual test plan](phase10-manual-test-plan.md) is executed.
+Status: **Implemented** on `main` (August 2026). Manual test plan executed.
 
 ## Goal
 
@@ -175,4 +175,4 @@ Do not ship Register redemption before Core posting, tenders, and signed-net che
 
 ## Parallel work
 
-Phase 10 is the next domain program after Phase 9. UDS-6/7 stay parked. Do not pull buyback or cash locations into these slices.
+Phase 11 is the next domain program. UDS-6/7 stay parked. Do not pull buyback or cash locations into stored-value slices.

--- a/docs/planning/phase10-stored-value/phase10-pos-issuance-and-tenders.md
+++ b/docs/planning/phase10-stored-value/phase10-pos-issuance-and-tenders.md
@@ -1,6 +1,6 @@
 # Phase 10 — POS issuance and tenders
 
-Status: **Proposed**. Implementation authority for how stored value joins completed POS facts.
+Status: **Accepted**. Implementation authority for how stored value joins completed POS facts.
 
 Companions: [phase10-schema.md](phase10-schema.md), [phase10-refund-post-void.md](phase10-refund-post-void.md), [mvp-contract.md](../phase4-6-point-of-sale/phase6-pos-mvp/mvp-contract.md), [operation-and-core-facts.md](../phase4-6-point-of-sale/phase4-point-of-sale/operation-and-core-facts.md), [ADR-020](../../adr/ADR-020-pos-operation-envelope-and-core-facts.md).
 

--- a/docs/planning/phase10-stored-value/phase10-refund-post-void.md
+++ b/docs/planning/phase10-stored-value/phase10-refund-post-void.md
@@ -1,6 +1,6 @@
 # Phase 10 — Refund and post-void
 
-Status: **Proposed**. Builds on [returns.md](../phase4-6-point-of-sale/phase6-pos-mvp/returns.md) and [post-void.md](../phase4-6-point-of-sale/phase6-pos-mvp/post-void.md). Gift-card refund destinations: [phase10-pos-issuance-and-tenders.md](phase10-pos-issuance-and-tenders.md). Unused-instrument return is **deferred**.
+Status: **Accepted**. Builds on [returns.md](../phase4-6-point-of-sale/phase6-pos-mvp/returns.md) and [post-void.md](../phase4-6-point-of-sale/phase6-pos-mvp/post-void.md). Gift-card refund destinations: [phase10-pos-issuance-and-tenders.md](phase10-pos-issuance-and-tenders.md). Unused-instrument return is **deferred**.
 
 ### Actually locked
 

--- a/docs/planning/phase10-stored-value/phase10-reporting-closeout.md
+++ b/docs/planning/phase10-stored-value/phase10-reporting-closeout.md
@@ -1,6 +1,6 @@
 # Phase 10 — Reporting and closeout
 
-Status: **Proposed**. Extends frozen Phase 5/6 closeout; do not invent Phase 11’s cash-movement ledger.
+Status: **Accepted**. Extends frozen Phase 5/6 closeout; do not invent Phase 11’s cash-movement ledger.
 
 Companions: [phase5-plan.md](../phase4-6-point-of-sale/phase5-cash-register/phase5-plan.md), [Pos::SessionTotals](../../../app/services/pos/session_totals.rb), [phase10-pos-issuance-and-tenders.md](phase10-pos-issuance-and-tenders.md).
 

--- a/docs/planning/phase10-stored-value/phase10-schema.md
+++ b/docs/planning/phase10-stored-value/phase10-schema.md
@@ -1,6 +1,6 @@
 # Phase 10 — Schema contract
 
-Status: **Proposed**. PostgreSQL is authoritative. Do not edit `db/schema.rb` until migrations land. UUIDv7 via `create_uuid_table` / application-assigned ids ([AGENTS.md](../../../AGENTS.md) §10).
+Status: **Accepted**. PostgreSQL is authoritative. UUIDv7 via `create_uuid_table` / application-assigned ids ([AGENTS.md](../../../AGENTS.md) §10).
 
 Companions: [phase10-plan.md](phase10-plan.md), [phase10-pos-issuance-and-tenders.md](phase10-pos-issuance-and-tenders.md), [phase10-gift-card-numbering.md](phase10-gift-card-numbering.md), [phase10-account-transfers-and-adjustments.md](phase10-account-transfers-and-adjustments.md).
 

--- a/docs/planning/phase10-stored-value/phase10-user-stories.md
+++ b/docs/planning/phase10-stored-value/phase10-user-stories.md
@@ -1,6 +1,6 @@
 # Phase 10 — User stories
 
-GitHub-issue-ready stories. Keep 10.4 issuance and signed-net in the same implementation PR when they land.
+Status: **Implemented** on `main`. GitHub-issue-ready stories used for slices 10.1–10.5.
 
 ## 10.1 — Stored-value core
 

--- a/docs/planning/phase8-customer-foundation/README.md
+++ b/docs/planning/phase8-customer-foundation/README.md
@@ -1,6 +1,6 @@
 # Phase 8 — Customer foundation (MVP)
 
-Status: **Complete** on `main` (August 2026, PR #42, merge `b5ed590`). [Phase 9 catalog enrichment](../phase9-catalog-enrichment/README.md) is implemented. Phase 10 stored value is specified in [phase10-stored-value](../phase10-stored-value/README.md).
+Status: **Complete** on `main` (August 2026, PR #42, merge `b5ed590`). [Phase 9 catalog enrichment](../phase9-catalog-enrichment/README.md) is implemented. [Phase 10 stored value](../phase10-stored-value/README.md) is implemented.
 
 | Document | Purpose |
 |---|---|

--- a/docs/planning/phase9-catalog-enrichment/README.md
+++ b/docs/planning/phase9-catalog-enrichment/README.md
@@ -1,6 +1,6 @@
 # Phase 9 — Catalog and bibliographic enrichment
 
-Status: **Implemented** (August 2026). After Phase 8 on `main`. [Phase 10 stored value](../phase10-stored-value/README.md) is proposed and may start in parallel but is not the primary stream.
+Status: **Implemented** (August 2026). After Phase 8 on `main`. [Phase 10 stored value](../phase10-stored-value/README.md) is implemented.
 
 Remediation: [phase9-remediation.md](phase9-remediation.md). Product forms: [product-forms-seed.md](product-forms-seed.md).
 

--- a/docs/planning/roadmap.md
+++ b/docs/planning/roadmap.md
@@ -46,6 +46,7 @@ Several roadmap goals are **not greenfield**. The forward phases below describe 
 |---|---|
 | Customers | Identity, contact lookup, duplicate suggestions, merge, requests, reservations, Register pickup |
 | Register / POS | Session opening, cash sales, mixed tenders, returns, blind close, Z reporting, transaction history |
+| Stored value | Store credit, trade credit, gift-card instruments, POS issuance and redemption, cash-out |
 | Financial | GL classifications, tax calculation, inventory valuation, immutable POS facts |
 | Product / catalog | Strong identifiers, classification, pricing, Used units, unified lookup, CSV import, bibliographic facts, local covers, subjects, reviewed ISBNdb apply |
 | Layout / UX | Warm Parchment tokens, grouped navigation, ActionButtonHelper on reference and non-purchasing screens; remaining migration belongs to the feature phase that changes the screen |
@@ -124,7 +125,7 @@ Coordination with UDS-4: [phase7.1-uds-coordination.md](phase7.1-purchasing-poli
 
 ## Phase 8 — Customer foundation (MVP)
 
-**Status:** **Complete** on `main` (PR #42, merge `b5ed590`). Planning packet: [phase8-customer-foundation/](phase8-customer-foundation/README.md). Phase 9 catalog enrichment is implemented; Phase 10 is proposed but is not the primary stream.
+**Status:** **Complete** on `main` (PR #42, merge `b5ed590`). Planning packet: [phase8-customer-foundation/](phase8-customer-foundation/README.md). Phase 9 catalog enrichment and Phase 10 stored value are implemented.
 
 Phase 7 created the minimum customer record required for requests. Phase 8 concentrates on **reliable identification**, **essential contact methods**, **duplicate prevention and safe merge**, and **minimal lifecycle governance**—not CRM, marketing, multiple contacts, or stored-value ledger design.
 
@@ -163,7 +164,7 @@ Phase 8 does not create stored-value accounts. It documents the identity contrac
 
 ## Phase 9 — Catalog and bibliographic enrichment
 
-**Status:** Implemented. Planning packet: [phase9-catalog-enrichment/](phase9-catalog-enrichment/README.md). Policy: [ADR-024](../adr/ADR-024-bibliographic-data-authority.md). Phase 10 is unblocked by customer identity but is not the primary stream.
+**Status:** Implemented. Planning packet: [phase9-catalog-enrichment/](phase9-catalog-enrichment/README.md). Policy: [ADR-024](../adr/ADR-024-bibliographic-data-authority.md). Phase 10 stored value is implemented.
 
 Extends Phases 2 and 6.1; does not replace the product model. Policy: [ADR-024](../adr/ADR-024-bibliographic-data-authority.md).
 
@@ -192,7 +193,7 @@ The external lookup boundary returns **normalized candidate data**; the Product 
 
 ## Phase 10 — Stored value
 
-**Status:** Implementation slices 10.1–10.5 land on `main`. Phase 10 is **not Complete** until the [manual test plan](phase10-stored-value/phase10-manual-test-plan.md) is executed. Planning packet: [phase10-stored-value/](phase10-stored-value/README.md). Policy: [ADR-025](../adr/ADR-025-domain-owned-operational-ledgers.md), [ADR-026](../adr/ADR-026-gift-card-number-protection.md).
+**Status:** **Implemented** on `main` (August 2026). Manual test plan executed. Planning packet: [phase10-stored-value/](phase10-stored-value/README.md). Policy: [ADR-025](../adr/ADR-025-domain-owned-operational-ledgers.md), [ADR-026](../adr/ADR-026-gift-card-number-protection.md), [ADR-027](../adr/ADR-027-admin-gift-card-prefix-last-four-inquiry.md).
 
 Stored-value redemption is **online-authorized** until a bounded offline mechanism exists ([ADR-005](../adr/ADR-005-terminal-originated-operations.md)). There is **no** universal operational financial-event table; each domain keeps its own immutable facts. Cross-domain accounting/export is Phase 14.
 
@@ -375,8 +376,8 @@ The following remain out of scope until a planning packet and ADR review justify
 | UDS-4 — Navigation and information architecture | **UDS-4.0–4.2 on `main`** ([uds-4-plan.md](ux-design-system/uds-4-plan.md)) |
 | UDS-5 — Administrative composition | **Complete** on `main` (PR #57; [uds-5-plan.md](ux-design-system/uds-5-plan.md)) |
 | Phase 8 — Customer foundation (MVP) | **Complete** on `main` (PR #42) |
-| Phase 9 — Catalog and bibliographic enrichment | **Implemented**; Phase 10 unblocked but not primary |
-| Phase 10 — Stored value | Slices 10.1–10.5 land on `main`; milestone remains open until the [manual test plan](phase10-stored-value/phase10-manual-test-plan.md) |
+| Phase 9 — Catalog and bibliographic enrichment | **Implemented** |
+| Phase 10 — Stored value | **Implemented** on `main`; [manual test plan](phase10-stored-value/phase10-manual-test-plan.md) executed |
 | Phase 11 — Cash accountability completion | After Phase 10 stored-value and Register integration |
 | Phase 12 — Used buyback | After 8–11 (payout after 10–11) |
 | Phase 13 — Customer workspace | After activity sources exist |
@@ -391,7 +392,7 @@ The following remain out of scope until a planning packet and ADR review justify
 
 | Document | Relationship |
 |---|---|
-| [Phase 10 stored value](phase10-stored-value/README.md) | Slices 10.1–10.5 on `main`; milestone open until manual gate; [ADR-025](../adr/ADR-025-domain-owned-operational-ledgers.md) |
+| [Phase 10 stored value](phase10-stored-value/README.md) | Implemented; [ADR-025](../adr/ADR-025-domain-owned-operational-ledgers.md), [ADR-026](../adr/ADR-026-gift-card-number-protection.md), [ADR-027](../adr/ADR-027-admin-gift-card-prefix-last-four-inquiry.md) |
 | [Phase planning packets](phase1-operational-foundation/phase1-plan.md) | Authoritative detail per implemented phase |
 | [Phase 7.1 purchasing closeout](phase7.1-purchasing-polish/README.md) | Phase 7 operability finish; [coordination with UDS-4](phase7.1-purchasing-polish/phase7.1-uds-coordination.md) |
 | [UDS-4 plan](ux-design-system/uds-4-plan.md) | Grouped navigation and cross-cutting adoption |


### PR DESCRIPTION
## Summary
- Record Phase 10 stored value as **Implemented** on `main` after the [manual test plan](docs/planning/phase10-stored-value/phase10-manual-test-plan.md) executed.
- Move the packet from Proposed to Implemented/Accepted/Complete, update the README and roadmap, and leave Phases 11–14 as the next proposed work.

## Verification
- Documentation-only; no application tests

## Documentation and migrations
- README, docs index, planning index, roadmap, Phase 8/9 pointers, Phase 10 packet
- No migrations

Made with [Cursor](https://cursor.com)