### PR TITLE
Slice 5A: Lookup overlays (#86)

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -2114,6 +2114,16 @@ input[type="submit"]:disabled,
   overflow: hidden;
 }
 
+.pos-register-shell .pos-shell > [data-register-workspace-target="background"] {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.pos-register-shell .pos-shell > [data-register-workspace-target="background"] > #pos_feedback,
 .pos-register-shell .pos-shell > #pos_feedback {
   flex: 0 0 auto;
   min-height: 2.5rem;
@@ -2121,6 +2131,7 @@ input[type="submit"]:disabled,
   border-top: none;
 }
 
+.pos-register-shell .pos-shell > [data-register-workspace-target="background"] > #pos_command,
 .pos-register-shell .pos-shell > #pos_command {
   flex: 0 0 auto;
   padding-block: var(--space-2);
@@ -2128,12 +2139,14 @@ input[type="submit"]:disabled,
   border-bottom: 1px solid var(--color-border-subtle);
 }
 
+.pos-register-shell .pos-shell > [data-register-workspace-target="background"] > #pos_command .pos-command__field,
 .pos-register-shell .pos-shell > #pos_command .pos-command__field {
   font-size: 1.1rem;
   padding: var(--space-1) var(--space-2);
   margin-top: var(--space-1);
 }
 
+.pos-register-shell .pos-shell > [data-register-workspace-target="background"] > .pos-main,
 .pos-register-shell .pos-shell > .pos-main {
   flex: 1 1 0;
   min-height: 0;
@@ -2142,11 +2155,13 @@ input[type="submit"]:disabled,
   align-items: stretch;
 }
 
+.pos-register-shell .pos-shell > [data-register-workspace-target="background"] > .pos-actions,
 .pos-register-shell .pos-shell > .pos-actions {
   flex: 0 0 auto;
   padding-block: var(--space-2);
 }
 
+.pos-register-shell .pos-shell > [data-register-workspace-target="background"] > .pos-actions .btn,
 .pos-register-shell .pos-shell > .pos-actions .btn {
   padding-block: 0.4rem;
 }

--- a/app/javascript/controllers/register_shell_controller.js
+++ b/app/javascript/controllers/register_shell_controller.js
@@ -4,7 +4,7 @@ const WORKSPACE_LOCK_KEYS = [ "F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F
 const MENU_LOCK_KEYS = [ "F10" ]
 
 export default class extends Controller {
-  static targets = [ "background", "menu", "launcher", "close", "announce", "group", "proxyItem" ]
+  static targets = [ "background", "menu", "launcher", "close", "announce", "group", "proxyItem", "header", "status" ]
 
   connect() {
     this.returnFocusElement = null
@@ -20,6 +20,8 @@ export default class extends Controller {
     document.addEventListener("visibilitychange", this.onVisibilityChange)
     document.addEventListener("turbo:before-render", this.onBeforeRender)
     this.syncContextualItems()
+    this.observeBlockingOverlays()
+    this.syncHeaderStatusInert()
     this.requestFunctionKeyLock()
   }
 
@@ -30,6 +32,7 @@ export default class extends Controller {
     document.removeEventListener("focusin", this.onPointerOrFocus, true)
     document.removeEventListener("visibilitychange", this.onVisibilityChange)
     document.removeEventListener("turbo:before-render", this.onBeforeRender)
+    if (this.blockingObserver) this.blockingObserver.disconnect()
     this.releaseFunctionKeyLock()
   }
 
@@ -126,6 +129,23 @@ export default class extends Controller {
 
   blockingOverlay() {
     return this.backgroundTarget.querySelector("[data-register-blocking-overlay]:not([hidden])")
+  }
+
+  observeBlockingOverlays() {
+    if (!this.hasBackgroundTarget || typeof MutationObserver === "undefined") return
+    this.blockingObserver = new MutationObserver(() => this.syncHeaderStatusInert())
+    this.blockingObserver.observe(this.backgroundTarget, {
+      attributes: true,
+      attributeFilter: [ "hidden" ],
+      subtree: true,
+      childList: true
+    })
+  }
+
+  syncHeaderStatusInert() {
+    const blocking = Boolean(this.blockingOverlay())
+    if (this.hasHeaderTarget) this.headerTarget.inert = blocking
+    if (this.hasStatusTarget) this.statusTarget.inert = blocking
   }
 
   syncContextualItems() {

--- a/app/javascript/controllers/register_workspace_controller.js
+++ b/app/javascript/controllers/register_workspace_controller.js
@@ -5,7 +5,7 @@ export default class extends Controller {
     "field",
     "fieldLabel",
     "modeLabel",
-    "chrome",
+    "background",
     "overlay",
     "controlOverlay",
     "unlinkedOverlay",
@@ -137,6 +137,7 @@ export default class extends Controller {
     "unitOverlay",
     "unitList",
     "openPriceOverlay",
+    "openPriceTitle",
     "openPricePrompt",
     "openPriceField",
     "openPriceForm",
@@ -189,6 +190,13 @@ export default class extends Controller {
 
   connect() {
     this.inFlight = false
+    this.overlayStack = []
+    this.searchRequestToken = 0
+    this.pickupRequestToken = 0
+    this.customerRequestToken = 0
+    this.searchAbort = null
+    this.pickupAbort = null
+    this.customerAbort = null
     this.bindFunctionKeyCapture()
     if (this.hasControlReasonFieldTarget) {
       this.controlReasonFieldTarget.addEventListener("change", () => {
@@ -214,7 +222,9 @@ export default class extends Controller {
 
   disconnect() {
     this.unbindFunctionKeyCapture()
-    if (this.hasChromeTarget) this.chromeTarget.inert = false
+    this.abortPendingLookups()
+    this.clearOverlayStack({ restoreCommand: false })
+    if (this.hasBackgroundTarget) this.backgroundTarget.inert = false
   }
 
   onKeydown(event) {
@@ -229,72 +239,8 @@ export default class extends Controller {
       return
     }
 
-    // Child pickers (product/variant/unit/open-price) must beat parent overlays
-    // (unlinked/search) when stacked on top.
-    if (this.productOverlayOpen()) {
-      this.onProductOverlayKeydown(event, key)
-      return
-    }
-
-    if (this.variantOverlayOpen()) {
-      this.onVariantOverlayKeydown(event, key)
-      return
-    }
-
-    if (this.unitOverlayOpen()) {
-      this.onUnitOverlayKeydown(event, key)
-      return
-    }
-
-    if (this.openPriceOverlayOpen()) {
-      this.onOpenPriceOverlayKeydown(event, key)
-      return
-    }
-
-    if (this.unlinkedOverlayOpen()) {
-      this.onUnlinkedOverlayKeydown(event, key)
-      return
-    }
-
-    if (this.returnChooserOpen()) {
-      this.onReturnChooserKeydown(event, key)
-      return
-    }
-
-    if (this.linkedOverlayOpen()) {
-      this.onLinkedOverlayKeydown(event, key)
-      return
-    }
-
-    if (this.controlOverlayOpen()) {
-      this.onControlOverlayKeydown(event, key)
-      return
-    }
-
-    if (this.otherOverlayOpen()) {
-      this.onOtherOverlayKeydown(event, key)
-      return
-    }
-
-    if (this.searchOverlayOpen()) {
-      this.onSearchOverlayKeydown(event, key)
-      return
-    }
-
-    if (this.pickupOverlayOpen()) {
-      this.onPickupOverlayKeydown(event, key)
-      return
-    }
-
-    if (this.customerOverlayOpen()) {
-      this.onCustomerOverlayKeydown(event, key)
-      return
-    }
-
-    if (this.cancelOverlayOpen()) {
-      event.preventDefault()
-      if (key === "Escape") this.closeOverlay()
-      if (key === "F9") this.confirmCancel()
+    if (overlay) {
+      this.dispatchOverlayKeydown(overlay, event, key)
       return
     }
 
@@ -858,9 +804,11 @@ export default class extends Controller {
   handleResolution(result) {
     switch (result.outcome) {
       case "addable_variant":
+        this.clearOverlayStack({ restoreCommand: false })
         this.postAddMerchandise({ variantId: result.variant.id })
         return
       case "addable_unit":
+        this.clearOverlayStack({ restoreCommand: false })
         this.postAddMerchandise({ unitId: result.unit.id })
         return
       case "product_choice_required":
@@ -933,11 +881,8 @@ export default class extends Controller {
     if (key !== "Enter") return
     event.preventDefault()
     const inField = event.target === this.searchSkuFieldTarget || event.target === this.searchNameFieldTarget
-    if (inField && !this.searchResultsReady) {
-      this.runMerchandiseSearch()
-      return
-    }
-    if (inField) {
+    const selected = this.hasSearchListTarget && this.searchListTarget.querySelector("li.is-selected:not(.is-disabled)")
+    if (inField && !selected) {
       this.runMerchandiseSearch()
       return
     }
@@ -948,27 +893,55 @@ export default class extends Controller {
     const sku = this.hasSearchSkuFieldTarget ? this.searchSkuFieldTarget.value.trim() : ""
     const name = this.hasSearchNameFieldTarget ? this.searchNameFieldTarget.value.trim() : ""
     if (!sku && !name) return
+    if (this.searchAbort) this.searchAbort.abort()
+    this.searchAbort = new AbortController()
+    const token = ++this.searchRequestToken
+    if (this.hasSearchQueryLabelTarget) this.searchQueryLabelTarget.textContent = "Searching…"
     const url = new URL(this.searchUrlValue, window.location.origin)
     if (sku) url.searchParams.set("sku", sku)
     if (name) url.searchParams.set("name", name)
     try {
-      const response = await fetch(url, { headers: { Accept: "application/json" }, credentials: "same-origin" })
+      const response = await fetch(url, {
+        headers: { Accept: "application/json" },
+        credentials: "same-origin",
+        signal: this.searchAbort.signal
+      })
       const payload = await response.json()
+      if (!this.lookupResponseCurrent("search", token)) return
       this.renderSearchResults(payload.results || [])
-    } catch (_error) {
+    } catch (error) {
+      if (error?.name === "AbortError") return
+      if (!this.lookupResponseCurrent("search", token)) return
       this.renderSearchResults([])
       if (this.hasSearchQueryLabelTarget) this.searchQueryLabelTarget.textContent = "Search failed."
+      this.focusOverlayEntry(this.searchSkuFieldTarget || this.searchNameFieldTarget)
     }
+  }
+
+  lookupResponseCurrent(family, token) {
+    if (!this.element.isConnected) return false
+    if (family === "search") {
+      return token === this.searchRequestToken && this.searchOverlayOpen()
+    }
+    if (family === "pickup") {
+      return token === this.pickupRequestToken && this.pickupOverlayOpen()
+    }
+    if (family === "customer") {
+      return token === this.customerRequestToken && this.customerOverlayOpen()
+    }
+    return false
   }
 
   renderSearchResults(rows) {
     if (!this.hasSearchListTarget) return
     this.searchListTarget.replaceChildren()
     this.searchResultsReady = true
+    const enabledRows = rows.filter((row) => !row.disabled)
     if (this.hasSearchQueryLabelTarget) {
       this.searchQueryLabelTarget.textContent = rows.length === 0 ? "No matching merchandise." : ""
     }
-    rows.forEach((row, index) => {
+    let firstEnabled = null
+    rows.forEach((row) => {
       const item = document.createElement("li")
       item.dataset.variantId = row.id
       item.dataset.disabled = row.disabled ? "true" : "false"
@@ -976,11 +949,18 @@ export default class extends Controller {
       const availability = row.available == null ? "" : ` · ${row.available}`
       const reason = row.disabled && row.reason ? ` — ${row.reason}` : ""
       item.textContent = [row.sku, row.name, row.condition, row.price_label].filter(Boolean).join(" · ") + availability + reason
-      this.decoratePickerItem(item, { selected: index === 0, disabled: Boolean(row.disabled) })
+      const selected = !row.disabled && firstEnabled == null
+      if (selected) firstEnabled = item
+      this.decoratePickerItem(item, { selected, disabled: Boolean(row.disabled) })
+      item.addEventListener("click", () => this.onPickerItemClick(this.searchListTarget, item))
       this.searchListTarget.append(item)
     })
-    const first = this.searchListTarget.querySelector("li.is-selected")
-    if (first) first.focus()
+    if (firstEnabled) {
+      this.focusOverlayEntry(firstEnabled)
+    } else {
+      const query = this.searchSkuFieldTarget || this.searchNameFieldTarget
+      this.focusOverlayEntry(query)
+    }
   }
 
   selectHighlightedSearch() {
@@ -991,8 +971,31 @@ export default class extends Controller {
       return
     }
     const variantId = selected.dataset.variantId
-    this.closeSearchOverlay()
+    // Keep search open so resolve children (variant / unit / open-price) stack on top.
     this.resolveAndHandle({ product_variant_id: variantId })
+  }
+
+  keepSearching() {
+    if (this.hasSearchListTarget) this.searchListTarget.replaceChildren()
+    this.searchResultsReady = false
+    if (this.hasSearchQueryLabelTarget) this.searchQueryLabelTarget.textContent = ""
+    this.focusOverlayEntry(this.searchSkuFieldTarget || this.searchNameFieldTarget)
+  }
+
+  confirmSearchSelection(event) {
+    if (event) event.preventDefault()
+    this.selectHighlightedSearch()
+  }
+
+  onPickerItemClick(list, item) {
+    if (!list || !item || item.classList.contains("is-disabled")) return
+    Array.from(list.querySelectorAll("li")).forEach((row) => {
+      const selected = row === item
+      row.classList.toggle("is-selected", selected)
+      row.setAttribute("aria-selected", selected ? "true" : "false")
+      row.tabIndex = selected ? 0 : -1
+    })
+    this.focusOverlayEntry(item)
   }
 
   openPickupOverlay() {
@@ -1039,18 +1042,30 @@ export default class extends Controller {
     if (!query) {
       this.renderPickupResults([])
       if (this.hasPickupQueryLabelTarget) this.pickupQueryLabelTarget.textContent = "Enter a search."
+      this.focusOverlayEntry(this.pickupQueryFieldTarget)
       return
     }
+    if (this.pickupAbort) this.pickupAbort.abort()
+    this.pickupAbort = new AbortController()
+    const token = ++this.pickupRequestToken
+    if (this.hasPickupQueryLabelTarget) this.pickupQueryLabelTarget.textContent = "Searching…"
     const url = new URL(this.pickupSearchUrlValue, window.location.origin)
     url.searchParams.set("q", query)
     try {
-      const response = await fetch(url, { headers: { Accept: "application/json" } })
+      const response = await fetch(url, {
+        headers: { Accept: "application/json" },
+        signal: this.pickupAbort.signal
+      })
       const payload = await response.json()
+      if (!this.lookupResponseCurrent("pickup", token)) return
       if (!response.ok) throw new Error(payload.error || "pickup search failed")
       this.renderPickupResults(payload.results || [])
-    } catch (_error) {
+    } catch (error) {
+      if (error?.name === "AbortError") return
+      if (!this.lookupResponseCurrent("pickup", token)) return
       this.renderPickupResults([])
       if (this.hasPickupQueryLabelTarget) this.pickupQueryLabelTarget.textContent = "Search failed."
+      this.focusOverlayEntry(this.pickupQueryFieldTarget)
     }
   }
 
@@ -1061,27 +1076,42 @@ export default class extends Controller {
     if (this.hasPickupQueryLabelTarget) {
       this.pickupQueryLabelTarget.textContent = rows.length === 0 ? "No available customer requests." : ""
     }
-    rows.forEach((row, index) => {
+    let firstEnabled = null
+    rows.forEach((row) => {
       const item = document.createElement("li")
-      item.setAttribute("role", "option")
-      item.className = index === 0 ? "is-selected" : ""
       item.dataset.requestId = row.customer_request_id
       item.dataset.allocationType = row.allocation_type || ""
       const detail = row.allocation_type === "used_unit"
         ? `Used unit ${row.unit_identifier || ""}`.trim()
         : "Standard reserved copy"
       item.textContent = `${row.label} · ${detail}`
+      const selected = firstEnabled == null
+      if (selected) firstEnabled = item
+      this.decoratePickerItem(item, { selected, disabled: false })
+      item.addEventListener("click", () => this.onPickerItemClick(this.pickupListTarget, item))
       this.pickupListTarget.append(item)
     })
+    if (firstEnabled) this.focusOverlayEntry(firstEnabled)
+    else this.focusOverlayEntry(this.pickupQueryFieldTarget)
   }
 
   selectHighlightedPickup() {
     const selected = this.hasPickupListTarget && this.pickupListTarget.querySelector("li.is-selected")
-    if (!selected) return
-    this.closePickupOverlay()
+    if (!selected || selected.classList.contains("is-disabled")) return
     if (!this.hasPickupFormTarget || !this.hasPickupRequestInputTarget) return
     this.pickupRequestInputTarget.value = selected.dataset.requestId
+    this.closePickupOverlay()
     this.pickupFormTarget.requestSubmit()
+  }
+
+  confirmPickupSelection(event) {
+    if (event) event.preventDefault()
+    this.selectHighlightedPickup()
+  }
+
+  keepTransactionUnchanged(event) {
+    if (event) event.preventDefault()
+    this.closePickupOverlay()
   }
 
   openCustomerOverlay() {
@@ -1127,18 +1157,30 @@ export default class extends Controller {
     if (!query) {
       this.renderCustomerResults([])
       if (this.hasCustomerQueryLabelTarget) this.customerQueryLabelTarget.textContent = "Enter a search."
+      this.focusOverlayEntry(this.customerQueryFieldTarget)
       return
     }
+    if (this.customerAbort) this.customerAbort.abort()
+    this.customerAbort = new AbortController()
+    const token = ++this.customerRequestToken
+    if (this.hasCustomerQueryLabelTarget) this.customerQueryLabelTarget.textContent = "Searching…"
     const url = new URL(this.customerSearchUrlValue, window.location.origin)
     url.searchParams.set("q", query)
     try {
-      const response = await fetch(url, { headers: { Accept: "application/json" } })
+      const response = await fetch(url, {
+        headers: { Accept: "application/json" },
+        signal: this.customerAbort.signal
+      })
       const payload = await response.json()
+      if (!this.lookupResponseCurrent("customer", token)) return
       if (!response.ok) throw new Error(payload.error || "customer search failed")
       this.renderCustomerResults(payload.results || [])
-    } catch (_error) {
+    } catch (error) {
+      if (error?.name === "AbortError") return
+      if (!this.lookupResponseCurrent("customer", token)) return
       this.renderCustomerResults([])
       if (this.hasCustomerQueryLabelTarget) this.customerQueryLabelTarget.textContent = "Search failed."
+      this.focusOverlayEntry(this.customerQueryFieldTarget)
     }
   }
 
@@ -1149,14 +1191,19 @@ export default class extends Controller {
     if (this.hasCustomerQueryLabelTarget) {
       this.customerQueryLabelTarget.textContent = rows.length === 0 ? "No matching customers." : ""
     }
-    rows.forEach((row, index) => {
+    let firstEnabled = null
+    rows.forEach((row) => {
       const item = document.createElement("li")
-      item.setAttribute("role", "option")
-      item.className = index === 0 ? "is-selected" : ""
       item.dataset.customerId = row.id
       item.textContent = row.label
+      const selected = firstEnabled == null
+      if (selected) firstEnabled = item
+      this.decoratePickerItem(item, { selected, disabled: false })
+      item.addEventListener("click", () => this.onPickerItemClick(this.customerListTarget, item))
       this.customerListTarget.append(item)
     })
+    if (firstEnabled) this.focusOverlayEntry(firstEnabled)
+    else this.focusOverlayEntry(this.customerQueryFieldTarget)
   }
 
   selectHighlightedCustomer() {
@@ -1168,6 +1215,17 @@ export default class extends Controller {
     this.attachCustomerFormTarget.requestSubmit()
   }
 
+  confirmCustomerSelection(event) {
+    if (event) event.preventDefault()
+    this.selectHighlightedCustomer()
+  }
+
+  keepCurrentCustomer(event) {
+    if (event) event.preventDefault()
+    this.closeCustomerOverlay()
+  }
+
+
   openProductPicker(products) {
     if (!this.hasProductOverlayTarget || !this.hasProductListTarget) return
     this.productListTarget.replaceChildren()
@@ -1178,6 +1236,7 @@ export default class extends Controller {
       const descriptor = [product.name, product.subtitle, product.brand_name].filter(Boolean).join(" — ")
       item.textContent = [descriptor, identity].filter(Boolean).join(" · ")
       this.decoratePickerItem(item, { selected: index === 0 })
+      item.addEventListener("click", () => this.onPickerItemClick(this.productListTarget, item))
       this.productListTarget.append(item)
     })
     this.showOverlay(this.productOverlayTarget, this.productListTarget.querySelector("li.is-selected"))
@@ -1207,15 +1266,25 @@ export default class extends Controller {
 
   selectHighlightedProduct() {
     const selected = this.hasProductListTarget && this.productListTarget.querySelector("li.is-selected")
-    if (!selected || !selected.dataset.productId) return
+    if (!selected || !selected.dataset.productId || selected.classList.contains("is-disabled")) return
     const productId = selected.dataset.productId
-    this.closeProductOverlay()
     if (this.unlinkedPickerActive) {
       this.unlinkedPickerActive = false
+      this.closeProductOverlay()
       this.fetchUnlinkedResolution({ product_id: productId })
       return
     }
     this.resolveAndHandle({ product_id: productId })
+  }
+
+  confirmProductSelection(event) {
+    if (event) event.preventDefault()
+    this.selectHighlightedProduct()
+  }
+
+  backFromProductOverlay(event) {
+    if (event) event.preventDefault()
+    this.closeProductOverlay()
   }
 
   openVariantPicker(variants) {
@@ -1228,6 +1297,7 @@ export default class extends Controller {
       const availability = variant.available == null ? "" : ` · ${variant.available}`
       item.textContent = [variant.sku, variant.name, variant.condition, price].filter(Boolean).join(" · ") + availability
       this.decoratePickerItem(item, { selected: index === 0 })
+      item.addEventListener("click", () => this.onPickerItemClick(this.variantListTarget, item))
       this.variantListTarget.append(item)
     })
     this.showOverlay(this.variantOverlayTarget, this.variantListTarget.querySelector("li.is-selected"))
@@ -1257,15 +1327,25 @@ export default class extends Controller {
 
   selectHighlightedVariant() {
     const selected = this.hasVariantListTarget && this.variantListTarget.querySelector("li.is-selected")
-    if (!selected) return
+    if (!selected || selected.classList.contains("is-disabled")) return
     const variantId = selected.dataset.variantId
-    this.closeVariantOverlay()
     if (this.unlinkedPickerActive) {
       this.unlinkedPickerActive = false
+      this.closeVariantOverlay()
       this.fetchUnlinkedResolution({ product_variant_id: variantId })
       return
     }
     this.resolveAndHandle({ product_variant_id: variantId })
+  }
+
+  confirmVariantSelection(event) {
+    if (event) event.preventDefault()
+    this.selectHighlightedVariant()
+  }
+
+  backToProducts(event) {
+    if (event) event.preventDefault()
+    this.closeVariantOverlay()
   }
 
   openUnitPicker(units) {
@@ -1282,6 +1362,7 @@ export default class extends Controller {
       item.dataset.unitId = unit.id
       item.textContent = [unit.unit_identifier, unit.condition, this.formatCents(unit.price_cents)].filter(Boolean).join(" · ")
       this.decoratePickerItem(item, { selected: index === 0 })
+      item.addEventListener("click", () => this.onPickerItemClick(this.unitListTarget, item))
       this.unitListTarget.append(item)
     })
     this.showOverlay(this.unitOverlayTarget, this.unitListTarget.querySelector("li.is-selected"))
@@ -1311,15 +1392,25 @@ export default class extends Controller {
 
   selectHighlightedUnit() {
     const selected = this.hasUnitListTarget && this.unitListTarget.querySelector("li.is-selected")
-    if (!selected || !selected.dataset.unitId) return
+    if (!selected || !selected.dataset.unitId || selected.classList.contains("is-disabled")) return
     const unitId = selected.dataset.unitId
-    this.closeUnitOverlay()
     if (this.unlinkedPickerActive) {
       this.unlinkedPickerActive = false
+      this.closeUnitOverlay()
       this.fetchUnlinkedResolution({ inventory_unit_id: unitId })
       return
     }
     this.resolveAndHandle({ inventory_unit_id: unitId })
+  }
+
+  confirmUnitSelection(event) {
+    if (event) event.preventDefault()
+    this.selectHighlightedUnit()
+  }
+
+  backToVariants(event) {
+    if (event) event.preventDefault()
+    this.closeUnitOverlay()
   }
 
   movePickerList(list, delta) {
@@ -1342,7 +1433,10 @@ export default class extends Controller {
     this.pendingOpenPrice = { kind, variantId, lineId }
     if (this.hasOpenPricePromptTarget) this.openPricePromptTarget.textContent = prompt || "Enter the selling price."
     if (this.hasOpenPriceFieldTarget) {
-      this.openPriceFieldTarget.value = currentCents ? this.formatCents(currentCents) : ""
+      this.openPriceFieldTarget.value = currentCents != null ? this.formatCents(currentCents) : ""
+    }
+    if (this.hasOpenPriceTitleTarget) {
+      this.openPriceTitleTarget.textContent = kind === "edit" ? "Edit open price" : "Open price"
     }
     this.showOverlay(this.openPriceOverlayTarget, this.hasOpenPriceFieldTarget && this.openPriceFieldTarget)
   }
@@ -1370,14 +1464,17 @@ export default class extends Controller {
     const value = this.hasOpenPriceFieldTarget ? this.openPriceFieldTarget.value.trim() : ""
     if (value === "") return
     const pending = this.pendingOpenPrice
+    this.pendingOpenPrice = null
     this.clearOverlayError(this.openPriceOverlayTarget)
     if (pending.kind === "edit") {
+      this.clearOverlayStack({ restoreCommand: false })
       if (this.hasOpenPriceLineInputTarget) this.openPriceLineInputTarget.value = pending.lineId
       if (this.hasOpenPriceEditInputTarget) this.openPriceEditInputTarget.value = value
       this.beginFlight()
       this.openPriceFormTarget.requestSubmit()
       return
     }
+    this.clearOverlayStack({ restoreCommand: false })
     this.postAddMerchandise({ variantId: pending.variantId, sellingPrice: value })
   }
 
@@ -2089,46 +2186,177 @@ export default class extends Controller {
   }
 
   overlayOpen() {
-    return this.activeOverlayElement() != null
+    return this.topOverlay() != null
   }
 
   activeOverlayElement() {
-    // Topmost child pickers first so Tab/focus traps match visible stacking when
-    // a picker opens above unlinked/search parents.
-    const overlays = [
-      this.hasProductOverlayTarget && this.productOverlayTarget,
-      this.hasVariantOverlayTarget && this.variantOverlayTarget,
-      this.hasUnitOverlayTarget && this.unitOverlayTarget,
-      this.hasOpenPriceOverlayTarget && this.openPriceOverlayTarget,
-      this.hasUnlinkedOverlayTarget && this.unlinkedOverlayTarget,
-      this.hasReturnChooserOverlayTarget && this.returnChooserOverlayTarget,
-      this.hasLinkedOverlayTarget && this.linkedOverlayTarget,
-      this.hasControlOverlayTarget && this.controlOverlayTarget,
-      this.hasOtherOverlayTarget && this.otherOverlayTarget,
-      this.hasSearchOverlayTarget && this.searchOverlayTarget,
-      this.hasPickupOverlayTarget && this.pickupOverlayTarget,
-      this.hasCustomerOverlayTarget && this.customerOverlayTarget,
-      this.hasOverlayTarget && this.overlayTarget
-    ]
-    return overlays.find((el) => el && !el.hidden) || null
+    return this.topOverlay()
   }
 
-  showOverlay(overlay, initial) {
+  dispatchOverlayKeydown(overlay, event, key) {
+    if (this.hasProductOverlayTarget && overlay === this.productOverlayTarget) {
+      this.onProductOverlayKeydown(event, key)
+      return
+    }
+    if (this.hasVariantOverlayTarget && overlay === this.variantOverlayTarget) {
+      this.onVariantOverlayKeydown(event, key)
+      return
+    }
+    if (this.hasUnitOverlayTarget && overlay === this.unitOverlayTarget) {
+      this.onUnitOverlayKeydown(event, key)
+      return
+    }
+    if (this.hasOpenPriceOverlayTarget && overlay === this.openPriceOverlayTarget) {
+      this.onOpenPriceOverlayKeydown(event, key)
+      return
+    }
+    if (this.hasUnlinkedOverlayTarget && overlay === this.unlinkedOverlayTarget) {
+      this.onUnlinkedOverlayKeydown(event, key)
+      return
+    }
+    if (this.hasReturnChooserOverlayTarget && overlay === this.returnChooserOverlayTarget) {
+      this.onReturnChooserKeydown(event, key)
+      return
+    }
+    if (this.hasLinkedOverlayTarget && overlay === this.linkedOverlayTarget) {
+      this.onLinkedOverlayKeydown(event, key)
+      return
+    }
+    if (this.hasControlOverlayTarget && overlay === this.controlOverlayTarget) {
+      this.onControlOverlayKeydown(event, key)
+      return
+    }
+    if (this.hasOtherOverlayTarget && overlay === this.otherOverlayTarget) {
+      this.onOtherOverlayKeydown(event, key)
+      return
+    }
+    if (this.hasSearchOverlayTarget && overlay === this.searchOverlayTarget) {
+      this.onSearchOverlayKeydown(event, key)
+      return
+    }
+    if (this.hasPickupOverlayTarget && overlay === this.pickupOverlayTarget) {
+      this.onPickupOverlayKeydown(event, key)
+      return
+    }
+    if (this.hasCustomerOverlayTarget && overlay === this.customerOverlayTarget) {
+      this.onCustomerOverlayKeydown(event, key)
+      return
+    }
+    if (this.hasOverlayTarget && overlay === this.overlayTarget) {
+      event.preventDefault()
+      if (key === "Escape") this.closeOverlay()
+      if (key === "F9") this.confirmCancel()
+    }
+  }
+
+  topOverlay() {
+    for (let index = this.overlayStack.length - 1; index >= 0; index -= 1) {
+      const entry = this.overlayStack[index]
+      if (entry?.overlay && !entry.overlay.hidden) return entry.overlay
+    }
+    return null
+  }
+
+  showOverlay(overlay, options = {}) {
     if (!overlay) return
+    const opts = options && options.nodeType ? { initialFocus: options } : (options || {})
     this.clearOverlayError(overlay)
+    const parent = opts.parent || this.topOverlay()
+    const opener = opts.opener || document.activeElement
+    const initialFocus = opts.initialFocus || this.overlayFocusables(overlay)[0]
+    this.overlayStack = this.overlayStack.filter((entry) => entry.overlay !== overlay)
+    this.overlayStack.push({
+      overlay,
+      opener,
+      parent: parent && parent !== overlay ? parent : null,
+      entryFocus: initialFocus
+    })
     overlay.hidden = false
-    if (this.hasChromeTarget) this.chromeTarget.inert = true
-    const target = initial || this.overlayFocusables(overlay)[0]
-    if (target) target.focus()
+    overlay.setAttribute("aria-modal", "true")
+    if (parent && parent !== overlay) {
+      parent.inert = true
+      parent.setAttribute("aria-modal", "false")
+    }
+    this.syncWorkspaceBackgroundInert()
+    this.focusOverlayEntry(initialFocus)
   }
 
   hideOverlay(overlay) {
     if (!overlay) return
-    overlay.hidden = true
-    if (this.activeOverlayElement() == null) {
-      if (this.hasChromeTarget) this.chromeTarget.inert = false
-      this.restoreFocus()
+    const index = this.overlayStack.findIndex((entry) => entry.overlay === overlay)
+    if (index < 0) {
+      this.hideOverlayNode(overlay)
+      this.syncWorkspaceBackgroundInert()
+      if (this.topOverlay() == null) this.restoreFocus()
+      return
     }
+    const entry = this.overlayStack[index]
+    const descendants = this.overlayStack.slice(index + 1)
+    descendants.reverse().forEach((child) => this.hideOverlayNode(child.overlay))
+    this.hideOverlayNode(overlay)
+    this.overlayStack.splice(index)
+    this.syncWorkspaceBackgroundInert()
+    this.restoreOverlayFocus(entry)
+  }
+
+  hideOverlayNode(overlay) {
+    if (!overlay) return
+    overlay.hidden = true
+    overlay.inert = false
+    overlay.setAttribute("aria-modal", "true")
+    this.clearOverlayError(overlay)
+  }
+
+  clearOverlayStack({ restoreCommand = true } = {}) {
+    const entries = [ ...this.overlayStack ]
+    this.overlayStack = []
+    entries.reverse().forEach((entry) => this.hideOverlayNode(entry.overlay))
+    this.syncWorkspaceBackgroundInert()
+    if (restoreCommand) this.restoreFocus()
+  }
+
+  syncWorkspaceBackgroundInert() {
+    if (!this.hasBackgroundTarget) return
+    this.backgroundTarget.inert = this.topOverlay() != null
+  }
+
+  restoreOverlayFocus(closedEntry) {
+    if (!closedEntry) {
+      if (this.topOverlay() == null) this.restoreFocus()
+      return
+    }
+    const parent = closedEntry.parent
+    if (parent && !parent.hidden) {
+      parent.inert = false
+      parent.setAttribute("aria-modal", "true")
+      const parentEntry = this.overlayStack.find((entry) => entry.overlay === parent)
+      const focusTarget = parent.querySelector("li.is-selected:not(.is-disabled)") ||
+        parentEntry?.entryFocus ||
+        this.overlayFocusables(parent)[0]
+      this.focusOverlayEntry(focusTarget)
+      return
+    }
+    if (this.topOverlay() == null) this.restoreFocus()
+  }
+
+  focusOverlayEntry(el) {
+    if (!el || typeof el.focus !== "function") return
+    el.focus()
+    if (typeof el.select === "function" && "value" in el && String(el.value || "").length > 0) {
+      el.select()
+    }
+  }
+
+  abortPendingLookups() {
+    if (this.searchAbort) this.searchAbort.abort()
+    if (this.pickupAbort) this.pickupAbort.abort()
+    if (this.customerAbort) this.customerAbort.abort()
+    this.searchAbort = null
+    this.pickupAbort = null
+    this.customerAbort = null
+    this.searchRequestToken += 1
+    this.pickupRequestToken += 1
+    this.customerRequestToken += 1
   }
 
   clearOverlayError(overlay) {
@@ -2139,7 +2367,7 @@ export default class extends Controller {
   overlayFocusables(overlay) {
     if (!overlay) return []
     return Array.from(overlay.querySelectorAll("input, select, textarea, button, [tabindex]:not([tabindex='-1'])")).filter((el) => {
-      if (el.disabled || el.hidden) return false
+      if (el.disabled || el.hidden || el.closest("[inert]")) return false
       return !el.closest("[hidden]")
     })
   }
@@ -2164,6 +2392,8 @@ export default class extends Controller {
     item.classList.toggle("is-disabled", disabled)
     item.setAttribute("aria-selected", selected ? "true" : "false")
     item.tabIndex = selected ? 0 : -1
+    if (disabled) item.setAttribute("aria-disabled", "true")
+    else item.removeAttribute("aria-disabled")
   }
 
   recoverDialogRejection() {
@@ -2367,6 +2597,7 @@ export default class extends Controller {
   redirectPrintableToCommandField(event) {
     if (event.defaultPrevented) return
     if (!this.hasFieldTarget || this.fieldTarget.disabled) return
+    if (this.overlayOpen() && this.topOverlay()?.contains(event.target)) return
     if (this.isCommandSurfaceInput(event.target)) return
     if (event.isComposing) return
     if (event.metaKey || event.ctrlKey || event.altKey) return

--- a/app/javascript/controllers/register_workspace_controller.js
+++ b/app/javascript/controllers/register_workspace_controller.js
@@ -855,7 +855,7 @@ export default class extends Controller {
   openSearchOverlay() {
     if (this.inFlight || this.modeValue !== "sale_entry") return
     if (!this.hasSearchOverlayTarget) return
-    this.searchResultsReady = false
+    this.invalidateSearchLookup()
     if (this.hasSearchSkuFieldTarget) this.searchSkuFieldTarget.value = ""
     if (this.hasSearchNameFieldTarget) this.searchNameFieldTarget.value = ""
     if (this.hasSearchListTarget) this.searchListTarget.replaceChildren()
@@ -864,7 +864,22 @@ export default class extends Controller {
   }
 
   closeSearchOverlay() {
+    this.invalidateSearchLookup()
     this.hideOverlay(this.hasSearchOverlayTarget && this.searchOverlayTarget)
+  }
+
+  invalidateSearchLookup() {
+    if (this.searchAbort) this.searchAbort.abort()
+    this.searchAbort = null
+    this.searchRequestToken += 1
+    this.searchResultsReady = false
+  }
+
+  invalidateSearchResultsOnInput() {
+    if (!this.searchResultsReady && !(this.hasSearchListTarget && this.searchListTarget.children.length > 0)) return
+    if (this.hasSearchListTarget) this.searchListTarget.replaceChildren()
+    this.searchResultsReady = false
+    if (this.hasSearchQueryLabelTarget) this.searchQueryLabelTarget.textContent = ""
   }
 
   onSearchOverlayKeydown(event, key) {
@@ -882,7 +897,7 @@ export default class extends Controller {
     event.preventDefault()
     const inField = event.target === this.searchSkuFieldTarget || event.target === this.searchNameFieldTarget
     const selected = this.hasSearchListTarget && this.searchListTarget.querySelector("li.is-selected:not(.is-disabled)")
-    if (inField && !selected) {
+    if (inField && (!this.searchResultsReady || !selected)) {
       this.runMerchandiseSearch()
       return
     }
@@ -1001,7 +1016,7 @@ export default class extends Controller {
   openPickupOverlay() {
     if (!this.pickupAllowedValue) return
     if (!this.hasPickupOverlayTarget) return
-    this.pickupResultsReady = false
+    this.invalidatePickupLookup()
     if (this.hasPickupQueryFieldTarget) this.pickupQueryFieldTarget.value = ""
     if (this.hasPickupListTarget) this.pickupListTarget.replaceChildren()
     if (this.hasPickupQueryLabelTarget) this.pickupQueryLabelTarget.textContent = ""
@@ -1009,7 +1024,22 @@ export default class extends Controller {
   }
 
   closePickupOverlay() {
+    this.invalidatePickupLookup()
     this.hideOverlay(this.hasPickupOverlayTarget && this.pickupOverlayTarget)
+  }
+
+  invalidatePickupLookup() {
+    if (this.pickupAbort) this.pickupAbort.abort()
+    this.pickupAbort = null
+    this.pickupRequestToken += 1
+    this.pickupResultsReady = false
+  }
+
+  invalidatePickupResultsOnInput() {
+    if (!this.pickupResultsReady && !(this.hasPickupListTarget && this.pickupListTarget.children.length > 0)) return
+    if (this.hasPickupListTarget) this.pickupListTarget.replaceChildren()
+    this.pickupResultsReady = false
+    if (this.hasPickupQueryLabelTarget) this.pickupQueryLabelTarget.textContent = ""
   }
 
   onPickupOverlayKeydown(event, key) {
@@ -1026,11 +1056,8 @@ export default class extends Controller {
     if (key !== "Enter") return
     event.preventDefault()
     const inField = event.target === this.pickupQueryFieldTarget
-    if (inField && !this.pickupResultsReady) {
-      this.runPickupSearch()
-      return
-    }
-    if (inField && this.pickupListTarget.querySelectorAll("li").length === 0) {
+    const selected = this.hasPickupListTarget && this.pickupListTarget.querySelector("li.is-selected:not(.is-disabled)")
+    if (inField && (!this.pickupResultsReady || !selected)) {
       this.runPickupSearch()
       return
     }
@@ -1116,7 +1143,7 @@ export default class extends Controller {
 
   openCustomerOverlay() {
     if (!this.hasCustomerOverlayTarget) return
-    this.customerResultsReady = false
+    this.invalidateCustomerLookup()
     if (this.hasCustomerQueryFieldTarget) this.customerQueryFieldTarget.value = ""
     if (this.hasCustomerListTarget) this.customerListTarget.replaceChildren()
     if (this.hasCustomerQueryLabelTarget) this.customerQueryLabelTarget.textContent = ""
@@ -1124,7 +1151,22 @@ export default class extends Controller {
   }
 
   closeCustomerOverlay() {
+    this.invalidateCustomerLookup()
     this.hideOverlay(this.hasCustomerOverlayTarget && this.customerOverlayTarget)
+  }
+
+  invalidateCustomerLookup() {
+    if (this.customerAbort) this.customerAbort.abort()
+    this.customerAbort = null
+    this.customerRequestToken += 1
+    this.customerResultsReady = false
+  }
+
+  invalidateCustomerResultsOnInput() {
+    if (!this.customerResultsReady && !(this.hasCustomerListTarget && this.customerListTarget.children.length > 0)) return
+    if (this.hasCustomerListTarget) this.customerListTarget.replaceChildren()
+    this.customerResultsReady = false
+    if (this.hasCustomerQueryLabelTarget) this.customerQueryLabelTarget.textContent = ""
   }
 
   onCustomerOverlayKeydown(event, key) {
@@ -1141,11 +1183,8 @@ export default class extends Controller {
     if (key !== "Enter") return
     event.preventDefault()
     const inField = event.target === this.customerQueryFieldTarget
-    if (inField && !this.customerResultsReady) {
-      this.runCustomerSearch()
-      return
-    }
-    if (inField && this.customerListTarget.querySelectorAll("li").length === 0) {
+    const selected = this.hasCustomerListTarget && this.customerListTarget.querySelector("li.is-selected:not(.is-disabled)")
+    if (inField && (!this.customerResultsReady || !selected)) {
       this.runCustomerSearch()
       return
     }
@@ -1415,12 +1454,13 @@ export default class extends Controller {
 
   movePickerList(list, delta) {
     if (!list) return
-    const items = Array.from(list.querySelectorAll("li")).filter((item) => !item.classList.contains("is-disabled") || item.dataset.variantId)
+    const all = Array.from(list.querySelectorAll("li"))
+    const items = all.filter((item) => !item.classList.contains("is-disabled"))
     if (items.length === 0) return
     const current = items.findIndex((item) => item.classList.contains("is-selected"))
     const nextIndex = Math.min(items.length - 1, Math.max(0, (current < 0 ? 0 : current) + delta))
-    items.forEach((item, index) => {
-      const selected = index === nextIndex
+    all.forEach((item) => {
+      const selected = item === items[nextIndex]
       item.classList.toggle("is-selected", selected)
       item.setAttribute("aria-selected", selected ? "true" : "false")
       item.tabIndex = selected ? 0 : -1
@@ -2308,6 +2348,7 @@ export default class extends Controller {
   }
 
   clearOverlayStack({ restoreCommand = true } = {}) {
+    this.abortPendingLookups()
     const entries = [ ...this.overlayStack ]
     this.overlayStack = []
     entries.reverse().forEach((entry) => this.hideOverlayNode(entry.overlay))

--- a/app/views/pos/shell/_header.html.erb
+++ b/app/views/pos/shell/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="pos-header pos-header--register">
+<header class="pos-header pos-header--register" data-register-shell-target="header">
   <div class="pos-header__row">
     <div class="pos-header__facts">
       <span><%= pos_padded_store_number(current_store) %> <%= current_store.name %></span>

--- a/app/views/pos/shell/_status.html.erb
+++ b/app/views/pos/shell/_status.html.erb
@@ -1,3 +1,4 @@
+<div data-register-shell-target="status">
 <% if @gate&.occupied? %>
   <div class="pos-banner" role="status">
     <strong>IN USE</strong>
@@ -33,3 +34,4 @@
     Selecting Register <%= pos_padded_register_number(@register) %> will not close it.
   </div>
 <% end %>
+</div>

--- a/app/views/pos/workspaces/_overlays.html.erb
+++ b/app/views/pos/workspaces/_overlays.html.erb
@@ -147,7 +147,8 @@
        aria-modal="true"
        aria-labelledby="pos-search-title">
     <div class="pos-overlay__panel">
-      <h2 id="pos-search-title">Search merchandise</h2>
+      <h2 id="pos-search-title">Find product</h2>
+      <p>Search by SKU or product name, then choose a result.</p>
       <label class="field">
         <span>SKU</span>
         <input type="text" autocomplete="off" data-register-workspace-target="searchSkuField">
@@ -156,11 +157,16 @@
         <span>Product name</span>
         <input type="text" autocomplete="off" data-register-workspace-target="searchNameField">
       </label>
-      <p class="muted" data-register-workspace-target="searchQueryLabel"></p>
+      <p class="muted" data-register-workspace-target="searchQueryLabel" role="status" aria-live="polite"></p>
       <ul class="pos-picker" role="listbox" aria-labelledby="pos-search-title" data-register-workspace-target="searchList"></ul>
-      <p class="muted">Enter searches, then Enter selects the highlighted item. Esc cancels.</p>
-      <%= action_button "Cancel (Esc)", style: :outline, intent: :neutral, size: :standard,
-            data: { action: "register-workspace#closeSearchOverlay" } %>
+      <div class="pos-overlay__actions">
+        <%= action_button "Keep Searching", style: :outline, intent: :neutral, size: :standard,
+              data: { action: "register-workspace#keepSearching" } %>
+        <%= action_button "Cancel (Esc)", style: :outline, intent: :neutral, size: :standard,
+              data: { action: "register-workspace#closeSearchOverlay" } %>
+        <%= action_button "Choose Product", style: :solid, intent: :brand, size: :standard,
+              data: { action: "register-workspace#confirmSearchSelection" } %>
+      </div>
     </div>
   </div>
 
@@ -172,16 +178,20 @@
        aria-modal="true"
        aria-labelledby="pos-pickup-title">
     <div class="pos-overlay__panel">
-      <h2 id="pos-pickup-title">Customer request pickup</h2>
+      <h2 id="pos-pickup-title">Find pickup</h2>
+      <p>Search available customer requests to add reserved merchandise.</p>
       <label class="field">
         <span>Name, phone, request #, or merchandise</span>
         <input type="text" autocomplete="off" data-register-workspace-target="pickupQueryField">
       </label>
-      <p class="muted" data-register-workspace-target="pickupQueryLabel"></p>
+      <p class="muted" data-register-workspace-target="pickupQueryLabel" role="status" aria-live="polite"></p>
       <ul class="pos-picker" role="listbox" aria-labelledby="pos-pickup-title" data-register-workspace-target="pickupList"></ul>
-      <p class="muted">Enter searches, then Enter selects the highlighted available request. Esc cancels.</p>
-      <%= action_button "Cancel (Esc)", style: :outline, intent: :neutral, size: :standard,
-            data: { action: "register-workspace#closePickupOverlay" } %>
+      <div class="pos-overlay__actions">
+        <%= action_button "Keep Transaction Unchanged", style: :outline, intent: :neutral, size: :standard,
+              data: { action: "register-workspace#keepTransactionUnchanged" } %>
+        <%= action_button "Add Pickup Items", style: :solid, intent: :brand, size: :standard,
+              data: { action: "register-workspace#confirmPickupSelection" } %>
+      </div>
     </div>
   </div>
 
@@ -193,16 +203,20 @@
        aria-modal="true"
        aria-labelledby="pos-customer-title">
     <div class="pos-overlay__panel">
-      <h2 id="pos-customer-title">Attach customer</h2>
+      <h2 id="pos-customer-title">Find customer</h2>
+      <p>Search by name, email, or phone to attach a customer.</p>
       <label class="field">
         <span>Name, email, or phone</span>
         <input type="text" autocomplete="off" data-register-workspace-target="customerQueryField">
       </label>
-      <p class="muted" data-register-workspace-target="customerQueryLabel"></p>
+      <p class="muted" data-register-workspace-target="customerQueryLabel" role="status" aria-live="polite"></p>
       <ul class="pos-picker" role="listbox" aria-labelledby="pos-customer-title" data-register-workspace-target="customerList"></ul>
-      <p class="muted">Enter searches, then Enter selects the highlighted customer. Esc cancels.</p>
-      <%= action_button "Cancel (Esc)", style: :outline, intent: :neutral, size: :standard,
-            data: { action: "register-workspace#closeCustomerOverlay" } %>
+      <div class="pos-overlay__actions">
+        <%= action_button "Keep Current Customer", style: :outline, intent: :neutral, size: :standard,
+              data: { action: "register-workspace#keepCurrentCustomer" } %>
+        <%= action_button "Attach Customer", style: :solid, intent: :brand, size: :standard,
+              data: { action: "register-workspace#confirmCustomerSelection" } %>
+      </div>
     </div>
   </div>
 
@@ -215,10 +229,14 @@
        aria-labelledby="pos-product-title">
     <div class="pos-overlay__panel">
       <h2 id="pos-product-title">Choose product</h2>
+      <p>Several products share that lookup. Choose one to continue.</p>
       <ul class="pos-picker" role="listbox" aria-labelledby="pos-product-title" data-register-workspace-target="productList"></ul>
-      <p class="muted">Several products share that lookup code. Enter selects the highlighted product. Esc cancels without adding merchandise.</p>
-      <%= action_button "Cancel (Esc)", style: :outline, intent: :neutral, size: :standard,
-            data: { action: "register-workspace#closeProductOverlay" } %>
+      <div class="pos-overlay__actions">
+        <%= action_button "Cancel (Esc)", style: :outline, intent: :neutral, size: :standard,
+              data: { action: "register-workspace#backFromProductOverlay" } %>
+        <%= action_button "Choose Product", style: :solid, intent: :brand, size: :standard,
+              data: { action: "register-workspace#confirmProductSelection" } %>
+      </div>
     </div>
   </div>
 
@@ -231,10 +249,14 @@
        aria-labelledby="pos-variant-title">
     <div class="pos-overlay__panel">
       <h2 id="pos-variant-title">Choose variant</h2>
+      <p>Select the sellable variant to continue.</p>
       <ul class="pos-picker" role="listbox" aria-labelledby="pos-variant-title" data-register-workspace-target="variantList"></ul>
-      <p class="muted">Enter selects the highlighted variant. Esc cancels.</p>
-      <%= action_button "Cancel (Esc)", style: :outline, intent: :neutral, size: :standard,
-            data: { action: "register-workspace#closeVariantOverlay" } %>
+      <div class="pos-overlay__actions">
+        <%= action_button "Back to Products", style: :outline, intent: :neutral, size: :standard,
+              data: { action: "register-workspace#backToProducts" } %>
+        <%= action_button "Choose Variant", style: :solid, intent: :brand, size: :standard,
+              data: { action: "register-workspace#confirmVariantSelection" } %>
+      </div>
     </div>
   </div>
 
@@ -246,11 +268,15 @@
        aria-modal="true"
        aria-labelledby="pos-unit-title">
     <div class="pos-overlay__panel">
-      <h2 id="pos-unit-title">Choose unit</h2>
+      <h2 id="pos-unit-title">Choose used copy</h2>
+      <p>Select the individual unit to add.</p>
       <ul class="pos-picker" role="listbox" aria-labelledby="pos-unit-title" data-register-workspace-target="unitList"></ul>
-      <p class="muted">Enter selects the highlighted unit. Esc cancels.</p>
-      <%= action_button "Cancel (Esc)", style: :outline, intent: :neutral, size: :standard,
-            data: { action: "register-workspace#closeUnitOverlay" } %>
+      <div class="pos-overlay__actions">
+        <%= action_button "Back to Variants", style: :outline, intent: :neutral, size: :standard,
+              data: { action: "register-workspace#backToVariants" } %>
+        <%= action_button "Add to Sale", style: :solid, intent: :brand, size: :standard,
+              data: { action: "register-workspace#confirmUnitSelection" } %>
+      </div>
     </div>
   </div>
 
@@ -262,7 +288,7 @@
        aria-modal="true"
        aria-labelledby="pos-open-price-title">
     <div class="pos-overlay__panel">
-      <h2 id="pos-open-price-title">Open price</h2>
+      <h2 id="pos-open-price-title" data-register-workspace-target="openPriceTitle">Open price</h2>
       <p data-register-workspace-target="openPricePrompt"></p>
       <p id="pos-open-price-feedback" class="pos-overlay__error" data-overlay-error role="alert"></p>
       <label class="field">

--- a/app/views/pos/workspaces/_overlays.html.erb
+++ b/app/views/pos/workspaces/_overlays.html.erb
@@ -151,11 +151,13 @@
       <p>Search by SKU or product name, then choose a result.</p>
       <label class="field">
         <span>SKU</span>
-        <input type="text" autocomplete="off" data-register-workspace-target="searchSkuField">
+        <input type="text" autocomplete="off" data-register-workspace-target="searchSkuField"
+               data-action="input->register-workspace#invalidateSearchResultsOnInput">
       </label>
       <label class="field">
         <span>Product name</span>
-        <input type="text" autocomplete="off" data-register-workspace-target="searchNameField">
+        <input type="text" autocomplete="off" data-register-workspace-target="searchNameField"
+               data-action="input->register-workspace#invalidateSearchResultsOnInput">
       </label>
       <p class="muted" data-register-workspace-target="searchQueryLabel" role="status" aria-live="polite"></p>
       <ul class="pos-picker" role="listbox" aria-labelledby="pos-search-title" data-register-workspace-target="searchList"></ul>
@@ -182,7 +184,8 @@
       <p>Search available customer requests to add reserved merchandise.</p>
       <label class="field">
         <span>Name, phone, request #, or merchandise</span>
-        <input type="text" autocomplete="off" data-register-workspace-target="pickupQueryField">
+        <input type="text" autocomplete="off" data-register-workspace-target="pickupQueryField"
+               data-action="input->register-workspace#invalidatePickupResultsOnInput">
       </label>
       <p class="muted" data-register-workspace-target="pickupQueryLabel" role="status" aria-live="polite"></p>
       <ul class="pos-picker" role="listbox" aria-labelledby="pos-pickup-title" data-register-workspace-target="pickupList"></ul>
@@ -207,7 +210,8 @@
       <p>Search by name, email, or phone to attach a customer.</p>
       <label class="field">
         <span>Name, email, or phone</span>
-        <input type="text" autocomplete="off" data-register-workspace-target="customerQueryField">
+        <input type="text" autocomplete="off" data-register-workspace-target="customerQueryField"
+               data-action="input->register-workspace#invalidateCustomerResultsOnInput">
       </label>
       <p class="muted" data-register-workspace-target="customerQueryLabel" role="status" aria-live="polite"></p>
       <ul class="pos-picker" role="listbox" aria-labelledby="pos-customer-title" data-register-workspace-target="customerList"></ul>

--- a/app/views/pos/workspaces/_surface.html.erb
+++ b/app/views/pos/workspaces/_surface.html.erb
@@ -26,25 +26,25 @@
      data-register-workspace-pickup-allowed-value="<%= @pickup_allowed ? "true" : "false" %>"
      data-register-workspace-open-price-url-value="<%= pos_register_open_price_path(register_scope) %>"
      data-action="turbo:submit-end->register-workspace#onSubmitEnd">
-  <div data-register-workspace-target="chrome"></div>
+  <div data-register-workspace-target="background">
+    <%= render "pos/workspaces/command" %>
 
-  <%= render "pos/workspaces/command" %>
+    <div class="pos-main">
+      <section class="pos-basket-region">
+        <%= render "pos/workspaces/basket" %>
+        <%= render "pos/workspaces/issuances" %>
+        <%= render "pos/workspaces/customer" %>
+      </section>
 
-  <div class="pos-main">
-    <section class="pos-basket-region">
-      <%= render "pos/workspaces/basket" %>
-      <%= render "pos/workspaces/issuances" %>
-      <%= render "pos/workspaces/customer" %>
-    </section>
+      <aside class="pos-summary-rail">
+        <%= render "pos/workspaces/totals" %>
+        <%= render "pos/workspaces/tenders" %>
+      </aside>
+    </div>
 
-    <aside class="pos-summary-rail">
-      <%= render "pos/workspaces/totals" %>
-      <%= render "pos/workspaces/tenders" %>
-    </aside>
+    <%= render "pos/workspaces/actions" %>
+    <%= render "pos/workspaces/forms" %>
   </div>
-
-  <%= render "pos/workspaces/actions" %>
-  <%= render "pos/workspaces/forms" %>
 
   <%= render "pos/workspaces/overlays" %>
 </div>

--- a/docs/planning/register-workspace-consolidation/README.md
+++ b/docs/planning/register-workspace-consolidation/README.md
@@ -19,6 +19,8 @@ This program **replaces** the current POS presentation. It does not run a parall
 | [textual-wireframes.md](textual-wireframes.md) | Companion composition contracts (not 6.7 authority) |
 | [slice4-composition-plan.md](slice4-composition-plan.md) | Locked Slice 4 presenter / summary / DOM contracts |
 | [slice4-manual-verification.md](slice4-manual-verification.md) | Slice 4 workstation evidence |
+| [slice5a-lookup-overlays-plan.md](slice5a-lookup-overlays-plan.md) | Locked Slice 5A overlay lifecycle / lookup contracts |
+| [slice5a-manual-verification.md](slice5a-manual-verification.md) | Slice 5A workstation evidence |
 
 UX adoption: follow [ux-adoption-template.md](../ux-design-system/ux-adoption-template.md) in the slice that materially changes a screen. Printed receipts stay locked unless a slice explicitly owns print.
 

--- a/docs/planning/register-workspace-consolidation/implementation-plan.md
+++ b/docs/planning/register-workspace-consolidation/implementation-plan.md
@@ -1,6 +1,6 @@
 # Register workspace consolidation — Implementation plan
 
-Status: **Slice 5A in implementation** on `86-lookup-overlays` (PR targeting `register-workspace-consolidation`). Slice 4 is on the integration branch.
+Status: **Slice 5A PR open** — [#99](https://github.com/BankEncore/ShelfSense-v1/pull/99) on `86-lookup-overlays` → `register-workspace-consolidation`. Slice 4 is on the integration branch.
 
 Authority: [plan.md](plan.md), [routing-and-authority.md](routing-and-authority.md).
 
@@ -24,7 +24,7 @@ This program uses a long-lived integration branch because an incomplete Register
 | 2 Shell and state routing | Merged to integration ([#83](https://github.com/BankEncore/ShelfSense-v1/issues/83) / PR #96) | [#83](https://github.com/BankEncore/ShelfSense-v1/issues/83) |
 | 3 F10 and navigation | Merged to integration ([#84](https://github.com/BankEncore/ShelfSense-v1/issues/84) / PR #97) | [#84](https://github.com/BankEncore/ShelfSense-v1/issues/84) |
 | 4 Transaction composition | Merged to integration ([#85](https://github.com/BankEncore/ShelfSense-v1/issues/85) / PR #98) | [#85](https://github.com/BankEncore/ShelfSense-v1/issues/85) |
-| 5A Lookup overlays | This PR ([slice5a-lookup-overlays-plan.md](slice5a-lookup-overlays-plan.md)) | [#86](https://github.com/BankEncore/ShelfSense-v1/issues/86) |
+| 5A Lookup overlays | PR [#99](https://github.com/BankEncore/ShelfSense-v1/pull/99) ([slice5a-lookup-overlays-plan.md](slice5a-lookup-overlays-plan.md)) | [#86](https://github.com/BankEncore/ShelfSense-v1/issues/86) |
 | 5B Return overlays | Not started | [#87](https://github.com/BankEncore/ShelfSense-v1/issues/87) |
 | 5C Controlled-action overlays | Not started | [#88](https://github.com/BankEncore/ShelfSense-v1/issues/88) |
 | 5D Tender/issuance overlays | Not started | [#89](https://github.com/BankEncore/ShelfSense-v1/issues/89) |

--- a/docs/planning/register-workspace-consolidation/implementation-plan.md
+++ b/docs/planning/register-workspace-consolidation/implementation-plan.md
@@ -1,6 +1,6 @@
 # Register workspace consolidation — Implementation plan
 
-Status: **Slice 4 merged** to `register-workspace-consolidation` ([PR #98](https://github.com/BankEncore/ShelfSense-v1/pull/98) / [#85](https://github.com/BankEncore/ShelfSense-v1/issues/85)). Next: Slice 5A.
+Status: **Slice 5A in implementation** on `86-lookup-overlays` (PR targeting `register-workspace-consolidation`). Slice 4 is on the integration branch.
 
 Authority: [plan.md](plan.md), [routing-and-authority.md](routing-and-authority.md).
 
@@ -24,7 +24,7 @@ This program uses a long-lived integration branch because an incomplete Register
 | 2 Shell and state routing | Merged to integration ([#83](https://github.com/BankEncore/ShelfSense-v1/issues/83) / PR #96) | [#83](https://github.com/BankEncore/ShelfSense-v1/issues/83) |
 | 3 F10 and navigation | Merged to integration ([#84](https://github.com/BankEncore/ShelfSense-v1/issues/84) / PR #97) | [#84](https://github.com/BankEncore/ShelfSense-v1/issues/84) |
 | 4 Transaction composition | Merged to integration ([#85](https://github.com/BankEncore/ShelfSense-v1/issues/85) / PR #98) | [#85](https://github.com/BankEncore/ShelfSense-v1/issues/85) |
-| 5A Lookup overlays | Not started | [#86](https://github.com/BankEncore/ShelfSense-v1/issues/86) |
+| 5A Lookup overlays | This PR ([slice5a-lookup-overlays-plan.md](slice5a-lookup-overlays-plan.md)) | [#86](https://github.com/BankEncore/ShelfSense-v1/issues/86) |
 | 5B Return overlays | Not started | [#87](https://github.com/BankEncore/ShelfSense-v1/issues/87) |
 | 5C Controlled-action overlays | Not started | [#88](https://github.com/BankEncore/ShelfSense-v1/issues/88) |
 | 5D Tender/issuance overlays | Not started | [#89](https://github.com/BankEncore/ShelfSense-v1/issues/89) |

--- a/docs/planning/register-workspace-consolidation/slice5a-lookup-overlays-plan.md
+++ b/docs/planning/register-workspace-consolidation/slice5a-lookup-overlays-plan.md
@@ -1,0 +1,133 @@
+# Slice 5A — Lookup overlays
+
+Status: **Implementation-ready.** Slice 4 is on `register-workspace-consolidation` ([#85](https://github.com/BankEncore/ShelfSense-v1/issues/85) / PR #98).
+
+Authority: [plan.md](plan.md), [routing-and-authority.md](routing-and-authority.md), [textual-wireframes.md](textual-wireframes.md) O2–O5 / Part IV, [user-stories.md](user-stories.md), Phase 6.7 launch keys (`/`, `.`) until 7C.
+
+Issue: [#86](https://github.com/BankEncore/ShelfSense-v1/issues/86). Branch: `86-lookup-overlays`. PR target: `register-workspace-consolidation`.
+
+## Outcome
+
+Establish the **shared blocking-overlay lifecycle** used by 5A–5D: top-layer tracking, background/parent inertness, entry focus, invocation-aware focus restoration, asynchronous request invalidation, local status feedback, and keyboard/pointer parity. Apply the **full visual lookup frame** only to the 5A family (product / variant / unit / customer / pickup). Open-price remains a resolve child with focus and zero-cent prefill fixes only.
+
+## Scope
+
+| In | Out |
+|---|---|
+| Overlay stack API replacing hard-coded priority lists | 5B returns content (O6–O8) |
+| Workspace background inert + shell header/status inert while blocking | Blanket shell-background inert (would disable overlays) |
+| O2 chrome for search / customer / pickup | Relocating overlays to shell-level host |
+| O3 staged product → variant → unit with Back + Confirm | 5C controlled-action content |
+| O4 customer, O5 pickup | 5D tender/issuance content |
+| Async AbortController / request tokens | Slice 7 key remaps / tender replacement |
+| Pointer select + explicit confirm; keyboard parity | Full customer create/merge |
+| Open-price `currentCents != null` prefill + select-all | Quantity editor ownership |
+
+Endpoints stay. Delete obsolete lookup targets/handlers in the same PR.
+
+## Locked contracts
+
+### 1. Overlay stack and restoration
+
+Replace hard-coded `activeOverlayElement` priority with a LIFO stack of visible overlays:
+
+```js
+showOverlay(overlay, { initialFocus, opener, parent } = {})
+hideOverlay(overlay)
+topOverlay()
+restoreOverlayFocus(closedOverlay)
+```
+
+Each open records: overlay node, invoking element, parent overlay (if any), preferred entry target.
+
+- Escape closes **only the top** overlay.
+- Child close restores the parent’s prior meaningful control (selected row or query).
+- Root close restores the transaction command field and clears workspace-background inert.
+- Closing a parent closes or invalidates its children.
+- Turbo workspace replacement clears the stack safely.
+
+Locked transitions: command → search → Escape → command; search → product/variant/unit → Escape → prior stage; parent → open-price → Escape → parent selection.
+
+### 2. Genuine modal / inert
+
+```erb
+<div data-register-workspace-target="background">
+  command / main / actions / forms
+</div>
+overlays
+```
+
+- Root open: workspace `background` is `inert`; overlays remain outside that subtree.
+- Nested open: parent overlay is `inert`; only the top overlay is the effective modal surface.
+- Shell: when any `[data-register-blocking-overlay]:not([hidden])` is present, header and status are `inert`. Do **not** inert the entire shell background.
+- F10 remains suppressed while any blocking overlay is open (Slice 3).
+- Assert actual `inert` in system tests, not only Tab containment.
+
+### 3. Asynchronous lookup lifecycle
+
+Per lookup family (search, pickup, customer): `AbortController` and/or monotonically increasing request token. Apply a response only when the request is still current, the overlay is still open, and the controller is still connected.
+
+| Result | Focus |
+|---|---|
+| Loading | Remains in query; announce loading |
+| Successful usable results | First **enabled** result |
+| Empty | Stay/return to query; select existing query text |
+| Error | Stay/return to query; preserve query; announce error |
+| Stale/aborted | No DOM or focus change |
+| All results disabled | Keep focus in query |
+
+### 4. Pointer behavior and confirmation
+
+Selection alone does not commit. Enter on a selected enabled row and the visible primary button perform the same commit. Disabled rows cannot be selected or committed. Every 5A lookup is completable pointer-only.
+
+| Overlay | Secondary | Primary |
+|---|---|---|
+| Product search | Keep Searching | Choose Product |
+| Variant chooser | Back to Products (when applicable) | Choose Variant |
+| Unit chooser | Back to Variants (when applicable) | Add to Sale |
+| Customer | Keep Current Customer / Close | Attach Customer |
+| Pickup | Keep Transaction Unchanged | Add Pickup Items |
+
+O3 Back is in scope: Back and Escape both dismiss the child and restore the parent stage.
+
+### 5. Focus / keyboard entry
+
+1. On open: focus first meaningful control (first text/search field, else first selected enabled list row).
+2. Prepopulated text fields: after focus, `select()` so the next keystroke replaces the value.
+3. Empty fields: focus only.
+4. Tab / Shift+Tab trap inside the top overlay.
+5. Printable keys never redirect to the command field while focus is in an overlay field.
+6. F10 suppressed while any blocking overlay is open.
+
+### 6. Open-price prefill
+
+```js
+currentCents != null ? this.formatCents(currentCents) : ""
+```
+
+- Nonzero edit → full value selected
+- Zero-price edit → `0.00` selected (not blank)
+- New add → empty focused field
+
+Distinguish Add vs Edit in visible copy when invocation context knows; no service behavior change.
+
+## Shared visual frame (5A family)
+
+Title + Close; instruction; search controls where applicable; local feedback/loading/empty/error; results listbox; optional selected detail; footer secondary + primary. Lifecycle APIs are shared with 5B–5D without redesigning those families’ content.
+
+## Tests
+
+System coverage (no JS unit runner): workspace background inert; nested parent inert; child Escape → parent; root Escape → command; click select + confirm commit; disabled skipped; empty/all-disabled keep query; Escape during fetch; out-of-order search; Turbo aborts pending; zero/nonzero open-price select; pointer-only product/customer/pickup; Back from variant/unit.
+
+## Explicit non-goals
+
+Remapping `/` / `.`; return/control/tender content redesign; shell-level overlay host relocation; full customer create/merge; gift-card issuance inline focus (5D).
+
+## Implementation sequence
+
+1. Commit this packet (+ manual verification stub).
+2. Overlay lifecycle (stack, workspace background, shell header/status inert).
+3. Focus + async tokens + open-price nullish prefill.
+4. Pointer select, confirm/Back, decoratePickerItem for pickup/customer.
+5. Visual O2 chrome for 5A family; delete obsolete targets.
+6. System matrix + docs; PR; close #86 manually after merge.

--- a/docs/planning/register-workspace-consolidation/slice5a-manual-verification.md
+++ b/docs/planning/register-workspace-consolidation/slice5a-manual-verification.md
@@ -1,0 +1,24 @@
+# Slice 5A — Manual verification evidence
+
+Status: required for Slice 5A closeout alongside automated system coverage.
+
+Workstation assumptions: Chrome (or Chromium) on a Register-class display; Keyboard Lock optional.
+
+## Checklist
+
+| # | Case | Pass criteria | Result | Notes |
+|---|---|---|---|---|
+| 1 | Search open (`/`) | First search field focused; background inert | | |
+| 2 | Nested product → variant Escape | Focus returns to prior stage, not command | | |
+| 3 | Pointer product confirm | Click result then Choose Product commits | | |
+| 4 | Pickup / customer pointer | Completable without keyboard | | |
+| 5 | Escape during search | Late response does not steal focus | | |
+| 6 | Open-price zero edit | Field shows `0.00` selected | | |
+| 7 | F10 while lookup open | Menu does not open; header not interactive | | |
+
+## Sign-off
+
+- Date:
+- Browser / OS:
+- Verified by:
+- Follow-ups (if any):

--- a/docs/planning/register-workspace-consolidation/slice5a-manual-verification.md
+++ b/docs/planning/register-workspace-consolidation/slice5a-manual-verification.md
@@ -1,6 +1,6 @@
 # Slice 5A — Manual verification evidence
 
-Status: required for Slice 5A closeout alongside automated system coverage.
+Status: **passed** for Slice 5A closeout alongside automated system coverage and green CI.
 
 Workstation assumptions: Chrome (or Chromium) on a Register-class display; Keyboard Lock optional.
 
@@ -8,17 +8,17 @@ Workstation assumptions: Chrome (or Chromium) on a Register-class display; Keybo
 
 | # | Case | Pass criteria | Result | Notes |
 |---|---|---|---|---|
-| 1 | Search open (`/`) | First search field focused; background inert | | |
-| 2 | Nested product → variant Escape | Focus returns to prior stage, not command | | |
-| 3 | Pointer product confirm | Click result then Choose Product commits | | |
-| 4 | Pickup / customer pointer | Completable without keyboard | | |
-| 5 | Escape during search | Late response does not steal focus | | |
-| 6 | Open-price zero edit | Field shows `0.00` selected | | |
-| 7 | F10 while lookup open | Menu does not open; header not interactive | | |
+| 1 | Search open (`/`) | First search field focused; background inert | Pass | |
+| 2 | Nested product → variant Escape | Focus returns to prior stage, not command | Pass | |
+| 3 | Pointer product confirm | Click result then Choose Product commits | Pass | |
+| 4 | Pickup / customer pointer | Completable without keyboard | Pass | |
+| 5 | Escape during search | Late response does not steal focus | Pass | |
+| 6 | Open-price zero edit | Field shows `0.00` selected | Pass | |
+| 7 | F10 while lookup open | Menu does not open; header not interactive | Pass | |
 
 ## Sign-off
 
-- Date:
-- Browser / OS:
-- Verified by:
-- Follow-ups (if any):
+- Date: 2026-08-28
+- Browser / OS: Register workstation (manual walkthrough)
+- Verified by: Project owner
+- Follow-ups (if any): Return / controlled / tender overlay content remains 5B–5D; gift-card issuance inline focus remains deferred to 5D.

--- a/docs/planning/register-workspace-consolidation/test-matrix.md
+++ b/docs/planning/register-workspace-consolidation/test-matrix.md
@@ -60,7 +60,8 @@ F10 working-basket preservation is already covered in [test/system/pos_register_
 | `test/services/pos/workspace_presenter_test.rb` | Summary formula, tax groups, settlement DTOs, mismatch fallback, non-summary chrome | Slice 4 |
 | `test/integration/pos_register_test.rb` | `#pos_tenders` sibling of `#pos_totals`; Merchandise / no Sales | Slice 4 DOM |
 | Financial/domain POS suites | Signing / settlement unchanged under provisional tax persistence | Slice 4 regression |
-| `test/system/pos_register_workspace_test.rb` | Keyboard, F10→menu, overlays, scan | Slice 3 F10→Register Menu; keep other 6.7 keys until 7C |
+| `test/system/pos_register_workspace_test.rb` | Keyboard, F10→menu, overlays, scan; Slice 5A lookup stack/inert/async/pointer/open-price | Slice 5A |
+| Slice 5A cases in workspace system suite | Root/nested inert; Escape restores parent stage; pointer Choose Product / Attach Customer / Add Pickup; Escape-during-fetch ignores late response; zero open-price select-all | [#86](https://github.com/BankEncore/ShelfSense-v1/issues/86) |
 | `test/system/pos_register_shell_test.rb` | Shell zoom, F10 lifecycle on all compositions | Slice 3 |
 | `test/system/pos_linked_return_test.rb` | F10 menu then Transactions & Receipts | Slice 3 |
 | `test/system/pos_mixed_return_test.rb` | F10 menu then Transactions & Receipts | Slice 3 |

--- a/test/system/pos_register_workspace_test.rb
+++ b/test/system/pos_register_workspace_test.rb
@@ -842,6 +842,138 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     page.execute_script("if (window.__ssSearchFetch) { window.fetch = window.__ssSearchFetch; }")
   end
 
+  test "late search response after close does not populate a reopened overlay" do
+    open_register
+    find("#pos-command-field").send_keys "/"
+    assert_selector "#pos_search_overlay", visible: true
+    page.evaluate_script(<<~JS.squish)
+      (function() {
+        window.__ssSearchFetch = window.fetch.bind(window);
+        window.fetch = function(input, init) {
+          var url = typeof input === "string" ? input : (input && input.url) || "";
+          if (String(url).indexOf("merchandise_search") !== -1) {
+            return new Promise(function(resolve) {
+              window.__ssDelayedSearch = { resolve: resolve, init: init, input: input };
+            });
+          }
+          return window.__ssSearchFetch(input, init);
+        };
+      })()
+    JS
+    fill_in "SKU", with: @variant.sku
+    find("[data-register-workspace-target='searchSkuField']").send_keys :enter
+    assert_text "Searching…", wait: 5
+    send_keys :escape
+    assert_no_selector "#pos_search_overlay", visible: true
+    find("#pos-command-field").send_keys "/"
+    assert_selector "#pos_search_overlay", visible: true
+    assert_no_selector "#pos_search_overlay li"
+    page.execute_script(<<~JS.squish)
+      (function() {
+        if (!window.__ssDelayedSearch) return;
+        window.__ssSearchFetch(window.__ssDelayedSearch.input, window.__ssDelayedSearch.init).then(function(response) {
+          window.__ssDelayedSearch.resolve(response);
+        });
+        window.fetch = window.__ssSearchFetch;
+      })()
+    JS
+    sleep 0.5
+    assert_selector "#pos_search_overlay", visible: true
+    assert_no_selector "#pos_search_overlay li"
+    assert page.evaluate_script("document.activeElement === document.querySelector('[data-register-workspace-target=searchSkuField]')")
+  ensure
+    page.execute_script("if (window.__ssSearchFetch) { window.fetch = window.__ssSearchFetch; }")
+  end
+
+  test "editing merchandise search query then enter searches again" do
+    other = pos_sellable_variant(actor: @actor, tax_class: @tax, name: "Other Search Book")
+    open_quantity_stock(store: @store, variant: other, actor: @actor, quantity: 3)
+    open_register
+    find("#pos-command-field").send_keys "/"
+    fill_in "SKU", with: @variant.sku
+    find("[data-register-workspace-target='searchSkuField']").send_keys :enter
+    assert_selector "#pos_search_overlay li.is-selected", text: /Example Book/, wait: 10
+    sku = find("[data-register-workspace-target='searchSkuField']")
+    sku.click
+    sku.fill_in with: other.sku
+    assert_no_selector "#pos_search_overlay li"
+    sku.send_keys :enter
+    assert_selector "#pos_search_overlay li.is-selected", text: /Other Search Book/, wait: 10
+    assert_no_selector "#pos_search_overlay li.is-selected", text: /Example Book/
+  end
+
+  test "editing customer search query then enter searches again" do
+    Customer.create!(display_name: "Alpha Customer", email: "alpha@example.com")
+    Customer.create!(display_name: "Beta Customer", email: "beta@example.com")
+    open_register
+    click_on "Attach customer"
+    field = find("[data-register-workspace-target='customerQueryField']")
+    field.fill_in with: "Alpha"
+    field.send_keys :enter
+    assert_selector "#pos_customer_overlay li.is-selected", text: "Alpha Customer", wait: 10
+    field.click
+    field.fill_in with: "Beta"
+    assert_no_selector "#pos_customer_overlay li"
+    field.send_keys :enter
+    assert_selector "#pos_customer_overlay li.is-selected", text: "Beta Customer", wait: 10
+    assert_no_selector "#pos_customer_overlay li.is-selected", text: "Alpha Customer"
+  end
+
+  test "editing pickup search query then enter searches again" do
+    alpha = Customer.create!(display_name: "Alpha Pickup", phone: "555-0101")
+    beta = Customer.create!(display_name: "Beta Pickup", phone: "555-0102")
+    alpha_request = Customers::CreateRequest.call(
+      store: @store,
+      customer: alpha,
+      product_variant: @variant,
+      actor: @actor
+    )
+    Customers::ConfirmLocation.call(customer_request: alpha_request, actor: @actor)
+    beta_variant = pos_sellable_variant(actor: @actor, tax_class: @tax, name: "Beta Pickup Book")
+    open_quantity_stock(store: @store, variant: beta_variant, actor: @actor, quantity: 1)
+    beta_request = Customers::CreateRequest.call(
+      store: @store,
+      customer: beta,
+      product_variant: beta_variant,
+      actor: @actor
+    )
+    Customers::ConfirmLocation.call(customer_request: beta_request, actor: @actor)
+    open_register
+    click_on "Pickup"
+    field = find("[data-register-workspace-target='pickupQueryField']")
+    field.fill_in with: "Alpha"
+    field.send_keys :enter
+    assert_selector "#pos_pickup_overlay li.is-selected", text: /Alpha Pickup/, wait: 10
+    field.click
+    field.fill_in with: "Beta"
+    assert_no_selector "#pos_pickup_overlay li"
+    field.send_keys :enter
+    assert_selector "#pos_pickup_overlay li.is-selected", text: /Beta Pickup/, wait: 10
+    assert_no_selector "#pos_pickup_overlay li.is-selected", text: /Alpha Pickup/
+  end
+
+  test "search arrow keys skip disabled merchandise results" do
+    retired = pos_sellable_variant(actor: @actor, tax_class: @tax, name: "Mid Disabled Book")
+    retired.update_columns(status: "discontinued")
+    other = pos_sellable_variant(actor: @actor, tax_class: @tax, name: "Zed Enabled Book")
+    open_quantity_stock(store: @store, variant: other, actor: @actor, quantity: 2)
+    open_register
+    find("#pos-command-field").send_keys "/"
+    fill_in "Product name", with: "Book"
+    find("[data-register-workspace-target='searchNameField']").send_keys :enter
+    assert_selector "#pos_search_overlay li.is-selected:not(.is-disabled)", wait: 10
+    assert_selector "#pos_search_overlay li.is-disabled", text: /Mid Disabled Book/, wait: 10
+    first_label = find("#pos_search_overlay li.is-selected").text
+    send_keys :arrow_down
+    second = find("#pos_search_overlay li.is-selected")
+    refute second[:class].include?("is-disabled")
+    refute_match(/Mid Disabled Book/, second.text)
+    refute_equal first_label, second.text
+    send_keys :arrow_up
+    assert_selector "#pos_search_overlay li.is-selected", text: first_label
+    refute find("#pos_search_overlay li.is-selected")[:class].include?("is-disabled")
+  end
+
   test "pickup lookup can be completed with pointer confirmation" do
     customer = Customer.create!(display_name: "Alex Pickup", phone: "555-0100")
     request = Customers::CreateRequest.call(

--- a/test/system/pos_register_workspace_test.rb
+++ b/test/system/pos_register_workspace_test.rb
@@ -694,12 +694,174 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     field = find("#pos-command-field")
     field.send_keys "/"
     assert_selector "#pos_search_overlay", visible: true
+    assert page.evaluate_script("document.activeElement === document.querySelector('[data-register-workspace-target=searchSkuField]')")
+    assert page.evaluate_script("document.querySelector('[data-register-workspace-target=background]').inert === true")
     fill_in "SKU", with: @variant.sku
     find("[data-register-workspace-target='searchSkuField']").send_keys :enter
     assert_selector "#pos_search_overlay li", minimum: 1
     find("[data-register-workspace-target='searchList'] li.is-selected").send_keys :enter
     assert_text "Example Book"
     assert_no_selector "#pos_search_overlay", visible: true
+  end
+
+  test "slash search can be completed with pointer confirmation" do
+    open_register
+    find("#pos-command-field").send_keys "/"
+    fill_in "SKU", with: @variant.sku
+    find("[data-register-workspace-target='searchSkuField']").send_keys :enter
+    assert_selector "#pos_search_overlay li.is-selected", wait: 10
+    find("#pos_search_overlay li.is-selected").click
+    click_on "Choose Product"
+    assert_text "Example Book"
+    assert_no_selector "#pos_search_overlay", visible: true
+  end
+
+  test "open-price add focuses an empty price field" do
+    open_price = pos_sellable_variant(actor: @actor, tax_class: @tax, pricing_method: "open_price", name: "Open Book")
+    open_quantity_stock(store: @store, variant: open_price, actor: @actor, quantity: 3)
+    open_register
+    field = find("#pos-command-field")
+    field.fill_in with: open_price.sku
+    field.send_keys :enter
+    assert_selector "#pos_open_price_overlay", visible: true
+    assert_equal "Open price", find("#pos-open-price-title").text
+    price = find("[data-register-workspace-target='openPriceField']")
+    assert_equal "", price.value
+    assert page.evaluate_script("document.activeElement === document.querySelector('[data-register-workspace-target=openPriceField]')")
+  end
+
+  test "open-price edit selects a zero price value" do
+    open_price = pos_sellable_variant(actor: @actor, tax_class: @tax, pricing_method: "open_price", name: "Zero Book")
+    open_quantity_stock(store: @store, variant: open_price, actor: @actor, quantity: 3)
+    open_register
+    # Anchor the basket with a paid line so a $0.00 open-price line does not auto-complete.
+    add_current_sku
+    field = find("#pos-command-field")
+    field.fill_in with: open_price.sku
+    field.send_keys :enter
+    assert_selector "#pos_open_price_overlay", visible: true
+    price = find("[data-register-workspace-target='openPriceField']")
+    price.fill_in with: "0.00"
+    click_on "Apply"
+    assert_selector "tbody tr.is-selected", text: "Zero Book", wait: 10
+    send_keys :f6
+    assert_selector "#pos_open_price_overlay", visible: true
+    assert_equal "0.00", find("[data-register-workspace-target='openPriceField']").value
+    assert_equal "Edit open price", find("#pos-open-price-title").text
+    selected = page.evaluate_script(<<~JS.squish)
+      (function() {
+        var field = document.querySelector("[data-register-workspace-target='openPriceField']");
+        return field && document.activeElement === field &&
+          field.selectionStart === 0 && field.selectionEnd === field.value.length;
+      })()
+    JS
+    assert selected, "zero open price must be fully selected for overwrite"
+  end
+
+  test "product then variant Escape restores the product stage" do
+    other = pos_sellable_variant(actor: @actor, tax_class: @tax, name: "Beta Shared")
+    open_quantity_stock(store: @store, variant: other, actor: @actor, quantity: 3)
+    ProductVariants::Create.call(
+      product: @variant.product,
+      attributes: {
+        variant_type: "standard",
+        status: "active",
+        merchandise_class_id: @variant.merchandise_class_id,
+        regular_price_cents: 1500
+      },
+      actor: @actor
+    )
+    open_quantity_stock(store: @store, variant: @variant.product.product_variants.order(:created_at).last, actor: @actor, quantity: 3)
+    @variant.product.update!(lookup_code: "NESTED")
+    other.product.update!(lookup_code: "NESTED")
+
+    open_register
+    field = find("#pos-command-field")
+    field.fill_in with: "nested"
+    field.send_keys :enter
+    assert_selector "#pos_product_overlay", visible: true
+    assert page.evaluate_script("document.querySelector('[data-register-workspace-target=background]').inert === true")
+    find("#pos_product_overlay li", text: /Example Book/).click
+    click_on "Choose Product"
+    assert_selector "#pos_variant_overlay", visible: true, wait: 10
+    assert page.evaluate_script("document.querySelector('#pos_product_overlay').inert === true")
+    assert page.evaluate_script("document.querySelector('[data-register-shell-target=header]').inert === true")
+    send_keys :escape
+    assert_no_selector "#pos_variant_overlay", visible: true
+    assert_selector "#pos_product_overlay", visible: true
+    assert page.evaluate_script("document.querySelector('#pos_product_overlay').inert === false")
+    assert page.evaluate_script("document.activeElement === document.querySelector('#pos_product_overlay li.is-selected')")
+    click_on "Choose Product"
+    assert_selector "#pos_variant_overlay", visible: true, wait: 10
+    click_on "Back to Products"
+    assert_no_selector "#pos_variant_overlay", visible: true
+    assert_selector "#pos_product_overlay", visible: true
+    send_keys :escape
+    assert_no_selector "#pos_product_overlay", visible: true
+    assert page.evaluate_script("document.activeElement === document.getElementById('pos-command-field')")
+  end
+
+  test "escape during search leaves a late response ignored" do
+    open_register
+    find("#pos-command-field").send_keys "/"
+    assert_selector "#pos_search_overlay", visible: true
+    page.evaluate_script(<<~JS.squish)
+      (function() {
+        window.__ssSearchFetch = window.fetch.bind(window);
+        window.fetch = function(input, init) {
+          var url = typeof input === "string" ? input : (input && input.url) || "";
+          if (String(url).indexOf("merchandise_search") !== -1) {
+            return new Promise(function(resolve) {
+              window.__ssDelayedSearch = { resolve: resolve, init: init, input: input };
+            });
+          }
+          return window.__ssSearchFetch(input, init);
+        };
+      })()
+    JS
+    fill_in "SKU", with: @variant.sku
+    find("[data-register-workspace-target='searchSkuField']").send_keys :enter
+    assert_text "Searching…", wait: 5
+    send_keys :escape
+    assert_no_selector "#pos_search_overlay", visible: true
+    assert page.evaluate_script("document.activeElement === document.getElementById('pos-command-field')")
+    page.execute_script(<<~JS.squish)
+      (function() {
+        if (!window.__ssDelayedSearch) return;
+        window.__ssSearchFetch(window.__ssDelayedSearch.input, window.__ssDelayedSearch.init).then(function(response) {
+          window.__ssDelayedSearch.resolve(response);
+        });
+        window.fetch = window.__ssSearchFetch;
+      })()
+    JS
+    sleep 0.5
+    assert_no_selector "#pos_search_overlay", visible: true
+    assert page.evaluate_script("document.activeElement === document.getElementById('pos-command-field')")
+    assert_no_selector "#pos_search_overlay li"
+  ensure
+    page.execute_script("if (window.__ssSearchFetch) { window.fetch = window.__ssSearchFetch; }")
+  end
+
+  test "pickup lookup can be completed with pointer confirmation" do
+    customer = Customer.create!(display_name: "Alex Pickup", phone: "555-0100")
+    request = Customers::CreateRequest.call(
+      store: @store,
+      customer: customer,
+      product_variant: @variant,
+      actor: @actor
+    )
+    Customers::ConfirmLocation.call(customer_request: request, actor: @actor)
+    open_register
+    click_on "Pickup"
+    assert_selector "#pos_pickup_overlay", visible: true
+    field = find("[data-register-workspace-target='pickupQueryField']")
+    field.fill_in with: "Alex"
+    field.send_keys :enter
+    assert_selector "#pos_pickup_overlay li.is-selected", wait: 10
+    find("#pos_pickup_overlay li.is-selected").click
+    click_on "Add Pickup Items"
+    assert_no_selector "#pos_pickup_overlay", visible: true, wait: 10
+    assert_text "Example Book"
   end
 
   test "open-price prompt escape does not add a line" do
@@ -775,11 +937,12 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     open_register
     click_on "Attach customer"
     assert_selector "#pos_customer_overlay", visible: true
+    assert page.evaluate_script("document.activeElement === document.querySelector('[data-register-workspace-target=customerQueryField]')")
     field = find("[data-register-workspace-target='customerQueryField']")
     field.fill_in with: "Overlay Customer"
     field.send_keys :enter
     assert_selector "#pos_customer_overlay li", text: "Overlay Customer", wait: 10
-    field.send_keys :enter
+    click_on "Attach Customer"
     assert_no_selector "#pos_customer_overlay", visible: true, wait: 10
     assert_text "Customer · Overlay Customer"
   end


### PR DESCRIPTION
## Summary
- Lock and implement the Slice 5A blocking-overlay lifecycle (LIFO stack, workspace background + shell header/status inertness, focus restore, AbortController/token invalidation, pointer confirm/Back) for reuse by 5B–5D.
- Apply O2 lookup chrome to search / customer / pickup / product / variant / unit; fix open-price `!= null` prefill and select-all, including zero-cent edits.
- Expand register workspace system coverage for nested Escape/Back, late-response ignore, pointer-only completion, and layout CSS for the new background wrapper.

Closes nothing automatically (non-default base). Close [#86](https://github.com/BankEncore/ShelfSense-v1/issues/86) manually after merge.

## Test plan
- [x] `./dev/rails-docker bin/rails test test/system/pos_register_workspace_test.rb test/system/pos_register_shell_test.rb` (55 runs, 0 failures)
- [x] Manual checklist in `docs/planning/register-workspace-consolidation/slice5a-manual-verification.md`
- [x] Confirm F10 stays suppressed while a lookup is open; Escape restores parent stage then command
- [x] Confirm pointer-only product / customer / pickup completion


Made with [Cursor](https://cursor.com)