### PR TITLE
11.2 — Non-sale cash activity

### DIFF
--- a/app/controllers/pos/cash_activities_controller.rb
+++ b/app/controllers/pos/cash_activities_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Pos
+  class CashActivitiesController < BaseController
+    before_action :load_open_session!
+
+    private
+
+    def load_open_session!
+      @session_record = cashier_target_session
+      return if @session_record
+
+      redirect_to pos_register_enter_path, alert: "Open a register before recording cash activity."
+    end
+
+    def require_cash_permission!(key)
+      return if Authorization::PermissionEvaluator.allowed?(
+        user: current_user,
+        permission_key: key,
+        store: current_store
+      )
+
+      redirect_to pos_path, alert: "You are not authorized to perform that cash action."
+    end
+
+    def parse_amount!
+      parsed = Money::ParseCents.call(params[:amount])
+      raise Cash::Error, "amount is required" if parsed.nil?
+      raise Cash::Error, "amount must be positive" unless parsed.positive?
+
+      parsed
+    end
+
+    def command_ids
+      {
+        source_id: params[:source_id].presence || SecureRandom.uuid_v7,
+        idempotency_key: params[:idempotency_key].presence || SecureRandom.uuid_v7
+      }
+    end
+  end
+end

--- a/app/controllers/pos/cash_drops_controller.rb
+++ b/app/controllers/pos/cash_drops_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Pos
+  class CashDropsController < CashActivitiesController
+    before_action -> { require_cash_permission!("pos.transact") }
+
+    def new; end
+
+    def create
+      Cash::Drop.call(
+        session: @session_record,
+        actor: current_user,
+        amount_cents: parse_amount!,
+        **command_ids
+      )
+      redirect_to pos_path, notice: "Drop recorded."
+    rescue Money::ParseCents::Error, Cash::Error, Pos::Denied => e
+      @error = e.message
+      render :new, status: :unprocessable_content
+    end
+  end
+end

--- a/app/controllers/pos/cash_paid_ins_controller.rb
+++ b/app/controllers/pos/cash_paid_ins_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Pos
+  class CashPaidInsController < CashActivitiesController
+    before_action -> { require_cash_permission!("cash.paid_in") }
+
+    def new
+      load_reasons!
+    end
+
+    def create
+      Cash::PaidIn.call(
+        session: @session_record,
+        actor: current_user,
+        amount_cents: parse_amount!,
+        reason_code: params[:reason_code],
+        notes: params[:notes],
+        **command_ids
+      )
+      redirect_to pos_path, notice: "Paid-in recorded."
+    rescue Money::ParseCents::Error, Cash::Error, Pos::Denied => e
+      load_reasons!
+      @error = e.message
+      render :new, status: :unprocessable_content
+    end
+
+    private
+
+    def load_reasons!
+      Cash::ActivityReasons.seed!
+      @reasons = CashActivityReason.active.where(operation_kind: "paid_in").order(:name)
+    end
+  end
+end

--- a/app/controllers/pos/cash_paid_outs_controller.rb
+++ b/app/controllers/pos/cash_paid_outs_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Pos
+  class CashPaidOutsController < CashActivitiesController
+    before_action -> { require_cash_permission!("cash.paid_out") }
+
+    def new
+      load_reasons!
+    end
+
+    def create
+      Cash::PaidOut.call(
+        session: @session_record,
+        actor: current_user,
+        amount_cents: parse_amount!,
+        reason_code: params[:reason_code],
+        notes: params[:notes],
+        approver_username: params[:approver_username],
+        approver_password: params[:approver_password],
+        **command_ids
+      )
+      redirect_to pos_path, notice: "Paid-out recorded."
+    rescue Money::ParseCents::Error, Cash::Error, Pos::Denied => e
+      load_reasons!
+      @error = e.message
+      render :new, status: :unprocessable_content
+    end
+
+    private
+
+    def load_reasons!
+      Cash::ActivityReasons.seed!
+      @reasons = CashActivityReason.active.where(operation_kind: "paid_out").order(:name)
+    end
+  end
+end

--- a/app/controllers/pos/cash_replenishments_controller.rb
+++ b/app/controllers/pos/cash_replenishments_controller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Pos
+  class CashReplenishmentsController < CashActivitiesController
+    before_action -> { require_cash_permission!("cash.move") }
+
+    def new
+      load_sessions!
+    end
+
+    def create
+      load_sessions!
+      Cash::Replenish.call(
+        session: @session_record,
+        actor: current_user,
+        amount_cents: parse_amount!,
+        **command_ids
+      )
+      redirect_to pos_path, notice: "Replenishment recorded."
+    rescue Money::ParseCents::Error, Cash::Error, Pos::Denied => e
+      load_sessions!
+      @error = e.message
+      render :new, status: :unprocessable_content
+    end
+
+    private
+
+    def load_open_session!
+      load_sessions!
+      return if @session_record
+
+      redirect_to pos_path, alert: "No open register session is available to replenish."
+    end
+
+    def load_sessions!
+      @open_sessions = PosSession.open.where(store: current_store).includes(:register, :cashier_user).order(:opened_at)
+      @session_record = if params[:pos_session_id].present?
+        @open_sessions.find_by(id: params[:pos_session_id])
+      else
+        cashier_target_session || @open_sessions.first
+      end
+    end
+  end
+end

--- a/app/controllers/pos/cash_reversals_controller.rb
+++ b/app/controllers/pos/cash_reversals_controller.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Pos
+  class CashReversalsController < CashActivitiesController
+    skip_before_action :load_open_session!
+    before_action -> { require_cash_permission!("cash.reverse") }
+
+    def new
+      load_form!
+    end
+
+    def create
+      operation = CashOperation.find(params.require(:cash_operation_id))
+      raise Cash::Error, "operation is not in this store" unless operation.store_id == current_store.id
+
+      Cash::Reverse.call(
+        operation: operation,
+        actor: current_user,
+        reason_code: params[:reason_code],
+        notes: params[:notes],
+        **command_ids
+      )
+      redirect_to pos_path, notice: "Cash operation reversed."
+    rescue Cash::Error, Pos::Denied, ActiveRecord::RecordNotFound => e
+      load_form!
+      @error = e.message
+      render :new, status: :unprocessable_content
+    end
+
+    private
+
+    def load_form!
+      Cash::ActivityReasons.seed!
+      @reasons = CashActivityReason.active.where(operation_kind: "reverse").order(:name)
+      open_ids = PosSession.open.where(store: current_store).select(:id)
+      @operations = CashOperation.where(store: current_store, pos_session_id: open_ids)
+                                 .where.not(operation_type: %w[initialize_safe reconcile reverse])
+                                 .order(occurred_at: :desc)
+                                 .select { |operation| Cash::Reverse.reversible?(operation) }
+    end
+  end
+end

--- a/app/models/cash_operation.rb
+++ b/app/models/cash_operation.rb
@@ -15,6 +15,8 @@ class CashOperation < ApplicationRecord
   has_one :cash_transfer, dependent: :restrict_with_exception
   has_one :cash_reconciliation, dependent: :restrict_with_exception
   has_one :cash_safe_initialization, dependent: :restrict_with_exception
+  has_one :cash_paid_in, dependent: :restrict_with_exception
+  has_one :cash_paid_out, dependent: :restrict_with_exception
 
   validates :operation_type, :business_date, :occurred_at, presence: true
   validates :operation_type, inclusion: { in: OPERATION_TYPES }

--- a/app/models/cash_paid_in.rb
+++ b/app/models/cash_paid_in.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CashPaidIn < ApplicationRecord
+  belongs_to :pos_session
+  belongs_to :cash_operation
+
+  validates :amount_cents, numericality: { only_integer: true, greater_than: 0 }
+  validates :reason_code, :reason_name_snapshot, presence: true
+
+  def readonly?
+    super || persisted?
+  end
+end

--- a/app/models/cash_paid_out.rb
+++ b/app/models/cash_paid_out.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CashPaidOut < ApplicationRecord
+  belongs_to :pos_session
+  belongs_to :cash_operation
+  has_one :pos_controlled_action, dependent: :restrict_with_exception
+
+  validates :amount_cents, numericality: { only_integer: true, greater_than: 0 }
+  validates :reason_code, :reason_name_snapshot, presence: true
+
+  def readonly?
+    super || persisted?
+  end
+end

--- a/app/models/pos_controlled_action.rb
+++ b/app/models/pos_controlled_action.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PosControlledAction < ApplicationRecord
-  ACTION_TYPES = %w[price_override line_discount tax_class_override unlinked_return post_void gift_card_cash_out].freeze
+  ACTION_TYPES = %w[price_override line_discount tax_class_override unlinked_return post_void gift_card_cash_out cash_paid_out].freeze
   POLICY_RESULTS = %w[direct approval_required].freeze
   POLICY_VERSION = "phase6_permission_tier_v1"
   FINGERPRINT_SCHEMA_VERSION = "v1"
@@ -9,6 +9,7 @@ class PosControlledAction < ApplicationRecord
   belongs_to :pos_transaction, optional: true
   belongs_to :pos_transaction_line, optional: true
   belongs_to :gift_card_cash_out, optional: true
+  belongs_to :cash_paid_out, optional: true
   belongs_to :performed_by_user, class_name: "User"
   belongs_to :approved_by_user, class_name: "User", optional: true
 
@@ -21,7 +22,7 @@ class PosControlledAction < ApplicationRecord
   validate :approver_matches_policy
 
   def readonly?
-    super || (persisted? && (pos_transaction&.commercially_immutable? || gift_card_cash_out_id.present?))
+    super || (persisted? && (pos_transaction&.commercially_immutable? || gift_card_cash_out_id.present? || cash_paid_out_id.present?))
   end
 
   private

--- a/app/models/pos_session.rb
+++ b/app/models/pos_session.rb
@@ -11,6 +11,8 @@ class PosSession < ApplicationRecord
   has_many :pos_transactions, dependent: :restrict_with_exception
   has_many :gift_card_cash_outs, dependent: :restrict_with_exception
   has_many :cash_entries, dependent: :restrict_with_exception
+  has_many :cash_paid_ins, dependent: :restrict_with_exception
+  has_many :cash_paid_outs, dependent: :restrict_with_exception
 
   validates :status, :opened_at, presence: true
   validates :status, inclusion: { in: STATUSES }

--- a/app/services/cash/activity_reasons.rb
+++ b/app/services/cash/activity_reasons.rb
@@ -5,7 +5,9 @@ module Cash
     SEEDS = [
       { code: "over_count", name: "Over count", operation_kind: "over" },
       { code: "short_count", name: "Short count", operation_kind: "short" },
+      { code: "paid_in_found", name: "Found cash", operation_kind: "paid_in" },
       { code: "paid_in_other", name: "Other paid-in", operation_kind: "paid_in", notes_required: true },
+      { code: "paid_out_supplies", name: "Store supplies", operation_kind: "paid_out" },
       { code: "paid_out_other", name: "Other paid-out", operation_kind: "paid_out", notes_required: true },
       { code: "reverse", name: "Reversal", operation_kind: "reverse", notes_required: true }
     ].freeze

--- a/app/services/cash/drop.rb
+++ b/app/services/cash/drop.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Cash
+  class Drop
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(session:, actor:, amount_cents:, source_id:, idempotency_key:)
+      @session = session
+      @actor = actor
+      @amount_cents = amount_cents
+      @source_id = source_id
+      @idempotency_key = idempotency_key
+    end
+
+    def call
+      amount = Integer(@amount_cents)
+      raise Error, "amount must be positive" unless amount.positive?
+      unless Authorization::PermissionEvaluator.allowed?(
+        user: @actor, permission_key: "pos.transact", store: @session.store
+      )
+        raise Error, "not authorized to drop cash from this session"
+      end
+
+      CashTransfer.transaction do
+        Cash::Locations.ensure!(@session.store)
+        safe = CashLocation.lock.find_by!(store: @session.store, location_type: "safe")
+        session = SessionGuard.lock_open_cashier_session!(@session, @actor)
+        AvailableCash.assert!(session, amount)
+        operation = Post.call(
+          operation_type: "transfer",
+          store: session.store,
+          performed_by: @actor,
+          pos_session: session,
+          source_id: @source_id,
+          idempotency_key: @idempotency_key,
+          entries: [
+            { pos_session: session, amount_cents: -amount, balance_after_cents: SessionGuard.session_balance_after(session, -amount) },
+            { cash_location: safe, amount_cents: amount }
+          ]
+        )
+        return operation.cash_transfer if operation.cash_transfer
+
+        CashTransfer.create!(
+          transfer_type: "drop",
+          amount_cents: amount,
+          source_pos_session: session,
+          destination_cash_location: safe,
+          cash_operation: operation
+        )
+      end
+    rescue Pos::Denied => e
+      raise Error, e.message
+    end
+  end
+end

--- a/app/services/cash/paid_in.rb
+++ b/app/services/cash/paid_in.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Cash
+  class PaidIn
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(session:, actor:, amount_cents:, reason_code:, source_id:, idempotency_key:, notes: nil)
+      @session = session
+      @actor = actor
+      @amount_cents = amount_cents
+      @reason_code = reason_code
+      @notes = notes.to_s.strip.presence
+      @source_id = source_id
+      @idempotency_key = idempotency_key
+    end
+
+    def call
+      amount = Integer(@amount_cents)
+      raise Error, "amount must be positive" unless amount.positive?
+      unless Authorization::PermissionEvaluator.allowed?(
+        user: @actor, permission_key: "cash.paid_in", store: @session.store
+      )
+        raise Error, "not authorized to record a paid-in"
+      end
+      reason = ActivityReasons.require!(@reason_code, "paid_in")
+      if reason.notes_required && @notes.blank?
+        raise Error, "notes are required"
+      end
+
+      CashPaidIn.transaction do
+        session = SessionGuard.lock_open_cashier_session!(@session, @actor)
+        operation = Post.call(
+          operation_type: "paid_in",
+          store: session.store,
+          performed_by: @actor,
+          pos_session: session,
+          source_id: @source_id,
+          idempotency_key: @idempotency_key,
+          reason_code: reason.code,
+          reason_name_snapshot: reason.name,
+          notes: @notes,
+          entries: [ {
+            pos_session: session,
+            amount_cents: amount,
+            balance_after_cents: SessionGuard.session_balance_after(session, amount)
+          } ]
+        )
+        return operation.cash_paid_in if operation.cash_paid_in
+
+        CashPaidIn.create!(
+          pos_session: session,
+          amount_cents: amount,
+          reason_code: reason.code,
+          reason_name_snapshot: reason.name,
+          notes: @notes,
+          cash_operation: operation
+        )
+      end
+    rescue Pos::Denied => e
+      raise Error, e.message
+    end
+  end
+end

--- a/app/services/cash/paid_out.rb
+++ b/app/services/cash/paid_out.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+module Cash
+  class PaidOut
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(
+      session:,
+      actor:,
+      amount_cents:,
+      reason_code:,
+      source_id:,
+      idempotency_key:,
+      notes: nil,
+      approver_username: nil,
+      approver_password: nil
+    )
+      @session = session
+      @actor = actor
+      @amount_cents = amount_cents
+      @reason_code = reason_code
+      @notes = notes.to_s.strip.presence
+      @source_id = source_id
+      @idempotency_key = idempotency_key
+      @approver_username = approver_username
+      @approver_password = approver_password
+    end
+
+    def call
+      amount = Integer(@amount_cents)
+      raise Error, "amount must be positive" unless amount.positive?
+      unless Authorization::PermissionEvaluator.allowed?(
+        user: @actor, permission_key: "cash.paid_out", store: @session.store
+      )
+        raise Error, "not authorized to record a paid-out"
+      end
+      reason = ActivityReasons.require!(@reason_code, "paid_out")
+      if reason.notes_required && @notes.blank?
+        raise Error, "notes are required"
+      end
+
+      CashPaidOut.transaction do
+        session = SessionGuard.lock_open_cashier_session!(@session, @actor)
+        AvailableCash.assert!(session, amount)
+        approved_by, policy = resolve_approver!(session, amount)
+        operation = Post.call(
+          operation_type: "paid_out",
+          store: session.store,
+          performed_by: @actor,
+          approved_by: approved_by,
+          pos_session: session,
+          source_id: @source_id,
+          idempotency_key: @idempotency_key,
+          reason_code: reason.code,
+          reason_name_snapshot: reason.name,
+          notes: @notes,
+          entries: [ {
+            pos_session: session,
+            amount_cents: -amount,
+            balance_after_cents: SessionGuard.session_balance_after(session, -amount)
+          } ]
+        )
+        return operation.cash_paid_out if operation.cash_paid_out
+
+        paid_out = CashPaidOut.create!(
+          pos_session: session,
+          amount_cents: amount,
+          reason_code: reason.code,
+          reason_name_snapshot: reason.name,
+          notes: @notes,
+          cash_operation: operation
+        )
+        record_controlled_action!(paid_out, approved_by, policy, reason)
+        paid_out
+      end
+    rescue Pos::Denied => e
+      raise Error, e.message
+    end
+
+    private
+
+    def resolve_approver!(session, amount)
+      if amount < Thresholds.paid_out_cents(session.store)
+        return [ nil, "direct" ]
+      end
+
+      if Authorization::PermissionEvaluator.allowed?(
+        user: @actor, permission_key: "cash.approve_paid_out", store: session.store
+      )
+        return [ nil, "direct" ]
+      end
+
+      approver = Pos::AuthenticateApprover.call(
+        username: @approver_username,
+        password: @approver_password,
+        store: session.store,
+        action_type: "cash_paid_out",
+        performer: @actor,
+        permission_key: "cash.approve_paid_out"
+      )
+      [ approver, "approval_required" ]
+    end
+
+    def record_controlled_action!(paid_out, approver, policy, reason)
+      material = {
+        "cash_paid_out_id" => paid_out.id.to_s,
+        "amount_cents" => paid_out.amount_cents,
+        "pos_session_id" => paid_out.pos_session_id.to_s
+      }
+      fingerprint = Pos::ControlledActionFingerprint.call(
+        action_type: "cash_paid_out",
+        cash_paid_out_id: paid_out.id,
+        material_values: material,
+        reason_code: reason.code,
+        reason_note: @notes
+      )
+      PosControlledAction.create!(
+        action_type: "cash_paid_out",
+        cash_paid_out: paid_out,
+        performed_by_user: @actor,
+        performed_by_name_snapshot: @actor.display_name,
+        approved_by_user: approver,
+        approved_by_name_snapshot: approver&.display_name,
+        reason_code: reason.code,
+        reason_name_snapshot: reason.name,
+        reason_note: @notes,
+        policy_result: policy,
+        policy_version: PosControlledAction::POLICY_VERSION,
+        fingerprint_schema_version: PosControlledAction::FINGERPRINT_SCHEMA_VERSION,
+        action_fingerprint: fingerprint,
+        material_values: material,
+        executed_at: Time.current
+      )
+    end
+  end
+end

--- a/app/services/cash/replenish.rb
+++ b/app/services/cash/replenish.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Cash
+  class Replenish
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(session:, actor:, amount_cents:, source_id:, idempotency_key:)
+      @session = session
+      @actor = actor
+      @amount_cents = amount_cents
+      @source_id = source_id
+      @idempotency_key = idempotency_key
+    end
+
+    def call
+      amount = Integer(@amount_cents)
+      raise Error, "amount must be positive" unless amount.positive?
+      unless Authorization::PermissionEvaluator.allowed?(
+        user: @actor, permission_key: "cash.move", store: @session.store
+      )
+        raise Error, "not authorized to replenish this session"
+      end
+
+      CashTransfer.transaction do
+        Cash::Locations.ensure!(@session.store)
+        safe = CashLocation.lock.find_by!(store: @session.store, location_type: "safe")
+        session = SessionGuard.lock_open_session!(@session)
+        SessionGuard.refuse_commercial_working!(session)
+        if safe.expected_balance_cents < amount
+          raise Error, "safe does not have enough cash for this replenishment"
+        end
+
+        operation = Post.call(
+          operation_type: "transfer",
+          store: session.store,
+          performed_by: @actor,
+          pos_session: session,
+          source_id: @source_id,
+          idempotency_key: @idempotency_key,
+          entries: [
+            { cash_location: safe, amount_cents: -amount },
+            { pos_session: session, amount_cents: amount, balance_after_cents: SessionGuard.session_balance_after(session, amount) }
+          ]
+        )
+        return operation.cash_transfer if operation.cash_transfer
+
+        CashTransfer.create!(
+          transfer_type: "replenishment",
+          amount_cents: amount,
+          source_cash_location: safe,
+          destination_pos_session: session,
+          cash_operation: operation
+        )
+      end
+    end
+  end
+end

--- a/app/services/cash/reverse.rb
+++ b/app/services/cash/reverse.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+module Cash
+  class Reverse
+    FORBIDDEN_TYPES = %w[initialize_safe reconcile].freeze
+    FORBIDDEN_TRANSFERS = %w[opening_float session_close].freeze
+
+    def self.reversible?(operation)
+      return false if operation.reverse? || operation.reversed?
+      return false if FORBIDDEN_TYPES.include?(operation.operation_type)
+
+      transfer = operation.cash_transfer
+      return false if transfer && FORBIDDEN_TRANSFERS.include?(transfer.transfer_type)
+      return false if transfer&.transfer_type == "deposit"
+
+      session_ids = operation.cash_entries.filter_map(&:pos_session_id).uniq
+      return true if session_ids.empty?
+
+      session_ids.one? && PosSession.where(id: session_ids.first, status: "open").exists?
+    end
+
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(operation:, actor:, source_id:, idempotency_key:, reason_code:, notes: nil)
+      @operation = operation
+      @actor = actor
+      @source_id = source_id
+      @idempotency_key = idempotency_key
+      @reason_code = reason_code
+      @notes = notes.to_s.strip.presence
+    end
+
+    def call
+      unless Authorization::PermissionEvaluator.allowed?(
+        user: @actor, permission_key: "cash.reverse", store: @operation.store
+      )
+        raise Error, "not authorized to reverse this cash operation"
+      end
+      raise Error, "operation is already a reverse" if @operation.reverse?
+      raise Error, "operation has already been reversed" if @operation.reversed?
+      raise Error, "this operation cannot be reversed" if FORBIDDEN_TYPES.include?(@operation.operation_type)
+
+      transfer = @operation.cash_transfer
+      if transfer && FORBIDDEN_TRANSFERS.include?(transfer.transfer_type)
+        raise Error, "this operation cannot be reversed"
+      end
+      if transfer&.transfer_type == "deposit"
+        raise Error, "deposit reversal is not available until deposit in transit is implemented"
+      end
+
+      reason = ActivityReasons.require!(@reason_code, "reverse")
+      if reason.notes_required && @notes.blank?
+        raise Error, "notes are required"
+      end
+
+      CashOperation.transaction do
+        original = CashOperation.lock.find(@operation.id)
+        raise Error, "operation has already been reversed" if original.reversed?
+
+        entries = original.cash_entries.order(:entry_sequence).to_a
+        Locations.ensure!(original.store)
+        entries.filter_map(&:cash_location_id).uniq.sort.each do |location_id|
+          CashLocation.lock.find(location_id)
+        end
+        session = lock_session_if_needed!(entries)
+
+        inverse = entries.map { |entry| inverse_entry(entry, session) }
+        Post.call(
+          operation_type: "reverse",
+          store: original.store,
+          performed_by: @actor,
+          pos_session: session,
+          reversal_of: original,
+          source_id: @source_id,
+          idempotency_key: @idempotency_key,
+          reason_code: reason.code,
+          reason_name_snapshot: reason.name,
+          notes: @notes,
+          entries: inverse
+        )
+      end
+    end
+
+    private
+
+    def lock_session_if_needed!(entries)
+      session_ids = entries.filter_map(&:pos_session_id).uniq
+      return if session_ids.empty?
+      raise Error, "session-targeted reverse requires a single session" unless session_ids.one?
+
+      session = SessionGuard.lock_open_session!(PosSession.find(session_ids.first))
+      SessionGuard.refuse_commercial_working!(session)
+      session
+    end
+
+    def inverse_entry(entry, session)
+      amount = -entry.amount_cents
+      if entry.pos_session_id.present?
+        {
+          pos_session: session,
+          amount_cents: amount,
+          balance_after_cents: SessionGuard.session_balance_after(session, amount),
+          reversal_of: entry
+        }
+      else
+        {
+          cash_location: entry.cash_location,
+          amount_cents: amount,
+          reversal_of: entry
+        }
+      end
+    end
+  end
+end

--- a/app/services/cash/session_guard.rb
+++ b/app/services/cash/session_guard.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Cash
+  module SessionGuard
+    module_function
+
+    def lock_open_session!(session)
+      locked = PosSession.lock.find(session.id)
+      raise Error, "session is not open" unless locked.open?
+
+      locked
+    end
+
+    def lock_open_cashier_session!(session, actor)
+      locked = Pos::Support.lock_open_cashier_session!(session, actor)
+      refuse_commercial_working!(locked)
+      locked
+    rescue Pos::Denied, Pos::Error => e
+      raise Error, e.message
+    end
+
+    def refuse_commercial_working!(session)
+      working = session.pos_transactions.working.first
+      return if working.nil? || !Pos::Support.commercial_content?(working)
+
+      raise Error, "complete or cancel the current transaction before this cash action"
+    end
+
+    def session_balance_after(session, delta)
+      Pos::SessionTotals.for(session).available_cash_cents + Integer(delta)
+    end
+  end
+end

--- a/app/services/pos/controlled_action_fingerprint.rb
+++ b/app/services/pos/controlled_action_fingerprint.rb
@@ -8,11 +8,12 @@ module Pos
       new(**attrs).call
     end
 
-    def initialize(action_type:, material_values:, reason_code:, reason_note: nil, transaction_id: nil, line_id: nil, cash_out_id: nil)
+    def initialize(action_type:, material_values:, reason_code:, reason_note: nil, transaction_id: nil, line_id: nil, cash_out_id: nil, cash_paid_out_id: nil)
       @action_type = action_type
       @transaction_id = transaction_id
       @line_id = line_id
       @cash_out_id = cash_out_id
+      @cash_paid_out_id = cash_paid_out_id
       @material_values = material_values
       @reason_code = reason_code
       @reason_note = reason_note
@@ -27,6 +28,7 @@ module Pos
       }
       payload["transaction_id"] = @transaction_id.to_s if @transaction_id.present?
       payload["cash_out_id"] = @cash_out_id.to_s if @cash_out_id.present?
+      payload["cash_paid_out_id"] = @cash_paid_out_id.to_s if @cash_paid_out_id.present?
       payload["line_id"] = @line_id.to_s if @line_id.present?
       payload["reason_note"] = @reason_note.to_s if @reason_code == "other"
       Idempotency::CanonicalJson.hash(payload)

--- a/app/services/pos/operator_report.rb
+++ b/app/services/pos/operator_report.rb
@@ -98,6 +98,7 @@ module Pos
           money_row("Cash refunds", @totals.cash_refund_cents),
           money_row("Gift-card cash-outs", @totals.gift_card_cash_out_cents),
           money_row("Gift-card cash-out reversals", @totals.gift_card_cash_out_reversal_cents),
+          signed_row("Non-sale cash", @totals.cash_movement_cents),
           signed_row("Expected Cash", @totals.expected_cash_cents)
         ]
       when :session

--- a/app/services/pos/session_totals.rb
+++ b/app/services/pos/session_totals.rb
@@ -151,15 +151,15 @@ module Pos
     end
 
     def cash_movement_cents
-      paid = CashEntry.joins(:cash_operation)
-                      .where(pos_session_id: @session.id)
-                      .where(cash_operations: { operation_type: %w[paid_in paid_out] })
-                      .sum(:amount_cents)
+      movements = CashEntry.joins(:cash_operation)
+                           .where(pos_session_id: @session.id)
+                           .where(cash_operations: { operation_type: %w[paid_in paid_out reverse] })
+                           .sum(:amount_cents)
       transfers = CashEntry.joins(cash_operation: :cash_transfer)
                            .where(pos_session_id: @session.id)
                            .where(cash_transfers: { transfer_type: %w[drop replenishment] })
                            .sum(:amount_cents)
-      paid + transfers
+      movements + transfers
     end
 
     def gift_card_cash_out_count

--- a/app/views/pos/cash_activities/_form.html.erb
+++ b/app/views/pos/cash_activities/_form.html.erb
@@ -1,0 +1,46 @@
+<% if @error.present? %>
+  <p class="pos-enter__alert" role="alert"><%= @error %></p>
+<% end %>
+
+<%= form_with url: url, method: :post, local: true, class: "pos-return-items" do %>
+  <%= hidden_field_tag :source_id, SecureRandom.uuid_v7 %>
+  <%= hidden_field_tag :idempotency_key, SecureRandom.uuid_v7 %>
+  <% if local_assigns[:sessions].present? %>
+    <div class="form-field">
+      <%= label_tag :pos_session_id, "Session" %>
+      <%= select_tag :pos_session_id,
+            options_for_select(sessions.map { |open_session|
+              [ "Register #{open_session.register.admin_label} · #{open_session.cashier_user.display_name}", open_session.id ]
+            }, local_assigns[:session_value]) %>
+    </div>
+  <% end %>
+  <div class="form-field">
+    <%= label_tag :amount, "Amount" %>
+    <%= text_field_tag :amount, local_assigns[:amount_value], inputmode: "decimal", autocomplete: "off", autofocus: true, required: true %>
+  </div>
+  <% if local_assigns[:reasons].present? %>
+    <div class="form-field">
+      <%= label_tag :reason_code, "Reason" %>
+      <%= select_tag :reason_code,
+            options_from_collection_for_select(reasons, :code, :name, local_assigns[:reason_value]) %>
+    </div>
+    <div class="form-field">
+      <%= label_tag :notes, "Notes" %>
+      <%= text_field_tag :notes, local_assigns[:notes_value], autocomplete: "off" %>
+    </div>
+  <% end %>
+  <% if local_assigns[:approval] %>
+    <div class="form-field">
+      <%= label_tag :approver_username, "Approver username (material paid-out)" %>
+      <%= text_field_tag :approver_username, params[:approver_username], autocomplete: "off" %>
+    </div>
+    <div class="form-field">
+      <%= label_tag :approver_password, "Approver password" %>
+      <%= password_field_tag :approver_password, nil, autocomplete: "current-password" %>
+    </div>
+  <% end %>
+  <div class="actions">
+    <%= submit_tag submit, class: "btn" %>
+    <%= link_to "POS Home", pos_path, class: "btn btn--ghost" %>
+  </div>
+<% end %>

--- a/app/views/pos/cash_drops/new.html.erb
+++ b/app/views/pos/cash_drops/new.html.erb
@@ -1,0 +1,11 @@
+<% content_for :title, "Drop" %>
+
+<main class="pos-history">
+  <%= render "pos/shared/report_nav" %>
+  <h1>Drop</h1>
+  <p>Move cash from this open session to the store safe. This is not session close.</p>
+  <%= render "pos/cash_activities/form",
+        url: pos_cash_drops_path,
+        submit: "Record drop",
+        amount_value: params[:amount] %>
+</main>

--- a/app/views/pos/cash_paid_ins/new.html.erb
+++ b/app/views/pos/cash_paid_ins/new.html.erb
@@ -1,0 +1,14 @@
+<% content_for :title, "Paid-in" %>
+
+<main class="pos-history">
+  <%= render "pos/shared/report_nav" %>
+  <h1>Paid-in</h1>
+  <p>Non-sale cash into this open Register session. This is not a tender.</p>
+  <%= render "pos/cash_activities/form",
+        url: pos_cash_paid_ins_path,
+        submit: "Record paid-in",
+        reasons: @reasons,
+        amount_value: params[:amount],
+        reason_value: params[:reason_code],
+        notes_value: params[:notes] %>
+</main>

--- a/app/views/pos/cash_paid_outs/new.html.erb
+++ b/app/views/pos/cash_paid_outs/new.html.erb
@@ -1,0 +1,15 @@
+<% content_for :title, "Paid-out" %>
+
+<main class="pos-history">
+  <%= render "pos/shared/report_nav" %>
+  <h1>Paid-out</h1>
+  <p>Non-sale cash out of this open Register session. Gift-card cash-out is not a paid-out.</p>
+  <%= render "pos/cash_activities/form",
+        url: pos_cash_paid_outs_path,
+        submit: "Record paid-out",
+        reasons: @reasons,
+        amount_value: params[:amount],
+        reason_value: params[:reason_code],
+        notes_value: params[:notes],
+        approval: true %>
+</main>

--- a/app/views/pos/cash_replenishments/new.html.erb
+++ b/app/views/pos/cash_replenishments/new.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, "Replenish" %>
+
+<main class="pos-history">
+  <%= render "pos/shared/report_nav" %>
+  <h1>Replenish</h1>
+  <p>Move cash from the store safe to an open Register session.</p>
+  <%= render "pos/cash_activities/form",
+        url: pos_cash_replenishments_path,
+        submit: "Record replenishment",
+        amount_value: params[:amount],
+        sessions: @open_sessions,
+        session_value: @session_record&.id %>
+</main>

--- a/app/views/pos/cash_reversals/new.html.erb
+++ b/app/views/pos/cash_reversals/new.html.erb
@@ -1,0 +1,41 @@
+<% content_for :title, "Reverse cash" %>
+
+<main class="pos-history">
+  <%= render "pos/shared/report_nav" %>
+  <h1>Reverse cash</h1>
+  <p>Reverse an eligible paid-in, paid-out, drop, or replenishment exactly once. Session close, over/short, and safe initialization cannot be reversed.</p>
+
+  <% if @error.present? %>
+    <p class="pos-enter__alert" role="alert"><%= @error %></p>
+  <% end %>
+
+  <% if @operations.blank? %>
+    <p>No reversible cash operations are available on an open session.</p>
+  <% else %>
+    <%= form_with url: pos_cash_reversals_path, method: :post, local: true, class: "pos-return-items" do %>
+      <%= hidden_field_tag :source_id, SecureRandom.uuid_v7 %>
+      <%= hidden_field_tag :idempotency_key, SecureRandom.uuid_v7 %>
+      <div class="form-field">
+        <%= label_tag :cash_operation_id, "Operation" %>
+        <%= select_tag :cash_operation_id,
+              options_for_select(@operations.map { |operation|
+                label = "#{operation.occurred_at.utc.iso8601} · #{operation.operation_type}"
+                [ label, operation.id ]
+              }, params[:cash_operation_id]) %>
+      </div>
+      <div class="form-field">
+        <%= label_tag :reason_code, "Reason" %>
+        <%= select_tag :reason_code,
+              options_from_collection_for_select(@reasons, :code, :name, params[:reason_code]) %>
+      </div>
+      <div class="form-field">
+        <%= label_tag :notes, "Notes" %>
+        <%= text_field_tag :notes, params[:notes], autocomplete: "off" %>
+      </div>
+      <div class="actions">
+        <%= submit_tag "Reverse", class: "btn" %>
+        <%= link_to "POS Home", pos_path, class: "btn btn--ghost" %>
+      </div>
+    <% end %>
+  <% end %>
+</main>

--- a/app/views/pos/homes/show.html.erb
+++ b/app/views/pos/homes/show.html.erb
@@ -61,6 +61,21 @@
     <% if @open_session && Authorization::PermissionEvaluator.allowed?(user: current_user, permission_key: "gift_cards.cash_out", store: current_store) %>
       <%= link_to "Gift-card cash-out", new_pos_cash_out_path, class: "btn btn--secondary" %>
     <% end %>
+    <% if @open_session && Authorization::PermissionEvaluator.allowed?(user: current_user, permission_key: "cash.paid_in", store: current_store) %>
+      <%= link_to "Paid-in", new_pos_cash_paid_in_path, class: "btn btn--secondary" %>
+    <% end %>
+    <% if @open_session && Authorization::PermissionEvaluator.allowed?(user: current_user, permission_key: "cash.paid_out", store: current_store) %>
+      <%= link_to "Paid-out", new_pos_cash_paid_out_path, class: "btn btn--secondary" %>
+    <% end %>
+    <% if @open_session %>
+      <%= link_to "Drop", new_pos_cash_drop_path, class: "btn btn--secondary" %>
+    <% end %>
+    <% if Authorization::PermissionEvaluator.allowed?(user: current_user, permission_key: "cash.move", store: current_store) %>
+      <%= link_to "Replenish", new_pos_cash_replenishment_path, class: "btn btn--secondary" %>
+    <% end %>
+    <% if Authorization::PermissionEvaluator.allowed?(user: current_user, permission_key: "cash.reverse", store: current_store) %>
+      <%= link_to "Reverse cash", new_pos_cash_reversal_path, class: "btn btn--secondary" %>
+    <% end %>
     <% if can_view_other_sessions? %>
       <%= link_to "Active Sessions", pos_active_sessions_path, class: "btn btn--secondary" %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -204,6 +204,11 @@ Rails.application.routes.draw do
       collection { post :lookup }
       member { post :reverse }
     end
+    resources :cash_paid_ins, only: %i[new create]
+    resources :cash_paid_outs, only: %i[new create]
+    resources :cash_drops, only: %i[new create]
+    resources :cash_replenishments, only: %i[new create]
+    resources :cash_reversals, only: %i[new create]
     get "register", to: "workspaces#show", as: :register_workspace
     get "register/merchandise_search", to: "workspaces#search", as: :register_merchandise_search
     get "register/merchandise_resolve", to: "workspaces#resolve", as: :register_merchandise_resolve

--- a/db/migrate/20260826200000_create_phase11_non_sale_cash.rb
+++ b/db/migrate/20260826200000_create_phase11_non_sale_cash.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+class CreatePhase11NonSaleCash < ActiveRecord::Migration[8.1]
+  def change
+    create_uuid_table :cash_paid_ins do |t|
+      t.uuid :pos_session_id, null: false
+      t.bigint :amount_cents, null: false
+      t.string :reason_code, null: false
+      t.string :reason_name_snapshot, null: false
+      t.text :notes
+      t.uuid :cash_operation_id, null: false
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+    add_index :cash_paid_ins, :cash_operation_id, unique: true
+    add_index :cash_paid_ins, :pos_session_id
+    add_foreign_key :cash_paid_ins, :pos_sessions
+    add_foreign_key :cash_paid_ins, :cash_operations
+    add_check_constraint :cash_paid_ins, "amount_cents > 0", name: "cash_paid_ins_amount_positive"
+
+    create_uuid_table :cash_paid_outs do |t|
+      t.uuid :pos_session_id, null: false
+      t.bigint :amount_cents, null: false
+      t.string :reason_code, null: false
+      t.string :reason_name_snapshot, null: false
+      t.text :notes
+      t.uuid :cash_operation_id, null: false
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+    add_index :cash_paid_outs, :cash_operation_id, unique: true
+    add_index :cash_paid_outs, :pos_session_id
+    add_foreign_key :cash_paid_outs, :pos_sessions
+    add_foreign_key :cash_paid_outs, :cash_operations
+    add_check_constraint :cash_paid_outs, "amount_cents > 0", name: "cash_paid_outs_amount_positive"
+
+    add_column :pos_controlled_actions, :cash_paid_out_id, :uuid
+    add_index :pos_controlled_actions, :cash_paid_out_id, unique: true,
+              where: "cash_paid_out_id IS NOT NULL",
+              name: "index_pos_controlled_actions_on_paid_out"
+    add_foreign_key :pos_controlled_actions, :cash_paid_outs
+
+    remove_check_constraint :pos_controlled_actions, name: "pos_controlled_actions_type_valid"
+    add_check_constraint :pos_controlled_actions,
+                         "action_type IN ('price_override', 'line_discount', 'tax_class_override', 'unlinked_return', 'post_void', 'gift_card_cash_out', 'cash_paid_out')",
+                         name: "pos_controlled_actions_type_valid"
+
+    remove_check_constraint :pos_controlled_actions, name: "pos_controlled_actions_line_scope"
+    add_check_constraint :pos_controlled_actions,
+                         <<~SQL.squish,
+                           (action_type = 'post_void' AND pos_transaction_line_id IS NULL AND pos_transaction_id IS NOT NULL AND gift_card_cash_out_id IS NULL AND cash_paid_out_id IS NULL)
+                           OR (action_type = 'gift_card_cash_out' AND pos_transaction_line_id IS NULL AND pos_transaction_id IS NULL AND gift_card_cash_out_id IS NOT NULL AND cash_paid_out_id IS NULL)
+                           OR (action_type = 'cash_paid_out' AND pos_transaction_line_id IS NULL AND pos_transaction_id IS NULL AND gift_card_cash_out_id IS NULL AND cash_paid_out_id IS NOT NULL)
+                           OR (action_type NOT IN ('post_void', 'gift_card_cash_out', 'cash_paid_out') AND pos_transaction_line_id IS NOT NULL AND pos_transaction_id IS NOT NULL AND gift_card_cash_out_id IS NULL AND cash_paid_out_id IS NULL)
+                         SQL
+                         name: "pos_controlled_actions_line_scope"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_26_180000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_26_200000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -204,6 +204,34 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_180000) do
     t.index ["store_id"], name: "index_cash_operations_on_store_id"
     t.check_constraint "approved_by_id IS NULL OR approved_by_id <> performed_by_id", name: "cash_operations_approver_differs"
     t.check_constraint "operation_type::text = ANY (ARRAY['initialize_safe'::character varying, 'transfer'::character varying, 'paid_in'::character varying, 'paid_out'::character varying, 'reconcile'::character varying, 'reverse'::character varying]::text[])", name: "cash_operations_type_valid"
+  end
+
+  create_table "cash_paid_ins", id: :uuid, default: nil, force: :cascade do |t|
+    t.bigint "amount_cents", null: false
+    t.uuid "cash_operation_id", null: false
+    t.timestamptz "created_at", null: false
+    t.text "notes"
+    t.uuid "pos_session_id", null: false
+    t.string "reason_code", null: false
+    t.string "reason_name_snapshot", null: false
+    t.timestamptz "updated_at", null: false
+    t.index ["cash_operation_id"], name: "index_cash_paid_ins_on_cash_operation_id", unique: true
+    t.index ["pos_session_id"], name: "index_cash_paid_ins_on_pos_session_id"
+    t.check_constraint "amount_cents > 0", name: "cash_paid_ins_amount_positive"
+  end
+
+  create_table "cash_paid_outs", id: :uuid, default: nil, force: :cascade do |t|
+    t.bigint "amount_cents", null: false
+    t.uuid "cash_operation_id", null: false
+    t.timestamptz "created_at", null: false
+    t.text "notes"
+    t.uuid "pos_session_id", null: false
+    t.string "reason_code", null: false
+    t.string "reason_name_snapshot", null: false
+    t.timestamptz "updated_at", null: false
+    t.index ["cash_operation_id"], name: "index_cash_paid_outs_on_cash_operation_id", unique: true
+    t.index ["pos_session_id"], name: "index_cash_paid_outs_on_pos_session_id"
+    t.check_constraint "amount_cents > 0", name: "cash_paid_outs_amount_positive"
   end
 
   create_table "cash_reconciliations", id: :uuid, default: nil, force: :cascade do |t|
@@ -770,6 +798,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_180000) do
     t.string "action_type", null: false
     t.string "approved_by_name_snapshot"
     t.uuid "approved_by_user_id"
+    t.uuid "cash_paid_out_id"
     t.timestamptz "created_at", null: false
     t.timestamptz "executed_at", null: false
     t.string "fingerprint_schema_version", null: false
@@ -786,14 +815,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_180000) do
     t.text "reason_note"
     t.timestamptz "updated_at", null: false
     t.index ["approved_by_user_id"], name: "index_pos_controlled_actions_on_approved_by_user_id"
+    t.index ["cash_paid_out_id"], name: "index_pos_controlled_actions_on_paid_out", unique: true, where: "(cash_paid_out_id IS NOT NULL)"
     t.index ["gift_card_cash_out_id"], name: "index_pos_controlled_actions_on_cash_out", unique: true, where: "(gift_card_cash_out_id IS NOT NULL)"
     t.index ["performed_by_user_id"], name: "index_pos_controlled_actions_on_performed_by_user_id"
     t.index ["pos_transaction_id", "action_type"], name: "index_pos_controlled_actions_one_post_void", unique: true, where: "((action_type)::text = 'post_void'::text)"
     t.index ["pos_transaction_id"], name: "index_pos_controlled_actions_on_pos_transaction_id"
     t.index ["pos_transaction_line_id", "action_type"], name: "index_pos_controlled_actions_effective_line", unique: true, where: "(pos_transaction_line_id IS NOT NULL)"
     t.index ["pos_transaction_line_id"], name: "index_pos_controlled_actions_on_pos_transaction_line_id"
-    t.check_constraint "action_type::text = 'post_void'::text AND pos_transaction_line_id IS NULL AND pos_transaction_id IS NOT NULL AND gift_card_cash_out_id IS NULL OR action_type::text = 'gift_card_cash_out'::text AND pos_transaction_line_id IS NULL AND pos_transaction_id IS NULL AND gift_card_cash_out_id IS NOT NULL OR (action_type::text <> ALL (ARRAY['post_void'::character varying, 'gift_card_cash_out'::character varying]::text[])) AND pos_transaction_line_id IS NOT NULL AND pos_transaction_id IS NOT NULL AND gift_card_cash_out_id IS NULL", name: "pos_controlled_actions_line_scope"
-    t.check_constraint "action_type::text = ANY (ARRAY['price_override'::character varying, 'line_discount'::character varying, 'tax_class_override'::character varying, 'unlinked_return'::character varying, 'post_void'::character varying, 'gift_card_cash_out'::character varying]::text[])", name: "pos_controlled_actions_type_valid"
+    t.check_constraint "action_type::text = 'post_void'::text AND pos_transaction_line_id IS NULL AND pos_transaction_id IS NOT NULL AND gift_card_cash_out_id IS NULL AND cash_paid_out_id IS NULL OR action_type::text = 'gift_card_cash_out'::text AND pos_transaction_line_id IS NULL AND pos_transaction_id IS NULL AND gift_card_cash_out_id IS NOT NULL AND cash_paid_out_id IS NULL OR action_type::text = 'cash_paid_out'::text AND pos_transaction_line_id IS NULL AND pos_transaction_id IS NULL AND gift_card_cash_out_id IS NULL AND cash_paid_out_id IS NOT NULL OR (action_type::text <> ALL (ARRAY['post_void'::character varying, 'gift_card_cash_out'::character varying, 'cash_paid_out'::character varying]::text[])) AND pos_transaction_line_id IS NOT NULL AND pos_transaction_id IS NOT NULL AND gift_card_cash_out_id IS NULL AND cash_paid_out_id IS NULL", name: "pos_controlled_actions_line_scope"
+    t.check_constraint "action_type::text = ANY (ARRAY['price_override'::character varying, 'line_discount'::character varying, 'tax_class_override'::character varying, 'unlinked_return'::character varying, 'post_void'::character varying, 'gift_card_cash_out'::character varying, 'cash_paid_out'::character varying]::text[])", name: "pos_controlled_actions_type_valid"
     t.check_constraint "approved_by_user_id IS NULL OR approved_by_user_id <> performed_by_user_id", name: "pos_controlled_actions_approver_not_performer"
     t.check_constraint "policy_result::text = 'approval_required'::text AND approved_by_user_id IS NOT NULL AND approved_by_name_snapshot IS NOT NULL OR policy_result::text = 'direct'::text AND approved_by_user_id IS NULL AND approved_by_name_snapshot IS NULL", name: "pos_controlled_actions_approver_matches_policy"
     t.check_constraint "policy_result::text = ANY (ARRAY['direct'::character varying::text, 'approval_required'::character varying::text])", name: "pos_controlled_actions_policy_valid"
@@ -1882,6 +1912,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_180000) do
   add_foreign_key "cash_operations", "stores"
   add_foreign_key "cash_operations", "users", column: "approved_by_id"
   add_foreign_key "cash_operations", "users", column: "performed_by_id"
+  add_foreign_key "cash_paid_ins", "cash_operations"
+  add_foreign_key "cash_paid_ins", "pos_sessions"
+  add_foreign_key "cash_paid_outs", "cash_operations"
+  add_foreign_key "cash_paid_outs", "pos_sessions"
   add_foreign_key "cash_reconciliations", "cash_counts"
   add_foreign_key "cash_reconciliations", "cash_locations"
   add_foreign_key "cash_reconciliations", "cash_operations"
@@ -1969,6 +2003,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_180000) do
   add_foreign_key "orders", "stores", on_delete: :restrict
   add_foreign_key "orders", "suppliers", on_delete: :restrict
   add_foreign_key "orders", "users", column: "cancelled_by_id", on_delete: :restrict
+  add_foreign_key "pos_controlled_actions", "cash_paid_outs"
   add_foreign_key "pos_controlled_actions", "gift_card_cash_outs"
   add_foreign_key "pos_controlled_actions", "pos_transaction_lines"
   add_foreign_key "pos_controlled_actions", "pos_transactions"

--- a/docs/planning/phase11-cash-accountability/phase11-implementation-plan.md
+++ b/docs/planning/phase11-cash-accountability/phase11-implementation-plan.md
@@ -72,8 +72,8 @@ If a later release needs to delay enforcement, that would be a feature gate or t
 | Slice | Status |
 |---|---|
 | 11.0 Contract / packet | **Complete** on `main` (planning packet). Merge-policy lock: this PR on `phase-11-cash-accountability` |
-| 11.1 Safe-backed session lifecycle | This PR |
-| 11.2 Non-sale cash activity | Not started |
+| 11.1 Safe-backed session lifecycle | **Complete** on `phase-11-cash-accountability` |
+| 11.2 Non-sale cash activity | This PR |
 | 11.3 Safe recon, deposit, store-day report | Not started |
 
 ## Integration notes

--- a/docs/planning/phase11-cash-accountability/phase11-non-sale-activity.md
+++ b/docs/planning/phase11-cash-accountability/phase11-non-sale-activity.md
@@ -1,6 +1,6 @@
 # Phase 11 — Non-sale cash activity
 
-Status: **Proposed**. Implementation authority for 11.2. Depends on 11.1 posting, session lock, and available-cash.
+Status: **Implemented** on `phase-11-cash-accountability` (this PR). Depends on 11.1 posting, session lock, and available-cash.
 
 ### Actually locked
 

--- a/docs/planning/phase11-cash-accountability/phase11-schema.md
+++ b/docs/planning/phase11-cash-accountability/phase11-schema.md
@@ -1,6 +1,6 @@
 # Phase 11 — Schema contract
 
-Status: **11.1 tables implemented** on the Phase 11 integration branch. 11.2/11.3 operation and transfer types are reserved in CHECKs. PostgreSQL is authoritative. UUIDv7 via `create_uuid_table` / application-assigned ids ([AGENTS.md](../../../AGENTS.md) §10).
+Status: **11.1–11.2 tables implemented** on the Phase 11 integration branch. 11.3 deposit source row is reserved. PostgreSQL is authoritative. UUIDv7 via `create_uuid_table` / application-assigned ids ([AGENTS.md](../../../AGENTS.md) §10).
 
 Companions: [phase11-plan.md](phase11-plan.md), [phase11-session-lifecycle.md](phase11-session-lifecycle.md), [phase5-schema.md](../phase4-6-point-of-sale/phase5-cash-register/phase5-schema.md).
 

--- a/test/integration/pos_cash_activities_test.rb
+++ b/test/integration/pos_cash_activities_test.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PosCashActivitiesTest < ActionDispatch::IntegrationTest
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    Cash::ActivityReasons.seed!
+    @context = pos_open_context(store: @store, actor: @actor, opening_float_cents: 10_000)
+    sign_in_as("admin")
+  end
+
+  test "cashier records a paid-in from POS Home" do
+    get pos_path
+    assert_response :success
+    assert_includes response.body, new_pos_cash_paid_in_path
+
+    post pos_cash_paid_ins_path, params: {
+      amount: "5.00",
+      reason_code: "paid_in_found",
+      source_id: SecureRandom.uuid_v7,
+      idempotency_key: SecureRandom.uuid_v7
+    }
+    assert_redirected_to pos_path
+    assert_equal 500, CashPaidIn.last.amount_cents
+  end
+
+  test "cashier records a drop from the session to the safe" do
+    post pos_cash_drops_path, params: {
+      amount: "20.00",
+      source_id: SecureRandom.uuid_v7,
+      idempotency_key: SecureRandom.uuid_v7
+    }
+    assert_redirected_to pos_path
+    assert_equal "drop", CashTransfer.order(:created_at).last.transfer_type
+  end
+
+  test "manager replenishes an open session from the safe" do
+    post pos_cash_replenishments_path, params: {
+      pos_session_id: @context[:session].id,
+      amount: "10.00",
+      source_id: SecureRandom.uuid_v7,
+      idempotency_key: SecureRandom.uuid_v7
+    }
+    assert_redirected_to pos_path
+    assert_equal "replenishment", CashTransfer.order(:created_at).last.transfer_type
+  end
+
+  test "manager reverses a paid-in without fabricating a source row" do
+    paid_in = Cash::PaidIn.call(
+      session: @context[:session],
+      actor: @actor,
+      amount_cents: 250,
+      reason_code: "paid_in_found",
+      source_id: SecureRandom.uuid_v7,
+      idempotency_key: SecureRandom.uuid_v7
+    )
+
+    post pos_cash_reversals_path, params: {
+      cash_operation_id: paid_in.cash_operation_id,
+      reason_code: "reverse",
+      notes: "Wrong amount",
+      source_id: SecureRandom.uuid_v7,
+      idempotency_key: SecureRandom.uuid_v7
+    }
+    assert_redirected_to pos_path
+    reverse = CashOperation.find_by!(reversal_of_id: paid_in.cash_operation_id)
+    assert_equal "reverse", reverse.operation_type
+    assert_nil reverse.cash_paid_in
+  end
+
+  test "associate does not see paid-in and cannot post one" do
+    clerk = pos_transacting_user(store: @store, assigned_by: @actor, username: "till_clerk")
+    pos_open_context(
+      store: @store,
+      actor: clerk,
+      register: Register.create!(store: @store, register_number: 15, name: "Clerk till"),
+      opening_float_cents: 10_000
+    )
+    delete session_path
+    sign_in_as("till_clerk")
+
+    get pos_path
+    assert_response :success
+    refute_includes response.body, new_pos_cash_paid_in_path
+    assert_includes response.body, new_pos_cash_drop_path
+
+    post pos_cash_paid_ins_path, params: {
+      amount: "1.00",
+      reason_code: "paid_in_found",
+      source_id: SecureRandom.uuid_v7,
+      idempotency_key: SecureRandom.uuid_v7
+    }
+    assert_redirected_to pos_path
+    assert_equal 0, CashPaidIn.count
+  end
+
+  private
+
+  def sign_in_as(username)
+    post session_path, params: { session: { username: username, password: "correct-horse-battery" } }
+  end
+end

--- a/test/services/cash/non_sale_activity_test.rb
+++ b/test/services/cash/non_sale_activity_test.rb
@@ -1,0 +1,325 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Cash
+  class NonSaleActivityTest < ActiveSupport::TestCase
+    setup do
+      @bootstrap = bootstrap!
+      @store = @bootstrap[:store]
+      @actor = @bootstrap[:administrator]
+      Cash::ActivityReasons.seed!
+      @context = pos_open_context(store: @store, actor: @actor, opening_float_cents: 10_000)
+      @session = @context[:session]
+    end
+
+    test "paid-in increases available cash and is not a tender" do
+      before = Pos::SessionTotals.for(@session).available_cash_cents
+      paid_in = Cash::PaidIn.call(
+        session: @session,
+        actor: @actor,
+        amount_cents: 500,
+        reason_code: "paid_in_found",
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+
+      assert_equal 500, paid_in.amount_cents
+      assert_equal before + 500, Pos::SessionTotals.for(@session.reload).available_cash_cents
+      assert_equal 0, Pos::SessionTotals.for(@session).cash_payment_cents
+      assert_equal "paid_in", paid_in.cash_operation.operation_type
+      cash = Pos::OperatorReport.session(
+        totals: Pos::SessionTotals.for(@session),
+        session: @session,
+        kind: :x
+      ).find { |group| group.title == "Cash custody" }
+      assert_equal 500, cash.rows.find { |row| row.label == "Non-sale cash" }.cents
+    end
+
+    test "paid-out below threshold is direct and decreases available cash" do
+      before = Pos::SessionTotals.for(@session).available_cash_cents
+      paid_out = Cash::PaidOut.call(
+        session: @session,
+        actor: @actor,
+        amount_cents: 400,
+        reason_code: "paid_out_supplies",
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+
+      assert_equal 400, paid_out.amount_cents
+      assert_equal before - 400, Pos::SessionTotals.for(@session.reload).available_cash_cents
+      action = paid_out.pos_controlled_action
+      assert_equal "direct", action.policy_result
+      assert_nil action.approved_by_user_id
+    end
+
+    test "material paid-out without approve permission requires a distinct approver" do
+      role = Role.create!(key: "payout_only_#{SecureRandom.hex(3)}", name: "Payout only", assignment_scope: "store")
+      %w[pos.transact cash.paid_out].each do |key|
+        RolePermission.create!(role: role, permission: Permission.find_by!(key: key), granted_by: @actor)
+      end
+      clerk = User.create!(
+        username: "payout_clerk",
+        display_name: "Payout clerk",
+        password: "correct-horse-battery",
+        password_confirmation: "correct-horse-battery"
+      )
+      RoleAssignment.create!(
+        user: clerk,
+        role: role,
+        store: @store,
+        assigned_by: @actor,
+        effective_at: Time.current
+      )
+      context = pos_open_context(
+        store: @store,
+        actor: clerk,
+        register: Register.create!(store: @store, register_number: 12, name: "Payout"),
+        opening_float_cents: 10_000
+      )
+
+      error = assert_raises(Cash::Error) do
+        Cash::PaidOut.call(
+          session: context[:session],
+          actor: clerk,
+          amount_cents: 5_000,
+          reason_code: "paid_out_supplies",
+          source_id: SecureRandom.uuid_v7,
+          idempotency_key: SecureRandom.uuid_v7
+        )
+      end
+      assert_match(/approver credentials are required/, error.message)
+    end
+
+    test "drop moves session cash to the safe" do
+      safe_before = Cash::Locations.safe_for!(@store).expected_balance_cents
+      session_before = Pos::SessionTotals.for(@session).available_cash_cents
+      transfer = Cash::Drop.call(
+        session: @session,
+        actor: @actor,
+        amount_cents: 2_000,
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+
+      assert_equal "drop", transfer.transfer_type
+      assert_equal session_before - 2_000, Pos::SessionTotals.for(@session.reload).available_cash_cents
+      assert_equal safe_before + 2_000, Cash::Locations.safe_for!(@store).expected_balance_cents
+    end
+
+    test "replenish moves safe cash to the session" do
+      safe_before = Cash::Locations.safe_for!(@store).expected_balance_cents
+      session_before = Pos::SessionTotals.for(@session).available_cash_cents
+      transfer = Cash::Replenish.call(
+        session: @session,
+        actor: @actor,
+        amount_cents: 1_500,
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+
+      assert_equal "replenishment", transfer.transfer_type
+      assert_equal session_before + 1_500, Pos::SessionTotals.for(@session.reload).available_cash_cents
+      assert_equal safe_before - 1_500, Cash::Locations.safe_for!(@store).expected_balance_cents
+    end
+
+    test "reverse of a paid-in restores available cash without a fabricated source row" do
+      paid_in = Cash::PaidIn.call(
+        session: @session,
+        actor: @actor,
+        amount_cents: 700,
+        reason_code: "paid_in_found",
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+      before = Pos::SessionTotals.for(@session.reload).available_cash_cents
+      reverse = Cash::Reverse.call(
+        operation: paid_in.cash_operation,
+        actor: @actor,
+        reason_code: "reverse",
+        notes: "Entered the wrong amount",
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+
+      assert_equal "reverse", reverse.operation_type
+      assert_equal paid_in.cash_operation.id, reverse.reversal_of_id
+      assert_nil reverse.cash_paid_in
+      assert_equal paid_in.amount_cents, CashPaidIn.find(paid_in.id).amount_cents
+      assert_equal before - 700, Pos::SessionTotals.for(@session.reload).available_cash_cents
+    end
+
+    test "does not reverse session close, over/short, or safe initialization" do
+      close = pos_close_session!(session: @session, actor: @actor, closing_count_cents: 10_000)
+      close_op = CashTransfer.find_by!(transfer_type: "session_close", source_pos_session: close).cash_operation
+      error = assert_raises(Cash::Error) do
+        Cash::Reverse.call(
+          operation: close_op,
+          actor: @actor,
+          reason_code: "reverse",
+          notes: "no",
+          source_id: SecureRandom.uuid_v7,
+          idempotency_key: SecureRandom.uuid_v7
+        )
+      end
+      assert_match(/cannot be reversed/, error.message)
+
+      init = CashSafeInitialization.find_by!(cash_location: Cash::Locations.safe_for!(@store))
+      error = assert_raises(Cash::Error) do
+        Cash::Reverse.call(
+          operation: init.cash_operation,
+          actor: @actor,
+          reason_code: "reverse",
+          notes: "no",
+          source_id: SecureRandom.uuid_v7,
+          idempotency_key: SecureRandom.uuid_v7
+        )
+      end
+      assert_match(/cannot be reversed/, error.message)
+    end
+
+    test "reverse of a drop restores session and safe cash without a fabricated transfer" do
+      transfer = Cash::Drop.call(
+        session: @session,
+        actor: @actor,
+        amount_cents: 1_200,
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+      session_before = Pos::SessionTotals.for(@session.reload).available_cash_cents
+      safe_before = Cash::Locations.safe_for!(@store).expected_balance_cents
+      reverse = Cash::Reverse.call(
+        operation: transfer.cash_operation,
+        actor: @actor,
+        reason_code: "reverse",
+        notes: "Dropped the wrong amount",
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+
+      assert_equal "reverse", reverse.operation_type
+      assert_nil reverse.cash_transfer
+      assert_equal "drop", CashTransfer.find(transfer.id).transfer_type
+      assert_equal session_before + 1_200, Pos::SessionTotals.for(@session.reload).available_cash_cents
+      assert_equal safe_before - 1_200, Cash::Locations.safe_for!(@store).expected_balance_cents
+    end
+
+    test "does not reverse the same operation twice" do
+      paid_in = Cash::PaidIn.call(
+        session: @session,
+        actor: @actor,
+        amount_cents: 300,
+        reason_code: "paid_in_found",
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+      reverse = Cash::Reverse.call(
+        operation: paid_in.cash_operation,
+        actor: @actor,
+        reason_code: "reverse",
+        notes: "first reverse",
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+      error = assert_raises(Cash::Error) do
+        Cash::Reverse.call(
+          operation: reverse,
+          actor: @actor,
+          reason_code: "reverse",
+          notes: "second reverse",
+          source_id: SecureRandom.uuid_v7,
+          idempotency_key: SecureRandom.uuid_v7
+        )
+      end
+      assert_match(/already a reverse/, error.message)
+
+      error = assert_raises(Cash::Error) do
+        Cash::Reverse.call(
+          operation: paid_in.cash_operation.reload,
+          actor: @actor,
+          reason_code: "reverse",
+          notes: "second reverse",
+          source_id: SecureRandom.uuid_v7,
+          idempotency_key: SecureRandom.uuid_v7
+        )
+      end
+      assert_match(/already been reversed/, error.message)
+    end
+
+    test "associates may drop but cannot paid-in, replenish, or reverse" do
+      clerk = pos_transacting_user(store: @store, assigned_by: @actor, username: "drop_clerk")
+      context = pos_open_context(
+        store: @store,
+        actor: clerk,
+        register: Register.create!(store: @store, register_number: 14, name: "Clerk"),
+        opening_float_cents: 10_000
+      )
+      session = context[:session]
+
+      Cash::Drop.call(
+        session: session,
+        actor: clerk,
+        amount_cents: 500,
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+
+      error = assert_raises(Cash::Error) do
+        Cash::PaidIn.call(
+          session: session,
+          actor: clerk,
+          amount_cents: 100,
+          reason_code: "paid_in_found",
+          source_id: SecureRandom.uuid_v7,
+          idempotency_key: SecureRandom.uuid_v7
+        )
+      end
+      assert_match(/not authorized/, error.message)
+
+      error = assert_raises(Cash::Error) do
+        Cash::Replenish.call(
+          session: session,
+          actor: clerk,
+          amount_cents: 100,
+          source_id: SecureRandom.uuid_v7,
+          idempotency_key: SecureRandom.uuid_v7
+        )
+      end
+      assert_match(/not authorized/, error.message)
+
+      drop = CashTransfer.find_by!(transfer_type: "drop", source_pos_session: session)
+      error = assert_raises(Cash::Error) do
+        Cash::Reverse.call(
+          operation: drop.cash_operation,
+          actor: clerk,
+          reason_code: "reverse",
+          notes: "no",
+          source_id: SecureRandom.uuid_v7,
+          idempotency_key: SecureRandom.uuid_v7
+        )
+      end
+      assert_match(/not authorized/, error.message)
+    end
+
+    test "paid-out is refused when available cash is insufficient" do
+      empty = pos_open_context(
+        store: @store,
+        actor: @actor,
+        register: Register.create!(store: @store, register_number: 13, name: "Empty"),
+        opening_float_cents: 0
+      )
+      error = assert_raises(Cash::Error) do
+        Cash::PaidOut.call(
+          session: empty[:session],
+          actor: @actor,
+          amount_cents: 100,
+          reason_code: "paid_out_supplies",
+          source_id: SecureRandom.uuid_v7,
+          idempotency_key: SecureRandom.uuid_v7
+        )
+      end
+      assert_equal Cash::INSUFFICIENT_AVAILABLE_CASH, error.message
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Post paid-in and paid-out on the open Register session as non-sale cash (not tenders, not gift-card cash-out), with catalog reasons and available-cash on paid-out.
- Add atomic session↔safe drop (`pos.transact`) and replenish (`cash.move`). Direct session-to-session transfer is not offered.
- Reverse eligible operations exactly once with inverse entries and `reversal_of_id`. The reverse has no fabricated paid-in, paid-out, or transfer source row. Session close, over/short, opening float, and safe initialization cannot be reversed.
- Material paid-out (`>=` effective store/org threshold) uses `cash.approve_paid_out` unless the performer is `direct`. Register surfaces are permission-gated from POS Home.

Closes #74.

## Verification
- `./dev/rails-docker bin/rails test` — 1142 runs, 0 failures, 1 skip
- `./dev/rails-docker bin/rubocop` on touched Ruby files — clean

## Notes
- Do not merge to `main`. This PR targets `phase-11-cash-accountability`.
- Deposit reversal stays refused until 11.3.

Made with [Cursor](https://cursor.com)