### PR TITLE
Harden Cash::Post replay and snapshot consumption

### DIFF
--- a/app/models/cash_count.rb
+++ b/app/models/cash_count.rb
@@ -13,8 +13,10 @@ class CashCount < ApplicationRecord
   validates :purpose, presence: true, inclusion: { in: PURPOSES }
   validates :status, presence: true, inclusion: { in: STATUSES }
   validates :total_cents, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :superseded_count_id, uniqueness: true, allow_nil: true
   validates :expected_cents_snapshot, :location_lock_version_snapshot, :business_date,
             presence: true, if: :location_snapshot_required?
+  validate :superseded_count_is_discarded
 
   def location_snapshot_required?
     purpose.in?(%w[safe_reconciliation deposit])
@@ -22,5 +24,14 @@ class CashCount < ApplicationRecord
 
   def readonly?
     super || persisted?
+  end
+
+  private
+
+  def superseded_count_is_discarded
+    return if superseded_count_id.blank?
+    return if superseded_count&.status == "discarded"
+
+    errors.add(:superseded_count, "must be a discarded snapshot")
   end
 end

--- a/app/models/cash_entry.rb
+++ b/app/models/cash_entry.rb
@@ -12,6 +12,7 @@ class CashEntry < ApplicationRecord
   validates :amount_cents, numericality: { other_than: 0, only_integer: true }
   validates :balance_after_cents, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validate :exactly_one_target
+  validate :target_belongs_to_operation_store
 
   def readonly?
     super || persisted?
@@ -22,6 +23,18 @@ class CashEntry < ApplicationRecord
   def exactly_one_target
     if pos_session_id.present? == cash_location_id.present?
       errors.add(:base, "exactly one of pos_session_id or cash_location_id is required")
+    end
+  end
+
+  def target_belongs_to_operation_store
+    return if cash_operation.blank?
+
+    store_id = cash_operation.store_id
+    if cash_location && cash_location.store_id != store_id
+      errors.add(:cash_location_id, "must belong to the operation store")
+    end
+    if pos_session && pos_session.store_id != store_id
+      errors.add(:pos_session_id, "must belong to the operation store")
     end
   end
 end

--- a/app/models/cash_operation.rb
+++ b/app/models/cash_operation.rb
@@ -22,6 +22,7 @@ class CashOperation < ApplicationRecord
   validates :operation_type, :business_date, :occurred_at, presence: true
   validates :operation_type, inclusion: { in: OPERATION_TYPES }
   validate :approver_differs_from_performer
+  validate :pos_session_belongs_to_store
 
   def readonly?
     super || persisted?
@@ -42,5 +43,12 @@ class CashOperation < ApplicationRecord
     return if approved_by_id != performed_by_id
 
     errors.add(:approved_by_id, "must differ from the performer")
+  end
+
+  def pos_session_belongs_to_store
+    return if pos_session.blank? || store_id.blank?
+    return if pos_session.store_id == store_id
+
+    errors.add(:pos_session_id, "must belong to the operation store")
   end
 end

--- a/app/services/cash/post.rb
+++ b/app/services/cash/post.rb
@@ -34,11 +34,11 @@ module Cash
       @occurred_at = occurred_at
       @pos_session = pos_session
       @approved_by = approved_by
-      @reason_code = reason_code
-      @reason_name_snapshot = reason_name_snapshot
-      @notes = notes
+      @reason_code = reason_code.to_s.strip.presence
+      @reason_name_snapshot = reason_name_snapshot.to_s.strip.presence
+      @notes = notes.to_s.strip.presence
       @reversal_of = reversal_of
-      @outbox_event_type = outbox_event_type
+      @outbox_event_type = outbox_event_type.to_s.strip.presence
       @correlation_id = correlation_id || SecureRandom.uuid_v7
     end
 
@@ -201,10 +201,27 @@ module Cash
 
     def lock_targets!
       location_ids = @entries.filter_map { |entry| location_id_for(entry) }.uniq.sort
-      session_ids = @entries.filter_map { |entry| session_id_for(entry) }.uniq.sort
+      session_ids = @entries.filter_map { |entry| session_id_for(entry) }
+      session_ids << @pos_session.id if @pos_session
+      session_ids = session_ids.compact.uniq.sort
       locked_locations = location_ids.index_with { |id| CashLocation.lock.find(id) }
       locked_sessions = session_ids.index_with { |id| PosSession.lock.find(id) }
+      assert_store_scope!(locked_locations, locked_sessions)
+      @pos_session = locked_sessions[@pos_session.id] if @pos_session
       [ locked_locations, locked_sessions ]
+    end
+
+    def assert_store_scope!(locked_locations, locked_sessions)
+      locked_locations.each_value do |location|
+        next if location.store_id == @store.id
+
+        raise Error, "cash location does not belong to this store"
+      end
+      locked_sessions.each_value do |session|
+        next if session.store_id == @store.id
+
+        raise Error, "session does not belong to this store"
+      end
     end
 
     def location_id_for(entry)
@@ -229,15 +246,23 @@ module Cash
       {
         operation_type: @operation_type,
         store_id: @store.id,
-        pos_session_id: @pos_session&.id,
+        performed_by_id: @performed_by.id,
         approved_by_id: @approved_by&.id,
+        pos_session_id: @pos_session&.id,
+        business_date: @business_date,
+        occurred_at: @occurred_at,
+        reason_code: @reason_code,
+        reason_name_snapshot: @reason_name_snapshot,
+        notes: @notes,
         reversal_of_id: @reversal_of&.id,
+        outbox_event_type: @outbox_event_type,
         entries: @entries.map { |entry|
           {
             cash_location_id: location_id_for(entry),
             pos_session_id: session_id_for(entry),
             amount_cents: Integer(entry.fetch(:amount_cents)),
-            balance_after_cents: entry[:balance_after_cents]
+            balance_after_cents: entry[:balance_after_cents],
+            reversal_of_id: entry[:reversal_of]&.id || entry[:reversal_of_id]
           }
         }
       }

--- a/app/services/cash/snapshot_count.rb
+++ b/app/services/cash/snapshot_count.rb
@@ -3,6 +3,8 @@
 module Cash
   class SnapshotCount
     STALE = "This count is stale because safe cash changed. Start a new count."
+    ALREADY_ACCEPTED = "This count has already been accepted."
+    NOT_DISCARDED = "This count is not a discarded snapshot."
 
     def self.start!(location:, purpose:)
       raise Error, "safe is not initialized" if location.safe? && !location.initialized?
@@ -29,16 +31,24 @@ module Cash
     end
 
     def self.accept!(count:, total_cents:)
+      locked = CashCount.lock.find(count.id)
+      raise Error, NOT_DISCARDED unless locked.status == "discarded"
+      raise Error, ALREADY_ACCEPTED if CashCount.exists?(superseded_count_id: locked.id)
+
       CashCount.create!(
-        purpose: count.purpose,
+        purpose: locked.purpose,
         total_cents: total_cents,
-        expected_cents_snapshot: count.expected_cents_snapshot,
-        location_lock_version_snapshot: count.location_lock_version_snapshot,
-        cash_location: count.cash_location,
+        expected_cents_snapshot: locked.expected_cents_snapshot,
+        location_lock_version_snapshot: locked.location_lock_version_snapshot,
+        cash_location: locked.cash_location,
         status: "accepted",
-        business_date: count.business_date,
-        superseded_count: count
+        business_date: locked.business_date,
+        superseded_count: locked
       )
+    rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
+      raise Error, ALREADY_ACCEPTED if CashCount.exists?(superseded_count_id: count.id)
+
+      raise Error, e.message
     end
   end
 end

--- a/db/migrate/20260827000000_add_cash_count_superseded_uniqueness.rb
+++ b/db/migrate/20260827000000_add_cash_count_superseded_uniqueness.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddCashCountSupersededUniqueness < ActiveRecord::Migration[8.1]
+  def change
+    add_index :cash_counts, :superseded_count_id,
+              unique: true,
+              where: "superseded_count_id IS NOT NULL",
+              name: "index_cash_counts_on_superseded_count_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_26_220000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_27_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -145,6 +145,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_26_220000) do
     t.index ["cash_location_id", "purpose", "business_date"], name: "index_cash_counts_on_location_purpose_date"
     t.index ["cash_location_id"], name: "index_cash_counts_on_cash_location_id"
     t.index ["pos_session_id"], name: "index_cash_counts_on_pos_session_id"
+    t.index ["superseded_count_id"], name: "index_cash_counts_on_superseded_count_id", unique: true, where: "(superseded_count_id IS NOT NULL)"
     t.check_constraint "purpose::text = ANY (ARRAY['session_open'::character varying, 'session_close'::character varying, 'safe_reconciliation'::character varying, 'deposit'::character varying, 'safe_initialization'::character varying]::text[])", name: "cash_counts_purpose_valid"
     t.check_constraint "status::text = ANY (ARRAY['discarded'::character varying, 'accepted'::character varying]::text[])", name: "cash_counts_status_valid"
     t.check_constraint "total_cents >= 0", name: "cash_counts_total_nonnegative"

--- a/docs/planning/phase11-cash-accountability/phase11-implementation-plan.md
+++ b/docs/planning/phase11-cash-accountability/phase11-implementation-plan.md
@@ -80,7 +80,7 @@ If a later release needs to delay enforcement, that would be a feature gate or t
 ## Integration notes
 
 - Extend `Pos::OpenSession`, `Pos::CloseSession`, `Pos::SessionTotals`, `GiftCards::CashOut`, and cash-refund completion/tender paths.
-- Add `Cash::Post` (name may vary) with location/session lock order, post-lock revalidation, idempotency, and nonnegative location checks—same shape as `StoredValue::Post`.
+- Add `Cash::Post` (name may vary) with location/session lock order, post-lock store-scope checks, revalidation, complete-command idempotency, and nonnegative location checks—same shape as `StoredValue::Post`.
 - Reuse `Pos::AuthenticateApprover` / `PosControlledAction` for Register-originated cash actions.
 - Bootstrap/demo and tests must initialize a safe before opening a session so Docker Register enter still works. Initialization still uses a distinct performer and approver.
 - Local commands remain Docker-only (`./dev/rails-docker`).

--- a/docs/planning/phase11-cash-accountability/phase11-non-sale-activity.md
+++ b/docs/planning/phase11-cash-accountability/phase11-non-sale-activity.md
@@ -55,4 +55,4 @@ Closed sessions stay closed. Close snapshots are never rewritten. Do **not** rev
 
 ## 8. Concurrency
 
-Same as 11.1: lock locations then sessions in UUID order; revalidate available cash after lock; idempotent retries; two drops/payouts cannot share the last cent.
+Same as 11.1: lock locations then sessions in UUID order; revalidate available cash after lock; idempotent retries of an identical complete `Cash::Post` payload; two drops/payouts cannot share the last cent. `Cash::Post` rejects any location or session whose `store_id` differs from the operation store.

--- a/docs/planning/phase11-cash-accountability/phase11-safe-and-reporting.md
+++ b/docs/planning/phase11-cash-accountability/phase11-safe-and-reporting.md
@@ -39,7 +39,7 @@ Optimistic contract:
 3. On submission, lock the location row in the posting transaction.
 4. Compare current `lock_version` and expected balance with the count’s snapshot.
 5. If either changed, the count is stale and cannot be accepted; staff must verify or recount.
-6. If unchanged, reconciliation (or zero-variance acceptance) posts atomically.
+6. If unchanged, lock the starting `cash_counts` row. It must still be the discarded snapshot and must not already be referenced by an accepted count (`superseded_count_id` unique where not null). Then reconciliation (or zero-variance acceptance) posts atomically. Reusing the same start row with a new command id is rejected even when expected cash did not move.
 
 Ordinary staff: blind until submit. `cash.view_expected_before_count` may reveal expected.
 

--- a/docs/planning/phase11-cash-accountability/phase11-schema.md
+++ b/docs/planning/phase11-cash-accountability/phase11-schema.md
@@ -46,8 +46,8 @@ MVP does not expose a second safe in UI. A later unique partial index change may
 | `occurred_at` | timestamptz | Required |
 | `performed_by_id` | uuid | Required |
 | `approved_by_id` | uuid, nullable | Set only for `approval_required`; omitted for `direct`; never equal to `performed_by_id` |
-| `pos_session_id` | uuid, nullable | When the operation is session-custody (open, close recon, paid-in/out, drop, replenish) |
-| `idempotency_operation_id` | uuid | FK to claimed `idempotency_operations` |
+| `pos_session_id` | uuid, nullable | When the operation is session-custody (open, close recon, paid-in/out, drop, replenish). Must belong to `store_id`. |
+| `idempotency_operation_id` | uuid | FK to claimed `idempotency_operations`. `Cash::Post` hashes the complete command (store, actor, session, dates, reason, notes, outbox type, entries), not only amounts. Optional text is stripped; blank becomes null. |
 | `reversal_of_id` | uuid, nullable | Unique when present |
 | `reason_code` | string, nullable | Required for paid-in/out, reconcile, reverse, manager close context as applicable |
 | `reason_name_snapshot` | string, nullable | Historic label |
@@ -72,7 +72,7 @@ Do **not** persist `pos_tender_id` or `gift_card_cash_out_id` on this table.
 | `reversal_of_id` | uuid, nullable | Unique when present |
 | `created_at` | timestamptz | Required |
 
-XOR: exactly one of `pos_session_id` or `cash_location_id`. Transfer operations have two entries that net to zero. Paid-in/out, initialize_safe, and reconcile are single-sided.
+XOR: exactly one of `pos_session_id` or `cash_location_id`. Transfer operations have two entries that net to zero. Paid-in/out, initialize_safe, and reconcile are single-sided. Each target’s `store_id` must equal the parent operation’s `store_id`. `Cash::Post` rejects cross-store locations and sessions, including a `pos_session` on the operation itself.
 
 No generic update of `amount_cents` after insert.
 
@@ -139,7 +139,7 @@ Immutable observations. They do not change expected cash until a reconciliation 
 | `location_lock_version_snapshot` | integer, nullable | Required with `expected_cents_snapshot`: that location’s `lock_version` at count start |
 | `pos_session_id` / `cash_location_id` | uuid, nullable | As applicable |
 | `status` | string | `discarded`, `accepted` |
-| `superseded_count_id` | uuid, nullable | Replacement before acceptance |
+| `superseded_count_id` | uuid, nullable | Replacement before acceptance. Unique where not null: accepting a snapshot consumes it. |
 
 Optional `cash_count_denomination_lines` (`quantity`, `denomination_cents`). When any line exists, lines must sum to `total_cents`. Denomination lines are **never required** (session, safe, deposit, or initialization).
 

--- a/test/models/cash_schema_test.rb
+++ b/test/models/cash_schema_test.rb
@@ -90,4 +90,93 @@ class CashSchemaTest < ActiveSupport::TestCase
     end
     assert_match(/already initialized/, error.message)
   end
+
+  test "superseded_count_id is unique when present" do
+    safe = Cash::Locations.safe_for!(@store)
+    start_count = Cash::SnapshotCount.start!(location: safe, purpose: "safe_reconciliation")
+    Cash::SnapshotCount.accept!(count: start_count, total_cents: start_count.expected_cents_snapshot)
+
+    assert_raises(ActiveRecord::RecordNotUnique) do
+      CashCount.insert!(
+        {
+          id: SecureRandom.uuid_v7,
+          purpose: "safe_reconciliation",
+          total_cents: start_count.expected_cents_snapshot,
+          status: "accepted",
+          superseded_count_id: start_count.id,
+          cash_location_id: safe.id,
+          created_at: Time.current
+        }
+      )
+    end
+  end
+
+  test "cash entries reject a location from another store" do
+    context = pos_open_context(store: @store, actor: @actor, opening_float_cents: 100)
+    other = Store.create!(
+      store_number: 81,
+      code: "other-cash",
+      name: "Other Cash",
+      legal_name: "Other Cash LLC",
+      timezone: "America/New_York",
+      country_code: "US"
+    )
+    operation = CashOperation.create!(
+      operation_type: "paid_in",
+      store: @store,
+      business_date: Date.current,
+      occurred_at: Time.current,
+      performed_by: @actor,
+      pos_session: context[:session],
+      idempotency_operation: IdempotencyOperation.create!(
+        source_id: SecureRandom.uuid_v7,
+        operation_type: "cash_post",
+        idempotency_key: SecureRandom.uuid_v7,
+        payload_hash: "x",
+        status: "completed"
+      )
+    )
+
+    error = assert_raises(ActiveRecord::RecordInvalid) do
+      CashEntry.create!(
+        cash_operation: operation,
+        entry_sequence: 0,
+        amount_cents: 1,
+        balance_after_cents: 1,
+        cash_location: Cash::Locations.safe_for!(other)
+      )
+    end
+    assert_match(/must belong to the operation store/, error.message)
+  end
+
+  test "cash operations reject a session from another store" do
+    other = Store.create!(
+      store_number: 82,
+      code: "other-session",
+      name: "Other Session",
+      legal_name: "Other Session LLC",
+      timezone: "America/New_York",
+      country_code: "US"
+    )
+    foreign_session = pos_open_context(store: other, actor: @actor, opening_float_cents: 0)[:session]
+
+    error = assert_raises(ActiveRecord::RecordInvalid) do
+      CashOperation.create!(
+        operation_type: "paid_in",
+        store: @store,
+        business_date: Date.current,
+        occurred_at: Time.current,
+        performed_by: @actor,
+        pos_session: foreign_session,
+        idempotency_operation: IdempotencyOperation.create!(
+          source_id: SecureRandom.uuid_v7,
+          operation_type: "cash_post",
+          idempotency_key: SecureRandom.uuid_v7,
+          payload_hash: "x",
+          status: "completed"
+        )
+      )
+    end
+    assert_match(/must belong to the operation store/, error.message)
+  end
 end

--- a/test/services/cash/post_test.rb
+++ b/test/services/cash/post_test.rb
@@ -97,16 +97,192 @@ module Cash
       assert_match(/differ/, error.message)
     end
 
+    test "identical complete payload replays" do
+      key = SecureRandom.uuid_v7
+      source = SecureRandom.uuid_v7
+      attrs = complete_session_post_attrs(key: key, source: source, notes: "  envelope  ")
+      first = Cash::Post.call(**attrs)
+      second = Cash::Post.call(**complete_session_post_attrs(key: key, source: source, notes: "envelope"))
+
+      assert_equal first.id, second.id
+      assert_equal "envelope", first.notes
+      assert_equal 1, CashOperation.where(id: first.id).count
+    end
+
+    test "changed reason is a payload mismatch" do
+      key = SecureRandom.uuid_v7
+      source = SecureRandom.uuid_v7
+      Cash::Post.call(**complete_session_post_attrs(key: key, source: source, reason_code: "paid_in_found"))
+
+      assert_raises(Idempotency::OperationService::PayloadMismatchError) do
+        Cash::Post.call(**complete_session_post_attrs(key: key, source: source, reason_code: "paid_in_other", notes: "other"))
+      end
+    end
+
+    test "changed notes are a payload mismatch" do
+      key = SecureRandom.uuid_v7
+      source = SecureRandom.uuid_v7
+      Cash::Post.call(**complete_session_post_attrs(key: key, source: source, notes: "first"))
+
+      assert_raises(Idempotency::OperationService::PayloadMismatchError) do
+        Cash::Post.call(**complete_session_post_attrs(key: key, source: source, notes: "second"))
+      end
+    end
+
+    test "changed actor is a payload mismatch" do
+      key = SecureRandom.uuid_v7
+      source = SecureRandom.uuid_v7
+      Cash::Post.call(**complete_session_post_attrs(key: key, source: source))
+      other = cash_distinct_approver(store: @store, assigned_by: @actor)
+
+      assert_raises(Idempotency::OperationService::PayloadMismatchError) do
+        Cash::Post.call(**complete_session_post_attrs(key: key, source: source, performed_by: other))
+      end
+    end
+
+    test "changed store is a payload mismatch" do
+      key = SecureRandom.uuid_v7
+      source = SecureRandom.uuid_v7
+      post_safe(250, key: key, source: source)
+      other = other_store
+
+      assert_raises(Idempotency::OperationService::PayloadMismatchError) do
+        Cash::Post.call(
+          operation_type: "initialize_safe",
+          store: other,
+          performed_by: @actor,
+          source_id: source,
+          idempotency_key: key,
+          entries: [ { cash_location: Cash::Locations.safe_for!(other), amount_cents: 250 } ]
+        )
+      end
+    end
+
+    test "changed outbox event type is a payload mismatch" do
+      key = SecureRandom.uuid_v7
+      source = SecureRandom.uuid_v7
+      post_safe(250, key: key, source: source)
+
+      assert_raises(Idempotency::OperationService::PayloadMismatchError) do
+        post_safe(250, key: key, source: source, outbox_event_type: "cash.deposit_prepared")
+      end
+    end
+
+    test "changed business date is a payload mismatch" do
+      key = SecureRandom.uuid_v7
+      source = SecureRandom.uuid_v7
+      Cash::Post.call(**complete_session_post_attrs(key: key, source: source, business_date: Date.current))
+
+      assert_raises(Idempotency::OperationService::PayloadMismatchError) do
+        Cash::Post.call(**complete_session_post_attrs(key: key, source: source, business_date: Date.current - 1))
+      end
+    end
+
+    test "changed occurred_at is a payload mismatch when supplied" do
+      key = SecureRandom.uuid_v7
+      source = SecureRandom.uuid_v7
+      at = Time.zone.parse("2026-08-26 12:00:00 UTC")
+      Cash::Post.call(**complete_session_post_attrs(key: key, source: source, occurred_at: at))
+
+      assert_raises(Idempotency::OperationService::PayloadMismatchError) do
+        Cash::Post.call(**complete_session_post_attrs(key: key, source: source, occurred_at: at + 1.second))
+      end
+    end
+
+    test "rejects a location that belongs to another store" do
+      other_safe = Cash::Locations.safe_for!(other_store)
+      before = other_safe.expected_balance_cents
+
+      error = assert_raises(Cash::Error) do
+        post_safe(25, cash_location: other_safe)
+      end
+      assert_match(/does not belong to this store/, error.message)
+      assert_equal before, other_safe.reload.expected_balance_cents
+      assert_equal 0, CashEntry.where(cash_location: other_safe).count
+    end
+
+    test "rejects a session that belongs to another store" do
+      context = pos_open_context(store: other_store, actor: @actor, opening_float_cents: 0)
+
+      error = assert_raises(Cash::Error) do
+        Cash::Post.call(
+          operation_type: "paid_in",
+          store: @store,
+          performed_by: @actor,
+          pos_session: context[:session],
+          source_id: SecureRandom.uuid_v7,
+          idempotency_key: SecureRandom.uuid_v7,
+          entries: [ { pos_session: context[:session], amount_cents: 100, balance_after_cents: 100 } ]
+        )
+      end
+      assert_match(/does not belong to this store/, error.message)
+    end
+
+    test "rejects a transfer that credits another store" do
+      other_safe = Cash::Locations.safe_for!(other_store)
+      home_before = @safe.expected_balance_cents
+      other_before = other_safe.expected_balance_cents
+
+      error = assert_raises(Cash::Error) do
+        Cash::Post.call(
+          operation_type: "transfer",
+          store: @store,
+          performed_by: @actor,
+          source_id: SecureRandom.uuid_v7,
+          idempotency_key: SecureRandom.uuid_v7,
+          entries: [
+            { cash_location: @safe, amount_cents: -100 },
+            { cash_location: other_safe, amount_cents: 100 }
+          ]
+        )
+      end
+      assert_match(/does not belong to this store/, error.message)
+      assert_equal home_before, @safe.reload.expected_balance_cents
+      assert_equal other_before, other_safe.reload.expected_balance_cents
+    end
+
     private
 
-    def post_safe(amount_cents, key: SecureRandom.uuid_v7, source: SecureRandom.uuid_v7)
+    def post_safe(amount_cents, key: SecureRandom.uuid_v7, source: SecureRandom.uuid_v7, **attrs)
       Cash::Post.call(
         operation_type: "initialize_safe",
-        store: @store,
-        performed_by: @actor,
+        store: attrs.fetch(:store, @store),
+        performed_by: attrs.fetch(:performed_by, @actor),
         source_id: source,
         idempotency_key: key,
-        entries: [ { cash_location: @safe, amount_cents: amount_cents } ]
+        entries: attrs[:entries] || [ { cash_location: attrs[:cash_location] || @safe, amount_cents: amount_cents } ],
+        **attrs.except(:store, :performed_by, :entries, :cash_location)
+      )
+    end
+
+    def complete_session_post_attrs(key:, source:, **overrides)
+      Cash::ActivityReasons.seed!
+      session = overrides.delete(:session) ||
+                (@complete_post_session ||= pos_open_context(store: @store, actor: @actor, opening_float_cents: 0)[:session])
+      {
+        operation_type: "paid_in",
+        store: @store,
+        performed_by: @actor,
+        pos_session: session,
+        source_id: source,
+        idempotency_key: key,
+        business_date: Date.current,
+        occurred_at: Time.zone.parse("2026-08-26 15:00:00 UTC"),
+        reason_code: "paid_in_found",
+        reason_name_snapshot: "Found cash",
+        notes: "envelope",
+        entries: [ { pos_session: session, amount_cents: 100, balance_after_cents: 100 } ]
+      }.merge(overrides)
+    end
+
+    def other_store
+      @other_store ||= Store.create!(
+        store_number: 88,
+        code: "east-cash",
+        name: "East",
+        legal_name: "East LLC",
+        timezone: "America/New_York",
+        country_code: "US"
       )
     end
   end

--- a/test/services/cash/safe_recon_and_deposit_test.rb
+++ b/test/services/cash/safe_recon_and_deposit_test.rb
@@ -32,6 +32,30 @@ module Cash
       report = Cash::StoreDayReport.for(store: @store, business_date: accepted.business_date)
       assert report.safe_reconciled?
       assert_includes report.status_labels, "safe reconciled"
+
+      error = assert_raises(Cash::Error) do
+        Cash::ReconcileSafe.call(
+          store: @store,
+          actor: @actor,
+          start_count: start_count,
+          count_cents: expected,
+          source_id: SecureRandom.uuid_v7,
+          idempotency_key: SecureRandom.uuid_v7
+        )
+      end
+      assert_equal Cash::SnapshotCount::ALREADY_ACCEPTED, error.message
+      assert_equal 1, CashCount.where(superseded_count_id: start_count.id).count
+      assert_equal 1, AuditEvent.where(action: "cash.reconcile_safe", outcome: "succeeded", subject_id: accepted.id).count
+    end
+
+    test "accept! refuses a snapshot that is not the discarded start row" do
+      start_count = Cash::SnapshotCount.start!(location: @safe.reload, purpose: "safe_reconciliation")
+      accepted = Cash::SnapshotCount.accept!(count: start_count, total_cents: start_count.expected_cents_snapshot)
+
+      error = assert_raises(Cash::Error) do
+        Cash::SnapshotCount.accept!(count: accepted, total_cents: accepted.total_cents)
+      end
+      assert_equal Cash::SnapshotCount::NOT_DISCARDED, error.message
     end
 
     test "nonzero safe over posts a reconciliation and rebases expected cash" do

--- a/test/services/cash/snapshot_count_concurrency_test.rb
+++ b/test/services/cash/snapshot_count_concurrency_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Cash
+  class SnapshotCountConcurrencyTest < ActiveSupport::TestCase
+    self.use_transactional_tests = false
+
+    setup do
+      @bootstrap = bootstrap!
+      @store = @bootstrap[:store]
+      @actor = @bootstrap[:administrator]
+      Cash::ActivityReasons.seed!
+      @safe = Cash::Locations.safe_for!(@store)
+      @start_count = Cash::SnapshotCount.start!(location: @safe, purpose: "safe_reconciliation")
+    end
+
+    teardown do
+      conn = ActiveRecord::Base.connection
+      tables = conn.tables - %w[schema_migrations ar_internal_metadata]
+      conn.disable_referential_integrity do
+        tables.each { |table| conn.execute("TRUNCATE TABLE #{conn.quote_table_name(table)} CASCADE") }
+      end
+    end
+
+    test "concurrent zero-variance accepts consume the snapshot once" do
+      start_id = @start_count.id
+      counted = @start_count.expected_cents_snapshot
+      store_id = @store.id
+      actor_id = @actor.id
+      results = Array.new(2)
+      errors = Array.new(2)
+      threads = 2.times.map do |i|
+        Thread.new do
+          ActiveRecord::Base.connection_pool.with_connection do
+            results[i] = Cash::ReconcileSafe.call(
+              store: Store.find(store_id),
+              actor: User.find(actor_id),
+              start_count: CashCount.find(start_id),
+              count_cents: counted,
+              source_id: SecureRandom.uuid_v7,
+              idempotency_key: SecureRandom.uuid_v7
+            )
+          rescue StandardError => e
+            errors[i] = e
+          end
+        end
+      end
+      threads.each { |thread| assert thread.join(20), "thread did not finish" }
+
+      successes = results.compact
+      failures = errors.compact
+      assert_equal 1, successes.size, "expected one accept, got #{successes.size}; errors=#{failures.map(&:message)}"
+      assert_equal 1, failures.size
+      assert_equal Cash::SnapshotCount::ALREADY_ACCEPTED, failures.first.message
+      assert_equal 1, CashCount.where(superseded_count_id: start_id).count
+      assert_equal 1, AuditEvent.where(action: "cash.reconcile_safe", outcome: "succeeded", subject_id: successes.first.id).count
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Consume each discarded cash-count snapshot once (lock, discarded-only accept, unique `superseded_count_id`) so zero-variance recon cannot be submitted twice.
- Hash the complete `Cash::Post` command (actor, store, dates, reason, notes, outbox type, entries) so a reused idempotency key with different intent is a payload mismatch.
- Reject locations and sessions that do not belong to the operation store, with model-level checks as defense in depth.

## Verification
- `./dev/rails-docker bin/rails test test/services/cash/post_test.rb test/services/cash/safe_recon_and_deposit_test.rb test/services/cash/snapshot_count_concurrency_test.rb test/models/cash_schema_test.rb test/services/cash/non_sale_activity_test.rb test/services/cash/session_lifecycle_test.rb test/integration/admin_cash_recon_deposit_test.rb`
- `./dev/rails-docker bin/rubocop` on the touched Ruby files

Closes #81

Made with [Cursor](https://cursor.com)