### PR TITLE
11.0 — Lock Phase 11 merge policy on the integration branch

### DIFF
--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -67,7 +67,7 @@ Small maintenance (dependency bumps, tiny fixes) may use an issue + PR without a
 
 ## Branches and pull requests
 
-Branch naming: `<issue-number>-<short-description>` (lowercase, hyphenated). Merge to the primary development branch (`main`). No long-lived phase branches unless a release strategy requires them.
+Branch naming: `<issue-number>-<short-description>` (lowercase, hyphenated). Merge to the primary development branch (`main`). No long-lived phase branches unless a release strategy requires them. **Phase 11 exception:** slice PRs target `phase-11-cash-accountability`; merge that branch to `main` only after the Phase 11 manual test plan is executed ([phase11-implementation-plan.md](planning/phase11-cash-accountability/phase11-implementation-plan.md)).
 
 PR structure:
 

--- a/docs/planning/phase11-cash-accountability/phase11-implementation-plan.md
+++ b/docs/planning/phase11-cash-accountability/phase11-implementation-plan.md
@@ -6,13 +6,18 @@ Authority: [phase11-plan.md](phase11-plan.md), [phase11-schema.md](phase11-schem
 
 ## Merge policy
 
-Issue branches PR **directly to `main`**. There is no Phase 11 integration branch.
+Phase 11 uses a long-lived integration branch because 11.1 makes `OpenSession` fail until every active store safe is initialized. Incomplete slices must stay off `main`.
 
-- Branch naming: `<issue-number>-<short-description>` ([github-workflow.md](../../github-workflow.md)).
-- Merge order: 11.0 packet docs → 11.1 → 11.2 → 11.3.
+- Integration branch: `phase-11-cash-accountability` (from `main`). This is the only long-lived Phase 11 branch.
+- Slice branches: `<issue-number>-<short-description>` ([github-workflow.md](../../github-workflow.md)).
+- Slice PRs target **`phase-11-cash-accountability`**, not `main`. Do not start slice N+1 until slice N is reviewed and merged into the integration branch.
+- Merge order: 11.0 merge-policy docs → 11.1 → 11.2 → 11.3.
 - 11.1 is **one** complete PR (reviewable commits, not independently mergeable): safe init, open transfer, `SessionTotals`, close transfer, available-cash, gift-card cash-out check, manager-assisted close, Z regression.
 - Do not ship paid-in/out or deposit before expected cash includes 11.1 transfers and over/short.
 - Navigation destinations land in the slice that introduces the screens.
+- Do **not** merge `phase-11-cash-accountability` to `main` until [phase11-manual-test-plan.md](phase11-manual-test-plan.md) is executed.
+
+GitHub tracker: [milestone Phase 11](https://github.com/BankEncore/ShelfSense-v1/milestone/6) — [#72](https://github.com/BankEncore/ShelfSense-v1/issues/72) 11.0, [#73](https://github.com/BankEncore/ShelfSense-v1/issues/73) 11.1, [#74](https://github.com/BankEncore/ShelfSense-v1/issues/74) 11.2, [#75](https://github.com/BankEncore/ShelfSense-v1/issues/75) 11.3.
 
 ## Locked decisions
 
@@ -65,7 +70,7 @@ If a later release needs to delay enforcement, that would be a feature gate or t
 
 | Slice | Status |
 |---|---|
-| 11.0 Contract / packet | **Complete** (this directory is implementation authority; land via the packet docs PR if not already on `main`) |
+| 11.0 Contract / packet | **Complete** on `main` (planning packet). Merge-policy lock: this PR on `phase-11-cash-accountability` |
 | 11.1 Safe-backed session lifecycle | Not started |
 | 11.2 Non-sale cash activity | Not started |
 | 11.3 Safe recon, deposit, store-day report | Not started |


### PR DESCRIPTION
## Summary
- Record the long-lived `phase-11-cash-accountability` integration branch as Phase 11’s merge policy.
- Slice PRs target that branch; the completed phase stays off `main` until the manual test plan is executed.
- Note the exception in `docs/github-workflow.md`. Tracker: milestone 6, issues #72–#75.

## Verification
- Docs-only; no application tests.

## Documentation and migrations
- `docs/planning/phase11-cash-accountability/phase11-implementation-plan.md`
- `docs/github-workflow.md`

Closes #72

Made with [Cursor](https://cursor.com)