### PR TITLE
11.3 — Safe recon, deposit, and store-day report

### DIFF
--- a/app/controllers/admin/cash_deposits_controller.rb
+++ b/app/controllers/admin/cash_deposits_controller.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module Admin
+  class CashDepositsController < BaseController
+    before_action -> { require_permission!("cash.prepare_deposit") }
+    before_action :ensure_store_selected
+
+    def index
+      @deposits = CashDeposit.where(store: current_store).includes(:cash_operation, :prepared_by).order(business_date: :desc, deposit_number: :desc)
+      @dit = Cash::Locations.deposit_in_transit_for!(current_store)
+    end
+
+    def new
+      @safe = Cash::Locations.safe_for!(current_store)
+      unless @safe.initialized?
+        redirect_to admin_cash_safe_path, alert: "Initialize the store safe before preparing a deposit."
+        return
+      end
+
+      @count = Cash::SnapshotCount.start!(location: @safe, purpose: "deposit")
+      @can_view_expected = Authorization::PermissionEvaluator.allowed?(
+        user: current_user, permission_key: "cash.view_expected_before_count", store: current_store
+      )
+    end
+
+    def create
+      @safe = Cash::Locations.safe_for!(current_store)
+      start_count = CashCount.find(params.require(:cash_count_id))
+      amount = Money::ParseCents.call(params[:amount])
+      raise Cash::Error, "amount is required" if amount.nil?
+
+      deposit = Cash::PrepareDeposit.call(
+        store: current_store,
+        actor: current_user,
+        start_count: start_count,
+        amount_cents: amount,
+        bag_reference: params[:bag_reference],
+        source_id: params[:source_id].presence || SecureRandom.uuid_v7,
+        idempotency_key: params[:idempotency_key].presence || SecureRandom.uuid_v7
+      )
+      redirect_to admin_cash_deposit_path(deposit), notice: "Deposit prepared."
+    rescue Money::ParseCents::Error, Cash::Error, ActiveRecord::RecordNotFound => e
+      @count = CashCount.find_by(id: params[:cash_count_id]) || Cash::SnapshotCount.start!(location: @safe, purpose: "deposit")
+      @can_view_expected = Authorization::PermissionEvaluator.allowed?(
+        user: current_user, permission_key: "cash.view_expected_before_count", store: current_store
+      )
+      @feedback = e.message
+      render :new, status: :unprocessable_content
+    end
+
+    def show
+      @deposit = CashDeposit.where(store: current_store).find(params[:id])
+      @dit = Cash::Locations.deposit_in_transit_for!(current_store)
+    end
+
+    def reverse
+      @deposit = CashDeposit.where(store: current_store).find(params[:id])
+      unless Authorization::PermissionEvaluator.allowed?(
+        user: current_user, permission_key: "cash.reverse", store: current_store
+      )
+        redirect_to admin_cash_deposit_path(@deposit), alert: "You are not authorized to reverse this deposit."
+        return
+      end
+
+      Cash::Reverse.call(
+        operation: @deposit.cash_operation,
+        actor: current_user,
+        reason_code: params[:reason_code].presence || "reverse",
+        notes: params[:notes],
+        source_id: params[:source_id].presence || SecureRandom.uuid_v7,
+        idempotency_key: params[:idempotency_key].presence || SecureRandom.uuid_v7
+      )
+      redirect_to admin_cash_deposit_path(@deposit), notice: "Deposit reversed."
+    rescue Cash::Error => e
+      @dit = Cash::Locations.deposit_in_transit_for!(current_store)
+      @feedback = e.message
+      render :show, status: :unprocessable_content
+    end
+
+    private
+
+    def ensure_store_selected
+      return if current_store
+
+      redirect_to new_store_selection_path, alert: "Select a store."
+    end
+  end
+end

--- a/app/controllers/admin/cash_safe_reconciliations_controller.rb
+++ b/app/controllers/admin/cash_safe_reconciliations_controller.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Admin
+  class CashSafeReconciliationsController < BaseController
+    before_action -> { require_permission!("cash.reconcile_safe") }
+    before_action :ensure_store_selected
+
+    def new
+      @safe = Cash::Locations.safe_for!(current_store)
+      unless @safe.initialized?
+        redirect_to admin_cash_safe_path, alert: "Initialize the store safe before reconciling."
+        return
+      end
+
+      Cash::ActivityReasons.seed!
+      @count = Cash::SnapshotCount.start!(location: @safe, purpose: "safe_reconciliation")
+      @can_view_expected = Authorization::PermissionEvaluator.allowed?(
+        user: current_user, permission_key: "cash.view_expected_before_count", store: current_store
+      )
+      @variance_reasons = CashActivityReason.active.where(operation_kind: %w[over short]).order(:name)
+    end
+
+    def create
+      @safe = Cash::Locations.safe_for!(current_store)
+      start_count = CashCount.find(params.require(:cash_count_id))
+      counted = Money::ParseCents.call(params[:count])
+      raise Cash::Error, "count is required" if counted.nil?
+
+      Cash::ReconcileSafe.call(
+        store: current_store,
+        actor: current_user,
+        start_count: start_count,
+        count_cents: counted,
+        reason_code: params[:variance_reason_code],
+        notes: params[:variance_notes],
+        approver_username: params[:approver_username],
+        approver_password: params[:approver_password],
+        source_id: params[:source_id].presence || SecureRandom.uuid_v7,
+        idempotency_key: params[:idempotency_key].presence || SecureRandom.uuid_v7
+      )
+      redirect_to admin_cash_safe_path, notice: "Safe count accepted."
+    rescue Money::ParseCents::Error, Cash::Error, Pos::Denied, ActiveRecord::RecordNotFound => e
+      @count = CashCount.find_by(id: params[:cash_count_id]) || Cash::SnapshotCount.start!(location: @safe, purpose: "safe_reconciliation")
+      @can_view_expected = Authorization::PermissionEvaluator.allowed?(
+        user: current_user, permission_key: "cash.view_expected_before_count", store: current_store
+      )
+      Cash::ActivityReasons.seed!
+      @variance_reasons = CashActivityReason.active.where(operation_kind: %w[over short]).order(:name)
+      @feedback = e.message
+      render :new, status: :unprocessable_content
+    end
+
+    private
+
+    def ensure_store_selected
+      return if current_store
+
+      redirect_to new_store_selection_path, alert: "Select a store."
+    end
+  end
+end

--- a/app/controllers/admin/cash_store_days_controller.rb
+++ b/app/controllers/admin/cash_store_days_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Admin
+  class CashStoreDaysController < BaseController
+    before_action -> { require_permission!("pos.sessions.view") }
+    before_action :ensure_store_selected
+
+    def show
+      @business_date = parse_business_date
+      @report = Cash::StoreDayReport.for(store: current_store, business_date: @business_date)
+      @safe = Cash::Locations.safe_for!(current_store)
+      @dit = Cash::Locations.deposit_in_transit_for!(current_store)
+    end
+
+    private
+
+    def parse_business_date
+      raw = params[:business_date].presence
+      return BusinessDate.for_store(current_store) if raw.blank?
+
+      Date.iso8601(raw)
+    rescue Date::Error
+      BusinessDate.for_store(current_store)
+    end
+
+    def ensure_store_selected
+      return if current_store
+
+      redirect_to new_store_selection_path, alert: "Select a store."
+    end
+  end
+end

--- a/app/models/cash_count.rb
+++ b/app/models/cash_count.rb
@@ -8,10 +8,17 @@ class CashCount < ApplicationRecord
   belongs_to :cash_location, optional: true
   belongs_to :superseded_count, class_name: "CashCount", optional: true
   has_many :cash_count_denomination_lines, dependent: :restrict_with_exception
+  has_one :cash_deposit, dependent: :restrict_with_exception
 
   validates :purpose, presence: true, inclusion: { in: PURPOSES }
   validates :status, presence: true, inclusion: { in: STATUSES }
   validates :total_cents, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :expected_cents_snapshot, :location_lock_version_snapshot, :business_date,
+            presence: true, if: :location_snapshot_required?
+
+  def location_snapshot_required?
+    purpose.in?(%w[safe_reconciliation deposit])
+  end
 
   def readonly?
     super || persisted?

--- a/app/models/cash_deposit.rb
+++ b/app/models/cash_deposit.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CashDeposit < ApplicationRecord
+  belongs_to :store
+  belongs_to :prepared_by, class_name: "User"
+  belongs_to :approved_by, class_name: "User", optional: true
+  belongs_to :cash_count
+  belongs_to :cash_operation
+
+  validates :business_date, :deposit_number, presence: true
+  validates :total_cents, numericality: { only_integer: true, greater_than: 0 }
+  validates :deposit_number, numericality: { only_integer: true, greater_than: 0 }
+
+  def readonly?
+    super || persisted?
+  end
+
+  def reversed?
+    cash_operation.reversed?
+  end
+end

--- a/app/models/cash_location.rb
+++ b/app/models/cash_location.rb
@@ -5,6 +5,7 @@ class CashLocation < ApplicationRecord
 
   belongs_to :store
   has_many :cash_entries, dependent: :restrict_with_exception
+  has_many :cash_counts, dependent: :restrict_with_exception
   has_one :cash_safe_initialization, dependent: :restrict_with_exception
 
   validates :location_type, presence: true, inclusion: { in: LOCATION_TYPES }

--- a/app/models/cash_operation.rb
+++ b/app/models/cash_operation.rb
@@ -17,6 +17,7 @@ class CashOperation < ApplicationRecord
   has_one :cash_safe_initialization, dependent: :restrict_with_exception
   has_one :cash_paid_in, dependent: :restrict_with_exception
   has_one :cash_paid_out, dependent: :restrict_with_exception
+  has_one :cash_deposit, dependent: :restrict_with_exception
 
   validates :operation_type, :business_date, :occurred_at, presence: true
   validates :operation_type, inclusion: { in: OPERATION_TYPES }

--- a/app/services/admin/navigation_catalog.rb
+++ b/app/services/admin/navigation_catalog.rb
@@ -99,6 +99,9 @@ module Admin
               dest(:gift_card_programs, "Gift-card programs", :admin_gift_card_programs_path, permission: "gift_cards.manage_programs", controllers: %w[admin/gift_card_programs]),
               dest(:gift_cards, "Gift cards", :inquiry_admin_gift_cards_path, permission: "gift_cards.view", controllers: %w[admin/gift_cards admin/gift_card_adjustments]),
               dest(:cash_safe, "Store safe", :admin_cash_safe_path, permission: "cash.initialize_safe", requires_store: true, controllers: %w[admin/cash_safes]),
+              dest(:cash_safe_reconciliation, "Reconcile safe", :new_admin_cash_safe_reconciliation_path, permission: "cash.reconcile_safe", requires_store: true, controllers: %w[admin/cash_safe_reconciliations]),
+              dest(:cash_deposits, "Deposits", :admin_cash_deposits_path, permission: "cash.prepare_deposit", requires_store: true, controllers: %w[admin/cash_deposits]),
+              dest(:cash_store_day, "Store-day cash", :admin_cash_store_day_path, permission: "pos.sessions.view", requires_store: true, controllers: %w[admin/cash_store_days]),
               dest(:stored_value_report, "Stored-value reporting", :admin_stored_value_report_path, permission: "stored_value.view_activity", controllers: %w[admin/stored_value_reports])
             ]
           ),

--- a/app/services/cash/prepare_deposit.rb
+++ b/app/services/cash/prepare_deposit.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+module Cash
+  class PrepareDeposit
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(
+      store:,
+      actor:,
+      start_count:,
+      amount_cents:,
+      source_id:,
+      idempotency_key:,
+      bag_reference: nil
+    )
+      @store = store
+      @actor = actor
+      @start_count = start_count
+      @amount_cents = amount_cents
+      @source_id = source_id
+      @idempotency_key = idempotency_key
+      @bag_reference = bag_reference.to_s.strip.presence
+    end
+
+    def call
+      amount = Integer(@amount_cents)
+      raise Error, "amount must be positive" unless amount.positive?
+      unless Authorization::PermissionEvaluator.allowed?(
+        user: @actor, permission_key: "cash.prepare_deposit", store: @store
+      )
+        raise Error, "not authorized to prepare a deposit"
+      end
+      raise Error, "count is not a deposit count" unless @start_count.purpose == "deposit"
+      raise Error, "count is not for this store" unless @start_count.cash_location.store_id == @store.id
+
+      payload = {
+        store_id: @store.id,
+        start_count_id: @start_count.id,
+        amount_cents: amount,
+        bag_reference: @bag_reference
+      }
+      op = Idempotency::OperationService.begin!(
+        source_id: @source_id,
+        operation_type: "cash_prepare_deposit",
+        idempotency_key: @idempotency_key,
+        payload: payload
+      )
+      if op.replayed
+        return CashDeposit.find(op.operation.result_id) if op.operation.result_id
+
+        raise Error, "idempotent replay missing result"
+      end
+
+      begin
+        result = nil
+        CashDeposit.transaction do
+          Locations.ensure!(@store)
+          safe = CashLocation.find(@start_count.cash_location_id)
+          dit = CashLocation.find_by!(store: @store, location_type: "deposit_in_transit")
+          [ safe.id, dit.id ].sort.each { |id| CashLocation.lock.find(id) }
+          safe.reload
+          dit.reload
+          raise Error, "safe is not initialized" unless safe.initialized?
+          SnapshotCount.assert_current!(safe, @start_count)
+          if amount > safe.expected_balance_cents
+            raise Error, "safe does not have enough cash for this deposit"
+          end
+
+          occurred_at = Time.current
+          business_date = @start_count.business_date || BusinessDate.for_store(@store, at: occurred_at)
+          deposit_number = CashDeposit.where(store: @store, business_date: business_date).maximum(:deposit_number).to_i + 1
+          accepted = SnapshotCount.accept!(count: @start_count, total_cents: amount)
+          operation = Post.call(
+            operation_type: "transfer",
+            store: @store,
+            performed_by: @actor,
+            source_id: SecureRandom.uuid_v7,
+            idempotency_key: SecureRandom.uuid_v7,
+            business_date: business_date,
+            occurred_at: occurred_at,
+            outbox_event_type: "cash.deposit_prepared",
+            entries: [
+              { cash_location: safe, amount_cents: -amount },
+              { cash_location: dit, amount_cents: amount }
+            ]
+          )
+          CashTransfer.create!(
+            transfer_type: "deposit",
+            amount_cents: amount,
+            source_cash_location: safe,
+            destination_cash_location: dit,
+            cash_operation: operation
+          )
+          deposit = CashDeposit.create!(
+            store: @store,
+            business_date: business_date,
+            deposit_number: deposit_number,
+            bag_reference: @bag_reference,
+            total_cents: amount,
+            prepared_by: @actor,
+            cash_count: accepted,
+            cash_operation: operation
+          )
+          Audit::Recorder.record!(
+            action: "cash.prepare_deposit",
+            outcome: "succeeded",
+            actor_user: @actor,
+            store: @store,
+            subject: deposit,
+            after_values: { total_cents: amount, deposit_number: deposit_number }
+          )
+          Idempotency::OperationService.complete!(
+            op.operation,
+            result_type: "CashDeposit",
+            result_id: deposit.id,
+            result_payload: { total_cents: amount }
+          )
+          result = deposit
+        end
+        result
+      rescue Error, ActiveRecord::RecordInvalid, ActiveRecord::StaleObjectError, ActiveRecord::RecordNotUnique => e
+        Idempotency::OperationService.fail!(op.operation, message: e.message)
+        Audit::Recorder.record!(
+          action: "cash.prepare_deposit",
+          outcome: "failed",
+          actor_user: @actor,
+          store: @store,
+          reason_text: e.message
+        )
+        raise Error, e.message
+      rescue Idempotency::OperationService::PayloadMismatchError
+        raise
+      end
+    end
+  end
+end

--- a/app/services/cash/reconcile_safe.rb
+++ b/app/services/cash/reconcile_safe.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+module Cash
+  class ReconcileSafe
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(
+      store:,
+      actor:,
+      start_count:,
+      count_cents:,
+      source_id:,
+      idempotency_key:,
+      reason_code: nil,
+      notes: nil,
+      approver_username: nil,
+      approver_password: nil
+    )
+      @store = store
+      @actor = actor
+      @start_count = start_count
+      @count_cents = count_cents
+      @source_id = source_id
+      @idempotency_key = idempotency_key
+      @reason_code = reason_code
+      @notes = notes
+      @approver_username = approver_username
+      @approver_password = approver_password
+    end
+
+    def call
+      counted = Integer(@count_cents)
+      raise Error, "count must be a non-negative amount" if counted.negative?
+      unless Authorization::PermissionEvaluator.allowed?(
+        user: @actor, permission_key: "cash.reconcile_safe", store: @store
+      )
+        raise Error, "not authorized to reconcile the safe"
+      end
+      raise Error, "count is not a safe reconciliation" unless @start_count.purpose == "safe_reconciliation"
+      raise Error, "count is not for this store" unless @start_count.cash_location.store_id == @store.id
+
+      payload = { store_id: @store.id, start_count_id: @start_count.id, count_cents: counted }
+      op = Idempotency::OperationService.begin!(
+        source_id: @source_id,
+        operation_type: "cash_reconcile_safe",
+        idempotency_key: @idempotency_key,
+        payload: payload
+      )
+      if op.replayed
+        return CashCount.find(op.operation.result_id) if op.operation.result_id
+
+        raise Error, "idempotent replay missing result"
+      end
+
+      begin
+        result = nil
+        CashCount.transaction do
+          Locations.ensure!(@store)
+          safe = CashLocation.lock.find(@start_count.cash_location_id)
+          raise Error, "safe is not initialized" unless safe.initialized?
+          SnapshotCount.assert_current!(safe, @start_count)
+
+          expected = safe.expected_balance_cents
+          variance = counted - expected
+          policy = VariancePolicy.for!(
+            store: @store,
+            actor: @actor,
+            variance_cents: variance,
+            reason_code: @reason_code,
+            notes: @notes,
+            approver_username: @approver_username,
+            approver_password: @approver_password
+          )
+          accepted = SnapshotCount.accept!(count: @start_count, total_cents: counted)
+
+          if variance != 0
+            operation = Post.call(
+              operation_type: "reconcile",
+              store: @store,
+              performed_by: @actor,
+              approved_by: policy.approved_by,
+              source_id: SecureRandom.uuid_v7,
+              idempotency_key: SecureRandom.uuid_v7,
+              reason_code: policy.reason.code,
+              reason_name_snapshot: policy.reason.name,
+              notes: policy.notes,
+              entries: [ { cash_location: safe, amount_cents: variance } ]
+            )
+            CashReconciliation.create!(
+              direction: variance.positive? ? "over" : "short",
+              expected_cents: expected,
+              counted_cents: counted,
+              variance_cents: variance,
+              cash_location: safe,
+              cash_count: accepted,
+              cash_operation: operation
+            )
+          end
+
+          Audit::Recorder.record!(
+            action: "cash.reconcile_safe",
+            outcome: "succeeded",
+            actor_user: @actor,
+            store: @store,
+            subject: accepted,
+            after_values: { counted_cents: counted, variance_cents: variance }
+          )
+          Idempotency::OperationService.complete!(
+            op.operation,
+            result_type: "CashCount",
+            result_id: accepted.id,
+            result_payload: { counted_cents: counted, variance_cents: variance }
+          )
+          result = accepted
+        end
+        result
+      rescue Error, ActiveRecord::RecordInvalid, ActiveRecord::StaleObjectError, Pos::Denied => e
+        Idempotency::OperationService.fail!(op.operation, message: e.message)
+        Audit::Recorder.record!(
+          action: "cash.reconcile_safe",
+          outcome: "failed",
+          actor_user: @actor,
+          store: @store,
+          reason_text: e.message
+        )
+        raise Error, e.message
+      rescue Idempotency::OperationService::PayloadMismatchError
+        raise
+      end
+    end
+  end
+end

--- a/app/services/cash/reverse.rb
+++ b/app/services/cash/reverse.rb
@@ -11,7 +11,6 @@ module Cash
 
       transfer = operation.cash_transfer
       return false if transfer && FORBIDDEN_TRANSFERS.include?(transfer.transfer_type)
-      return false if transfer&.transfer_type == "deposit"
 
       session_ids = operation.cash_entries.filter_map(&:pos_session_id).uniq
       return true if session_ids.empty?
@@ -45,9 +44,6 @@ module Cash
       transfer = @operation.cash_transfer
       if transfer && FORBIDDEN_TRANSFERS.include?(transfer.transfer_type)
         raise Error, "this operation cannot be reversed"
-      end
-      if transfer&.transfer_type == "deposit"
-        raise Error, "deposit reversal is not available until deposit in transit is implemented"
       end
 
       reason = ActivityReasons.require!(@reason_code, "reverse")

--- a/app/services/cash/safe_totals.rb
+++ b/app/services/cash/safe_totals.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Cash
+  class SafeTotals
+    def self.for(location)
+      new(location)
+    end
+
+    def initialize(location)
+      @location = location
+    end
+
+    def expected_cents
+      @location.expected_balance_cents
+    end
+
+    def from_entries_cents
+      CashEntry.where(cash_location_id: @location.id).sum(:amount_cents)
+    end
+  end
+end

--- a/app/services/cash/snapshot_count.rb
+++ b/app/services/cash/snapshot_count.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Cash
+  class SnapshotCount
+    STALE = "This count is stale because safe cash changed. Start a new count."
+
+    def self.start!(location:, purpose:)
+      raise Error, "safe is not initialized" if location.safe? && !location.initialized?
+
+      locked = CashLocation.lock.find(location.id)
+      raise Error, "safe is not initialized" if locked.safe? && !locked.initialized?
+
+      CashCount.create!(
+        purpose: purpose,
+        total_cents: 0,
+        expected_cents_snapshot: locked.expected_balance_cents,
+        location_lock_version_snapshot: locked.lock_version,
+        cash_location: locked,
+        status: "discarded",
+        business_date: BusinessDate.for_store(locked.store)
+      )
+    end
+
+    def self.assert_current!(location, count)
+      if location.lock_version != count.location_lock_version_snapshot ||
+         location.expected_balance_cents != count.expected_cents_snapshot
+        raise Error, STALE
+      end
+    end
+
+    def self.accept!(count:, total_cents:)
+      CashCount.create!(
+        purpose: count.purpose,
+        total_cents: total_cents,
+        expected_cents_snapshot: count.expected_cents_snapshot,
+        location_lock_version_snapshot: count.location_lock_version_snapshot,
+        cash_location: count.cash_location,
+        status: "accepted",
+        business_date: count.business_date,
+        superseded_count: count
+      )
+    end
+  end
+end

--- a/app/services/cash/store_day_report.rb
+++ b/app/services/cash/store_day_report.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+module Cash
+  class StoreDayReport
+    SessionRow = Struct.new(
+      :session, :register_label, :cashier_name, :closer_name, :manager_assisted,
+      :opening_float_cents, :cash_payment_cents, :cash_refund_cents, :gift_card_cash_out_cents,
+      :expected_cents, :counted_cents, :variance_cents, :open, keyword_init: true
+    )
+    ReasonRow = Struct.new(:reason_code, :reason_name, :amount_cents, :count, keyword_init: true)
+    DepositRow = Struct.new(:deposit, :reversed, keyword_init: true)
+
+    def self.for(store:, business_date:)
+      new(store: store, business_date: business_date)
+    end
+
+    def initialize(store:, business_date:)
+      @store = store
+      @business_date = business_date
+    end
+
+    def incomplete?
+      sessions.any?(&:open)
+    end
+
+    def sessions_closed?
+      sessions.any? && sessions.none?(&:open)
+    end
+
+    def safe_reconciled?
+      accepted_safe_counts.exists?
+    end
+
+    def deposit_prepared?
+      deposits.any?
+    end
+
+    def status_labels
+      labels = []
+      labels << "incomplete" if incomplete?
+      labels << "sessions closed" if sessions_closed?
+      labels << "safe reconciled" if safe_reconciled?
+      labels << "deposit prepared" if deposit_prepared?
+      labels.presence || [ "no cash activity" ]
+    end
+
+    def sessions
+      @sessions ||= session_records.map { |session| session_row(session) }
+    end
+
+    def paid_ins
+      @paid_ins ||= reason_rows(CashPaidIn.where(pos_session_id: session_ids))
+    end
+
+    def paid_outs
+      @paid_outs ||= reason_rows(CashPaidOut.where(pos_session_id: session_ids))
+    end
+
+    def drop_cents
+      session_transfers("drop")
+    end
+
+    def replenishment_cents
+      session_transfers("replenishment")
+    end
+
+    def latest_safe_count
+      accepted_safe_counts.order(created_at: :desc).first
+    end
+
+    def safe_expected_cents
+      latest_safe_count&.expected_cents_snapshot
+    end
+
+    def safe_counted_cents
+      latest_safe_count&.total_cents
+    end
+
+    def safe_variance_cents
+      return if latest_safe_count.blank?
+
+      latest_safe_count.total_cents - latest_safe_count.expected_cents_snapshot
+    end
+
+    def retained_cents
+      Locations.safe_for!(@store).expected_balance_cents
+    end
+
+    def dit_balance_cents
+      Locations.deposit_in_transit_for!(@store).expected_balance_cents
+    end
+
+    def deposits
+      @deposits ||= CashDeposit.where(store: @store, business_date: @business_date)
+                               .includes(:cash_operation)
+                               .order(:deposit_number)
+                               .map { |deposit| DepositRow.new(deposit: deposit, reversed: deposit.reversed?) }
+    end
+
+    def reversals
+      @reversals ||= CashOperation.where(store: @store, business_date: @business_date, operation_type: "reverse")
+                                  .order(:occurred_at)
+    end
+
+    def open_sessions
+      sessions.select(&:open)
+    end
+
+    private
+
+    def session_records
+      @session_records ||= PosSession.joins(:reporting_period)
+                                     .where(store_id: @store.id, pos_reporting_periods: { business_date: @business_date })
+                                     .includes(:register, :cashier_user, :closed_by_user, :reporting_period)
+                                     .order(:opened_at)
+                                     .to_a
+    end
+
+    def session_ids
+      session_records.map(&:id)
+    end
+
+    def session_row(session)
+      totals = Pos::SessionTotals.for(session)
+      SessionRow.new(
+        session: session,
+        register_label: session.register.admin_label,
+        cashier_name: session.cashier_user.display_name,
+        closer_name: session.closed_by_user&.display_name,
+        manager_assisted: session.closed? && session.closed_by_user_id.present? &&
+          session.closed_by_user_id != session.cashier_user_id,
+        opening_float_cents: session.opening_float_cents,
+        cash_payment_cents: totals.cash_payment_cents,
+        cash_refund_cents: totals.cash_refund_cents,
+        gift_card_cash_out_cents: totals.gift_card_cash_out_cents,
+        expected_cents: session.closed? ? session.closing_expected_cash_cents : totals.expected_cash_cents,
+        counted_cents: session.closing_count_cents,
+        variance_cents: session.closing_variance_cents,
+        open: session.open?
+      )
+    end
+
+    def reason_rows(relation)
+      relation.group(:reason_code, :reason_name_snapshot)
+              .pluck(:reason_code, :reason_name_snapshot, Arel.sql("SUM(amount_cents)"), Arel.sql("COUNT(*)"))
+              .map { |code, name, amount, count|
+                ReasonRow.new(reason_code: code, reason_name: name, amount_cents: amount.to_i, count: count)
+              }
+    end
+
+    def session_transfers(type)
+      CashTransfer.where(transfer_type: type)
+                  .joins(:cash_operation)
+                  .where(cash_operations: { store_id: @store.id, business_date: @business_date })
+                  .sum(:amount_cents)
+    end
+
+    def accepted_safe_counts
+      CashCount.where(
+        purpose: "safe_reconciliation",
+        status: "accepted",
+        business_date: @business_date,
+        cash_location_id: Locations.safe_for!(@store).id
+      )
+    end
+  end
+end

--- a/app/services/cash/variance_policy.rb
+++ b/app/services/cash/variance_policy.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Cash
+  class VariancePolicy
+    Result = Struct.new(:reason, :approved_by, :notes, keyword_init: true)
+
+    def self.for!(
+      store:,
+      actor:,
+      variance_cents:,
+      reason_code:,
+      notes:,
+      approver_username: nil,
+      approver_password: nil
+    )
+      notes = notes.to_s.strip.presence
+      return Result.new(reason: nil, approved_by: nil, notes: notes) if variance_cents.zero?
+
+      kind = variance_cents.positive? ? "over" : "short"
+      reason = ActivityReasons.require!(reason_code, kind)
+      raise Error, "variance notes are required" if reason.notes_required && notes.blank?
+
+      abs_variance = variance_cents.abs
+      raise Error, "a note is required for this variance" if abs_variance >= Thresholds.note_cents(store) && notes.blank?
+
+      approved_by = nil
+      if abs_variance >= Thresholds.approval_cents(store)
+        unless Authorization::PermissionEvaluator.allowed?(
+          user: actor, permission_key: "cash.approve_variance", store: store
+        )
+          approved_by = Pos::AuthenticateApprover.call(
+            username: approver_username,
+            password: approver_password,
+            store: store,
+            action_type: "cash_variance",
+            performer: actor,
+            permission_key: "cash.approve_variance"
+          )
+        end
+      end
+
+      Result.new(reason: reason, approved_by: approved_by, notes: notes)
+    end
+  end
+end

--- a/app/views/admin/cash_deposits/index.html.erb
+++ b/app/views/admin/cash_deposits/index.html.erb
@@ -1,0 +1,21 @@
+<% content_for :title, "Deposits" %>
+<%= render "shared/page_header",
+      title: "Deposits",
+      actions: action_link_to("Prepare deposit", new_admin_cash_deposit_path, style: :solid, intent: :brand) %>
+
+<p>Deposit in transit (cumulative ledger): <%= format_money_cents(@dit.expected_balance_cents) %>. This total is not treated as cash still physically in the store.</p>
+
+<% rows = @deposits.map { |deposit|
+     [
+       deposit.business_date.iso8601,
+       deposit.deposit_number,
+       format_money_cents(deposit.total_cents),
+       deposit.bag_reference.presence || "—",
+       deposit.prepared_by.display_name,
+       deposit.reversed? ? "Reversed" : "In transit",
+       link_to("View", admin_cash_deposit_path(deposit))
+     ]
+   } %>
+<%= render "shared/data_table",
+      headers: ["Business date", "Number", "Amount", "Reference", "Prepared by", "Status", ""],
+      rows: rows %>

--- a/app/views/admin/cash_deposits/new.html.erb
+++ b/app/views/admin/cash_deposits/new.html.erb
@@ -1,0 +1,30 @@
+<% content_for :title, "Prepare deposit" %>
+<%= render "shared/page_header", title: "Prepare deposit" %>
+
+<p>Move counted cash from the store safe to deposit in transit. Bank confirmation is not part of this step. The deposit-in-transit balance is cumulative ledger cash, not cash still in the store.</p>
+
+<% if @feedback.present? %>
+  <p role="alert"><%= @feedback %></p>
+<% end %>
+
+<% if @can_view_expected %>
+  <p>Safe expected when this count started: <%= format_money_cents(@count.expected_cents_snapshot) %></p>
+<% else %>
+  <p>This is a blind count of the deposit. Expected safe cash is hidden until you submit.</p>
+<% end %>
+
+<%= form_with url: admin_cash_deposits_path, method: :post, class: "form" do %>
+  <%= hidden_field_tag :cash_count_id, @count.id %>
+  <%= hidden_field_tag :source_id, params[:source_id].presence || SecureRandom.uuid_v7 %>
+  <%= hidden_field_tag :idempotency_key, params[:idempotency_key].presence || SecureRandom.uuid_v7 %>
+  <div class="form-field">
+    <%= label_tag :amount, "Deposit amount" %>
+    <%= text_field_tag :amount, params[:amount], required: true, inputmode: "decimal", autocomplete: "off" %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :bag_reference, "Bag or reference (optional)" %>
+    <%= text_field_tag :bag_reference, params[:bag_reference], autocomplete: "off" %>
+  </div>
+  <%= submit_tag "Prepare deposit", class: "btn" %>
+  <%= link_to "Deposits", admin_cash_deposits_path, class: "btn btn--ghost" %>
+<% end %>

--- a/app/views/admin/cash_deposits/show.html.erb
+++ b/app/views/admin/cash_deposits/show.html.erb
@@ -1,0 +1,37 @@
+<% content_for :title, "Deposit #{@deposit.deposit_number}" %>
+<%= render "shared/page_header", title: "Deposit #{@deposit.deposit_number}" %>
+
+<% if @feedback.present? %>
+  <p role="alert"><%= @feedback %></p>
+<% end %>
+
+<dl>
+  <dt>Business date</dt>
+  <dd><%= @deposit.business_date.iso8601 %></dd>
+  <dt>Amount</dt>
+  <dd><%= format_money_cents(@deposit.total_cents) %></dd>
+  <dt>Bag or reference</dt>
+  <dd><%= @deposit.bag_reference.presence || "—" %></dd>
+  <dt>Prepared by</dt>
+  <dd><%= @deposit.prepared_by.display_name %></dd>
+  <dt>Status</dt>
+  <dd><%= @deposit.reversed? ? "Reversed" : "In transit" %></dd>
+  <dt>Deposit in transit (cumulative)</dt>
+  <dd><%= format_money_cents(@dit.expected_balance_cents) %></dd>
+</dl>
+
+<% if !@deposit.reversed? && Authorization::PermissionEvaluator.allowed?(user: current_user, permission_key: "cash.reverse", store: current_store) %>
+  <h2>Reverse while in transit</h2>
+  <%= form_with url: reverse_admin_cash_deposit_path(@deposit), method: :post, class: "form" do %>
+    <%= hidden_field_tag :source_id, SecureRandom.uuid_v7 %>
+    <%= hidden_field_tag :idempotency_key, SecureRandom.uuid_v7 %>
+    <%= hidden_field_tag :reason_code, "reverse" %>
+    <div class="form-field">
+      <%= label_tag :notes, "Notes" %>
+      <%= text_field_tag :notes, params[:notes], required: true, autocomplete: "off" %>
+    </div>
+    <%= submit_tag "Reverse deposit", class: "btn" %>
+  <% end %>
+<% end %>
+
+<p><%= link_to "All deposits", admin_cash_deposits_path %></p>

--- a/app/views/admin/cash_safe_reconciliations/new.html.erb
+++ b/app/views/admin/cash_safe_reconciliations/new.html.erb
@@ -1,0 +1,44 @@
+<% content_for :title, "Reconcile store safe" %>
+<%= render "shared/page_header", title: "Reconcile store safe" %>
+
+<p>Count the store safe. Session results are not allocated onto this count. Cash activity may continue; a stale count is rejected.</p>
+
+<% if @feedback.present? %>
+  <p role="alert"><%= @feedback %></p>
+<% end %>
+
+<% if @can_view_expected %>
+  <p>Expected when this count started: <%= format_money_cents(@count.expected_cents_snapshot) %></p>
+<% else %>
+  <p>This is a blind count. Expected cash is hidden until you submit.</p>
+<% end %>
+
+<%= form_with url: admin_cash_safe_reconciliation_path, method: :post, class: "form" do %>
+  <%= hidden_field_tag :cash_count_id, @count.id %>
+  <%= hidden_field_tag :source_id, params[:source_id].presence || SecureRandom.uuid_v7 %>
+  <%= hidden_field_tag :idempotency_key, params[:idempotency_key].presence || SecureRandom.uuid_v7 %>
+  <div class="form-field">
+    <%= label_tag :count, "Counted cash" %>
+    <%= text_field_tag :count, params[:count], required: true, inputmode: "decimal", autocomplete: "off" %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :variance_reason_code, "Over/short reason (required if counted cash differs)" %>
+    <%= select_tag :variance_reason_code,
+          options_from_collection_for_select(@variance_reasons, :code, :name, params[:variance_reason_code]),
+          include_blank: "None" %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :variance_notes, "Over/short note" %>
+    <%= text_field_tag :variance_notes, params[:variance_notes], autocomplete: "off" %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :approver_username, "Approver username (material over/short)" %>
+    <%= text_field_tag :approver_username, params[:approver_username], autocomplete: "off" %>
+  </div>
+  <div class="form-field">
+    <%= label_tag :approver_password, "Approver password" %>
+    <%= password_field_tag :approver_password, nil, autocomplete: "current-password" %>
+  </div>
+  <%= submit_tag "Accept count", class: "btn" %>
+  <%= link_to "Store safe", admin_cash_safe_path, class: "btn btn--ghost" %>
+<% end %>

--- a/app/views/admin/cash_safes/show.html.erb
+++ b/app/views/admin/cash_safes/show.html.erb
@@ -6,4 +6,16 @@
 
 <% unless @safe.initialized? %>
   <p><%= action_link_to("Initialize safe", new_admin_cash_safe_path, style: :solid, intent: :brand) %></p>
+<% else %>
+  <p>
+    <% if Authorization::PermissionEvaluator.allowed?(user: current_user, permission_key: "cash.reconcile_safe", store: current_store) %>
+      <%= action_link_to("Reconcile safe", new_admin_cash_safe_reconciliation_path, style: :solid, intent: :brand) %>
+    <% end %>
+    <% if Authorization::PermissionEvaluator.allowed?(user: current_user, permission_key: "cash.prepare_deposit", store: current_store) %>
+      <%= action_link_to("Prepare deposit", new_admin_cash_deposit_path, style: :ghost, intent: :neutral) %>
+    <% end %>
+    <% if Authorization::PermissionEvaluator.allowed?(user: current_user, permission_key: "pos.sessions.view", store: current_store) %>
+      <%= action_link_to("Store-day cash", admin_cash_store_day_path, style: :ghost, intent: :neutral) %>
+    <% end %>
+  </p>
 <% end %>

--- a/app/views/admin/cash_store_days/show.html.erb
+++ b/app/views/admin/cash_store_days/show.html.erb
@@ -1,0 +1,81 @@
+<% content_for :title, "Store-day cash" %>
+<%= render "shared/page_header", title: "Store-day cash", subtitle: current_store.admin_label %>
+
+<%= form_with url: admin_cash_store_day_path, method: :get, class: "form" do %>
+  <div class="form-field">
+    <%= label_tag :business_date, "Business date" %>
+    <%= date_field_tag :business_date, @business_date.iso8601 %>
+  </div>
+  <%= submit_tag "Show", class: "btn" %>
+<% end %>
+
+<p>Status: <%= @report.status_labels.to_sentence %>. This report is not a close gate. Tomorrow can open on retained safe cash.</p>
+<p>Deposit in transit (cumulative ledger, not cash still in the store): <%= format_money_cents(@report.dit_balance_cents) %></p>
+<p>Retained on the store safe now: <%= format_money_cents(@report.retained_cents) %></p>
+
+<h2 class="section__title">Sessions</h2>
+<% session_rows = @report.sessions.map { |row|
+     [
+       row.register_label,
+       row.cashier_name,
+       row.closer_name.presence || "—",
+       row.manager_assisted ? "Yes" : "No",
+       format_money_cents(row.opening_float_cents),
+       format_money_cents(row.cash_payment_cents),
+       format_money_cents(row.cash_refund_cents),
+       format_money_cents(row.gift_card_cash_out_cents),
+       format_money_cents(row.expected_cents),
+       row.counted_cents.nil? ? "—" : format_money_cents(row.counted_cents),
+       row.variance_cents.nil? ? "—" : format_money_cents(row.variance_cents),
+       row.open ? "Open" : "Closed"
+     ]
+   } %>
+<%= render "shared/data_table",
+      headers: ["Register", "Cashier", "Closer", "Manager-assisted", "Opening float", "Cash in", "Cash refunds", "Gift-card cash-outs", "Expected", "Counted", "Variance", "Status"],
+      rows: session_rows %>
+
+<h2 class="section__title">Non-sale cash</h2>
+<p>Drops: <%= format_money_cents(@report.drop_cents) %>. Replenishments: <%= format_money_cents(@report.replenishment_cents) %>.</p>
+<% paid_in_rows = @report.paid_ins.map { |row| [ row.reason_name, row.count, format_money_cents(row.amount_cents) ] } %>
+<%= render "shared/data_table", headers: ["Paid-in reason", "Count", "Amount"], rows: paid_in_rows %>
+<% paid_out_rows = @report.paid_outs.map { |row| [ row.reason_name, row.count, format_money_cents(row.amount_cents) ] } %>
+<%= render "shared/data_table", headers: ["Paid-out reason", "Count", "Amount"], rows: paid_out_rows %>
+
+<h2 class="section__title">Safe</h2>
+<% if @report.latest_safe_count %>
+  <p>
+    Counted <%= format_money_cents(@report.safe_counted_cents) %>
+    against expected <%= format_money_cents(@report.safe_expected_cents) %>
+    (<%= format_money_cents(@report.safe_variance_cents) %> variance).
+  </p>
+<% else %>
+  <p>No accepted safe reconciliation count for this business date.</p>
+<% end %>
+
+<h2 class="section__title">Deposits for this date</h2>
+<% deposit_rows = @report.deposits.map { |row|
+     [
+       row.deposit.deposit_number,
+       format_money_cents(row.deposit.total_cents),
+       row.deposit.bag_reference.presence || "—",
+       row.reversed ? "Reversed" : "In transit",
+       link_to("View", admin_cash_deposit_path(row.deposit))
+     ]
+   } %>
+<%= render "shared/data_table",
+      headers: ["Number", "Amount", "Reference", "Status", ""],
+      rows: deposit_rows %>
+
+<h2 class="section__title">Reversals</h2>
+<% reversal_rows = @report.reversals.map { |operation|
+     [
+       operation.occurred_at.utc.iso8601,
+       operation.operation_type,
+       operation.notes.presence || "—"
+     ]
+   } %>
+<%= render "shared/data_table", headers: ["Occurred", "Type", "Notes"], rows: reversal_rows %>
+
+<% if @report.open_sessions.any? %>
+  <p>Open sessions remain. That is incomplete for this date; it does not block the next business date.</p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -118,6 +118,11 @@ Rails.application.routes.draw do
       member { post :reactivate }
     end
     resource :cash_safe, only: %i[show new create], controller: "cash_safes"
+    resource :cash_safe_reconciliation, only: %i[new create], controller: "cash_safe_reconciliations"
+    resources :cash_deposits, only: %i[index new create show] do
+      member { post :reverse }
+    end
+    resource :cash_store_day, only: :show, controller: "cash_store_days"
     resources :gift_cards, only: %i[index show] do
       collection do
         get :inquiry

--- a/db/migrate/20260826220000_create_phase11_safe_recon_and_deposit.rb
+++ b/db/migrate/20260826220000_create_phase11_safe_recon_and_deposit.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class CreatePhase11SafeReconAndDeposit < ActiveRecord::Migration[8.1]
+  def change
+    add_column :cash_counts, :business_date, :date
+    add_index :cash_counts, [ :cash_location_id, :purpose, :business_date ],
+              name: "index_cash_counts_on_location_purpose_date"
+
+    create_uuid_table :cash_deposits do |t|
+      t.uuid :store_id, null: false
+      t.date :business_date, null: false
+      t.integer :deposit_number, null: false
+      t.string :bag_reference
+      t.bigint :total_cents, null: false
+      t.uuid :prepared_by_id, null: false
+      t.uuid :approved_by_id
+      t.uuid :cash_count_id, null: false
+      t.uuid :cash_operation_id, null: false
+      t.timestamptz :created_at, null: false
+      t.timestamptz :updated_at, null: false
+    end
+    add_index :cash_deposits, :cash_operation_id, unique: true
+    add_index :cash_deposits, :cash_count_id
+    add_index :cash_deposits, :store_id
+    add_index :cash_deposits, [ :store_id, :business_date, :deposit_number ],
+              unique: true, name: "index_cash_deposits_on_store_date_number"
+    add_foreign_key :cash_deposits, :stores
+    add_foreign_key :cash_deposits, :users, column: :prepared_by_id
+    add_foreign_key :cash_deposits, :users, column: :approved_by_id
+    add_foreign_key :cash_deposits, :cash_counts
+    add_foreign_key :cash_deposits, :cash_operations
+    add_check_constraint :cash_deposits, "total_cents > 0", name: "cash_deposits_total_positive"
+    add_check_constraint :cash_deposits, "deposit_number > 0", name: "cash_deposits_number_positive"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_26_200000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_26_220000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -132,6 +132,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_200000) do
   end
 
   create_table "cash_counts", id: :uuid, default: nil, force: :cascade do |t|
+    t.date "business_date"
     t.uuid "cash_location_id"
     t.timestamptz "created_at", null: false
     t.bigint "expected_cents_snapshot"
@@ -141,11 +142,32 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_200000) do
     t.string "status", null: false
     t.uuid "superseded_count_id"
     t.bigint "total_cents", null: false
+    t.index ["cash_location_id", "purpose", "business_date"], name: "index_cash_counts_on_location_purpose_date"
     t.index ["cash_location_id"], name: "index_cash_counts_on_cash_location_id"
     t.index ["pos_session_id"], name: "index_cash_counts_on_pos_session_id"
     t.check_constraint "purpose::text = ANY (ARRAY['session_open'::character varying, 'session_close'::character varying, 'safe_reconciliation'::character varying, 'deposit'::character varying, 'safe_initialization'::character varying]::text[])", name: "cash_counts_purpose_valid"
     t.check_constraint "status::text = ANY (ARRAY['discarded'::character varying, 'accepted'::character varying]::text[])", name: "cash_counts_status_valid"
     t.check_constraint "total_cents >= 0", name: "cash_counts_total_nonnegative"
+  end
+
+  create_table "cash_deposits", id: :uuid, default: nil, force: :cascade do |t|
+    t.uuid "approved_by_id"
+    t.string "bag_reference"
+    t.date "business_date", null: false
+    t.uuid "cash_count_id", null: false
+    t.uuid "cash_operation_id", null: false
+    t.timestamptz "created_at", null: false
+    t.integer "deposit_number", null: false
+    t.uuid "prepared_by_id", null: false
+    t.uuid "store_id", null: false
+    t.bigint "total_cents", null: false
+    t.timestamptz "updated_at", null: false
+    t.index ["cash_count_id"], name: "index_cash_deposits_on_cash_count_id"
+    t.index ["cash_operation_id"], name: "index_cash_deposits_on_cash_operation_id", unique: true
+    t.index ["store_id", "business_date", "deposit_number"], name: "index_cash_deposits_on_store_date_number", unique: true
+    t.index ["store_id"], name: "index_cash_deposits_on_store_id"
+    t.check_constraint "deposit_number > 0", name: "cash_deposits_number_positive"
+    t.check_constraint "total_cents > 0", name: "cash_deposits_total_positive"
   end
 
   create_table "cash_entries", id: :uuid, default: nil, force: :cascade do |t|
@@ -1901,6 +1923,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_200000) do
   add_foreign_key "cash_counts", "cash_counts", column: "superseded_count_id"
   add_foreign_key "cash_counts", "cash_locations"
   add_foreign_key "cash_counts", "pos_sessions"
+  add_foreign_key "cash_deposits", "cash_counts"
+  add_foreign_key "cash_deposits", "cash_operations"
+  add_foreign_key "cash_deposits", "stores"
+  add_foreign_key "cash_deposits", "users", column: "approved_by_id"
+  add_foreign_key "cash_deposits", "users", column: "prepared_by_id"
   add_foreign_key "cash_entries", "cash_entries", column: "reversal_of_id"
   add_foreign_key "cash_entries", "cash_locations"
   add_foreign_key "cash_entries", "cash_operations"

--- a/docs/planning/phase11-cash-accountability/phase11-implementation-plan.md
+++ b/docs/planning/phase11-cash-accountability/phase11-implementation-plan.md
@@ -1,6 +1,6 @@
 # Phase 11 — Implementation plan
 
-Status: **Proposed** (11.2–11.3 not started). Living file: update slice status when work lands.
+Status: **Proposed** (11.3 in this PR). Living file: update slice status when work lands.
 
 Authority: [phase11-plan.md](phase11-plan.md), [phase11-schema.md](phase11-schema.md), [ADR-021](../../adr/ADR-021-register-and-terminal-identity.md), [ADR-025](../../adr/ADR-025-domain-owned-operational-ledgers.md).
 
@@ -73,8 +73,8 @@ If a later release needs to delay enforcement, that would be a feature gate or t
 |---|---|
 | 11.0 Contract / packet | **Complete** on `main` (planning packet). Merge-policy lock: this PR on `phase-11-cash-accountability` |
 | 11.1 Safe-backed session lifecycle | **Complete** on `phase-11-cash-accountability` |
-| 11.2 Non-sale cash activity | This PR |
-| 11.3 Safe recon, deposit, store-day report | Not started |
+| 11.2 Non-sale cash activity | **Complete** on `phase-11-cash-accountability` |
+| 11.3 Safe recon, deposit, store-day report | This PR |
 
 ## Integration notes
 

--- a/docs/planning/phase11-cash-accountability/phase11-safe-and-reporting.md
+++ b/docs/planning/phase11-cash-accountability/phase11-safe-and-reporting.md
@@ -1,6 +1,6 @@
 # Phase 11 — Safe reconciliation and reporting
 
-Status: **Proposed**. Implementation authority for 11.3. Deposit in transit is in Phase 11; bank confirmation is not.
+Status: **Implemented** on `phase-11-cash-accountability` (this PR). Deposit in transit is in Phase 11; bank confirmation is not.
 
 ### Actually locked
 

--- a/docs/planning/phase11-cash-accountability/phase11-schema.md
+++ b/docs/planning/phase11-cash-accountability/phase11-schema.md
@@ -1,6 +1,6 @@
 # Phase 11 — Schema contract
 
-Status: **11.1–11.2 tables implemented** on the Phase 11 integration branch. 11.3 deposit source row is reserved. PostgreSQL is authoritative. UUIDv7 via `create_uuid_table` / application-assigned ids ([AGENTS.md](../../../AGENTS.md) §10).
+Status: **11.1–11.3 tables implemented** on the Phase 11 integration branch. PostgreSQL is authoritative. UUIDv7 via `create_uuid_table` / application-assigned ids ([AGENTS.md](../../../AGENTS.md) §10).
 
 Companions: [phase11-plan.md](phase11-plan.md), [phase11-session-lifecycle.md](phase11-session-lifecycle.md), [phase5-schema.md](../phase4-6-point-of-sale/phase5-cash-register/phase5-schema.md).
 
@@ -134,6 +134,7 @@ Immutable observations. They do not change expected cash until a reconciliation 
 |---|---|---|
 | `purpose` | string | `session_open`, `session_close`, `safe_reconciliation`, `deposit`, `safe_initialization` |
 | `total_cents` | bigint | ≥ 0; authoritative |
+| `business_date` | date, nullable | Required for `safe_reconciliation` and `deposit`; store-day status uses this date, never `created_at` |
 | `expected_cents_snapshot` | bigint, nullable | Required for `safe_reconciliation` and `deposit` (the location being counted): expected balance when the count **started** |
 | `location_lock_version_snapshot` | integer, nullable | Required with `expected_cents_snapshot`: that location’s `lock_version` at count start |
 | `pos_session_id` / `cash_location_id` | uuid, nullable | As applicable |

--- a/test/integration/admin_cash_recon_deposit_test.rb
+++ b/test/integration/admin_cash_recon_deposit_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AdminCashReconDepositTest < ActionDispatch::IntegrationTest
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    Cash::ActivityReasons.seed!
+    sign_in_as("admin")
+    post store_selection_path, params: { store_id: @store.id }
+  end
+
+  test "manager accepts a zero-variance safe count from the admin screen" do
+    safe = Cash::Locations.safe_for!(@store)
+    get new_admin_cash_safe_reconciliation_path
+    assert_response :success
+    count_id = CashCount.where(purpose: "safe_reconciliation", status: "discarded").order(:created_at).last.id
+
+    post admin_cash_safe_reconciliation_path, params: {
+      cash_count_id: count_id,
+      count: format("%.2f", safe.expected_balance_cents / 100.0),
+      source_id: SecureRandom.uuid_v7,
+      idempotency_key: SecureRandom.uuid_v7
+    }
+    assert_redirected_to admin_cash_safe_path
+    assert CashCount.exists?(purpose: "safe_reconciliation", status: "accepted")
+    assert_equal 0, CashReconciliation.where(cash_location: safe).count
+  end
+
+  test "manager prepares and reverses a deposit" do
+    get new_admin_cash_deposit_path
+    assert_response :success
+    count_id = CashCount.where(purpose: "deposit", status: "discarded").order(:created_at).last.id
+
+    post admin_cash_deposits_path, params: {
+      cash_count_id: count_id,
+      amount: "15.00",
+      bag_reference: "A1",
+      source_id: SecureRandom.uuid_v7,
+      idempotency_key: SecureRandom.uuid_v7
+    }
+    deposit = CashDeposit.last
+    assert_redirected_to admin_cash_deposit_path(deposit)
+    follow_redirect!
+    assert_match(/In transit/, response.body)
+
+    post reverse_admin_cash_deposit_path(deposit), params: {
+      notes: "Still in the office",
+      source_id: SecureRandom.uuid_v7,
+      idempotency_key: SecureRandom.uuid_v7
+    }
+    assert_redirected_to admin_cash_deposit_path(deposit)
+    assert deposit.cash_operation.reload.reversed?
+  end
+
+  test "store-day report is not a close gate and lists deposits" do
+    start_count = Cash::SnapshotCount.start!(
+      location: Cash::Locations.safe_for!(@store),
+      purpose: "deposit"
+    )
+    Cash::PrepareDeposit.call(
+      store: @store,
+      actor: @actor,
+      start_count: start_count,
+      amount_cents: 800,
+      source_id: SecureRandom.uuid_v7,
+      idempotency_key: SecureRandom.uuid_v7
+    )
+
+    get admin_cash_store_day_path, params: { business_date: BusinessDate.for_store(@store).iso8601 }
+    assert_response :success
+    assert_match(/Store-day cash/, response.body)
+    assert_match(/deposit prepared/, response.body)
+    assert_match(/not a close gate/, response.body)
+    assert_match(/\$8.00/, response.body)
+  end
+
+  private
+
+  def sign_in_as(username)
+    post session_path, params: { session: { username: username, password: "correct-horse-battery" } }
+  end
+end

--- a/test/services/admin/navigation_view_model_test.rb
+++ b/test/services/admin/navigation_view_model_test.rb
@@ -35,6 +35,9 @@ class Admin::NavigationViewModelTest < ActiveSupport::TestCase
     assert nav.groups.find { |g| g.key == :pos_operations }.destinations.any? { |d| d.key == :gift_card_programs }
     assert nav.groups.find { |g| g.key == :pos_operations }.destinations.any? { |d| d.key == :stored_value_report }
     assert nav.groups.find { |g| g.key == :pos_operations }.destinations.any? { |d| d.key == :cash_safe }
+    assert nav.groups.find { |g| g.key == :pos_operations }.destinations.any? { |d| d.key == :cash_safe_reconciliation }
+    assert nav.groups.find { |g| g.key == :pos_operations }.destinations.any? { |d| d.key == :cash_deposits }
+    assert nav.groups.find { |g| g.key == :pos_operations }.destinations.any? { |d| d.key == :cash_store_day }
 
     assert nav.groups.find { |g| g.key == :merchandise }.current
     assert_equal :products, nav.current_destination.key

--- a/test/services/cash/safe_recon_and_deposit_test.rb
+++ b/test/services/cash/safe_recon_and_deposit_test.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Cash
+  class SafeReconAndDepositTest < ActiveSupport::TestCase
+    setup do
+      @bootstrap = bootstrap!
+      @store = @bootstrap[:store]
+      @actor = @bootstrap[:administrator]
+      Cash::ActivityReasons.seed!
+      @safe = Cash::Locations.safe_for!(@store)
+      @context = pos_open_context(store: @store, actor: @actor, opening_float_cents: 10_000)
+      @session = @context[:session]
+    end
+
+    test "zero-variance safe recon accepts the count without a reconciliation row" do
+      expected = @safe.reload.expected_balance_cents
+      start_count = Cash::SnapshotCount.start!(location: @safe, purpose: "safe_reconciliation")
+      accepted = Cash::ReconcileSafe.call(
+        store: @store,
+        actor: @actor,
+        start_count: start_count,
+        count_cents: expected,
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+
+      assert_equal "accepted", accepted.status
+      assert_equal expected, accepted.total_cents
+      assert_equal 0, CashReconciliation.where(cash_location: @safe).count
+      report = Cash::StoreDayReport.for(store: @store, business_date: accepted.business_date)
+      assert report.safe_reconciled?
+      assert_includes report.status_labels, "safe reconciled"
+    end
+
+    test "nonzero safe over posts a reconciliation and rebases expected cash" do
+      expected = @safe.reload.expected_balance_cents
+      start_count = Cash::SnapshotCount.start!(location: @safe, purpose: "safe_reconciliation")
+      accepted = Cash::ReconcileSafe.call(
+        store: @store,
+        actor: @actor,
+        start_count: start_count,
+        count_cents: expected + 250,
+        reason_code: "over_count",
+        notes: "Found an extra bundle",
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+
+      recon = CashReconciliation.find_by!(cash_count: accepted)
+      assert_equal "over", recon.direction
+      assert_equal 250, recon.variance_cents
+      assert_equal expected + 250, @safe.reload.expected_balance_cents
+      assert_equal Cash::SafeTotals.for(@safe).from_entries_cents, @safe.expected_balance_cents
+    end
+
+    test "activity during a safe count makes the count stale" do
+      start_count = Cash::SnapshotCount.start!(location: @safe, purpose: "safe_reconciliation")
+      Cash::Drop.call(
+        session: @session,
+        actor: @actor,
+        amount_cents: 500,
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+
+      error = assert_raises(Cash::Error) do
+        Cash::ReconcileSafe.call(
+          store: @store,
+          actor: @actor,
+          start_count: start_count,
+          count_cents: start_count.expected_cents_snapshot,
+          source_id: SecureRandom.uuid_v7,
+          idempotency_key: SecureRandom.uuid_v7
+        )
+      end
+      assert_equal Cash::SnapshotCount::STALE, error.message
+    end
+
+    test "deposit moves safe cash to deposit in transit" do
+      safe_before = @safe.reload.expected_balance_cents
+      dit = Cash::Locations.deposit_in_transit_for!(@store)
+      start_count = Cash::SnapshotCount.start!(location: @safe, purpose: "deposit")
+      deposit = Cash::PrepareDeposit.call(
+        store: @store,
+        actor: @actor,
+        start_count: start_count,
+        amount_cents: 2_000,
+        bag_reference: "BAG-1",
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+
+      assert_equal 2_000, deposit.total_cents
+      assert_equal 1, deposit.deposit_number
+      assert_equal "BAG-1", deposit.bag_reference
+      assert_equal "deposit", deposit.cash_operation.cash_transfer.transfer_type
+      assert_equal safe_before - 2_000, @safe.reload.expected_balance_cents
+      assert_equal 2_000, dit.reload.expected_balance_cents
+      assert OutboxMessage.exists?(event_type: "cash.deposit_prepared")
+    end
+
+    test "reverse of a deposit restores the safe without fabricating a deposit row" do
+      start_count = Cash::SnapshotCount.start!(location: @safe.reload, purpose: "deposit")
+      deposit = Cash::PrepareDeposit.call(
+        store: @store,
+        actor: @actor,
+        start_count: start_count,
+        amount_cents: 1_500,
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+      safe_before = @safe.reload.expected_balance_cents
+      dit_before = Cash::Locations.deposit_in_transit_for!(@store).expected_balance_cents
+      reverse = Cash::Reverse.call(
+        operation: deposit.cash_operation,
+        actor: @actor,
+        reason_code: "reverse",
+        notes: "Bag never left the store",
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+
+      assert_equal "reverse", reverse.operation_type
+      assert_nil reverse.cash_deposit
+      assert_equal 1_500, CashDeposit.find(deposit.id).total_cents
+      assert deposit.cash_operation.reload.reversed?
+      assert_equal safe_before + 1_500, @safe.reload.expected_balance_cents
+      assert_equal dit_before - 1_500, Cash::Locations.deposit_in_transit_for!(@store).expected_balance_cents
+
+      error = assert_raises(Cash::Error) do
+        Cash::Reverse.call(
+          operation: deposit.cash_operation,
+          actor: @actor,
+          reason_code: "reverse",
+          notes: "again",
+          source_id: SecureRandom.uuid_v7,
+          idempotency_key: SecureRandom.uuid_v7
+        )
+      end
+      assert_match(/already been reversed/, error.message)
+    end
+
+    test "store-day lists that date's deposits and treats DIT as cumulative" do
+      Cash::PaidIn.call(
+        session: @session,
+        actor: @actor,
+        amount_cents: 300,
+        reason_code: "paid_in_found",
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+      first = Cash::SnapshotCount.start!(location: @safe.reload, purpose: "deposit")
+      Cash::PrepareDeposit.call(
+        store: @store,
+        actor: @actor,
+        start_count: first,
+        amount_cents: 1_000,
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+      second = Cash::SnapshotCount.start!(location: @safe.reload, purpose: "deposit")
+      Cash::PrepareDeposit.call(
+        store: @store,
+        actor: @actor,
+        start_count: second,
+        amount_cents: 400,
+        source_id: SecureRandom.uuid_v7,
+        idempotency_key: SecureRandom.uuid_v7
+      )
+      report = Cash::StoreDayReport.for(
+        store: @store,
+        business_date: BusinessDate.for_store(@store)
+      )
+
+      assert_equal 2, report.deposits.size
+      assert_equal [ 1, 2 ], report.deposits.map { |row| row.deposit.deposit_number }
+      assert_equal 1_400, report.dit_balance_cents
+      assert report.deposit_prepared?
+      assert_includes report.status_labels, "incomplete"
+      assert_equal 300, report.paid_ins.sum(&:amount_cents)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Start a safe or deposit count with expected/`lock_version` snapshots; submit revalidates and rejects stale counts so cash activity can continue during entry.
- Zero-variance safe recon accepts the count with no `cash_reconciliations` row; store-day **safe reconciled** comes from that accepted count. Nonzero variance uses the same reason/note/approval bands as session close.
- Prepare deposit moves counted safe cash to deposit in transit. Reverse while in transit restores the safe and leaves the original deposit row unchanged.
- Store-day cash is a report, not a close gate. It lists that date’s deposits individually and treats DIT as cumulative ledger cash, not cash still in the store.

Closes #75.

## Verification
- `./dev/rails-docker bin/rails test` — 1151 runs, 0 failures, 1 skip
- `./dev/rails-docker bin/rubocop` on touched Ruby files — clean

## Notes
- Do not merge to `main`. This PR targets `phase-11-cash-accountability`.
- Merge the completed phase to `main` only after [phase11-manual-test-plan.md](docs/planning/phase11-cash-accountability/phase11-manual-test-plan.md) is executed.

Made with [Cursor](https://cursor.com)