### PR TITLE
Slice 5B: Return overlays (#87)

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1944,6 +1944,12 @@ input[type="submit"]:disabled,
   font-weight: 600;
 }
 
+.pos-picker li .muted {
+  display: block;
+  margin-top: 0.25rem;
+  font-weight: 400;
+}
+
 .pos-line-flags {
   display: block;
   margin-top: 0.15rem;

--- a/app/javascript/controllers/register_workspace_controller.js
+++ b/app/javascript/controllers/register_workspace_controller.js
@@ -136,8 +136,10 @@ export default class extends Controller {
     "productList",
     "variantOverlay",
     "variantList",
+    "variantBack",
     "unitOverlay",
     "unitList",
+    "unitBack",
     "openPriceOverlay",
     "openPriceTitle",
     "openPricePrompt",
@@ -1331,6 +1333,7 @@ export default class extends Controller {
 
   openVariantPicker(variants) {
     if (!this.hasVariantOverlayTarget || !this.hasVariantListTarget) return
+    this.syncNestedPickerBackLabels()
     this.variantListTarget.replaceChildren()
     variants.forEach((variant, index) => {
       const item = document.createElement("li")
@@ -1391,8 +1394,19 @@ export default class extends Controller {
     this.abortUnlinkedPicker()
   }
 
+  syncNestedPickerBackLabels() {
+    const unlinked = Boolean(this.unlinkedPickerActive)
+    if (this.hasVariantBackTarget) {
+      this.variantBackTarget.textContent = unlinked ? "Back to Item Lookup" : "Back to Products"
+    }
+    if (this.hasUnitBackTarget) {
+      this.unitBackTarget.textContent = unlinked ? "Back to Item Lookup" : "Back to Variants"
+    }
+  }
+
   openUnitPicker(units) {
     if (!this.hasUnitOverlayTarget || !this.hasUnitListTarget) return
+    this.syncNestedPickerBackLabels()
     this.unitListTarget.replaceChildren()
     if (units.length === 0) {
       const item = document.createElement("li")
@@ -1534,14 +1548,25 @@ export default class extends Controller {
     if (this.inFlight || this.modeValue !== "sale_entry") return
     if (!this.hasReturnChooserOverlayTarget) return
     const items = Array.from(this.returnChooserListTarget.querySelectorAll("li"))
-    items.forEach((item, index) => {
-      this.decoratePickerItem(item, { selected: index === 0 })
+    const unlinkedProhibited = this.policyFor("unlinked_return") === "prohibited"
+    let firstEnabled = null
+    items.forEach((item) => {
+      const disabled = item.dataset.choice === "unlinked" && unlinkedProhibited
+      const muted = item.querySelector(".muted")
+      if (item.dataset.choice === "unlinked" && muted) {
+        muted.textContent = disabled
+          ? "Not available for your role."
+          : "Requires a reason and may require authorization."
+      }
+      const selected = !disabled && firstEnabled == null
+      if (selected) firstEnabled = item
+      this.decoratePickerItem(item, { selected, disabled })
       item.onclick = () => {
         this.onPickerItemClick(this.returnChooserListTarget, item)
         this.syncReturnChooserContinue()
       }
     })
-    this.showOverlay(this.returnChooserOverlayTarget, this.returnChooserListTarget.querySelector("li.is-selected"))
+    this.showOverlay(this.returnChooserOverlayTarget, firstEnabled || items[0])
     this.syncReturnChooserContinue()
   }
 
@@ -1591,10 +1616,7 @@ export default class extends Controller {
     const choice = selected.dataset.choice
     // Keep chooser on the stack as parent of linked/unlinked.
     if (choice === "unlinked") {
-      if (this.policyFor("unlinked_return") === "prohibited") {
-        this.showFeedback("Return without receipt is not available.")
-        return
-      }
+      if (this.policyFor("unlinked_return") === "prohibited") return
       this.openUnlinkedOverlay()
       return
     }
@@ -1761,6 +1783,9 @@ export default class extends Controller {
     if (this.inFlight) return
     const stage = this.linkedStage || "lookup"
     if (stage === "lines") {
+      // Abandon any in-flight lookup/lines request before reversing stage.
+      this.invalidateLinkedLookup()
+      if (this.hasLinkedQueryLabelTarget) this.linkedQueryLabelTarget.textContent = ""
       if (this.linkedReceiptCacheHtml) {
         this.linkedStage = "receipts"
         if (this.hasLinkedListTarget) this.linkedListTarget.innerHTML = this.linkedReceiptCacheHtml
@@ -1783,6 +1808,8 @@ export default class extends Controller {
       return
     }
     if (stage === "receipts") {
+      this.invalidateLinkedLookup()
+      if (this.hasLinkedQueryLabelTarget) this.linkedQueryLabelTarget.textContent = ""
       this.linkedStage = "lookup"
       this.linkedReceiptCacheHtml = null
       if (this.hasLinkedListTarget) this.linkedListTarget.replaceChildren()

--- a/app/javascript/controllers/register_workspace_controller.js
+++ b/app/javascript/controllers/register_workspace_controller.js
@@ -79,6 +79,7 @@ export default class extends Controller {
     "unlinkedApproverUserInput",
     "unlinkedApproverPasswordInput",
     "unlinkedFeedback",
+    "unlinkedQueryLabel",
     "unlinkedPreview",
     "unlinkedDescription",
     "unlinkedReferenceLabel",
@@ -92,6 +93,7 @@ export default class extends Controller {
     "unlinkedApproverUsername",
     "unlinkedApproverPassword",
     "unlinkedCancel",
+    "unlinkedLookup",
     "unlinkedApply",
     "dontCancel",
     "confirmCancel",
@@ -149,14 +151,22 @@ export default class extends Controller {
     "returnButton",
     "returnChooserOverlay",
     "returnChooserList",
+    "returnChooserCancel",
+    "returnChooserContinue",
     "linkedOverlay",
+    "linkedInstruction",
+    "linkedLookupWrap",
     "linkedLookupField",
     "linkedFeedback",
+    "linkedQueryLabel",
     "linkedList",
+    "linkedDetailsWrap",
     "linkedQuantityField",
     "linkedReasonField",
     "linkedNoteWrap",
     "linkedNoteField",
+    "linkedSecondary",
+    "linkedPrimary",
     "linkedReturnForm",
     "linkedOriginalInput",
     "linkedQuantityInput",
@@ -194,9 +204,14 @@ export default class extends Controller {
     this.searchRequestToken = 0
     this.pickupRequestToken = 0
     this.customerRequestToken = 0
+    this.linkedInvocation = 0
+    this.unlinkedInvocation = 0
     this.searchAbort = null
     this.pickupAbort = null
     this.customerAbort = null
+    this.linkedAbort = null
+    this.unlinkedAbort = null
+    this.linkedStage = "lookup"
     this.bindFunctionKeyCapture()
     if (this.hasControlReasonFieldTarget) {
       this.controlReasonFieldTarget.addEventListener("change", () => {
@@ -206,6 +221,12 @@ export default class extends Controller {
     if (this.hasUnlinkedReasonFieldTarget) {
       this.unlinkedReasonFieldTarget.addEventListener("change", () => {
         this.toggleHidden(this.hasUnlinkedNoteWrapTarget && this.unlinkedNoteWrapTarget, this.unlinkedReasonFieldTarget.value !== "other")
+        this.syncUnlinkedPrimaryEnabled()
+      })
+    }
+    if (this.hasLinkedReasonFieldTarget) {
+      this.linkedReasonFieldTarget.addEventListener("change", () => {
+        this.onLinkedReasonChange()
       })
     }
     if (this.autoCompleteValue) {
@@ -415,7 +436,7 @@ export default class extends Controller {
   onUnlinkedOverlayKeydown(event, key = this.functionKey(event) || event.key) {
     if (key === "Escape") {
       event.preventDefault()
-      this.closeUnlinkedOverlay()
+      this.backFromUnlinkedOverlay()
       return
     }
     if (key === "F9") {
@@ -427,7 +448,7 @@ export default class extends Controller {
     const target = event.target
     if (this.hasUnlinkedIdentifierFieldTarget && target === this.unlinkedIdentifierFieldTarget) {
       event.preventDefault()
-      this.resolveUnlinkedIdentifier()
+      this.lookUpUnlinkedItem()
       return
     }
     if (this.hasUnlinkedApproverUsernameTarget && target === this.unlinkedApproverUsernameTarget) {
@@ -437,7 +458,7 @@ export default class extends Controller {
     }
     if (this.hasUnlinkedApproverPasswordTarget && target === this.unlinkedApproverPasswordTarget) {
       event.preventDefault()
-      if (this.unlinkedApproverPasswordTarget.value.trim() !== "") this.submitUnlinkedReturn()
+      if (this.unlinkedApproverPasswordTarget.value.trim() !== "" && this.unlinkedAddReady()) this.submitUnlinkedReturn()
       return
     }
     if (this.isActionableControl(target)) return
@@ -446,30 +467,11 @@ export default class extends Controller {
   }
 
   advanceOrApplyUnlinkedOverlay() {
-    if (!this.unlinkedPreviewPayload) return
-    if (this.policyFor("unlinked_return") !== "approval_required") {
-      this.submitUnlinkedReturn()
+    if (!this.unlinkedPreviewPayload) {
+      this.lookUpUnlinkedItem()
       return
     }
-    if (this.hasUnlinkedReasonFieldTarget &&
-        this.unlinkedReasonFieldTarget.value === "other" &&
-        this.hasUnlinkedNoteFieldTarget &&
-        this.unlinkedNoteFieldTarget.value.trim() === "" &&
-        this.hasUnlinkedNoteWrapTarget &&
-        !this.unlinkedNoteWrapTarget.hidden) {
-      this.unlinkedNoteFieldTarget.focus()
-      return
-    }
-    if (this.hasUnlinkedApproverUsernameTarget && !this.unlinkedApproverWrapTarget?.hidden) {
-      if (this.unlinkedApproverUsernameTarget.value.trim() === "") {
-        this.unlinkedApproverUsernameTarget.focus()
-        return
-      }
-      if (this.hasUnlinkedApproverPasswordTarget) {
-        this.unlinkedApproverPasswordTarget.focus()
-        return
-      }
-    }
+    if (!this.unlinkedAddReady()) return
     this.submitUnlinkedReturn()
   }
 
@@ -1324,6 +1326,7 @@ export default class extends Controller {
   backFromProductOverlay(event) {
     if (event) event.preventDefault()
     this.closeProductOverlay()
+    this.abortUnlinkedPicker()
   }
 
   openVariantPicker(variants) {
@@ -1385,6 +1388,7 @@ export default class extends Controller {
   backToProducts(event) {
     if (event) event.preventDefault()
     this.closeVariantOverlay()
+    this.abortUnlinkedPicker()
   }
 
   openUnitPicker(units) {
@@ -1450,6 +1454,7 @@ export default class extends Controller {
   backToVariants(event) {
     if (event) event.preventDefault()
     this.closeUnitOverlay()
+    this.abortUnlinkedPicker()
   }
 
   movePickerList(list, delta) {
@@ -1531,12 +1536,24 @@ export default class extends Controller {
     const items = Array.from(this.returnChooserListTarget.querySelectorAll("li"))
     items.forEach((item, index) => {
       this.decoratePickerItem(item, { selected: index === 0 })
+      item.onclick = () => {
+        this.onPickerItemClick(this.returnChooserListTarget, item)
+        this.syncReturnChooserContinue()
+      }
     })
     this.showOverlay(this.returnChooserOverlayTarget, this.returnChooserListTarget.querySelector("li.is-selected"))
+    this.syncReturnChooserContinue()
   }
 
   closeReturnChooser() {
+    this.invalidateLinkedLookup()
+    this.invalidateUnlinkedLookup()
     this.hideOverlay(this.hasReturnChooserOverlayTarget && this.returnChooserOverlayTarget)
+  }
+
+  keepSaleMode(event) {
+    if (event) event.preventDefault()
+    this.closeReturnChooser()
   }
 
   onReturnChooserKeydown(event, key) {
@@ -1548,19 +1565,31 @@ export default class extends Controller {
     if (key === "ArrowUp" || key === "ArrowDown") {
       event.preventDefault()
       this.movePickerList(this.returnChooserListTarget, key === "ArrowUp" ? -1 : 1)
+      this.syncReturnChooserContinue()
       return
     }
     if (key === "Enter") {
       event.preventDefault()
-      this.selectReturnChooser()
+      this.confirmReturnChooser()
     }
   }
 
+  syncReturnChooserContinue() {
+    if (!this.hasReturnChooserContinueTarget) return
+    const selected = this.hasReturnChooserListTarget && this.returnChooserListTarget.querySelector("li.is-selected:not(.is-disabled)")
+    this.returnChooserContinueTarget.disabled = !selected
+  }
+
+  confirmReturnChooser(event) {
+    if (event) event.preventDefault()
+    this.selectReturnChooser()
+  }
+
   selectReturnChooser() {
-    const selected = this.hasReturnChooserListTarget && this.returnChooserListTarget.querySelector("li.is-selected")
+    const selected = this.hasReturnChooserListTarget && this.returnChooserListTarget.querySelector("li.is-selected:not(.is-disabled)")
     if (!selected) return
     const choice = selected.dataset.choice
-    this.closeReturnChooser()
+    // Keep chooser on the stack as parent of linked/unlinked.
     if (choice === "unlinked") {
       if (this.policyFor("unlinked_return") === "prohibited") {
         this.showFeedback("Return without receipt is not available.")
@@ -1575,18 +1604,42 @@ export default class extends Controller {
   openLinkedOverlay() {
     if (this.inFlight || this.modeValue !== "sale_entry") return
     if (!this.hasLinkedOverlayTarget) return
-    this.linkedMode = "lookup"
+    this.invalidateLinkedLookup()
+    this.linkedStage = "lookup"
     if (this.hasLinkedLookupFieldTarget) this.linkedLookupFieldTarget.value = ""
     if (this.hasLinkedFeedbackTarget) this.linkedFeedbackTarget.textContent = ""
+    if (this.hasLinkedQueryLabelTarget) this.linkedQueryLabelTarget.textContent = ""
     if (this.hasLinkedListTarget) this.linkedListTarget.replaceChildren()
     if (this.hasLinkedQuantityFieldTarget) this.linkedQuantityFieldTarget.value = "1"
     this.populateLinkedReasons()
     this.toggleHidden(this.hasLinkedNoteWrapTarget && this.linkedNoteWrapTarget, true)
+    this.syncLinkedStageChrome()
     this.showOverlay(this.linkedOverlayTarget, this.hasLinkedLookupFieldTarget && this.linkedLookupFieldTarget)
   }
 
   closeLinkedOverlay() {
+    this.invalidateLinkedLookup()
     this.hideOverlay(this.hasLinkedOverlayTarget && this.linkedOverlayTarget)
+  }
+
+  invalidateLinkedLookup() {
+    if (this.linkedAbort) this.linkedAbort.abort()
+    this.linkedAbort = null
+    this.linkedInvocation += 1
+  }
+
+  invalidateLinkedResultsOnInput() {
+    this.syncLinkedPrimaryEnabled()
+    const hasResults = this.hasLinkedListTarget && this.linkedListTarget.children.length > 0
+    const searching = this.hasLinkedQueryLabelTarget && this.linkedQueryLabelTarget.textContent
+    if (this.linkedStage === "lookup" && !hasResults && !searching) return
+    this.invalidateLinkedLookup()
+    if (this.hasLinkedListTarget) this.linkedListTarget.replaceChildren()
+    if (this.hasLinkedFeedbackTarget) this.linkedFeedbackTarget.textContent = ""
+    if (this.hasLinkedQueryLabelTarget) this.linkedQueryLabelTarget.textContent = ""
+    this.linkedReceiptCacheHtml = null
+    this.linkedStage = "lookup"
+    this.syncLinkedStageChrome()
   }
 
   populateLinkedReasons() {
@@ -1605,91 +1658,243 @@ export default class extends Controller {
     })
   }
 
+  onLinkedReasonChange() {
+    const reason = this.hasLinkedReasonFieldTarget ? this.linkedReasonFieldTarget.value : ""
+    this.toggleHidden(this.hasLinkedNoteWrapTarget && this.linkedNoteWrapTarget, reason !== "other")
+    this.syncLinkedPrimaryEnabled()
+  }
+
+  syncLinkedStageChrome() {
+    const stage = this.linkedStage || "lookup"
+    if (this.hasLinkedLookupWrapTarget) this.linkedLookupWrapTarget.hidden = stage !== "lookup"
+    if (this.hasLinkedDetailsWrapTarget) this.linkedDetailsWrapTarget.hidden = stage !== "lines"
+    if (this.hasLinkedInstructionTarget) {
+      if (stage === "lookup") this.linkedInstructionTarget.textContent = "Find a receipt, then choose returnable items."
+      else if (stage === "receipts") this.linkedInstructionTarget.textContent = "Select a receipt to view returnable items."
+      else this.linkedInstructionTarget.textContent = "Select a returnable line and enter return details."
+    }
+    if (this.hasLinkedSecondaryTarget) {
+      if (stage === "lookup") this.linkedSecondaryTarget.textContent = "Back to Return Options"
+      else if (stage === "receipts") this.linkedSecondaryTarget.textContent = "Back"
+      else this.linkedSecondaryTarget.textContent = "Back to Receipts"
+    }
+    if (this.hasLinkedPrimaryTarget) {
+      if (stage === "lookup") this.linkedPrimaryTarget.textContent = "Find Receipt"
+      else if (stage === "receipts") this.linkedPrimaryTarget.textContent = "View Returnable Items"
+      else this.linkedPrimaryTarget.textContent = "Add Return"
+    }
+    this.syncLinkedPrimaryEnabled()
+  }
+
+  syncLinkedPrimaryEnabled() {
+    if (this.hasLinkedSecondaryTarget) this.linkedSecondaryTarget.disabled = this.inFlight
+    if (!this.hasLinkedPrimaryTarget) return
+    const stage = this.linkedStage || "lookup"
+    if (stage === "lookup") {
+      const query = this.hasLinkedLookupFieldTarget ? this.linkedLookupFieldTarget.value.trim() : ""
+      this.linkedPrimaryTarget.disabled = !query || this.inFlight
+      return
+    }
+    const selected = this.hasLinkedListTarget && this.linkedListTarget.querySelector("li.is-selected:not(.is-disabled)")
+    if (stage === "receipts") {
+      this.linkedPrimaryTarget.disabled = !selected || this.inFlight
+      return
+    }
+    this.linkedPrimaryTarget.disabled = !this.linkedLineReady(selected) || this.inFlight
+  }
+
+  linkedLineReady(selected) {
+    if (!selected || selected.classList.contains("is-disabled")) return false
+    const reason = this.hasLinkedReasonFieldTarget ? this.linkedReasonFieldTarget.value : ""
+    if (!reason) return false
+    if (reason === "other" && this.hasLinkedNoteFieldTarget && this.linkedNoteFieldTarget.value.trim() === "") return false
+    if (selected.dataset.quantityFixed !== "true") {
+      const qty = this.hasLinkedQuantityFieldTarget ? this.linkedQuantityFieldTarget.value.trim() : ""
+      if (!qty || Number(qty) <= 0) return false
+    }
+    return true
+  }
+
   onLinkedOverlayKeydown(event, key) {
     if (key === "Escape") {
       event.preventDefault()
-      this.closeLinkedOverlay()
+      this.linkedEscapeOrBack()
       return
     }
     if (key === "ArrowUp" || key === "ArrowDown") {
       event.preventDefault()
+      if (this.linkedStage === "lookup") return
       this.movePickerList(this.linkedListTarget, key === "ArrowUp" ? -1 : 1)
+      this.syncLinkedPrimaryEnabled()
       return
     }
     if (key !== "Enter") return
     event.preventDefault()
-    if (event.target === this.linkedLookupFieldTarget) {
+    if (event.target === this.linkedLookupFieldTarget || this.linkedStage === "lookup") {
       this.runLinkedLookup()
+      return
+    }
+    this.linkedPrimaryAction()
+  }
+
+  linkedSecondaryAction(event) {
+    if (event) event.preventDefault()
+    this.linkedEscapeOrBack()
+  }
+
+  linkedPrimaryAction(event) {
+    if (event) event.preventDefault()
+    if (this.inFlight) return
+    const stage = this.linkedStage || "lookup"
+    if (stage === "lookup") {
+      this.runLinkedLookup()
+      return
+    }
+    if (stage === "receipts") {
+      this.selectHighlightedLinked()
       return
     }
     this.selectHighlightedLinked()
   }
 
+  linkedEscapeOrBack() {
+    if (this.inFlight) return
+    const stage = this.linkedStage || "lookup"
+    if (stage === "lines") {
+      if (this.linkedReceiptCacheHtml) {
+        this.linkedStage = "receipts"
+        if (this.hasLinkedListTarget) this.linkedListTarget.innerHTML = this.linkedReceiptCacheHtml
+        this.linkedListTarget.querySelectorAll("li").forEach((item) => {
+          item.addEventListener("click", () => {
+            this.onPickerItemClick(this.linkedListTarget, item)
+            this.syncLinkedPrimaryEnabled()
+          })
+        })
+        this.syncLinkedStageChrome()
+        const first = this.linkedListTarget.querySelector("li.is-selected:not(.is-disabled)") ||
+          this.linkedListTarget.querySelector("li:not(.is-disabled)")
+        this.focusOverlayEntry(first)
+        return
+      }
+      this.linkedStage = "lookup"
+      if (this.hasLinkedListTarget) this.linkedListTarget.replaceChildren()
+      this.syncLinkedStageChrome()
+      this.focusOverlayEntry(this.hasLinkedLookupFieldTarget && this.linkedLookupFieldTarget)
+      return
+    }
+    if (stage === "receipts") {
+      this.linkedStage = "lookup"
+      this.linkedReceiptCacheHtml = null
+      if (this.hasLinkedListTarget) this.linkedListTarget.replaceChildren()
+      if (this.hasLinkedFeedbackTarget) this.linkedFeedbackTarget.textContent = ""
+      this.syncLinkedStageChrome()
+      this.focusOverlayEntry(this.hasLinkedLookupFieldTarget && this.linkedLookupFieldTarget)
+      return
+    }
+    this.closeLinkedOverlay()
+  }
+
   async runLinkedLookup(params = {}) {
     const query = this.hasLinkedLookupFieldTarget ? this.linkedLookupFieldTarget.value.trim() : ""
+    if (!params.transaction_id && !query) return
+    if (this.linkedAbort) this.linkedAbort.abort()
+    this.linkedAbort = new AbortController()
+    const token = ++this.linkedInvocation
+    if (this.hasLinkedQueryLabelTarget) this.linkedQueryLabelTarget.textContent = "Searching…"
     const url = new URL(this.linkedLookupUrlValue, window.location.origin)
     if (params.transaction_id) url.searchParams.set("transaction_id", params.transaction_id)
-    else if (query) url.searchParams.set("q", query)
-    else return
+    else url.searchParams.set("q", query)
     try {
-      const response = await fetch(url, { headers: { Accept: "application/json" }, credentials: "same-origin" })
+      const response = await fetch(url, {
+        headers: { Accept: "application/json" },
+        credentials: "same-origin",
+        signal: this.linkedAbort.signal
+      })
       const payload = await response.json()
+      if (!this.linkedResponseCurrent(token)) return
       this.renderLinkedLookup(payload)
-    } catch (_error) {
+    } catch (error) {
+      if (error?.name === "AbortError") return
+      if (!this.linkedResponseCurrent(token)) return
       if (this.hasLinkedFeedbackTarget) this.linkedFeedbackTarget.textContent = "no returnable original found"
+      if (this.hasLinkedQueryLabelTarget) this.linkedQueryLabelTarget.textContent = ""
+      this.focusOverlayEntry(this.hasLinkedLookupFieldTarget && this.linkedLookupFieldTarget)
     }
+  }
+
+  linkedResponseCurrent(token) {
+    if (!this.element.isConnected) return false
+    if (token !== this.linkedInvocation) return false
+    return this.linkedOverlayOpen()
   }
 
   renderLinkedLookup(payload) {
     if (this.hasLinkedFeedbackTarget) this.linkedFeedbackTarget.textContent = payload.message || ""
+    if (this.hasLinkedQueryLabelTarget) this.linkedQueryLabelTarget.textContent = ""
     if (!this.hasLinkedListTarget) return
     this.linkedListTarget.replaceChildren()
     if (payload.outcome === "receipts") {
-      this.linkedMode = "receipts"
+      this.linkedStage = "receipts"
+      this.linkedReceiptCacheHtml = null
       ;(payload.receipts || []).forEach((receipt, index) => {
         const item = document.createElement("li")
         item.dataset.transactionId = receipt.id
         item.textContent = receipt.transaction_reference
-        this.decoratePickerItem(item, { selected: index === 0 })
+        const selected = index === 0
+        this.decoratePickerItem(item, { selected, disabled: false })
+        item.addEventListener("click", () => {
+          this.onPickerItemClick(this.linkedListTarget, item)
+          this.syncLinkedPrimaryEnabled()
+        })
         this.linkedListTarget.append(item)
       })
+      this.linkedReceiptCacheHtml = this.linkedListTarget.innerHTML
     } else if (payload.outcome === "lines") {
-      this.linkedMode = "lines"
-      ;(payload.lines || []).forEach((line, index) => {
+      this.linkedStage = "lines"
+      let firstEnabled = null
+      ;(payload.lines || []).forEach((line) => {
         const item = document.createElement("li")
         item.dataset.lineId = line.id
         item.dataset.remaining = String(line.remaining)
         item.dataset.quantityFixed = line.quantity_fixed ? "true" : "false"
+        const ineligible = line.remaining <= 0 || Boolean(line.ineligible)
         const unit = line.unit_identifier ? ` · ${line.unit_identifier}` : ""
-        item.textContent = `${line.description} · remaining ${line.remaining}${unit}`
-        this.decoratePickerItem(item, { selected: index === 0 })
+        const reason = line.ineligible_reason ? ` — ${line.ineligible_reason}` : ""
+        item.textContent = `${line.description} · remaining ${line.remaining}${unit}${reason}`
+        const selected = !ineligible && firstEnabled == null
+        if (selected) firstEnabled = item
+        this.decoratePickerItem(item, { selected, disabled: ineligible })
+        item.addEventListener("click", () => {
+          this.onPickerItemClick(this.linkedListTarget, item)
+          this.syncLinkedPrimaryEnabled()
+        })
         this.linkedListTarget.append(item)
       })
+    } else if (this.hasLinkedQueryLabelTarget) {
+      this.linkedQueryLabelTarget.textContent = payload.message || "No matching receipts."
+      this.linkedStage = "lookup"
     }
-    const first = this.linkedListTarget.querySelector("li.is-selected")
-    if (first) first.focus()
+    this.syncLinkedStageChrome()
+    const first = this.linkedListTarget.querySelector("li.is-selected:not(.is-disabled)")
+    if (first) this.focusOverlayEntry(first)
+    else this.focusOverlayEntry(this.hasLinkedLookupFieldTarget && this.linkedLookupFieldTarget)
   }
 
   selectHighlightedLinked() {
-    const selected = this.hasLinkedListTarget && this.linkedListTarget.querySelector("li.is-selected")
+    if (this.inFlight) return
+    const selected = this.hasLinkedListTarget && this.linkedListTarget.querySelector("li.is-selected:not(.is-disabled)")
     if (!selected) return
-    if (this.linkedMode === "receipts") {
+    if (this.linkedStage === "receipts") {
+      this.linkedReceiptCacheHtml = this.linkedListTarget.innerHTML
       this.runLinkedLookup({ transaction_id: selected.dataset.transactionId })
       return
     }
-    if (this.linkedMode !== "lines") return
+    if (this.linkedStage !== "lines") return
+    if (!this.linkedLineReady(selected)) {
+      if (this.hasLinkedFeedbackTarget) this.linkedFeedbackTarget.textContent = "Complete quantity, reason, and note."
+      return
+    }
     const reason = this.hasLinkedReasonFieldTarget ? this.linkedReasonFieldTarget.value : ""
-    if (!reason) {
-      if (this.hasLinkedFeedbackTarget) this.linkedFeedbackTarget.textContent = "Select a return reason."
-      if (this.hasLinkedReasonFieldTarget) this.linkedReasonFieldTarget.focus()
-      return
-    }
-    if (reason === "other" && this.hasLinkedNoteFieldTarget && this.linkedNoteFieldTarget.value.trim() === "") {
-      this.toggleHidden(this.hasLinkedNoteWrapTarget && this.linkedNoteWrapTarget, false)
-      if (this.hasLinkedFeedbackTarget) this.linkedFeedbackTarget.textContent = "reason note is required"
-      this.linkedNoteFieldTarget.focus()
-      return
-    }
     const quantity = selected.dataset.quantityFixed === "true"
       ? "1"
       : (this.hasLinkedQuantityFieldTarget ? this.linkedQuantityFieldTarget.value.trim() : "1")
@@ -1701,6 +1906,7 @@ export default class extends Controller {
     }
     this.clearOverlayError(this.linkedOverlayTarget)
     this.beginFlight()
+    this.syncLinkedPrimaryEnabled()
     this.linkedReturnFormTarget.requestSubmit()
   }
 
@@ -1945,27 +2151,58 @@ export default class extends Controller {
     if (this.policyFor("unlinked_return") === "prohibited") return
     if (!this.hasUnlinkedOverlayTarget) return
 
+    this.invalidateUnlinkedLookup()
     this.resetUnlinkedOverlay()
     this.populateUnlinkedReasons()
     const needsApprover = this.policyFor("unlinked_return") === "approval_required"
     this.toggleHidden(this.hasUnlinkedApproverWrapTarget && this.unlinkedApproverWrapTarget, !needsApprover)
+    this.syncUnlinkedPrimaryEnabled()
     this.showOverlay(this.unlinkedOverlayTarget, this.hasUnlinkedIdentifierFieldTarget && this.unlinkedIdentifierFieldTarget)
   }
 
   closeUnlinkedOverlay() {
+    this.invalidateUnlinkedLookup()
+    this.unlinkedPickerActive = false
     this.hideOverlay(this.hasUnlinkedOverlayTarget && this.unlinkedOverlayTarget)
+  }
+
+  backFromUnlinkedOverlay(event) {
+    if (event) event.preventDefault()
+    if (this.inFlight) return
+    this.closeUnlinkedOverlay()
+  }
+
+  invalidateUnlinkedLookup() {
+    if (this.unlinkedAbort) this.unlinkedAbort.abort()
+    this.unlinkedAbort = null
+    this.unlinkedInvocation += 1
+  }
+
+  invalidateUnlinkedResultsOnInput() {
+    this.syncUnlinkedPrimaryEnabled()
+    if (!this.unlinkedPreviewPayload && !(this.hasUnlinkedQueryLabelTarget && this.unlinkedQueryLabelTarget.textContent)) return
+    this.invalidateUnlinkedLookup()
+    this.clearUnlinkedPreviewState()
+    this.unlinkedSelection = null
+    this.unlinkedPickerActive = false
+    if (this.hasUnlinkedFeedbackTarget) this.unlinkedFeedbackTarget.textContent = ""
+    if (this.hasUnlinkedQueryLabelTarget) this.unlinkedQueryLabelTarget.textContent = ""
+    this.syncUnlinkedPrimaryEnabled()
   }
 
   resetUnlinkedOverlay() {
     this.unlinkedPreviewPayload = null
+    this.unlinkedSelection = null
+    this.unlinkedPickerActive = false
     if (this.hasUnlinkedFeedbackTarget) this.unlinkedFeedbackTarget.textContent = ""
+    if (this.hasUnlinkedQueryLabelTarget) this.unlinkedQueryLabelTarget.textContent = ""
     if (this.hasUnlinkedIdentifierFieldTarget) this.unlinkedIdentifierFieldTarget.value = ""
     this.toggleHidden(this.hasUnlinkedPreviewTarget && this.unlinkedPreviewTarget, true)
-    if (this.hasUnlinkedApplyTarget) this.unlinkedApplyTarget.hidden = true
     if (this.hasUnlinkedNoteFieldTarget) this.unlinkedNoteFieldTarget.value = ""
     this.toggleHidden(this.hasUnlinkedNoteWrapTarget && this.unlinkedNoteWrapTarget, true)
     if (this.hasUnlinkedApproverUsernameTarget) this.unlinkedApproverUsernameTarget.value = ""
     if (this.hasUnlinkedApproverPasswordTarget) this.unlinkedApproverPasswordTarget.value = ""
+    this.syncUnlinkedPrimaryEnabled()
   }
 
   populateUnlinkedReasons() {
@@ -1982,6 +2219,17 @@ export default class extends Controller {
       option.textContent = entry.name
       this.unlinkedReasonFieldTarget.appendChild(option)
     })
+  }
+
+  onUnlinkedReasonChange() {
+    const reason = this.hasUnlinkedReasonFieldTarget ? this.unlinkedReasonFieldTarget.value : ""
+    this.toggleHidden(this.hasUnlinkedNoteWrapTarget && this.unlinkedNoteWrapTarget, reason !== "other")
+    this.syncUnlinkedPrimaryEnabled()
+  }
+
+  lookUpUnlinkedItem(event) {
+    if (event) event.preventDefault()
+    this.resolveUnlinkedIdentifier()
   }
 
   async resolveUnlinkedIdentifier() {
@@ -2001,6 +2249,10 @@ export default class extends Controller {
     if (params.product_id) body.set("product_id", params.product_id)
     if (params.product_variant_id) body.set("product_variant_id", params.product_variant_id)
     if (params.inventory_unit_id) body.set("inventory_unit_id", params.inventory_unit_id)
+    if (this.unlinkedAbort) this.unlinkedAbort.abort()
+    this.unlinkedAbort = new AbortController()
+    const invocation = ++this.unlinkedInvocation
+    if (this.hasUnlinkedQueryLabelTarget) this.unlinkedQueryLabelTarget.textContent = "Looking up…"
     try {
       const response = await fetch(this.unlinkedLookupUrlValue, {
         method: "POST",
@@ -2009,18 +2261,31 @@ export default class extends Controller {
           "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
           "X-CSRF-Token": token || ""
         },
-        body: body.toString()
+        body: body.toString(),
+        signal: this.unlinkedAbort.signal
       })
       const payload = await response.json()
+      if (!this.unlinkedResponseCurrent(invocation)) return
       this.handleUnlinkedResolution(payload, response.ok)
-    } catch (_error) {
+    } catch (error) {
+      if (error?.name === "AbortError") return
+      if (!this.unlinkedResponseCurrent(invocation)) return
       this.showUnlinkedFeedback("merchandise not found")
       this.clearUnlinkedPreviewState()
       this.unlinkedSelection = null
     }
   }
 
+  unlinkedResponseCurrent(invocation) {
+    if (!this.element.isConnected) return false
+    if (invocation !== this.unlinkedInvocation) return false
+    if (!this.unlinkedOverlayOpen()) return false
+    // Must remain in stack ancestry (chooser may be parent).
+    return this.overlayStack.some((entry) => entry.overlay === this.unlinkedOverlayTarget && !entry.overlay.hidden)
+  }
+
   handleUnlinkedResolution(payload, ok) {
+    if (this.hasUnlinkedQueryLabelTarget) this.unlinkedQueryLabelTarget.textContent = ""
     const outcome = payload.outcome || (ok ? "resolved" : "unavailable")
     switch (outcome) {
       case "resolved":
@@ -2049,11 +2314,12 @@ export default class extends Controller {
   clearUnlinkedPreviewState() {
     this.unlinkedPreviewPayload = null
     this.toggleHidden(this.hasUnlinkedPreviewTarget && this.unlinkedPreviewTarget, true)
-    if (this.hasUnlinkedApplyTarget) this.unlinkedApplyTarget.hidden = true
+    this.syncUnlinkedPrimaryEnabled()
   }
 
   applyUnlinkedPreview(payload) {
     this.unlinkedPreviewPayload = payload
+    this.unlinkedPickerActive = false
     if (this.hasUnlinkedFeedbackTarget) this.unlinkedFeedbackTarget.textContent = ""
     this.toggleHidden(this.hasUnlinkedPreviewTarget && this.unlinkedPreviewTarget, false)
     if (this.hasUnlinkedDescriptionTarget) this.unlinkedDescriptionTarget.textContent = payload.description || ""
@@ -2069,20 +2335,52 @@ export default class extends Controller {
       this.unlinkedQuantityFieldTarget.value = "1"
       this.unlinkedQuantityFieldTarget.disabled = fixed
     }
-    if (this.hasUnlinkedApplyTarget) this.unlinkedApplyTarget.hidden = false
+    this.syncUnlinkedPrimaryEnabled()
 
     const focusTarget = (this.hasUnlinkedQuantityFieldTarget && !fixed)
       ? this.unlinkedQuantityFieldTarget
       : (this.hasUnlinkedReasonFieldTarget && this.unlinkedReasonFieldTarget)
-    this.showOverlay(this.unlinkedOverlayTarget, focusTarget)
+    // Restore unlinked as top if nested pickers closed.
+    if (this.topOverlay() !== this.unlinkedOverlayTarget) {
+      this.showOverlay(this.unlinkedOverlayTarget, focusTarget)
+    } else {
+      this.focusOverlayEntry(focusTarget)
+    }
   }
 
-  // Abandon a stacked merchandise picker opened from Return without receipt.
-  // Closes only the picker; keeps the unlinked overlay open and restores focus.
+  unlinkedAddReady() {
+    if (!this.unlinkedPreviewPayload || this.inFlight) return false
+    const reason = this.hasUnlinkedReasonFieldTarget ? this.unlinkedReasonFieldTarget.value : ""
+    if (!reason) return false
+    if (reason === "other" && this.hasUnlinkedNoteFieldTarget && this.unlinkedNoteFieldTarget.value.trim() === "") return false
+    const price = this.hasUnlinkedPriceFieldTarget ? this.unlinkedPriceFieldTarget.value.trim() : ""
+    if (price === "") return false
+    if (!this.unlinkedPreviewPayload.quantity_fixed) {
+      const qty = this.hasUnlinkedQuantityFieldTarget ? this.unlinkedQuantityFieldTarget.value.trim() : ""
+      if (!qty || Number(qty) <= 0) return false
+    }
+    if (this.policyFor("unlinked_return") === "approval_required") {
+      const user = this.hasUnlinkedApproverUsernameTarget ? this.unlinkedApproverUsernameTarget.value.trim() : ""
+      const pass = this.hasUnlinkedApproverPasswordTarget ? this.unlinkedApproverPasswordTarget.value : ""
+      if (!user || !pass) return false
+    }
+    return true
+  }
+
+  syncUnlinkedPrimaryEnabled() {
+    if (this.hasUnlinkedCancelTarget) this.unlinkedCancelTarget.disabled = this.inFlight
+    if (this.hasUnlinkedLookupTarget) {
+      const query = this.hasUnlinkedIdentifierFieldTarget ? this.unlinkedIdentifierFieldTarget.value.trim() : ""
+      this.unlinkedLookupTarget.disabled = this.inFlight || !query
+    }
+    if (!this.hasUnlinkedApplyTarget) return
+    this.unlinkedApplyTarget.disabled = !this.unlinkedAddReady()
+  }
+
+  // Abandon a stacked merchandise picker opened from unlinked return.
   abortUnlinkedPicker() {
     if (!this.unlinkedPickerActive) return
     this.unlinkedPickerActive = false
-    this.unlinkedSelection = null
     if (this.unlinkedOverlayOpen() && this.hasUnlinkedIdentifierFieldTarget) {
       this.unlinkedIdentifierFieldTarget.focus()
     }
@@ -2092,9 +2390,10 @@ export default class extends Controller {
     if (this.hasUnlinkedFeedbackTarget) this.unlinkedFeedbackTarget.textContent = message
   }
 
-  submitUnlinkedReturn() {
+  submitUnlinkedReturn(event) {
+    if (event) event.preventDefault()
     if (this.inFlight || !this.hasUnlinkedFormTarget) return
-    if (!this.unlinkedPreviewPayload) return
+    if (!this.unlinkedAddReady()) return
     if (this.hasUnlinkedIdentifierInputTarget) {
       this.unlinkedIdentifierInputTarget.value = this.hasUnlinkedIdentifierFieldTarget
         ? this.unlinkedIdentifierFieldTarget.value.trim()
@@ -2147,6 +2446,7 @@ export default class extends Controller {
     }
     this.clearOverlayError(this.unlinkedOverlayTarget)
     this.beginFlight()
+    this.syncUnlinkedPrimaryEnabled()
     this.unlinkedFormTarget.requestSubmit()
   }
 
@@ -2313,6 +2613,7 @@ export default class extends Controller {
     })
     overlay.hidden = false
     overlay.setAttribute("aria-modal", "true")
+    overlay.style.zIndex = String(1000 + (this.overlayStack.length * 10))
     if (parent && parent !== overlay) {
       parent.inert = true
       parent.setAttribute("aria-modal", "false")
@@ -2343,6 +2644,7 @@ export default class extends Controller {
     if (!overlay) return
     overlay.hidden = true
     overlay.inert = false
+    overlay.style.zIndex = ""
     overlay.setAttribute("aria-modal", "true")
     this.clearOverlayError(overlay)
   }
@@ -2392,12 +2694,18 @@ export default class extends Controller {
     if (this.searchAbort) this.searchAbort.abort()
     if (this.pickupAbort) this.pickupAbort.abort()
     if (this.customerAbort) this.customerAbort.abort()
+    if (this.linkedAbort) this.linkedAbort.abort()
+    if (this.unlinkedAbort) this.unlinkedAbort.abort()
     this.searchAbort = null
     this.pickupAbort = null
     this.customerAbort = null
+    this.linkedAbort = null
+    this.unlinkedAbort = null
     this.searchRequestToken += 1
     this.pickupRequestToken += 1
     this.customerRequestToken += 1
+    this.linkedInvocation += 1
+    this.unlinkedInvocation += 1
   }
 
   clearOverlayError(overlay) {
@@ -2444,6 +2752,9 @@ export default class extends Controller {
     this.enableReadyActions()
     if (this.hasControlApproverPasswordInputTarget) this.controlApproverPasswordInputTarget.value = ""
     if (this.hasUnlinkedApproverPasswordInputTarget) this.unlinkedApproverPasswordInputTarget.value = ""
+    if (this.hasUnlinkedApproverPasswordTarget) this.unlinkedApproverPasswordTarget.value = ""
+    this.syncUnlinkedPrimaryEnabled()
+    this.syncLinkedPrimaryEnabled()
     const overlay = this.activeOverlayElement()
     if (!overlay) return
     overlay.querySelectorAll("input[type='password']").forEach((field) => {

--- a/app/views/pos/workspaces/_overlays.html.erb
+++ b/app/views/pos/workspaces/_overlays.html.erb
@@ -80,11 +80,16 @@
        aria-modal="true"
        aria-labelledby="pos-unlinked-title">
     <div class="pos-overlay__panel pos-overlay__panel--control">
-      <h2 id="pos-unlinked-title">Return without receipt</h2>
+      <h2 id="pos-unlinked-title">Unlinked return</h2>
+      <p>Scan or look up merchandise to return without a receipt.</p>
       <p id="pos-unlinked-feedback" class="pos-overlay__error" data-register-workspace-target="unlinkedFeedback" data-overlay-error role="alert"></p>
+      <p class="muted" data-register-workspace-target="unlinkedQueryLabel" role="status" aria-live="polite"></p>
 
-      <label for="pos-unlinked-identifier">Scan or identifier</label>
-      <input id="pos-unlinked-identifier" class="pos-command__field" data-register-workspace-target="unlinkedIdentifierField" autocomplete="off">
+      <label for="pos-unlinked-identifier">Scan or enter item</label>
+      <input id="pos-unlinked-identifier" class="pos-command__field"
+             data-register-workspace-target="unlinkedIdentifierField"
+             data-action="input->register-workspace#invalidateUnlinkedResultsOnInput"
+             autocomplete="off">
 
       <div id="pos_unlinked_preview" data-register-workspace-target="unlinkedPreview" hidden>
         <p data-register-workspace-target="unlinkedDescription"></p>
@@ -92,32 +97,44 @@
 
         <div data-register-workspace-target="unlinkedQuantityWrap">
           <label for="pos-unlinked-quantity">Quantity</label>
-          <input id="pos-unlinked-quantity" class="pos-command__field" data-register-workspace-target="unlinkedQuantityField" inputmode="numeric" autocomplete="off" value="1">
+          <input id="pos-unlinked-quantity" class="pos-command__field" data-register-workspace-target="unlinkedQuantityField"
+                 data-action="input->register-workspace#syncUnlinkedPrimaryEnabled change->register-workspace#syncUnlinkedPrimaryEnabled"
+                 inputmode="numeric" autocomplete="off" value="1">
         </div>
 
         <label for="pos-unlinked-reason">Return reason</label>
-        <select id="pos-unlinked-reason" class="pos-command__field" data-register-workspace-target="unlinkedReasonField"></select>
+        <select id="pos-unlinked-reason" class="pos-command__field" data-register-workspace-target="unlinkedReasonField"
+                data-action="change->register-workspace#onUnlinkedReasonChange"></select>
 
         <div data-register-workspace-target="unlinkedNoteWrap" hidden>
           <label for="pos-unlinked-note">Note</label>
-          <input id="pos-unlinked-note" class="pos-command__field" data-register-workspace-target="unlinkedNoteField" maxlength="200" autocomplete="off">
+          <input id="pos-unlinked-note" class="pos-command__field" data-register-workspace-target="unlinkedNoteField"
+                 data-action="input->register-workspace#syncUnlinkedPrimaryEnabled"
+                 maxlength="200" autocomplete="off">
         </div>
 
         <label for="pos-unlinked-price">Return unit price</label>
-        <input id="pos-unlinked-price" class="pos-command__field" data-register-workspace-target="unlinkedPriceField" inputmode="decimal" autocomplete="off">
+        <input id="pos-unlinked-price" class="pos-command__field" data-register-workspace-target="unlinkedPriceField"
+               data-action="input->register-workspace#syncUnlinkedPrimaryEnabled"
+               inputmode="decimal" autocomplete="off">
 
         <div data-register-workspace-target="unlinkedApproverWrap" hidden>
           <label for="pos-unlinked-approver-username">Approver username</label>
-          <input id="pos-unlinked-approver-username" class="pos-command__field" data-register-workspace-target="unlinkedApproverUsername" autocomplete="off">
+          <input id="pos-unlinked-approver-username" class="pos-command__field" data-register-workspace-target="unlinkedApproverUsername"
+                 data-action="input->register-workspace#syncUnlinkedPrimaryEnabled" autocomplete="off">
           <label for="pos-unlinked-approver-password">Approver password</label>
-          <input id="pos-unlinked-approver-password" class="pos-command__field" type="password" data-register-workspace-target="unlinkedApproverPassword" autocomplete="off">
+          <input id="pos-unlinked-approver-password" class="pos-command__field" type="password"
+                 data-register-workspace-target="unlinkedApproverPassword"
+                 data-action="input->register-workspace#syncUnlinkedPrimaryEnabled" autocomplete="off">
         </div>
       </div>
 
       <div class="pos-overlay__actions">
-        <%= action_button "Don't return (Esc)", style: :outline, intent: :neutral, size: :standard,
-              data: { action: "register-workspace#closeUnlinkedOverlay", register_workspace_target: "unlinkedCancel" } %>
-        <%= action_button "Add return", style: :solid, intent: :brand, size: :standard, hidden: true,
+        <%= action_button "Back to Return Options", style: :outline, intent: :neutral, size: :standard,
+              data: { action: "register-workspace#backFromUnlinkedOverlay", register_workspace_target: "unlinkedCancel" } %>
+        <%= action_button "Look Up Item", style: :outline, intent: :neutral, size: :standard,
+              data: { action: "register-workspace#lookUpUnlinkedItem", register_workspace_target: "unlinkedLookup" } %>
+        <%= action_button "Add Unlinked Return", style: :solid, intent: :brand, size: :standard, disabled: true,
               data: { action: "register-workspace#submitUnlinkedReturn", register_workspace_target: "unlinkedApply" } %>
       </div>
     </div>
@@ -316,14 +333,24 @@
        aria-modal="true"
        aria-labelledby="pos-return-chooser-title">
     <div class="pos-overlay__panel">
-      <h2 id="pos-return-chooser-title">RETURN</h2>
+      <h2 id="pos-return-chooser-title">Start return</h2>
+      <p>Choose how to find the original purchase.</p>
       <ul class="pos-picker" role="listbox" aria-labelledby="pos-return-chooser-title" data-register-workspace-target="returnChooserList">
-        <li data-choice="linked" class="is-selected" role="option" tabindex="0" aria-selected="true">Linked return</li>
-        <li data-choice="unlinked" role="option" tabindex="-1" aria-selected="false">Unlinked return</li>
+        <li data-choice="linked" class="is-selected" role="option" tabindex="0" aria-selected="true">
+          Find Original Receipt
+          <span class="muted">Best when the customer's purchase can be identified.</span>
+        </li>
+        <li data-choice="unlinked" role="option" tabindex="-1" aria-selected="false">
+          Unlinked Return
+          <span class="muted">Requires a reason and may require authorization.</span>
+        </li>
       </ul>
-      <p class="muted">Enter chooses. Esc cancels.</p>
-      <%= action_button "Cancel (Esc)", style: :outline, intent: :neutral, size: :standard,
-            data: { action: "register-workspace#closeReturnChooser" } %>
+      <div class="pos-overlay__actions">
+        <%= action_button "Keep Sale Mode", style: :outline, intent: :neutral, size: :standard,
+              data: { action: "register-workspace#keepSaleMode", register_workspace_target: "returnChooserCancel" } %>
+        <%= action_button "Continue", style: :solid, intent: :brand, size: :standard,
+              data: { action: "register-workspace#confirmReturnChooser", register_workspace_target: "returnChooserContinue" } %>
+      </div>
     </div>
   </div>
 
@@ -335,27 +362,39 @@
        aria-modal="true"
        aria-labelledby="pos-linked-title">
     <div class="pos-overlay__panel">
-      <h2 id="pos-linked-title">Linked return</h2>
-      <label class="field">
+      <h2 id="pos-linked-title">Return from original receipt</h2>
+      <p data-register-workspace-target="linkedInstruction">Find a receipt, then choose returnable items.</p>
+      <label class="field" data-register-workspace-target="linkedLookupWrap">
         <span>Receipt, merchandise, or unit</span>
-        <input type="text" autocomplete="off" data-register-workspace-target="linkedLookupField">
+        <input type="text" autocomplete="off" data-register-workspace-target="linkedLookupField"
+               data-action="input->register-workspace#invalidateLinkedResultsOnInput">
       </label>
       <p id="pos-linked-feedback" class="pos-overlay__error" data-register-workspace-target="linkedFeedback" data-overlay-error role="alert"></p>
+      <p class="muted" data-register-workspace-target="linkedQueryLabel" role="status" aria-live="polite"></p>
       <ul class="pos-picker" role="listbox" aria-labelledby="pos-linked-title" data-register-workspace-target="linkedList"></ul>
-      <label class="field">
-        <span>Qty</span>
-        <input type="text" inputmode="numeric" autocomplete="off" value="1" data-register-workspace-target="linkedQuantityField">
-      </label>
-      <label class="field">
-        <span>Reason</span>
-        <select data-register-workspace-target="linkedReasonField"></select>
-      </label>
-      <label class="field" hidden data-register-workspace-target="linkedNoteWrap">
-        <span>Note</span>
-        <input type="text" maxlength="200" autocomplete="off" data-register-workspace-target="linkedNoteField">
-      </label>
-      <p class="muted">Enter in the lookup field searches. Enter on a highlighted line adds it. Esc cancels.</p>
-      <%= action_button "Cancel (Esc)", style: :outline, intent: :neutral, size: :standard,
-            data: { action: "register-workspace#closeLinkedOverlay" } %>
+      <div data-register-workspace-target="linkedDetailsWrap" hidden>
+        <label class="field">
+          <span>Qty</span>
+          <input type="text" inputmode="numeric" autocomplete="off" value="1"
+                 data-register-workspace-target="linkedQuantityField"
+                 data-action="input->register-workspace#syncLinkedPrimaryEnabled">
+        </label>
+        <label class="field">
+          <span>Reason</span>
+          <select data-register-workspace-target="linkedReasonField"
+                  data-action="change->register-workspace#onLinkedReasonChange"></select>
+        </label>
+        <label class="field" hidden data-register-workspace-target="linkedNoteWrap">
+          <span>Note</span>
+          <input type="text" maxlength="200" autocomplete="off" data-register-workspace-target="linkedNoteField"
+                 data-action="input->register-workspace#syncLinkedPrimaryEnabled">
+        </label>
+      </div>
+      <div class="pos-overlay__actions">
+        <%= action_button "Back to Return Options", style: :outline, intent: :neutral, size: :standard,
+              data: { action: "register-workspace#linkedSecondaryAction", register_workspace_target: "linkedSecondary" } %>
+        <%= action_button "Find Receipt", style: :solid, intent: :brand, size: :standard,
+              data: { action: "register-workspace#linkedPrimaryAction", register_workspace_target: "linkedPrimary" } %>
+      </div>
     </div>
   </div>

--- a/app/views/pos/workspaces/_overlays.html.erb
+++ b/app/views/pos/workspaces/_overlays.html.erb
@@ -274,7 +274,7 @@
       <ul class="pos-picker" role="listbox" aria-labelledby="pos-variant-title" data-register-workspace-target="variantList"></ul>
       <div class="pos-overlay__actions">
         <%= action_button "Back to Products", style: :outline, intent: :neutral, size: :standard,
-              data: { action: "register-workspace#backToProducts" } %>
+              data: { action: "register-workspace#backToProducts", register_workspace_target: "variantBack" } %>
         <%= action_button "Choose Variant", style: :solid, intent: :brand, size: :standard,
               data: { action: "register-workspace#confirmVariantSelection" } %>
       </div>
@@ -294,7 +294,7 @@
       <ul class="pos-picker" role="listbox" aria-labelledby="pos-unit-title" data-register-workspace-target="unitList"></ul>
       <div class="pos-overlay__actions">
         <%= action_button "Back to Variants", style: :outline, intent: :neutral, size: :standard,
-              data: { action: "register-workspace#backToVariants" } %>
+              data: { action: "register-workspace#backToVariants", register_workspace_target: "unitBack" } %>
         <%= action_button "Add to Sale", style: :solid, intent: :brand, size: :standard,
               data: { action: "register-workspace#confirmUnitSelection" } %>
       </div>

--- a/docs/planning/register-workspace-consolidation/README.md
+++ b/docs/planning/register-workspace-consolidation/README.md
@@ -21,6 +21,8 @@ This program **replaces** the current POS presentation. It does not run a parall
 | [slice4-manual-verification.md](slice4-manual-verification.md) | Slice 4 workstation evidence |
 | [slice5a-lookup-overlays-plan.md](slice5a-lookup-overlays-plan.md) | Locked Slice 5A overlay lifecycle / lookup contracts |
 | [slice5a-manual-verification.md](slice5a-manual-verification.md) | Slice 5A workstation evidence |
+| [slice5b-return-overlays-plan.md](slice5b-return-overlays-plan.md) | Locked Slice 5B return overlay contracts |
+| [slice5b-manual-verification.md](slice5b-manual-verification.md) | Slice 5B workstation evidence |
 
 UX adoption: follow [ux-adoption-template.md](../ux-design-system/ux-adoption-template.md) in the slice that materially changes a screen. Printed receipts stay locked unless a slice explicitly owns print.
 

--- a/docs/planning/register-workspace-consolidation/implementation-plan.md
+++ b/docs/planning/register-workspace-consolidation/implementation-plan.md
@@ -1,6 +1,6 @@
 # Register workspace consolidation — Implementation plan
 
-Status: **Slice 5A merged** on `register-workspace-consolidation` ([#86](https://github.com/BankEncore/ShelfSense-v1/issues/86) / PR [#99](https://github.com/BankEncore/ShelfSense-v1/pull/99)). Next: Slice 5B return overlays.
+Status: **Slice 5B in implementation** on `87-return-overlays` (PR targeting `register-workspace-consolidation`). Slice 5A is on the integration branch.
 
 Authority: [plan.md](plan.md), [routing-and-authority.md](routing-and-authority.md).
 
@@ -25,7 +25,7 @@ This program uses a long-lived integration branch because an incomplete Register
 | 3 F10 and navigation | Merged to integration ([#84](https://github.com/BankEncore/ShelfSense-v1/issues/84) / PR #97) | [#84](https://github.com/BankEncore/ShelfSense-v1/issues/84) |
 | 4 Transaction composition | Merged to integration ([#85](https://github.com/BankEncore/ShelfSense-v1/issues/85) / PR #98) | [#85](https://github.com/BankEncore/ShelfSense-v1/issues/85) |
 | 5A Lookup overlays | Merged to integration ([#86](https://github.com/BankEncore/ShelfSense-v1/issues/86) / PR [#99](https://github.com/BankEncore/ShelfSense-v1/pull/99)) | [#86](https://github.com/BankEncore/ShelfSense-v1/issues/86) |
-| 5B Return overlays | Not started | [#87](https://github.com/BankEncore/ShelfSense-v1/issues/87) |
+| 5B Return overlays | This PR ([slice5b-return-overlays-plan.md](slice5b-return-overlays-plan.md)) | [#87](https://github.com/BankEncore/ShelfSense-v1/issues/87) |
 | 5C Controlled-action overlays | Not started | [#88](https://github.com/BankEncore/ShelfSense-v1/issues/88) |
 | 5D Tender/issuance overlays | Not started | [#89](https://github.com/BankEncore/ShelfSense-v1/issues/89) |
 | 6A Customer-service surfaces | Not started | [#90](https://github.com/BankEncore/ShelfSense-v1/issues/90) |

--- a/docs/planning/register-workspace-consolidation/slice5b-manual-verification.md
+++ b/docs/planning/register-workspace-consolidation/slice5b-manual-verification.md
@@ -1,0 +1,24 @@
+# Slice 5B — Manual verification evidence
+
+Status: required for Slice 5B closeout alongside automated system coverage.
+
+Workstation assumptions: Chrome (or Chromium) on a Register-class display; Keyboard Lock optional.
+
+## Checklist
+
+| # | Case | Pass criteria | Result | Notes |
+|---|---|---|---|---|
+| 1 | Return chooser open (`−`) | Continue focused path; background inert | | |
+| 2 | Linked Escape ladder | lines → receipts → lookup → chooser → command | | |
+| 3 | Unlinked Escape to chooser | Not command; chooser selection restored | | |
+| 4 | Pointer Add Return / Add Unlinked Return | Completable without keyboard | | |
+| 5 | Failed unlinked commit | Overlay stays; fields preserved; password cleared | | |
+| 6 | Successful return add | No return overlay; line selected | | |
+| 7 | F10 while return overlay open | Menu does not open | | |
+
+## Sign-off
+
+- Date:
+- Browser / OS:
+- Verified by:
+- Follow-ups (if any):

--- a/docs/planning/register-workspace-consolidation/slice5b-return-overlays-plan.md
+++ b/docs/planning/register-workspace-consolidation/slice5b-return-overlays-plan.md
@@ -1,0 +1,154 @@
+# Slice 5B — Return overlays
+
+Status: **Implementation-ready.** Slice 5A is on `register-workspace-consolidation` ([#86](https://github.com/BankEncore/ShelfSense-v1/issues/86) / PR [#99](https://github.com/BankEncore/ShelfSense-v1/pull/99)).
+
+Authority: [plan.md](plan.md), [routing-and-authority.md](routing-and-authority.md), [textual-wireframes.md](textual-wireframes.md) O6–O8 / Part IV, [user-stories.md](user-stories.md), [slice5a-lookup-overlays-plan.md](slice5a-lookup-overlays-plan.md) (lifecycle), Phase 6.7 launch key (`−`) until 7C.
+
+Issue: [#87](https://github.com/BankEncore/ShelfSense-v1/issues/87). Branch: `87-return-overlays`. PR target: `register-workspace-consolidation`.
+
+## Outcome
+
+Migrate **O6–O8 return overlays** onto the shared 5A blocking-overlay lifecycle: stack, inertness, focus restore, async invalidation, local status, and keyboard/pointer parity. Introduce an explicit linked stage machine with stage-aware Escape/Back, commit-open-during-submit failure contracts, full resolution-chain invocation generations, and eligibility/enablement parity. Keep 5C confirmation / O11 and 5D tender content out of scope.
+
+## Scope
+
+| In | Out |
+|---|---|
+| O6 chooser, O7 linked, O8 unlinked **content** on 5A lifecycle | 5C controlled-action / O9–O11 confirmation redesign |
+| Chooser as **parent** of linked/unlinked (stack restore) | Nesting a new O11 approval overlay (keep inline approver fields) |
+| Explicit `linkedStage`; stage-aware Escape/Back | 5D tender/issuance content |
+| Pointer select + explicit confirm; eligibility/enablement | New return domain services / endpoints |
+| Full async generation for linked + unlinked resolve chains | Slice 7 key remaps |
+| Commit open-during-submit + failure preserve / password clear | History “Return items” chrome unless it already uses these overlays |
+| Delete obsolete return-only targets/handlers in the same PR | Relocating overlays to a shell-level host |
+
+Launch key remains Phase 6.7 (`−` / Return (−)). Endpoints stay.
+
+## Locked contracts
+
+### 1. Overlay stack transitions
+
+```text
+command → chooser → Escape → command
+chooser → linked → Escape from lookup / Back to Return Options → chooser
+chooser → unlinked → Escape / Back to Return Options → chooser
+unlinked → product/variant/unit → Escape/Back → unlinked
+```
+
+Child close never skips an open parent. Closing chooser invalidates/closes linked/unlinked children and their resolve generations.
+
+Reuse 5A APIs: `showOverlay` / `hideOverlay` / `topOverlay` / `restoreOverlayFocus`. Do not replace-open linked/unlinked after closing the chooser.
+
+### 2. Linked stage machine (explicit)
+
+```js
+this.linkedStage = "lookup" // lookup | receipts | lines
+```
+
+Do **not** infer stage from list `data-*` contents.
+
+| Stage | Primary | Secondary / Back |
+|---|---|---|
+| `lookup` | Find Receipt | Back to Return Options (→ chooser) |
+| `receipts` | View Returnable Items | Back to lookup |
+| `lines` | Add Return | Back to Receipts |
+
+**Add Return** is shown/enabled only when a returnable line is selected and required return details are ready.
+
+**Escape ladder** (same function as Back where they mean the same transition):
+
+```text
+linked lines    → Escape → receipt results
+receipt results → Escape → receipt lookup
+receipt lookup  → Escape → chooser
+chooser         → Escape → command
+```
+
+Stage-aware Escape operates *inside* the linked overlay node. Overlay-stack LIFO still applies to real children (chooser → linked/unlinked → product/variant/unit).
+
+### 3. Visual frames and control naming
+
+| Surface | Title | Secondary | Primary |
+|---|---|---|---|
+| Chooser | Start return | Keep Sale Mode / Close Return | Continue |
+| Linked `lookup` | Return from original receipt | Back to Return Options | Find Receipt |
+| Linked `receipts` | Return from original receipt | Back (to lookup) | View Returnable Items |
+| Linked `lines` | Return from original receipt | Back to Receipts | Add Return |
+| Unlinked | Unlinked return | Keep Transaction Unchanged / Back to Return Options | Look Up Item → then Add Unlinked Return when ready |
+
+Chooser options use explanatory copy (Find Original Receipt / Unlinked Return). **Keep Transaction Unchanged** is for final entry forms; intermediate stages use destination-explicit Back labels.
+
+### 4. Commit and failure lifecycle
+
+Return overlays **remain open** during submission:
+
+- Do not close or pop the child before `requestSubmit()`
+- Disable mutation controls while in flight; prevent double submission
+- Successful Turbo workspace replacement clears the entire stack naturally
+- Rejected validation restores the **same child and stage**
+- Preserve identifier, receipt/line selection, quantity, reason, note, and price
+- Always clear approver passwords after a failed attempt
+
+### 5. Async invalidation — full resolution chains
+
+One **invocation generation** per root return child:
+
+```text
+unlinked invocation
+  ├── identifier resolve
+  ├── product choice resolve
+  ├── variant choice resolve
+  └── unit choice resolve
+
+linked invocation
+  ├── receipt lookup
+  └── receipt → lines request
+```
+
+A response may apply only when: controller connected; invocation generation matches; overlay remains in active stack ancestry; response matches current identifier/selection.
+
+Closing unlinked (or its chooser parent) invalidates the entire unlinked chain. Same for linked. Query changes immediately invalidate prior results and selections (and for linked: clear receipt, lines stage, and entered line details).
+
+### 6. Eligibility and action enablement
+
+- Navigation skips disabled/ineligible rows
+- Pointer clicks cannot select disabled rows
+- Primary buttons stay **disabled** until an eligible selection / ready state exists
+- Ineligible reasons remain readable but cannot become the active option
+- **Add Unlinked Return** enabled only when: merchandise resolved, valid quantity/price, reason present, required note present, and required approval credentials present
+
+### 7. Focus / inert / F10
+
+Reuse 5A stack APIs. Workspace background inert with root return overlay; parent inert while child open; shell header/status inert; F10 suppressed. Nested picker Back calls `abortUnlinkedPicker` (same as Esc). O11 nesting is out — keep inline unlinked approver wrap.
+
+## Implementation sequence
+
+1. Packet — this document + manual stub; README / implementation-plan status.
+2. Chooser-as-parent stack + O6 chrome.
+3. Linked staged workflow (`linkedStage`, Escape ladder, async generations).
+4. Unlinked workflow (full resolve-chain invalidation, nested-picker cleanup, enablement).
+5. Submission failure/success lifecycle and sensitive-field clearing.
+6. Pointer / disabled / action-enablement parity.
+7. Tests + docs + PR; close #87 after merge.
+
+## Tests (required)
+
+- Full linked Escape ladder: lines → receipts → lookup → chooser → command
+- Chooser Escape → command; child Escape from lookup → chooser
+- Workspace/parent inert while return overlays open
+- Pointer-only: Continue, Add Return, Add Unlinked Return
+- Query edit invalidates; Enter re-searches; disabled rows not selectable
+- Escape during fetch → reopen → late response ignored
+- Nested picker Back clears `unlinkedPickerActive`
+- Submission failure while nested: unlinked visible, chooser inert, non-secrets preserved, password cleared
+- Success clears ancestry: no return overlay; new return line selected
+
+No JS unit-test framework.
+
+## Explicit non-goals
+
+- O11 / 5C confirmation redesign
+- Remapping `−` or other 6.7 keys
+- New return financial/domain model
+- Shell-level overlay host relocation
+- Controlled price/discount/tax overlays (5C)

--- a/docs/planning/register-workspace-consolidation/test-matrix.md
+++ b/docs/planning/register-workspace-consolidation/test-matrix.md
@@ -62,7 +62,7 @@ F10 working-basket preservation is already covered in [test/system/pos_register_
 | Financial/domain POS suites | Signing / settlement unchanged under provisional tax persistence | Slice 4 regression |
 | `test/system/pos_register_workspace_test.rb` | Keyboard, F10→menu, overlays, scan; Slice 5A lookup stack/inert/async/pointer/open-price; Slice 5B return Escape ladder / chooser stack / linked add | Slice 5A–5B |
 | Slice 5A cases in workspace system suite | Root/nested inert; Escape restores parent stage; pointer Choose Product / Attach Customer / Add Pickup; Escape-during-fetch ignores late response; zero open-price select-all | [#86](https://github.com/BankEncore/ShelfSense-v1/issues/86) |
-| Slice 5B return overlay cases | Chooser parent stack; linked Escape ladder; linked add clears ancestry; unlinked failure preserves fields/clears password; nested picker Cancel aborts | [#87](https://github.com/BankEncore/ShelfSense-v1/issues/87) |
+| Slice 5B return overlay cases | Chooser parent stack; linked Escape ladder; Escape during lines fetch ignores late response; prohibited unlinked disabled in chooser; linked add clears ancestry; unlinked failure preserves fields/clears password; nested picker Cancel aborts; unlinked variant Back to Item Lookup | [#87](https://github.com/BankEncore/ShelfSense-v1/issues/87) |
 | `test/system/pos_register_shell_test.rb` | Shell zoom, F10 lifecycle on all compositions | Slice 3 |
 | `test/system/pos_linked_return_test.rb` | F10 menu then Transactions & Receipts | Slice 3 |
 | `test/system/pos_mixed_return_test.rb` | F10 menu then Transactions & Receipts; Escape restores chooser then command | Slice 3 / 5B |

--- a/docs/planning/register-workspace-consolidation/test-matrix.md
+++ b/docs/planning/register-workspace-consolidation/test-matrix.md
@@ -60,13 +60,14 @@ F10 working-basket preservation is already covered in [test/system/pos_register_
 | `test/services/pos/workspace_presenter_test.rb` | Summary formula, tax groups, settlement DTOs, mismatch fallback, non-summary chrome | Slice 4 |
 | `test/integration/pos_register_test.rb` | `#pos_tenders` sibling of `#pos_totals`; Merchandise / no Sales | Slice 4 DOM |
 | Financial/domain POS suites | Signing / settlement unchanged under provisional tax persistence | Slice 4 regression |
-| `test/system/pos_register_workspace_test.rb` | Keyboard, F10→menu, overlays, scan; Slice 5A lookup stack/inert/async/pointer/open-price | Slice 5A |
+| `test/system/pos_register_workspace_test.rb` | Keyboard, F10→menu, overlays, scan; Slice 5A lookup stack/inert/async/pointer/open-price; Slice 5B return Escape ladder / chooser stack / linked add | Slice 5A–5B |
 | Slice 5A cases in workspace system suite | Root/nested inert; Escape restores parent stage; pointer Choose Product / Attach Customer / Add Pickup; Escape-during-fetch ignores late response; zero open-price select-all | [#86](https://github.com/BankEncore/ShelfSense-v1/issues/86) |
+| Slice 5B return overlay cases | Chooser parent stack; linked Escape ladder; linked add clears ancestry; unlinked failure preserves fields/clears password; nested picker Cancel aborts | [#87](https://github.com/BankEncore/ShelfSense-v1/issues/87) |
 | `test/system/pos_register_shell_test.rb` | Shell zoom, F10 lifecycle on all compositions | Slice 3 |
 | `test/system/pos_linked_return_test.rb` | F10 menu then Transactions & Receipts | Slice 3 |
-| `test/system/pos_mixed_return_test.rb` | F10 menu then Transactions & Receipts | Slice 3 |
+| `test/system/pos_mixed_return_test.rb` | F10 menu then Transactions & Receipts; Escape restores chooser then command | Slice 3 / 5B |
 | `test/services/pos/register_menu_test.rb` | Menu capability keys | Slice 3 |
-| `test/system/pos_unlinked_return_test.rb` | Interaction | Preserve; retarget if chrome changes |
+| `test/system/pos_unlinked_return_test.rb` | Unlinked chrome, nested picker, approval failure while chooser parent inert | [#87](https://github.com/BankEncore/ShelfSense-v1/issues/87) |
 | `test/system/pos_close_z_test.rb` | Interaction | Preserve |
 
 ## Gap characterization (this slice)

--- a/test/system/pos_mixed_return_test.rb
+++ b/test/system/pos_mixed_return_test.rb
@@ -88,7 +88,7 @@ class PosMixedReturnTest < ApplicationSystemTestCase
     click_on "Return (-)"
     send_keys :arrow_down
     send_keys :enter
-    assert_text "Return without receipt"
+    assert_text "Unlinked return"
     identifier = find("#pos-unlinked-identifier")
     identifier.fill_in with: @twenty.sku
     identifier.send_keys :enter
@@ -96,6 +96,9 @@ class PosMixedReturnTest < ApplicationSystemTestCase
     assert_equal 0, PosTransaction.working.find_by!(register: @register).pos_transaction_lines.count
     send_keys :escape
     assert_no_selector "#pos_unlinked_overlay", visible: true
+    assert_selector "#pos_return_chooser", visible: true
+    send_keys :escape
+    assert_no_selector "#pos_return_chooser", visible: true
     assert_equal "pos-command-field", page.evaluate_script("document.activeElement && document.activeElement.id")
 
     add_sku(@thirty.sku)
@@ -168,7 +171,7 @@ class PosMixedReturnTest < ApplicationSystemTestCase
     assert_text "Priced", wait: 5
     fill_in "Return unit price", with: price
     select "Changed mind", from: "Return reason"
-    click_on "Add return"
+    click_on "Add Unlinked Return"
     assert_text "Unlinked return", wait: 10
   end
 

--- a/test/system/pos_register_workspace_test.rb
+++ b/test/system/pos_register_workspace_test.rb
@@ -1047,21 +1047,97 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     open_register
     click_on "Return (-)"
     assert_selector "#pos_return_chooser", visible: true
-    assert_selector "#pos_return_chooser li.is-selected", text: "Linked return"
+    assert_selector "#pos_return_chooser li.is-selected", text: /Find Original Receipt/
     assert page.evaluate_script("document.activeElement === document.querySelector('#pos_return_chooser li.is-selected')")
+    assert page.evaluate_script("document.querySelector('[data-register-workspace-target=background]').inert === true")
     send_keys :arrow_down
     send_keys :enter
     assert_selector "#pos_unlinked_overlay", visible: true
+    assert_selector "#pos_return_chooser", visible: :all
+    assert page.evaluate_script("document.querySelector('#pos_return_chooser').inert === true")
     send_keys :escape
     assert_no_selector "#pos_unlinked_overlay", visible: true
+    assert_selector "#pos_return_chooser", visible: true
+    send_keys :escape
+    assert_no_selector "#pos_return_chooser", visible: true
     click_on "Return (-)"
-    send_keys :enter
+    click_on "Continue"
     assert_selector "#pos_linked_overlay", visible: true
     assert_field "Receipt, merchandise, or unit"
     send_keys :escape
     assert_no_selector "#pos_linked_overlay", visible: true
+    assert_selector "#pos_return_chooser", visible: true
     send_keys "-"
     assert_selector "#pos_return_chooser", visible: true
+  end
+
+  test "linked return Escape ladder restores stages then chooser" do
+    open_register
+    2.times do
+      field = find("#pos-command-field")
+      field.fill_in with: @variant.sku
+      field.send_keys :enter
+      click_on "Tender (+)"
+      field = find("#pos-command-field")
+      field.fill_in with: "25.00"
+      field.send_keys :enter
+      send_keys :enter
+      assert_text "Transaction complete", wait: 10
+      click_on "New transaction"
+      assert_text "SALE ENTRY", wait: 10
+    end
+
+    click_on "Return (-)"
+    click_on "Continue"
+    assert_selector "#pos_linked_overlay", visible: true
+    field = find("[data-register-workspace-target='linkedLookupField']")
+    field.fill_in with: @variant.sku
+    click_on "Find Receipt"
+    assert_selector "#pos_linked_overlay li", minimum: 2, wait: 10
+    assert_button "View Returnable Items"
+    click_on "View Returnable Items"
+    assert_selector "[data-register-workspace-target='linkedPrimary']", text: "Add Return", wait: 10
+    assert_selector "#pos_linked_overlay li", minimum: 1
+    send_keys :escape
+    assert_button "View Returnable Items"
+    send_keys :escape
+    assert_button "Find Receipt"
+    assert_field "Receipt, merchandise, or unit"
+    send_keys :escape
+    assert_no_selector "#pos_linked_overlay", visible: true
+    assert_selector "#pos_return_chooser", visible: true
+    send_keys :escape
+    assert_no_selector "#pos_return_chooser", visible: true
+    assert_equal "pos-command-field", page.evaluate_script("document.activeElement && document.activeElement.id")
+  end
+
+  test "linked return add via overlay clears return overlay ancestry" do
+    open_register
+    field = find("#pos-command-field")
+    field.fill_in with: @variant.sku
+    field.send_keys :enter
+    click_on "Tender (+)"
+    field = find("#pos-command-field")
+    field.fill_in with: "25.00"
+    field.send_keys :enter
+    send_keys :enter
+    assert_text "Transaction complete", wait: 10
+    sale = PosTransaction.completed.find_by!(register: @register)
+    click_on "New transaction"
+    assert_text "SALE ENTRY", wait: 10
+
+    click_on "Return (-)"
+    click_on "Continue"
+    field = find("[data-register-workspace-target='linkedLookupField']")
+    field.fill_in with: sale.transaction_reference
+    click_on "Find Receipt"
+    assert_selector "#pos_linked_overlay li.is-selected", wait: 10
+    find("[data-register-workspace-target='linkedReasonField']").select "Changed mind"
+    click_on "Add Return"
+    assert_text "RETURN", wait: 10
+    assert_no_selector "#pos_linked_overlay", visible: true
+    assert_no_selector "#pos_return_chooser", visible: true
+    assert_selector "tr.is-selected[data-direction='return']"
   end
 
   test "cashier attaches a customer from operational search overlay" do

--- a/test/system/pos_register_workspace_test.rb
+++ b/test/system/pos_register_workspace_test.rb
@@ -1111,6 +1111,116 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     assert_equal "pos-command-field", page.evaluate_script("document.activeElement && document.activeElement.id")
   end
 
+  test "linked return Escape during lines fetch ignores the late response" do
+    open_register
+    2.times do
+      field = find("#pos-command-field")
+      field.fill_in with: @variant.sku
+      field.send_keys :enter
+      click_on "Tender (+)"
+      field = find("#pos-command-field")
+      field.fill_in with: "25.00"
+      field.send_keys :enter
+      send_keys :enter
+      assert_text "Transaction complete", wait: 10
+      click_on "New transaction"
+      assert_text "SALE ENTRY", wait: 10
+    end
+
+    click_on "Return (-)"
+    click_on "Continue"
+    field = find("[data-register-workspace-target='linkedLookupField']")
+    field.fill_in with: @variant.sku
+    click_on "Find Receipt"
+    assert_selector "#pos_linked_overlay li", minimum: 2, wait: 10
+    assert_button "View Returnable Items"
+
+    page.evaluate_script(<<~JS.squish)
+      (function() {
+        window.__ssLinkedFetch = window.fetch.bind(window);
+        window.__ssHoldLinkedLines = true;
+        window.__ssDelayedLinked = null;
+        window.fetch = function(input, init) {
+          var url = "";
+          if (typeof input === "string") url = input;
+          else if (input && typeof input.url === "string") url = input.url;
+          else if (input) url = String(input);
+          if (window.__ssHoldLinkedLines && url.indexOf("linked_return_lookup") !== -1) {
+            return new Promise(function(resolve) {
+              window.__ssDelayedLinked = { resolve: resolve, init: init, input: input };
+            });
+          }
+          return window.__ssLinkedFetch(input, init);
+        };
+      })()
+    JS
+
+    find("#pos_linked_overlay li.is-selected").send_keys :enter
+    assert_text "Searching…", wait: 5
+    assert page.evaluate_script("window.__ssDelayedLinked != null")
+    send_keys :escape
+    assert_button "Find Receipt"
+    assert_field "Receipt, merchandise, or unit"
+
+    page.execute_script(<<~JS.squish)
+      (function() {
+        window.__ssHoldLinkedLines = false;
+        if (!window.__ssDelayedLinked) return;
+        window.__ssLinkedFetch(window.__ssDelayedLinked.input, window.__ssDelayedLinked.init).then(function(response) {
+          window.__ssDelayedLinked.resolve(response);
+        });
+        window.fetch = window.__ssLinkedFetch;
+      })()
+    JS
+    sleep 0.5
+    assert_button "Find Receipt"
+    assert_selector "[data-register-workspace-target='linkedPrimary']", text: "Find Receipt"
+    assert page.evaluate_script("document.activeElement === document.querySelector('[data-register-workspace-target=linkedLookupField]')")
+  ensure
+    page.execute_script("window.__ssHoldLinkedLines = false; if (window.__ssLinkedFetch) { window.fetch = window.__ssLinkedFetch; }")
+  end
+
+  test "prohibited unlinked return is disabled in the chooser" do
+    role = Role.create!(key: "linked_only_#{SecureRandom.hex(3)}", name: "Linked only", assignment_scope: "store")
+    RolePermission.create!(
+      role: role,
+      permission: Permission.find_by!(key: "pos.transact"),
+      granted_by: @actor
+    )
+    user = User.create!(
+      username: "linked_only_clerk",
+      display_name: "Linked Only",
+      password: "correct-horse-battery",
+      password_confirmation: "correct-horse-battery"
+    )
+    RoleAssignment.create!(
+      user: user,
+      role: role,
+      store: @store,
+      assigned_by: @actor,
+      effective_at: Time.current
+    )
+
+    visit new_session_path
+    fill_in "session_username", with: "linked_only_clerk"
+    fill_in "session_password", with: "correct-horse-battery"
+    find_field("session_password").send_keys :enter
+    assert_text "Signed in successfully"
+    visit pos_register_enter_path(register_id: @register.id)
+    fill_in "Opening float", with: "0.00"
+    click_on "Open register"
+    assert_text "SALE ENTRY", wait: 10
+
+    click_on "Return (-)"
+    assert_selector "#pos_return_chooser li[data-choice='unlinked'].is-disabled", text: /Not available for your role/
+    assert_selector "#pos_return_chooser li[data-choice='linked'].is-selected"
+    send_keys :arrow_down
+    assert_selector "#pos_return_chooser li[data-choice='linked'].is-selected"
+    click_on "Continue"
+    assert_selector "#pos_linked_overlay", visible: true
+    assert_no_selector "#pos_unlinked_overlay", visible: true
+  end
+
   test "linked return add via overlay clears return overlay ancestry" do
     open_register
     field = find("#pos-command-field")

--- a/test/system/pos_unlinked_return_test.rb
+++ b/test/system/pos_unlinked_return_test.rb
@@ -197,6 +197,32 @@ class PosUnlinkedReturnTest < ApplicationSystemTestCase
     assert_field "pos-unlinked-identifier"
   end
 
+  test "unlinked variant picker Back label returns to item lookup" do
+    ProductVariants::Create.call(
+      product: @variant.product,
+      attributes: {
+        variant_type: "standard",
+        status: "active",
+        merchandise_class_id: @variant.merchandise_class_id,
+        regular_price_cents: 1500
+      },
+      actor: @actor
+    )
+    open_quantity_stock(store: @store, variant: @variant.product.product_variants.order(:created_at).last, actor: @actor, quantity: 2)
+
+    open_register_as("admin")
+    open_unlinked_overlay
+    identifier = find("#pos-unlinked-identifier")
+    identifier.fill_in with: @variant.product.primary_identifier
+    identifier.send_keys :enter
+    assert_selector "#pos_variant_overlay", visible: true, wait: 5
+    assert_button "Back to Item Lookup"
+    click_on "Back to Item Lookup"
+    assert_no_selector "#pos_variant_overlay", visible: true
+    assert_selector "#pos_unlinked_overlay", visible: true
+    assert_field "pos-unlinked-identifier"
+  end
+
   private
 
   def open_register_as(username)

--- a/test/system/pos_unlinked_return_test.rb
+++ b/test/system/pos_unlinked_return_test.rb
@@ -27,7 +27,7 @@ class PosUnlinkedReturnTest < ApplicationSystemTestCase
     open_register_as("clerk_sys65c")
     assert_no_button "Return without receipt"
     open_unlinked_overlay
-    assert_text "Return without receipt"
+    assert_text "Unlinked return"
 
     identifier = find("#pos-unlinked-identifier")
     identifier.fill_in with: @variant.sku
@@ -42,7 +42,7 @@ class PosUnlinkedReturnTest < ApplicationSystemTestCase
     password = find("#pos-unlinked-approver-password", visible: :all)
     scroll_to password
     password.fill_in with: "correct-horse-battery"
-    click_on "Add return"
+    click_on "Add Unlinked Return"
 
     assert_text "RETURN", wait: 10
     assert_text "Unlinked return"
@@ -84,7 +84,7 @@ class PosUnlinkedReturnTest < ApplicationSystemTestCase
     assert_text used_variant.product.name, wait: 5
     assert_no_selector "#pos-unlinked-quantity", visible: true
     select "Changed mind", from: "Return reason"
-    click_on "Add return"
+    click_on "Add Unlinked Return"
     assert_text "Unlinked return", wait: 10
 
     click_on "Refund (+)"
@@ -122,7 +122,7 @@ class PosUnlinkedReturnTest < ApplicationSystemTestCase
     assert_equal 0, PosTransaction.working.find_by!(register: @register).pos_transaction_lines.count
 
     select "Defective", from: "Return reason"
-    click_on "Add return"
+    click_on "Add Unlinked Return"
 
     assert_text "RETURN", wait: 10
     assert_text "Unlinked return"
@@ -149,6 +149,52 @@ class PosUnlinkedReturnTest < ApplicationSystemTestCase
     assert_selector "#pos_unlinked_overlay", visible: true
     assert_field "pos-unlinked-identifier"
     assert_equal 0, PosTransaction.working.find_by!(register: @register).pos_transaction_lines.count
+  end
+
+  test "rejected unlinked approver credentials keep nested overlays and clear password" do
+    open_register_as("clerk_sys65c")
+    open_unlinked_overlay
+    assert_selector "#pos_return_chooser", visible: :all
+    assert page.evaluate_script("document.querySelector('#pos_return_chooser').inert === true")
+
+    identifier = find("#pos-unlinked-identifier")
+    identifier.fill_in with: @variant.sku
+    identifier.send_keys :enter
+    assert_text "Example Book", wait: 5
+    fill_in "Return unit price", with: "18.00"
+    select "Defective", from: "Return reason"
+    find("#pos-unlinked-approver-username", visible: true).fill_in with: "mgr_sys65c"
+    password = find("#pos-unlinked-approver-password", visible: :all)
+    scroll_to password
+    password.fill_in with: "wrong-password"
+    click_on "Add Unlinked Return"
+
+    assert_selector "#pos-unlinked-feedback", text: /approver/i, wait: 10
+    assert_selector "#pos_unlinked_overlay", visible: true
+    assert_selector "#pos_return_chooser", visible: :all
+    assert page.evaluate_script("document.querySelector('#pos_return_chooser').inert === true")
+    assert_equal "18.00", find("#pos-unlinked-price").value
+    assert_equal "defective", find("#pos-unlinked-reason").value
+    assert_equal "mgr_sys65c", find("#pos-unlinked-approver-username").value
+    assert_equal "", find("#pos-unlinked-approver-password", visible: :all).value
+  end
+
+  test "pointer Back on nested product picker restores unlinked overlay" do
+    other = pos_sellable_variant(actor: @actor, tax_class: @tax, name: "Delta Shared Return")
+    open_quantity_stock(store: @store, variant: other, actor: @actor, quantity: 2)
+    @variant.product.update!(lookup_code: "UNL-BACK")
+    other.product.update!(lookup_code: "UNL-BACK")
+
+    open_register_as("admin")
+    open_unlinked_overlay
+    identifier = find("#pos-unlinked-identifier")
+    identifier.fill_in with: "unl-back"
+    identifier.send_keys :enter
+    assert_selector "#pos_product_overlay", visible: true, wait: 5
+    click_on "Cancel (Esc)"
+    assert_no_selector "#pos_product_overlay", visible: true
+    assert_selector "#pos_unlinked_overlay", visible: true
+    assert_field "pos-unlinked-identifier"
   end
 
   private


### PR DESCRIPTION
## Summary
- Migrate O6–O8 return overlays onto the Slice 5A blocking-overlay lifecycle: chooser as stack parent of linked/unlinked, stack-depth z-index, workspace/parent inertness, and Escape restoring the parent stage.
- Add an explicit linked `linkedStage` machine (lookup → receipts → lines) with stage-aware Back/Escape, async invocation generations, query invalidation, and primary enablement; keep unlinked approver fields inline (O11/5C out of scope).
- Keep overlays open through submit; clear passwords and preserve non-secret fields on failure; successful Turbo workspace replace clears the return ancestry.

## Test plan
- [x] `./dev/rails-docker bin/rails test test/system/pos_unlinked_return_test.rb test/system/pos_mixed_return_test.rb test/system/pos_register_workspace_test.rb test/system/pos_register_shell_test.rb test/system/pos_linked_return_test.rb` (74 runs, 0 failures)
- [x] Manual checklist in `docs/planning/register-workspace-consolidation/slice5b-manual-verification.md`
- [ ] After merge into `register-workspace-consolidation`, close [#87](https://github.com/BankEncore/ShelfSense-v1/issues/87) manually (non-default base)


Made with [Cursor](https://cursor.com)