### PR TITLE
Slice 5C: Controlled-action overlays (#88)

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1906,6 +1906,28 @@ input[type="submit"]:disabled,
   margin-top: var(--space-3);
 }
 
+.pos-overlay__context {
+  display: grid;
+  gap: var(--space-2);
+  margin: 0;
+}
+
+.pos-overlay__context > div {
+  display: grid;
+  grid-template-columns: 7rem 1fr;
+  gap: var(--space-2);
+}
+
+.pos-overlay__context dt {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-weight: 500;
+}
+
+.pos-overlay__context dd {
+  margin: 0;
+}
+
 .pos-overlay__error {
   min-height: 1.25em;
   margin: var(--space-2) 0 0;

--- a/app/controllers/pos/workspaces_controller.rb
+++ b/app/controllers/pos/workspaces_controller.rb
@@ -8,6 +8,7 @@ module Pos
       "open_price" => "pos-open-price-feedback",
       "linked_return" => "pos-linked-feedback"
     }.freeze
+    APPROVAL_FEEDBACK_ID = "pos-approval-feedback"
 
     before_action :require_register!, except: :complete
     before_action :prepare_workspace!, except: %i[show continue complete]
@@ -668,16 +669,19 @@ module Pos
       yield
     rescue Pos::Denied
       redirect_to root_path, alert: "You are not authorized to perform that action."
+    rescue Pos::OverlayFailure => e
+      recover_from_overlay_failure(e, error_mode)
     rescue Pos::StaleObject
-      recover_from_workspace_error("This sale was changed. Reload and try again.", error_mode, persist_overlay: false)
+      recover_from_overlay_failure(Pos::OverlayFailure.stale, error_mode, persist_overlay: false)
     rescue Pos::InvalidatedDialogBasis => e
-      recover_from_workspace_error(e.message, error_mode, persist_overlay: false)
+      recover_from_overlay_failure(Pos::OverlayFailure.parent_validation(e.message), error_mode, persist_overlay: false)
     rescue Money::ParseCents::Error, Pos::Error => e
-      recover_from_workspace_error(e.message, error_mode)
+      recover_from_overlay_failure(Pos::OverlayFailure.parent_validation(e.message), error_mode)
     end
 
-    def recover_from_workspace_error(message, error_mode, persist_overlay: persist_overlay_error?)
-      @feedback = message
+    def recover_from_overlay_failure(failure, error_mode, persist_overlay: nil)
+      @overlay_failure = failure
+      @feedback = failure.message
       @transaction.reload
       @command_value = params[:identifier] || params[:quantity] || params[:tender_amount]
       if @transaction.completed?
@@ -685,7 +689,8 @@ module Pos
         return
       end
 
-      if persist_overlay
+      persist = persist_overlay.nil? ? overlay_error_dom_id.present? : persist_overlay
+      if persist
         respond_overlay_error(error_mode)
         return
       end
@@ -694,11 +699,20 @@ module Pos
       respond_workspace
     end
 
+    def recover_from_workspace_error(message, error_mode, persist_overlay: persist_overlay_error?)
+      recover_from_overlay_failure(Pos::OverlayFailure.parent_validation(message), error_mode, persist_overlay: persist_overlay)
+    end
+
     def persist_overlay_error?
       overlay_error_dom_id.present?
     end
 
     def overlay_error_dom_id
+      failure = @overlay_failure
+      if failure&.authorization?
+        return APPROVAL_FEEDBACK_ID
+      end
+
       return OVERLAY_ERROR_TARGETS[action_name] if OVERLAY_ERROR_TARGETS.key?(action_name)
       return "pos-open-price-feedback" if action_name == "merchandise" && params[:selling_price].present?
 
@@ -707,6 +721,7 @@ module Pos
 
     def respond_overlay_error(error_mode)
       @overlay_error_dom_id = overlay_error_dom_id
+      @overlay_failure ||= Pos::OverlayFailure.parent_validation(@feedback)
       respond_to do |format|
         format.turbo_stream { render "pos/workspaces/dialog_error", status: :unprocessable_entity }
         format.html do

--- a/app/controllers/pos/workspaces_controller.rb
+++ b/app/controllers/pos/workspaces_controller.rb
@@ -667,11 +667,16 @@ module Pos
 
     def rescue_workspace(error_mode: "sale_entry")
       yield
+    rescue Pos::ApproverAuthenticationFailed, Pos::ApproverNotAuthorized, Pos::SelfApprovalProhibited => e
+      # Safety net if a service raises typed approver errors without converting first.
+      recover_from_overlay_failure(Pos::OverlayFailure.from_approver_error(e), error_mode)
     rescue Pos::Denied
       redirect_to root_path, alert: "You are not authorized to perform that action."
     rescue Pos::OverlayFailure => e
       recover_from_overlay_failure(e, error_mode)
     rescue Pos::StaleObject
+      # Stale working state replaces the workspace (packet: proposed values against a
+      # changed line are unsafe). Cashier reopens the action on the refreshed line.
       recover_from_overlay_failure(Pos::OverlayFailure.stale, error_mode, persist_overlay: false)
     rescue Pos::InvalidatedDialogBasis => e
       recover_from_overlay_failure(Pos::OverlayFailure.parent_validation(e.message), error_mode, persist_overlay: false)

--- a/app/javascript/controllers/register_workspace_controller.js
+++ b/app/javascript/controllers/register_workspace_controller.js
@@ -48,6 +48,7 @@ export default class extends Controller {
     "controlApproverPasswordInput",
     "controlTitle",
     "controlLineLabel",
+    "controlCurrentLabel",
     "controlPriceWrap",
     "controlDiscountWrap",
     "controlTaxWrap",
@@ -57,12 +58,27 @@ export default class extends Controller {
     "controlReasonField",
     "controlNoteWrap",
     "controlNoteField",
-    "controlApproverWrap",
-    "approverUsername",
-    "approverPassword",
     "controlCancel",
     "controlApply",
     "controlRemove",
+    "approvalOverlay",
+    "approvalActionLabel",
+    "approvalItemLabel",
+    "approvalCurrentWrap",
+    "approvalCurrentHeading",
+    "approvalCurrentLabel",
+    "approvalProposedWrap",
+    "approvalProposedHeading",
+    "approvalProposedLabel",
+    "approvalQtyWrap",
+    "approvalQtyLabel",
+    "approvalReasonLabel",
+    "approvalBack",
+    "approvalAuthorize",
+    "approverUsername",
+    "approverPassword",
+    "overlayFailureMeta",
+    "cancelConsequence",
     "unlinkedIdentifierField",
     "unlinkedIdentifierInput",
     "unlinkedProductIdInput",
@@ -89,9 +105,6 @@ export default class extends Controller {
     "unlinkedNoteWrap",
     "unlinkedNoteField",
     "unlinkedPriceField",
-    "unlinkedApproverWrap",
-    "unlinkedApproverUsername",
-    "unlinkedApproverPassword",
     "unlinkedCancel",
     "unlinkedLookup",
     "unlinkedApply",
@@ -203,6 +216,7 @@ export default class extends Controller {
   connect() {
     this.inFlight = false
     this.overlayStack = []
+    this.confirmationInvocation = null
     this.searchRequestToken = 0
     this.pickupRequestToken = 0
     this.customerRequestToken = 0
@@ -246,6 +260,8 @@ export default class extends Controller {
   disconnect() {
     this.unbindFunctionKeyCapture()
     this.abortPendingLookups()
+    this.clearConfirmationCredentials()
+    this.confirmationInvocation = null
     this.clearOverlayStack({ restoreCommand: false })
     if (this.hasBackgroundTarget) this.backgroundTarget.inert = false
   }
@@ -382,46 +398,22 @@ export default class extends Controller {
       this.closeControlOverlay()
       return
     }
-    if (key === "F9") {
+    if (key === "F9" || key === "F10") {
       event.preventDefault()
       return
     }
     if (key !== "Enter") return
 
     const target = event.target
-    if (this.hasApproverUsernameTarget && target === this.approverUsernameTarget) {
-      event.preventDefault()
-      if (this.hasApproverPasswordTarget) this.approverPasswordTarget.focus()
-      return
-    }
-    if (this.hasApproverPasswordTarget && target === this.approverPasswordTarget) {
-      event.preventDefault()
-      if (this.approverPasswordTarget.value.trim() !== "") this.submitControlApply()
-      return
-    }
     if (this.isActionableControl(target)) return
     event.preventDefault()
     this.advanceOrApplyControlOverlay()
   }
 
   advanceOrApplyControlOverlay() {
-    if (this.policyFor(this.currentControlAction) !== "approval_required") {
-      this.submitControlApply()
-      return
-    }
     if (this.controlReasonNeedsNote()) {
       this.controlNoteFieldTarget.focus()
       return
-    }
-    if (this.hasApproverUsernameTarget && !this.controlApproverWrapTarget?.hidden) {
-      if (this.approverUsernameTarget.value.trim() === "") {
-        this.approverUsernameTarget.focus()
-        return
-      }
-      if (this.hasApproverPasswordTarget) {
-        this.approverPasswordTarget.focus()
-        return
-      }
     }
     this.submitControlApply()
   }
@@ -435,13 +427,41 @@ export default class extends Controller {
       !this.controlNoteWrapTarget.hidden
   }
 
+  onApprovalOverlayKeydown(event, key = this.functionKey(event) || event.key) {
+    if (key === "Escape") {
+      event.preventDefault()
+      this.backFromApprovalOverlay()
+      return
+    }
+    if (key === "F9" || key === "F10") {
+      event.preventDefault()
+      return
+    }
+    if (key !== "Enter") return
+
+    const target = event.target
+    if (this.hasApproverUsernameTarget && target === this.approverUsernameTarget) {
+      event.preventDefault()
+      if (this.hasApproverPasswordTarget) this.approverPasswordTarget.focus()
+      return
+    }
+    if (this.hasApproverPasswordTarget && target === this.approverPasswordTarget) {
+      event.preventDefault()
+      if (this.approverPasswordTarget.value.trim() !== "") this.authorizeAndSubmit()
+      return
+    }
+    if (this.isActionableControl(target)) return
+    event.preventDefault()
+    this.authorizeAndSubmit()
+  }
+
   onUnlinkedOverlayKeydown(event, key = this.functionKey(event) || event.key) {
     if (key === "Escape") {
       event.preventDefault()
       this.backFromUnlinkedOverlay()
       return
     }
-    if (key === "F9") {
+    if (key === "F9" || key === "F10") {
       event.preventDefault()
       return
     }
@@ -451,16 +471,6 @@ export default class extends Controller {
     if (this.hasUnlinkedIdentifierFieldTarget && target === this.unlinkedIdentifierFieldTarget) {
       event.preventDefault()
       this.lookUpUnlinkedItem()
-      return
-    }
-    if (this.hasUnlinkedApproverUsernameTarget && target === this.unlinkedApproverUsernameTarget) {
-      event.preventDefault()
-      if (this.hasUnlinkedApproverPasswordTarget) this.unlinkedApproverPasswordTarget.focus()
-      return
-    }
-    if (this.hasUnlinkedApproverPasswordTarget && target === this.unlinkedApproverPasswordTarget) {
-      event.preventDefault()
-      if (this.unlinkedApproverPasswordTarget.value.trim() !== "" && this.unlinkedAddReady()) this.submitUnlinkedReturn()
       return
     }
     if (this.isActionableControl(target)) return
@@ -2110,26 +2120,61 @@ export default class extends Controller {
       })
       return
     }
-    this.openControlOverlay("price_override", "Price override")
+    this.openControlOverlay("price_override")
   }
 
   openLineDiscount() {
-    this.openControlOverlay("line_discount", "Line discount")
+    this.openControlOverlay("line_discount")
   }
 
   openTaxClassOverride() {
-    this.openControlOverlay("tax_class_override", "Tax Class override")
+    this.openControlOverlay("tax_class_override")
   }
 
-  openControlOverlay(actionType, title) {
+  controlChromeFor(actionType) {
+    if (actionType === "price_override") {
+      return {
+        title: "Change Selling Price",
+        keepLabel: "Keep Current Price",
+        removeLabel: "Remove Price Override",
+        currentPrefix: "Current price",
+        backLabel: "Back to Price Change",
+        authorizeLabel: "Authorize and Apply",
+        actionLabel: "Price change"
+      }
+    }
+    if (actionType === "line_discount") {
+      return {
+        title: "Apply Line Discount",
+        keepLabel: "Keep Current Discount",
+        removeLabel: "Remove Line Discount",
+        currentPrefix: "Current discount",
+        backLabel: "Back to Discount",
+        authorizeLabel: "Authorize and Apply",
+        actionLabel: "Line discount"
+      }
+    }
+    return {
+      title: "Change Tax Class",
+      keepLabel: "Keep Current Tax Class",
+      removeLabel: "Restore Original Tax Class",
+      currentPrefix: "Current tax class",
+      backLabel: "Back to Tax Class",
+      authorizeLabel: "Authorize and Apply",
+      actionLabel: "Tax class change"
+    }
+  }
+
+  openControlOverlay(actionType) {
     if (this.inFlight) return
     if (this.modeValue !== "sale_entry") return
+    const chrome = this.controlChromeFor(actionType)
     if (this.policyFor(actionType) === "prohibited") {
-      this.showFeedback(`${title} is not available.`)
+      this.showFeedback(`${chrome.title} is not available.`)
       return
     }
     if (this.selectedReturnLine()) {
-      this.showFeedback(`${title} is not available on a return line.`)
+      this.showFeedback(`${chrome.title} is not available on a return line.`)
       return
     }
     const row = this.selectedRow()
@@ -2139,8 +2184,13 @@ export default class extends Controller {
     }
 
     this.currentControlAction = actionType
-    if (this.hasControlTitleTarget) this.controlTitleTarget.textContent = title
+    if (this.hasControlTitleTarget) this.controlTitleTarget.textContent = chrome.title
+    if (this.hasControlCancelTarget) this.controlCancelTarget.textContent = chrome.keepLabel
+    if (this.hasControlRemoveTarget) this.controlRemoveTarget.textContent = chrome.removeLabel
     if (this.hasControlLineLabelTarget) this.controlLineLabelTarget.textContent = row.dataset.description || "Selected line"
+    if (this.hasControlCurrentLabelTarget) {
+      this.controlCurrentLabelTarget.textContent = this.controlCurrentSummary(row, actionType, chrome)
+    }
     this.toggleHidden(this.hasControlPriceWrapTarget && this.controlPriceWrapTarget, actionType !== "price_override")
     this.toggleHidden(this.hasControlDiscountWrapTarget && this.controlDiscountWrapTarget, actionType !== "line_discount")
     this.toggleHidden(this.hasControlTaxWrapTarget && this.controlTaxWrapTarget, actionType !== "tax_class_override")
@@ -2150,7 +2200,7 @@ export default class extends Controller {
       this.controlPriceFieldTarget.value = this.formatCents(row.dataset.sellingCents)
     }
     if (actionType === "line_discount" && this.hasControlDiscountFieldTarget) {
-      this.controlDiscountFieldTarget.value = row.dataset.discountBp ? this.formatCents(row.dataset.discountBp) : ""
+      this.controlDiscountFieldTarget.value = row.dataset.discountBp ? this.formatBasisPoints(row.dataset.discountBp) : ""
     }
     if (actionType === "tax_class_override" && this.hasControlTaxFieldTarget && row.dataset.taxClassId) {
       this.controlTaxFieldTarget.value = row.dataset.taxClassId
@@ -2158,17 +2208,37 @@ export default class extends Controller {
     this.populateReasons(actionType)
     this.toggleHidden(this.hasControlNoteWrapTarget && this.controlNoteWrapTarget, true)
     if (this.hasControlNoteFieldTarget) this.controlNoteFieldTarget.value = ""
-    const needsApprover = this.policyFor(actionType) === "approval_required"
-    this.toggleHidden(this.hasControlApproverWrapTarget && this.controlApproverWrapTarget, !needsApprover)
-    if (this.hasApproverUsernameTarget) this.approverUsernameTarget.value = ""
-    if (this.hasApproverPasswordTarget) this.approverPasswordTarget.value = ""
     const hasExisting = this.lineHasAction(row, actionType)
     if (this.hasControlRemoveTarget) this.controlRemoveTarget.hidden = !hasExisting
 
     this.showOverlay(this.controlOverlayTarget)
   }
 
+  controlCurrentSummary(row, actionType, chrome) {
+    if (actionType === "price_override") {
+      return `${chrome.currentPrefix} $${this.formatCents(row.dataset.sellingCents)}`
+    }
+    if (actionType === "line_discount") {
+      const bp = row.dataset.discountBp
+      return bp ? `${chrome.currentPrefix} ${this.formatBasisPoints(bp)}%` : `${chrome.currentPrefix} none`
+    }
+    const name = this.taxClassOptionLabel(row.dataset.taxClassId) || row.dataset.taxClassName || "—"
+    return `${chrome.currentPrefix} ${name}`
+  }
+
+  taxClassOptionLabel(id) {
+    if (!this.hasControlTaxFieldTarget || !id) return null
+    const option = Array.from(this.controlTaxFieldTarget.options).find((entry) => entry.value === String(id))
+    return option ? option.textContent : null
+  }
+
+  formatBasisPoints(bp) {
+    const value = Number(bp || 0)
+    return (value / 100).toFixed(value % 100 === 0 ? 0 : 2)
+  }
+
   closeControlOverlay() {
+    if (this.approvalOverlayOpen()) this.closeApprovalOverlay({ clearInvocation: true })
     this.hideOverlay(this.hasControlOverlayTarget && this.controlOverlayTarget)
   }
 
@@ -2181,13 +2251,12 @@ export default class extends Controller {
     this.invalidateUnlinkedLookup()
     this.resetUnlinkedOverlay()
     this.populateUnlinkedReasons()
-    const needsApprover = this.policyFor("unlinked_return") === "approval_required"
-    this.toggleHidden(this.hasUnlinkedApproverWrapTarget && this.unlinkedApproverWrapTarget, !needsApprover)
     this.syncUnlinkedPrimaryEnabled()
     this.showOverlay(this.unlinkedOverlayTarget, this.hasUnlinkedIdentifierFieldTarget && this.unlinkedIdentifierFieldTarget)
   }
 
   closeUnlinkedOverlay() {
+    if (this.approvalOverlayOpen()) this.closeApprovalOverlay({ clearInvocation: true })
     this.invalidateUnlinkedLookup()
     this.unlinkedPickerActive = false
     this.hideOverlay(this.hasUnlinkedOverlayTarget && this.unlinkedOverlayTarget)
@@ -2227,8 +2296,6 @@ export default class extends Controller {
     this.toggleHidden(this.hasUnlinkedPreviewTarget && this.unlinkedPreviewTarget, true)
     if (this.hasUnlinkedNoteFieldTarget) this.unlinkedNoteFieldTarget.value = ""
     this.toggleHidden(this.hasUnlinkedNoteWrapTarget && this.unlinkedNoteWrapTarget, true)
-    if (this.hasUnlinkedApproverUsernameTarget) this.unlinkedApproverUsernameTarget.value = ""
-    if (this.hasUnlinkedApproverPasswordTarget) this.unlinkedApproverPasswordTarget.value = ""
     this.syncUnlinkedPrimaryEnabled()
   }
 
@@ -2386,11 +2453,6 @@ export default class extends Controller {
       const qty = this.hasUnlinkedQuantityFieldTarget ? this.unlinkedQuantityFieldTarget.value.trim() : ""
       if (!qty || Number(qty) <= 0) return false
     }
-    if (this.policyFor("unlinked_return") === "approval_required") {
-      const user = this.hasUnlinkedApproverUsernameTarget ? this.unlinkedApproverUsernameTarget.value.trim() : ""
-      const pass = this.hasUnlinkedApproverPasswordTarget ? this.unlinkedApproverPasswordTarget.value : ""
-      if (!user || !pass) return false
-    }
     return true
   }
 
@@ -2421,6 +2483,53 @@ export default class extends Controller {
     if (event) event.preventDefault()
     if (this.inFlight || !this.hasUnlinkedFormTarget) return
     if (!this.unlinkedAddReady()) return
+    if (this.policyFor("unlinked_return") === "approval_required") {
+      this.openUnlinkedAuthorization()
+      return
+    }
+    this.commitUnlinkedReturn()
+  }
+
+  openUnlinkedAuthorization() {
+    const reasonCode = this.hasUnlinkedReasonFieldTarget ? this.unlinkedReasonFieldTarget.value : ""
+    const reasonName = this.reasonDisplayName(this.returnReasonsValue, reasonCode)
+    const qty = this.unlinkedPreviewPayload.quantity_fixed
+      ? "1"
+      : (this.hasUnlinkedQuantityFieldTarget ? this.unlinkedQuantityFieldTarget.value.trim() : "1")
+    const price = this.hasUnlinkedPriceFieldTarget ? this.unlinkedPriceFieldTarget.value.trim() : ""
+    this.openAuthorizationOverlay({
+      consumer: "unlinked_return",
+      operation: "apply",
+      parentOverlay: this.unlinkedOverlayTarget,
+      formTarget: "unlinkedForm",
+      context: {
+        actionLabel: "Unlinked return",
+        itemLabel: this.hasUnlinkedDescriptionTarget ? this.unlinkedDescriptionTarget.textContent : "",
+        currentLabel: "",
+        proposedLabel: `$${price}`,
+        qtyLabel: qty,
+        reasonLabel: reasonName,
+        backLabel: "Back to Unlinked Return",
+        authorizeLabel: "Authorize and Add Return",
+        showQty: true,
+        showCurrent: false,
+        proposedHeading: "Return amount"
+      }
+    })
+  }
+
+  commitUnlinkedReturn({ credentials = null } = {}) {
+    if (this.inFlight || !this.hasUnlinkedFormTarget) return
+    this.fillUnlinkedForm(credentials)
+    this.clearOverlayError(this.unlinkedOverlayTarget)
+    if (this.approvalOverlayOpen()) this.clearOverlayError(this.approvalOverlayTarget)
+    this.beginFlight()
+    this.syncUnlinkedPrimaryEnabled()
+    this.unlinkedFormTarget.requestSubmit()
+    this.clearHiddenApproverPasswords()
+  }
+
+  fillUnlinkedForm(credentials = null) {
     if (this.hasUnlinkedIdentifierInputTarget) {
       this.unlinkedIdentifierInputTarget.value = this.hasUnlinkedIdentifierFieldTarget
         ? this.unlinkedIdentifierFieldTarget.value.trim()
@@ -2461,46 +2570,125 @@ export default class extends Controller {
     if (this.hasUnlinkedExpectedTaxInputTarget) {
       this.unlinkedExpectedTaxInputTarget.value = this.unlinkedPreviewPayload.tax_class_id || ""
     }
-    if (this.hasUnlinkedApproverUserInputTarget) {
-      this.unlinkedApproverUserInputTarget.value = this.hasUnlinkedApproverUsernameTarget
-        ? this.unlinkedApproverUsernameTarget.value.trim()
-        : ""
-    }
-    if (this.hasUnlinkedApproverPasswordInputTarget) {
-      this.unlinkedApproverPasswordInputTarget.value = this.hasUnlinkedApproverPasswordTarget
-        ? this.unlinkedApproverPasswordTarget.value
-        : ""
-    }
-    this.clearOverlayError(this.unlinkedOverlayTarget)
-    this.beginFlight()
-    this.syncUnlinkedPrimaryEnabled()
-    this.unlinkedFormTarget.requestSubmit()
+    const username = credentials?.username || ""
+    const password = credentials?.password || ""
+    if (this.hasUnlinkedApproverUserInputTarget) this.unlinkedApproverUserInputTarget.value = username
+    if (this.hasUnlinkedApproverPasswordInputTarget) this.unlinkedApproverPasswordInputTarget.value = password
   }
 
-  submitControlApply() {
+  submitControlApply(event) {
+    if (event) event.preventDefault()
     if (this.inFlight || !this.hasControlFormTarget) return
-    this.fillControlForm("apply")
+    if (this.policyFor(this.currentControlAction) === "approval_required") {
+      this.openControlAuthorization("apply")
+      return
+    }
+    this.commitControlOperation("apply")
+  }
+
+  submitControlRemove(event) {
+    if (event) event.preventDefault()
+    if (this.inFlight || !this.hasControlFormTarget) return
+    if (this.policyFor(this.currentControlAction) === "approval_required") {
+      this.openControlAuthorization("remove")
+      return
+    }
+    this.commitControlOperation("remove")
+  }
+
+  openControlAuthorization(operation) {
+    const action = this.currentControlAction
+    const chrome = this.controlChromeFor(action)
+    const row = this.selectedRow()
+    const reasonCode = this.hasControlReasonFieldTarget ? this.controlReasonFieldTarget.value : ""
+    const reasonName = operation === "remove"
+      ? "Remove existing adjustment"
+      : this.reasonDisplayName(this.reasonsValue?.[action], reasonCode)
+    const proposed = operation === "remove"
+      ? "Restore original"
+      : this.controlProposedLabel(action)
+    this.openAuthorizationOverlay({
+      consumer: action,
+      operation,
+      parentOverlay: this.controlOverlayTarget,
+      formTarget: "controlForm",
+      context: {
+        actionLabel: operation === "remove" ? `${chrome.actionLabel} removal` : chrome.actionLabel,
+        itemLabel: this.hasControlLineLabelTarget ? this.controlLineLabelTarget.textContent : "",
+        currentLabel: this.controlCurrentValueLabel(row, action),
+        proposedLabel: proposed,
+        reasonLabel: reasonName,
+        backLabel: chrome.backLabel,
+        authorizeLabel: chrome.authorizeLabel,
+        showQty: false,
+        showCurrent: true,
+        proposedHeading: "Proposed"
+      }
+    })
+  }
+
+  controlCurrentValueLabel(row, actionType) {
+    if (!row) return ""
+    if (actionType === "price_override") return `$${this.formatCents(row.dataset.sellingCents)}`
+    if (actionType === "line_discount") {
+      const bp = row.dataset.discountBp
+      return bp ? `${this.formatBasisPoints(bp)}%` : "none"
+    }
+    return this.taxClassOptionLabel(row.dataset.taxClassId) || row.dataset.taxClassName || "—"
+  }
+
+  controlProposedLabel(actionType) {
+    if (actionType === "price_override") {
+      const value = this.hasControlPriceFieldTarget ? this.controlPriceFieldTarget.value.trim() : ""
+      return value ? `$${value}` : ""
+    }
+    if (actionType === "line_discount") {
+      const value = this.hasControlDiscountFieldTarget ? this.controlDiscountFieldTarget.value.trim() : ""
+      return value ? `${value}%` : ""
+    }
+    if (!this.hasControlTaxFieldTarget) return ""
+    const option = this.controlTaxFieldTarget.selectedOptions?.[0]
+    return option ? option.textContent : ""
+  }
+
+  reasonDisplayName(entries, code) {
+    if (!code) return ""
+    if (Array.isArray(entries)) {
+      const match = entries.find((entry) => entry.code === code)
+      return match?.name || code
+    }
+    if (entries && typeof entries === "object") {
+      return entries[code] || code
+    }
+    return code
+  }
+
+  commitControlOperation(operation, { credentials = null } = {}) {
+    if (this.inFlight || !this.hasControlFormTarget) return
+    this.fillControlForm(operation, credentials)
     this.clearOverlayError(this.controlOverlayTarget)
+    if (this.approvalOverlayOpen()) this.clearOverlayError(this.approvalOverlayTarget)
     this.beginFlight()
     this.controlFormTarget.requestSubmit()
+    this.clearHiddenApproverPasswords()
   }
 
-  submitControlRemove() {
-    if (this.inFlight || !this.hasControlFormTarget) return
-    this.fillControlForm("remove")
-    this.clearOverlayError(this.controlOverlayTarget)
-    this.beginFlight()
-    this.controlFormTarget.requestSubmit()
-  }
-
-  fillControlForm(operation) {
+  fillControlForm(operation, credentials = null) {
     this.syncSelectedLine()
     const action = this.currentControlAction
     const applying = operation === "apply"
     if (this.hasControlActionInputTarget) this.controlActionInputTarget.value = action || ""
     if (this.hasControlOperationInputTarget) this.controlOperationInputTarget.value = operation
-    if (this.hasControlReasonInputTarget) this.controlReasonInputTarget.value = this.hasControlReasonFieldTarget ? this.controlReasonFieldTarget.value : ""
-    if (this.hasControlNoteInputTarget) this.controlNoteInputTarget.value = this.hasControlNoteFieldTarget ? this.controlNoteFieldTarget.value.trim() : ""
+    if (this.hasControlReasonInputTarget) {
+      this.controlReasonInputTarget.value = applying && this.hasControlReasonFieldTarget
+        ? this.controlReasonFieldTarget.value
+        : ""
+    }
+    if (this.hasControlNoteInputTarget) {
+      this.controlNoteInputTarget.value = applying && this.hasControlNoteFieldTarget
+        ? this.controlNoteFieldTarget.value.trim()
+        : ""
+    }
     if (this.hasControlPriceInputTarget) {
       this.controlPriceInputTarget.value = applying && action === "price_override" && this.hasControlPriceFieldTarget
         ? this.controlPriceFieldTarget.value.trim()
@@ -2516,12 +2704,95 @@ export default class extends Controller {
         ? this.controlTaxFieldTarget.value
         : ""
     }
-    if (this.hasControlApproverUserInputTarget) {
-      this.controlApproverUserInputTarget.value = this.hasApproverUsernameTarget ? this.approverUsernameTarget.value.trim() : ""
+    const username = credentials?.username || ""
+    const password = credentials?.password || ""
+    if (this.hasControlApproverUserInputTarget) this.controlApproverUserInputTarget.value = username
+    if (this.hasControlApproverPasswordInputTarget) this.controlApproverPasswordInputTarget.value = password
+  }
+
+  openAuthorizationOverlay(invocation) {
+    if (!this.hasApprovalOverlayTarget) return
+    // Whitelisted fields only — never store credentials or callbacks.
+    this.confirmationInvocation = {
+      consumer: invocation.consumer,
+      operation: invocation.operation,
+      parentOverlay: invocation.parentOverlay,
+      formTarget: invocation.formTarget,
+      context: { ...(invocation.context || {}) }
     }
-    if (this.hasControlApproverPasswordInputTarget) {
-      this.controlApproverPasswordInputTarget.value = this.hasApproverPasswordTarget ? this.approverPasswordTarget.value : ""
+    const ctx = this.confirmationInvocation.context
+    if (this.hasApprovalActionLabelTarget) this.approvalActionLabelTarget.textContent = ctx.actionLabel || ""
+    if (this.hasApprovalItemLabelTarget) this.approvalItemLabelTarget.textContent = ctx.itemLabel || ""
+    if (this.hasApprovalCurrentLabelTarget) this.approvalCurrentLabelTarget.textContent = ctx.currentLabel || ""
+    if (this.hasApprovalProposedLabelTarget) this.approvalProposedLabelTarget.textContent = ctx.proposedLabel || ""
+    if (this.hasApprovalReasonLabelTarget) this.approvalReasonLabelTarget.textContent = ctx.reasonLabel || ""
+    if (this.hasApprovalQtyLabelTarget) this.approvalQtyLabelTarget.textContent = ctx.qtyLabel || ""
+    if (this.hasApprovalCurrentHeadingTarget) this.approvalCurrentHeadingTarget.textContent = "Current"
+    if (this.hasApprovalProposedHeadingTarget) {
+      this.approvalProposedHeadingTarget.textContent = ctx.proposedHeading || "Proposed"
     }
+    this.toggleHidden(this.hasApprovalCurrentWrapTarget && this.approvalCurrentWrapTarget, ctx.showCurrent === false)
+    this.toggleHidden(this.hasApprovalQtyWrapTarget && this.approvalQtyWrapTarget, !ctx.showQty)
+    if (this.hasApprovalBackTarget) this.approvalBackTarget.textContent = ctx.backLabel || "Back"
+    if (this.hasApprovalAuthorizeTarget) this.approvalAuthorizeTarget.textContent = ctx.authorizeLabel || "Authorize"
+    this.clearApprovalCredentials({ keepUsername: false })
+    this.clearOverlayError(this.approvalOverlayTarget)
+    this.showOverlay(this.approvalOverlayTarget, this.hasApproverUsernameTarget && this.approverUsernameTarget)
+  }
+
+  backFromApprovalOverlay(event) {
+    if (event) event.preventDefault()
+    if (this.inFlight) return
+    this.closeApprovalOverlay({ clearInvocation: true })
+  }
+
+  closeApprovalOverlay({ clearInvocation = true } = {}) {
+    this.clearApprovalCredentials({ keepUsername: false })
+    if (clearInvocation) this.confirmationInvocation = null
+    this.hideOverlay(this.hasApprovalOverlayTarget && this.approvalOverlayTarget)
+  }
+
+  authorizeAndSubmit(event) {
+    if (event) event.preventDefault()
+    if (this.inFlight) return
+    const invocation = this.confirmationInvocation
+    if (!invocation) return
+    const username = this.hasApproverUsernameTarget ? this.approverUsernameTarget.value.trim() : ""
+    const password = this.hasApproverPasswordTarget ? this.approverPasswordTarget.value : ""
+    if (!username || !password) {
+      if (this.hasApproverUsernameTarget && !username) {
+        this.approverUsernameTarget.focus()
+        return
+      }
+      if (this.hasApproverPasswordTarget) this.approverPasswordTarget.focus()
+      return
+    }
+    const credentials = { username, password }
+    if (this.hasApproverPasswordTarget) this.approverPasswordTarget.value = ""
+    if (invocation.formTarget === "controlForm") {
+      this.commitControlOperation(invocation.operation, { credentials })
+      return
+    }
+    if (invocation.formTarget === "unlinkedForm") {
+      this.commitUnlinkedReturn({ credentials })
+    }
+  }
+
+  clearApprovalCredentials({ keepUsername = false } = {}) {
+    if (!keepUsername && this.hasApproverUsernameTarget) this.approverUsernameTarget.value = ""
+    if (this.hasApproverPasswordTarget) this.approverPasswordTarget.value = ""
+    this.clearHiddenApproverPasswords()
+  }
+
+  clearHiddenApproverPasswords() {
+    if (this.hasControlApproverPasswordInputTarget) this.controlApproverPasswordInputTarget.value = ""
+    if (this.hasUnlinkedApproverPasswordInputTarget) this.unlinkedApproverPasswordInputTarget.value = ""
+  }
+
+  clearConfirmationCredentials() {
+    this.clearApprovalCredentials({ keepUsername: false })
+    if (this.hasControlApproverUserInputTarget) this.controlApproverUserInputTarget.value = ""
+    if (this.hasUnlinkedApproverUserInputTarget) this.unlinkedApproverUserInputTarget.value = ""
   }
 
   confirmCancel() {
@@ -2591,6 +2862,10 @@ export default class extends Controller {
     }
     if (this.hasControlOverlayTarget && overlay === this.controlOverlayTarget) {
       this.onControlOverlayKeydown(event, key)
+      return
+    }
+    if (this.hasApprovalOverlayTarget && overlay === this.approvalOverlayTarget) {
+      this.onApprovalOverlayKeydown(event, key)
       return
     }
     if (this.hasOtherOverlayTarget && overlay === this.otherOverlayTarget) {
@@ -2669,6 +2944,10 @@ export default class extends Controller {
 
   hideOverlayNode(overlay) {
     if (!overlay) return
+    if (this.hasApprovalOverlayTarget && overlay === this.approvalOverlayTarget) {
+      this.clearApprovalCredentials({ keepUsername: false })
+      this.confirmationInvocation = null
+    }
     overlay.hidden = true
     overlay.inert = false
     overlay.style.zIndex = ""
@@ -2678,6 +2957,8 @@ export default class extends Controller {
 
   clearOverlayStack({ restoreCommand = true } = {}) {
     this.abortPendingLookups()
+    this.clearConfirmationCredentials()
+    this.confirmationInvocation = null
     const entries = [ ...this.overlayStack ]
     this.overlayStack = []
     entries.reverse().forEach((entry) => this.hideOverlayNode(entry.overlay))
@@ -2777,11 +3058,39 @@ export default class extends Controller {
     if (this.hasFieldTarget) this.fieldTarget.disabled = false
     if (this.hasReferenceFieldTarget) this.referenceFieldTarget.disabled = false
     this.enableReadyActions()
-    if (this.hasControlApproverPasswordInputTarget) this.controlApproverPasswordInputTarget.value = ""
-    if (this.hasUnlinkedApproverPasswordInputTarget) this.unlinkedApproverPasswordInputTarget.value = ""
-    if (this.hasUnlinkedApproverPasswordTarget) this.unlinkedApproverPasswordTarget.value = ""
     this.syncUnlinkedPrimaryEnabled()
     this.syncLinkedPrimaryEnabled()
+
+    const failure = this.readOverlayFailure()
+    const kind = failure?.kind
+    this.clearHiddenApproverPasswords()
+
+    if (kind === "authorization_failed" || kind === "authorization_prohibited") {
+      if (this.hasApproverPasswordTarget) this.approverPasswordTarget.value = ""
+      const focusField = kind === "authorization_prohibited" && this.hasApproverUsernameTarget
+        ? this.approverUsernameTarget
+        : (this.hasApproverPasswordTarget && this.approverPasswordTarget)
+      if (focusField) {
+        focusField.focus()
+        if (typeof focusField.select === "function") focusField.select()
+      }
+      return
+    }
+
+    if (kind === "parent_validation_failed" || kind === "stale_transaction") {
+      if (this.approvalOverlayOpen()) this.closeApprovalOverlay({ clearInvocation: true })
+      const parent = this.activeOverlayElement()
+      if (!parent) return
+      const focusables = this.overlayFocusables(parent)
+      const firstField = focusables.find((el) => el.matches("input, select, textarea"))
+      if (firstField) {
+        firstField.focus()
+        return
+      }
+      if (focusables[0]) focusables[0].focus()
+      return
+    }
+
     const overlay = this.activeOverlayElement()
     if (!overlay) return
     overlay.querySelectorAll("input[type='password']").forEach((field) => {
@@ -2797,12 +3106,30 @@ export default class extends Controller {
     if (first) first.focus()
   }
 
+  readOverlayFailure() {
+    const nodes = [
+      ...(this.hasOverlayFailureMetaTarget ? this.overlayFailureMetaTargets : []),
+      ...Array.from(this.element.querySelectorAll("[data-overlay-error-kind]"))
+    ]
+    const node = nodes.find((entry) => entry?.dataset?.overlayErrorKind)
+    if (!node) return null
+    return {
+      kind: node.dataset.overlayErrorKind,
+      field: node.dataset.overlayErrorField || null,
+      message: node.textContent || ""
+    }
+  }
+
   cancelOverlayOpen() {
     return this.hasOverlayTarget && !this.overlayTarget.hidden
   }
 
   controlOverlayOpen() {
     return this.hasControlOverlayTarget && !this.controlOverlayTarget.hidden
+  }
+
+  approvalOverlayOpen() {
+    return this.hasApprovalOverlayTarget && !this.approvalOverlayTarget.hidden
   }
 
   unlinkedOverlayOpen() {

--- a/app/javascript/controllers/register_workspace_controller.js
+++ b/app/javascript/controllers/register_workspace_controller.js
@@ -2579,6 +2579,7 @@ export default class extends Controller {
   submitControlApply(event) {
     if (event) event.preventDefault()
     if (this.inFlight || !this.hasControlFormTarget) return
+    if (!this.ensureControlReady("apply")) return
     if (this.policyFor(this.currentControlAction) === "approval_required") {
       this.openControlAuthorization("apply")
       return
@@ -2589,11 +2590,70 @@ export default class extends Controller {
   submitControlRemove(event) {
     if (event) event.preventDefault()
     if (this.inFlight || !this.hasControlFormTarget) return
+    if (!this.ensureControlReady("remove")) return
     if (this.policyFor(this.currentControlAction) === "approval_required") {
       this.openControlAuthorization("remove")
       return
     }
     this.commitControlOperation("remove")
+  }
+
+  ensureControlReady(operation) {
+    const action = this.currentControlAction
+    const row = this.selectedRow()
+    if (operation === "remove") {
+      if (!row || !this.lineHasAction(row, action)) {
+        this.showControlFeedback("There is no adjustment to remove.")
+        if (this.hasControlCancelTarget) this.controlCancelTarget.focus()
+        return false
+      }
+      return true
+    }
+
+    if (action === "price_override") {
+      const value = this.hasControlPriceFieldTarget ? this.controlPriceFieldTarget.value.trim() : ""
+      if (!value) {
+        this.showControlFeedback("Enter a selling price.")
+        if (this.hasControlPriceFieldTarget) this.controlPriceFieldTarget.focus()
+        return false
+      }
+    } else if (action === "line_discount") {
+      const value = this.hasControlDiscountFieldTarget ? this.controlDiscountFieldTarget.value.trim() : ""
+      if (!value) {
+        this.showControlFeedback("Enter a discount percent.")
+        if (this.hasControlDiscountFieldTarget) this.controlDiscountFieldTarget.focus()
+        return false
+      }
+    } else if (action === "tax_class_override") {
+      const value = this.hasControlTaxFieldTarget ? this.controlTaxFieldTarget.value : ""
+      if (!value) {
+        this.showControlFeedback("Choose a Tax Class.")
+        if (this.hasControlTaxFieldTarget) this.controlTaxFieldTarget.focus()
+        return false
+      }
+    }
+
+    const reason = this.hasControlReasonFieldTarget ? this.controlReasonFieldTarget.value : ""
+    if (!reason) {
+      this.showControlFeedback("Choose a reason.")
+      if (this.hasControlReasonFieldTarget) this.controlReasonFieldTarget.focus()
+      return false
+    }
+    if (reason === "other") {
+      const note = this.hasControlNoteFieldTarget ? this.controlNoteFieldTarget.value.trim() : ""
+      if (!note) {
+        this.showControlFeedback("Enter a note for Other.")
+        this.toggleHidden(this.hasControlNoteWrapTarget && this.controlNoteWrapTarget, false)
+        if (this.hasControlNoteFieldTarget) this.controlNoteFieldTarget.focus()
+        return false
+      }
+    }
+    return true
+  }
+
+  showControlFeedback(message) {
+    const node = this.controlOverlayTarget?.querySelector("[data-overlay-error]")
+    if (node) node.textContent = message
   }
 
   openControlAuthorization(operation) {
@@ -3067,7 +3127,7 @@ export default class extends Controller {
 
     if (kind === "authorization_failed" || kind === "authorization_prohibited") {
       if (this.hasApproverPasswordTarget) this.approverPasswordTarget.value = ""
-      const focusField = kind === "authorization_prohibited" && this.hasApproverUsernameTarget
+      const focusField = (kind === "authorization_prohibited" || failure?.field === "approver_username") && this.hasApproverUsernameTarget
         ? this.approverUsernameTarget
         : (this.hasApproverPasswordTarget && this.approverPasswordTarget)
       if (focusField) {
@@ -3077,7 +3137,7 @@ export default class extends Controller {
       return
     }
 
-    if (kind === "parent_validation_failed" || kind === "stale_transaction") {
+    if (kind === "parent_validation_failed") {
       if (this.approvalOverlayOpen()) this.closeApprovalOverlay({ clearInvocation: true })
       const parent = this.activeOverlayElement()
       if (!parent) return
@@ -3090,6 +3150,9 @@ export default class extends Controller {
       if (focusables[0]) focusables[0].focus()
       return
     }
+
+    // stale_transaction replaces the workspace via Turbo — no overlay to recover.
+    if (kind === "stale_transaction") return
 
     const overlay = this.activeOverlayElement()
     if (!overlay) return

--- a/app/services/pos/approver_authentication_failed.rb
+++ b/app/services/pos/approver_authentication_failed.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Pos
+  # Raised when approver username/password are missing or do not authenticate.
+  class ApproverAuthenticationFailed < Denied; end
+end

--- a/app/services/pos/approver_not_authorized.rb
+++ b/app/services/pos/approver_not_authorized.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Pos
+  # Raised when an authenticated approver lacks store permission (or is the system actor).
+  class ApproverNotAuthorized < Denied; end
+end

--- a/app/services/pos/authenticate_approver.rb
+++ b/app/services/pos/authenticate_approver.rb
@@ -16,20 +16,26 @@ module Pos
     end
 
     def call
-      raise Pos::Denied, "approver credentials are required" if @username.blank? || @password.blank?
+      if @username.blank? || @password.blank?
+        raise Pos::ApproverAuthenticationFailed, "approver credentials are required"
+      end
 
       user = User.find_by("lower(username) = ?", @username.downcase)
-      raise Pos::Denied, "approver credentials are invalid" unless user&.authenticatable?
-      raise Pos::Denied, "approver credentials are invalid" unless user.authenticate(@password)
-      raise Pos::Denied, "approver cannot be the performer" if user.id == @performer.id
-      raise Pos::Denied, "approver cannot be the system actor" if user.system_actor?
+      unless user&.authenticatable?
+        raise Pos::ApproverAuthenticationFailed, "approver credentials are invalid"
+      end
+      unless user.authenticate(@password)
+        raise Pos::ApproverAuthenticationFailed, "approver credentials are invalid"
+      end
+      raise Pos::SelfApprovalProhibited, "approver cannot be the performer" if user.id == @performer.id
+      raise Pos::ApproverNotAuthorized, "approver cannot be the system actor" if user.system_actor?
 
       unless Authorization::PermissionEvaluator.allowed?(
         user: user,
         permission_key: @permission_key,
         store: @store
       )
-        raise Pos::Denied, "approver is not authorized at this store"
+        raise Pos::ApproverNotAuthorized, "approver is not authorized at this store"
       end
 
       user

--- a/app/services/pos/execute_controlled_action.rb
+++ b/app/services/pos/execute_controlled_action.rb
@@ -61,7 +61,8 @@ module Pos
       end
     rescue Pos::Denied => e
       record_denied!(e.message)
-      raise Pos::Error, e.message if e.message.start_with?("approver")
+      failure = Pos::OverlayFailure.from_denied(e)
+      raise failure if failure
 
       raise
     rescue Pos::Tax::UnresolvedApplicability => e
@@ -107,6 +108,14 @@ module Pos
       policy = Pos::ControlledActionPolicy.result(user: @actor, store: transaction.store, action_type: @action_type)
       raise Pos::Denied, "not authorized to perform this action" if policy == :prohibited
       raise Pos::Error, "remove the line discount before changing the price override" if @action_type == "price_override" && line.manually_discounted?
+
+      Pos::AuthenticateApprover.call(
+        username: @approver_username,
+        password: @approver_password,
+        store: transaction.store,
+        action_type: @action_type,
+        performer: @actor
+      ) if policy == :approval_required
 
       before = snapshot_line(line)
       restore_mutation!(line)

--- a/app/services/pos/execute_controlled_action.rb
+++ b/app/services/pos/execute_controlled_action.rb
@@ -61,7 +61,7 @@ module Pos
       end
     rescue Pos::Denied => e
       record_denied!(e.message)
-      failure = Pos::OverlayFailure.from_denied(e)
+      failure = Pos::OverlayFailure.from_approver_error(e)
       raise failure if failure
 
       raise

--- a/app/services/pos/execute_unlinked_return.rb
+++ b/app/services/pos/execute_unlinked_return.rb
@@ -113,7 +113,7 @@ module Pos
       end
     rescue Pos::Denied => e
       record_denied!(e.message)
-      failure = Pos::OverlayFailure.from_denied(e)
+      failure = Pos::OverlayFailure.from_approver_error(e)
       raise failure if failure
 
       raise

--- a/app/services/pos/execute_unlinked_return.rb
+++ b/app/services/pos/execute_unlinked_return.rb
@@ -113,7 +113,8 @@ module Pos
       end
     rescue Pos::Denied => e
       record_denied!(e.message)
-      raise Pos::Error, e.message if e.message.start_with?("approver")
+      failure = Pos::OverlayFailure.from_denied(e)
+      raise failure if failure
 
       raise
     rescue Pos::Tax::UnresolvedApplicability, Inventory::ReturnValuation::Error => e

--- a/app/services/pos/overlay_failure.rb
+++ b/app/services/pos/overlay_failure.rb
@@ -2,7 +2,7 @@
 
 module Pos
   # Typed workspace-overlay failure for Turbo dialog recovery.
-  # Maps domain exceptions at the response boundary — clients must not parse English copy.
+  # Maps domain exception classes at the response boundary — never English copy.
   class OverlayFailure < StandardError
     KINDS = %i[
       authorization_failed
@@ -22,16 +22,21 @@ module Pos
       super(message)
     end
 
-    def self.from_denied(error)
-      message = error.message.to_s
-      case message
-      when /\Aapprover credentials/, /approver cannot be the performer/, /approver cannot be the system actor/
+    def self.from_approver_error(error)
+      case error
+      when Pos::ApproverAuthenticationFailed
         new(
           kind: :authorization_failed,
           field: :approver_password,
           message: "Manager credentials were not accepted."
         )
-      when /approver is not authorized/
+      when Pos::SelfApprovalProhibited
+        new(
+          kind: :authorization_prohibited,
+          field: :approver_username,
+          message: "You cannot approve your own action."
+        )
+      when Pos::ApproverNotAuthorized
         new(
           kind: :authorization_prohibited,
           field: :approver_username,

--- a/app/services/pos/overlay_failure.rb
+++ b/app/services/pos/overlay_failure.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Pos
+  # Typed workspace-overlay failure for Turbo dialog recovery.
+  # Maps domain exceptions at the response boundary — clients must not parse English copy.
+  class OverlayFailure < StandardError
+    KINDS = %i[
+      authorization_failed
+      authorization_prohibited
+      parent_validation_failed
+      stale_transaction
+      transport_uncertain
+    ].freeze
+
+    attr_reader :kind, :field
+
+    def initialize(kind:, message:, field: nil)
+      @kind = kind.to_sym
+      raise ArgumentError, "unknown overlay failure kind: #{@kind}" unless KINDS.include?(@kind)
+
+      @field = field&.to_sym
+      super(message)
+    end
+
+    def self.from_denied(error)
+      message = error.message.to_s
+      case message
+      when /\Aapprover credentials/, /approver cannot be the performer/, /approver cannot be the system actor/
+        new(
+          kind: :authorization_failed,
+          field: :approver_password,
+          message: "Manager credentials were not accepted."
+        )
+      when /approver is not authorized/
+        new(
+          kind: :authorization_prohibited,
+          field: :approver_username,
+          message: "This manager cannot authorize that action."
+        )
+      else
+        nil
+      end
+    end
+
+    def self.parent_validation(message)
+      new(kind: :parent_validation_failed, message: message.to_s)
+    end
+
+    def self.stale(message = "This sale was changed. Reload and try again.")
+      new(kind: :stale_transaction, message: message)
+    end
+
+    def authorization?
+      kind == :authorization_failed || kind == :authorization_prohibited
+    end
+  end
+end

--- a/app/services/pos/self_approval_prohibited.rb
+++ b/app/services/pos/self_approval_prohibited.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Pos
+  # Raised when the performer attempts to approve their own controlled action.
+  class SelfApprovalProhibited < Denied; end
+end

--- a/app/services/pos/workspace_presenter.rb
+++ b/app/services/pos/workspace_presenter.rb
@@ -103,11 +103,15 @@ module Pos
       parts = []
       sale_qty = @lines.select(&:sale?).sum { |line| line.quantity.to_i }
       return_qty = @lines.select(&:return?).sum { |line| line.quantity.to_i.abs }
-      issuance_count = @issuances.size
+      activation_count = @issuances.count(&:activation?)
+      reload_count = @issuances.count(&:reload_issuance?)
       parts << "#{sale_qty} #{sale_qty == 1 ? "item" : "items"} for sale" if sale_qty.positive?
       parts << "#{return_qty} #{return_qty == 1 ? "returned item" : "returned items"}" if return_qty.positive?
-      if issuance_count.positive?
-        parts << "#{issuance_count} gift card #{issuance_count == 1 ? "activation" : "activations"}"
+      if activation_count.positive?
+        parts << "#{activation_count} gift card #{activation_count == 1 ? "activation" : "activations"}"
+      end
+      if reload_count.positive?
+        parts << "#{reload_count} gift card #{reload_count == 1 ? "reload" : "reloads"}"
       end
       return "All working content will be discarded." if parts.empty?
 

--- a/app/services/pos/workspace_presenter.rb
+++ b/app/services/pos/workspace_presenter.rb
@@ -32,6 +32,7 @@ module Pos
       :issuance_remove_available,
       :pickup_available,
       :gift_card_programs_available,
+      :cancel_consequence,
       :feedback
     )
 
@@ -91,11 +92,35 @@ module Pos
         issuance_remove_available: capability?(:issuance_remove_available),
         pickup_available: capability?(:pickup_available),
         gift_card_programs_available: capability?(:gift_card_programs_available),
+        cancel_consequence: cancel_consequence,
         feedback: @feedback
       )
     end
 
     private
+
+    def cancel_consequence
+      parts = []
+      sale_qty = @lines.select(&:sale?).sum { |line| line.quantity.to_i }
+      return_qty = @lines.select(&:return?).sum { |line| line.quantity.to_i.abs }
+      issuance_count = @issuances.size
+      parts << "#{sale_qty} #{sale_qty == 1 ? "item" : "items"} for sale" if sale_qty.positive?
+      parts << "#{return_qty} #{return_qty == 1 ? "returned item" : "returned items"}" if return_qty.positive?
+      if issuance_count.positive?
+        parts << "#{issuance_count} gift card #{issuance_count == 1 ? "activation" : "activations"}"
+      end
+      return "All working content will be discarded." if parts.empty?
+
+      list =
+        if parts.length == 1
+          parts.first
+        elsif parts.length == 2
+          "#{parts[0]} and #{parts[1]}"
+        else
+          "#{parts[0...-1].join(", ")}, and #{parts[-1]}"
+        end
+      "#{list} will be discarded."
+    end
 
     def locked?
       %w[completion_pending completion_failed].include?(@ui_mode)

--- a/app/views/pos/workspaces/_basket.html.erb
+++ b/app/views/pos/workspaces/_basket.html.erb
@@ -28,6 +28,7 @@
             data-selling-cents="<%= line.selling_unit_price_cents %>"
             data-discount-bp="<%= line.manual_discount_basis_points %>"
             data-tax-class-id="<%= line.tax_class_id %>"
+            data-tax-class-name="<%= line.tax_class_name_snapshot %>"
             data-pricing-method-snapshot="<%= line.pricing_method_snapshot %>"
             aria-selected="<%= line.id == selected_id %>">
           <td><%= line.id == selected_id ? ">" : "" %> <%= display_quantity %></td>

--- a/app/views/pos/workspaces/_overlays.html.erb
+++ b/app/views/pos/workspaces/_overlays.html.erb
@@ -7,11 +7,45 @@
        aria-labelledby="pos-cancel-title">
     <div class="pos-overlay__panel">
       <h2 id="pos-cancel-title">Cancel this transaction?</h2>
-      <p>Lines will not be sold or returned. No receipt. No inventory movement.</p>
-      <%= action_button "Don't cancel (Esc)", style: :outline, intent: :neutral, size: :standard,
-            data: { action: "register-workspace#closeOverlay", register_workspace_target: "dontCancel" } %>
-      <%= action_button "Cancel transaction (F9)", style: :solid, intent: :danger, size: :standard,
-            data: { action: "register-workspace#confirmCancel", register_workspace_target: "confirmCancel" } %>
+      <p data-register-workspace-target="cancelConsequence"><%= @workspace&.cancel_consequence.presence || "All working content will be discarded." %></p>
+      <p>No receipt, inventory movement, or stored-value issuance will be completed.</p>
+      <div class="pos-overlay__actions">
+        <%= action_button "Keep Transaction", style: :outline, intent: :neutral, size: :standard,
+              data: { action: "register-workspace#closeOverlay", register_workspace_target: "dontCancel" } %>
+        <%= action_button "Cancel Transaction (F9)", style: :solid, intent: :danger, size: :standard,
+              data: { action: "register-workspace#confirmCancel", register_workspace_target: "confirmCancel" } %>
+      </div>
+    </div>
+  </div>
+
+  <div class="pos-overlay" data-register-blocking-overlay
+       id="pos_approval_overlay"
+       hidden
+       data-register-workspace-target="approvalOverlay"
+       role="dialog"
+       aria-modal="true"
+       aria-labelledby="pos-approval-title">
+    <div class="pos-overlay__panel pos-overlay__panel--control">
+      <h2 id="pos-approval-title">Manager authorization</h2>
+      <dl class="pos-overlay__context">
+        <div><dt>Action</dt><dd data-register-workspace-target="approvalActionLabel"></dd></div>
+        <div><dt>Item</dt><dd data-register-workspace-target="approvalItemLabel"></dd></div>
+        <div data-register-workspace-target="approvalCurrentWrap"><dt data-register-workspace-target="approvalCurrentHeading">Current</dt><dd data-register-workspace-target="approvalCurrentLabel"></dd></div>
+        <div data-register-workspace-target="approvalProposedWrap"><dt data-register-workspace-target="approvalProposedHeading">Proposed</dt><dd data-register-workspace-target="approvalProposedLabel"></dd></div>
+        <div data-register-workspace-target="approvalQtyWrap" hidden><dt>Qty</dt><dd data-register-workspace-target="approvalQtyLabel"></dd></div>
+        <div><dt>Reason</dt><dd data-register-workspace-target="approvalReasonLabel"></dd></div>
+      </dl>
+      <p id="pos-approval-feedback" class="pos-overlay__error" data-overlay-error role="alert"></p>
+      <label for="pos-approver-username">Approver username</label>
+      <input id="pos-approver-username" class="pos-command__field" data-register-workspace-target="approverUsername" autocomplete="off">
+      <label for="pos-approver-password">Approver password</label>
+      <input id="pos-approver-password" class="pos-command__field" type="password" data-register-workspace-target="approverPassword" autocomplete="off">
+      <div class="pos-overlay__actions">
+        <%= action_button "Back", style: :outline, intent: :neutral, size: :standard,
+              data: { action: "register-workspace#backFromApprovalOverlay", register_workspace_target: "approvalBack" } %>
+        <%= action_button "Authorize", style: :solid, intent: :brand, size: :standard,
+              data: { action: "register-workspace#authorizeAndSubmit", register_workspace_target: "approvalAuthorize" } %>
+      </div>
     </div>
   </div>
 
@@ -25,10 +59,11 @@
     <div class="pos-overlay__panel pos-overlay__panel--control">
       <h2 id="pos-control-title" data-register-workspace-target="controlTitle">Controlled action</h2>
       <p data-register-workspace-target="controlLineLabel"></p>
+      <p class="muted" data-register-workspace-target="controlCurrentLabel"></p>
       <p id="pos-control-feedback" class="pos-overlay__error" data-overlay-error role="alert"></p>
 
       <div data-register-workspace-target="controlPriceWrap">
-        <label for="pos-control-price">Selling price</label>
+        <label for="pos-control-price">New selling price</label>
         <input id="pos-control-price" class="pos-command__field" data-register-workspace-target="controlPriceField" inputmode="decimal" autocomplete="off">
       </div>
 
@@ -54,15 +89,8 @@
         <input id="pos-control-note" class="pos-command__field" data-register-workspace-target="controlNoteField" maxlength="200" autocomplete="off">
       </div>
 
-      <div data-register-workspace-target="controlApproverWrap" hidden>
-        <label for="pos-approver-username">Approver username</label>
-        <input id="pos-approver-username" class="pos-command__field" data-register-workspace-target="approverUsername" autocomplete="off">
-        <label for="pos-approver-password">Approver password</label>
-        <input id="pos-approver-password" class="pos-command__field" type="password" data-register-workspace-target="approverPassword" autocomplete="off">
-      </div>
-
       <div class="pos-overlay__actions">
-        <%= action_button "Don't apply (Esc)", style: :outline, intent: :neutral, size: :standard,
+        <%= action_button "Keep Current", style: :outline, intent: :neutral, size: :standard,
               data: { action: "register-workspace#closeControlOverlay", register_workspace_target: "controlCancel" } %>
         <%= action_button "Apply", style: :solid, intent: :brand, size: :standard,
               data: { action: "register-workspace#submitControlApply", register_workspace_target: "controlApply" } %>
@@ -117,16 +145,6 @@
         <input id="pos-unlinked-price" class="pos-command__field" data-register-workspace-target="unlinkedPriceField"
                data-action="input->register-workspace#syncUnlinkedPrimaryEnabled"
                inputmode="decimal" autocomplete="off">
-
-        <div data-register-workspace-target="unlinkedApproverWrap" hidden>
-          <label for="pos-unlinked-approver-username">Approver username</label>
-          <input id="pos-unlinked-approver-username" class="pos-command__field" data-register-workspace-target="unlinkedApproverUsername"
-                 data-action="input->register-workspace#syncUnlinkedPrimaryEnabled" autocomplete="off">
-          <label for="pos-unlinked-approver-password">Approver password</label>
-          <input id="pos-unlinked-approver-password" class="pos-command__field" type="password"
-                 data-register-workspace-target="unlinkedApproverPassword"
-                 data-action="input->register-workspace#syncUnlinkedPrimaryEnabled" autocomplete="off">
-        </div>
       </div>
 
       <div class="pos-overlay__actions">

--- a/app/views/pos/workspaces/dialog_error.turbo_stream.erb
+++ b/app/views/pos/workspaces/dialog_error.turbo_stream.erb
@@ -1,3 +1,5 @@
 <%= turbo_stream.update @overlay_error_dom_id do %>
-  <%= @feedback %>
+  <span data-overlay-error-kind="<%= @overlay_failure.kind %>"
+        data-overlay-error-field="<%= @overlay_failure.field %>"
+        data-register-workspace-target="overlayFailureMeta"><%= @overlay_failure.message %></span>
 <% end %>

--- a/docs/planning/register-workspace-consolidation/README.md
+++ b/docs/planning/register-workspace-consolidation/README.md
@@ -23,6 +23,8 @@ This program **replaces** the current POS presentation. It does not run a parall
 | [slice5a-manual-verification.md](slice5a-manual-verification.md) | Slice 5A workstation evidence |
 | [slice5b-return-overlays-plan.md](slice5b-return-overlays-plan.md) | Locked Slice 5B return overlay contracts |
 | [slice5b-manual-verification.md](slice5b-manual-verification.md) | Slice 5B workstation evidence |
+| [slice5c-controlled-actions-plan.md](slice5c-controlled-actions-plan.md) | Locked Slice 5C controlled-action / confirmation contracts |
+| [slice5c-manual-verification.md](slice5c-manual-verification.md) | Slice 5C workstation evidence |
 
 UX adoption: follow [ux-adoption-template.md](../ux-design-system/ux-adoption-template.md) in the slice that materially changes a screen. Printed receipts stay locked unless a slice explicitly owns print.
 

--- a/docs/planning/register-workspace-consolidation/implementation-plan.md
+++ b/docs/planning/register-workspace-consolidation/implementation-plan.md
@@ -1,6 +1,6 @@
 # Register workspace consolidation — Implementation plan
 
-Status: **Slice 5B merged** on `register-workspace-consolidation` ([#87](https://github.com/BankEncore/ShelfSense-v1/issues/87) / PR [#100](https://github.com/BankEncore/ShelfSense-v1/pull/100)). Next: Slice 5C controlled-action overlays.
+Status: **Slice 5C in implementation** on `88-controlled-action-overlays` (PR targeting `register-workspace-consolidation`). Slice 5B is on the integration branch.
 
 Authority: [plan.md](plan.md), [routing-and-authority.md](routing-and-authority.md).
 
@@ -26,7 +26,7 @@ This program uses a long-lived integration branch because an incomplete Register
 | 4 Transaction composition | Merged to integration ([#85](https://github.com/BankEncore/ShelfSense-v1/issues/85) / PR #98) | [#85](https://github.com/BankEncore/ShelfSense-v1/issues/85) |
 | 5A Lookup overlays | Merged to integration ([#86](https://github.com/BankEncore/ShelfSense-v1/issues/86) / PR [#99](https://github.com/BankEncore/ShelfSense-v1/pull/99)) | [#86](https://github.com/BankEncore/ShelfSense-v1/issues/86) |
 | 5B Return overlays | Merged to integration ([#87](https://github.com/BankEncore/ShelfSense-v1/issues/87) / PR [#100](https://github.com/BankEncore/ShelfSense-v1/pull/100)) | [#87](https://github.com/BankEncore/ShelfSense-v1/issues/87) |
-| 5C Controlled-action overlays | Not started | [#88](https://github.com/BankEncore/ShelfSense-v1/issues/88) |
+| 5C Controlled-action overlays | This PR ([slice5c-controlled-actions-plan.md](slice5c-controlled-actions-plan.md)) | [#88](https://github.com/BankEncore/ShelfSense-v1/issues/88) |
 | 5D Tender/issuance overlays | Not started | [#89](https://github.com/BankEncore/ShelfSense-v1/issues/89) |
 | 6A Customer-service surfaces | Not started | [#90](https://github.com/BankEncore/ShelfSense-v1/issues/90) |
 | 6B Till and session detail | Not started | [#91](https://github.com/BankEncore/ShelfSense-v1/issues/91) |

--- a/docs/planning/register-workspace-consolidation/slice5c-controlled-actions-plan.md
+++ b/docs/planning/register-workspace-consolidation/slice5c-controlled-actions-plan.md
@@ -110,11 +110,11 @@ Tax-class **names** and formatted money—never internal IDs. Escape/Back closes
 
 ### 6. Cancel transaction
 
-Presenter-authored consequences using **quantities**, not DOM row counts. Include gift-card issuances when present; omit absent components. Do not invent tender reversal; honor existing cancel gates.
+Presenter-authored consequences using **quantities**, not DOM row counts. Include gift-card issuances when present, counting **activations** and **reloads** separately; omit absent components. Do not invent tender reversal; honor existing cancel gates.
 
 ### 7. Typed failure classification
 
-Closed vocabulary (no message-prefix UI routing):
+Closed vocabulary (no message-prefix / English-copy UI routing):
 
 ```text
 authorization_failed
@@ -124,16 +124,22 @@ stale_transaction
 transport_uncertain
 ```
 
-Turbo / dialog error exposes `data-overlay-error-kind` and `data-overlay-error-field`. Adapter at workspace response boundary maps domain exceptions.
+Approver denials are typed at their source (`Pos::ApproverAuthenticationFailed`, `Pos::SelfApprovalProhibited`, `Pos::ApproverNotAuthorized`). The workspace boundary maps those classes onto `OverlayFailure` kinds. Human-readable messages are independent of routing.
+
+Turbo / dialog error exposes `data-overlay-error-kind` and `data-overlay-error-field`.
 
 | Kind | Visible layer | Focus |
 |---|---|---|
 | `authorization_failed` | O18 | Password |
 | `authorization_prohibited` | O18 | Username or safe dismiss |
 | `parent_validation_failed` | Parent (pop O18) | Invalid field |
-| `stale_transaction` | Parent (pop O18) | Local error |
+| `stale_transaction` | **Refreshed workspace** (overlay ancestry cleared) | Command / selected line when it still exists |
 | `transport_uncertain` | Existing recovery | Retry |
 | Success | Refreshed workspace | Command / selected line |
+
+**Stale policy (amended):** When the working transaction’s `lock_version` no longer matches, do **not** preserve O9/O18 with proposed values. Reload the workspace, keep the refreshed line selected when it still exists, surface the stale message prominently, and require the cashier to reopen the action. Preserving a proposed override against a concurrently changed line is unsafe.
+
+O9 must be client-ready (proposed value, managed reason, required note; existing adjustment for remove) before opening O18. Server validation remains authoritative.
 
 ### 8. Stack transitions
 

--- a/docs/planning/register-workspace-consolidation/slice5c-controlled-actions-plan.md
+++ b/docs/planning/register-workspace-consolidation/slice5c-controlled-actions-plan.md
@@ -1,6 +1,6 @@
 # Slice 5C — Controlled actions and confirmation
 
-Status: **Implementation-ready.** Slice 5B is on `register-workspace-consolidation` ([#87](https://github.com/BankEncore/ShelfSense-v1/issues/87) / PR [#100](https://github.com/BankEncore/ShelfSense-v1/pull/100)).
+Status: **Implemented** on `88-controlled-action-overlays` (PR targeting `register-workspace-consolidation`).
 
 Authority: [plan.md](plan.md), [routing-and-authority.md](routing-and-authority.md), [textual-wireframes.md](textual-wireframes.md) O9 / O18 / P14, [user-stories.md](user-stories.md), [slice5a-lookup-overlays-plan.md](slice5a-lookup-overlays-plan.md) (lifecycle), [slice5b-return-overlays-plan.md](slice5b-return-overlays-plan.md) (deferred O18 nesting).
 

--- a/docs/planning/register-workspace-consolidation/slice5c-controlled-actions-plan.md
+++ b/docs/planning/register-workspace-consolidation/slice5c-controlled-actions-plan.md
@@ -1,0 +1,169 @@
+# Slice 5C — Controlled actions and confirmation
+
+Status: **Implementation-ready.** Slice 5B is on `register-workspace-consolidation` ([#87](https://github.com/BankEncore/ShelfSense-v1/issues/87) / PR [#100](https://github.com/BankEncore/ShelfSense-v1/pull/100)).
+
+Authority: [plan.md](plan.md), [routing-and-authority.md](routing-and-authority.md), [textual-wireframes.md](textual-wireframes.md) O9 / O18 / P14, [user-stories.md](user-stories.md), [slice5a-lookup-overlays-plan.md](slice5a-lookup-overlays-plan.md) (lifecycle), [slice5b-return-overlays-plan.md](slice5b-return-overlays-plan.md) (deferred O18 nesting).
+
+Issue: [#88](https://github.com/BankEncore/ShelfSense-v1/issues/88). Branch: `88-controlled-action-overlays`. PR target: `register-workspace-consolidation`.
+
+**ID note:** Wireframe **O11** is tender selection (5D). Manager authorization is **O18**.
+
+## Outcome
+
+Migrate O9 price / discount / tax onto action-specific chrome on the shared 5A lifecycle. Introduce one confirmation-frame primitive with **authorization** (O18) and **destructive** variants. Nest O18 for controlled actions and unlinked returns without a separate approval side effect. Migrate Cancel Transaction onto the destructive frame with presenter-authored consequences. Only named consumers. Typed `OverlayFailure` routing at the workspace response boundary.
+
+## Scope
+
+| In | Out |
+|---|---|
+| O9 price / discount / tax content on 5A lifecycle | Quantity editor (command-field mode) |
+| Shared confirmation frame (authorization + destructive) | Open-ended P14 migration |
+| Nested O18 for controlled-action **and** unlinked-return approval | Separate “manager approved” client side effect |
+| Cancel transaction destructive frame (presenter consequences) | Second confirmation for remove-adjustment |
+| Direct O9 remove with explicit labels; O18 only if removal needs auth | Cancel tendering / remove tender (Slice 7) |
+| Typed `OverlayFailure` vocabulary | Close session, cash-op, post-void, abandon-completion |
+| Delete inline `controlApproverWrap` / `unlinkedApproverWrap` | Gift-card issuance (O10) / tender selection (O11) — 5D |
+| Invocation isolation + credential lifecycle | New controlled-action domain mutation services |
+
+Endpoints stay. Preserve `#pos_overlay`, Stimulus cancel targets, F9, and cancel service unless this packet explicitly supersedes them. Launch keys remain Phase 6.7 until 7C.
+
+## Named confirmation consumers (closed list)
+
+No additional P14 consumer may enter the PR unless added here by name:
+
+| Consumer | Behavior |
+|---|---|
+| Price override authorization | O9 → O18 → atomic apply |
+| Discount authorization | O9 → O18 → atomic apply |
+| Tax-class authorization | O9 → O18 → atomic apply |
+| Unlinked-return authorization | Unlinked → O18 → atomic add |
+| Cancel transaction | Destructive frame; existing cancel service |
+| Remove existing adjustment | **Direct** explicit O9 action |
+| Removal requiring authorization | O9 → O18 → atomic remove |
+| Additional destructive confirmation for remove | **Out of scope** |
+| Cancel tendering / remove tender / close session / abandon completion / cash ops / post-void | **No** |
+
+## One frame, two semantics
+
+```text
+Confirmation frame (shared lifecycle chrome)
+├── authorization (O18)
+│   ├── context summary
+│   ├── username / password
+│   └── Back to parent · Authorize and Apply / Authorize and Add Return
+└── destructive
+    ├── presenter-authored consequence
+    ├── Keep / safe alternative
+    └── destructive commit
+```
+
+## Locked contracts
+
+### 1. Invocation record (no secrets)
+
+```js
+{
+  consumer: "price_override", // line_discount | tax_class_override | unlinked_return | cancel_transaction
+  operation: "apply",         // remove | cancel
+  parentOverlay,
+  formTarget,
+  context                     // non-secret display strings only
+}
+```
+
+Never store password, username/password pair, arbitrary callbacks, markup selectors, or prebuilt HTML.
+
+### 2. Credential lifecycle
+
+```text
+Password exists only in O18 fields and the command form during active submission.
+It is never retained in the invocation object or restored with parent values.
+```
+
+1. Read O18 fields at Authorize.
+2. Copy into existing command form immediately before `requestSubmit()`.
+3. Submit once (auth + mutation one server operation).
+4. Clear hidden password once the request payload is captured.
+5. Clear visible + hidden passwords on failure, close, Escape, parent close, disconnect, Turbo replace, or aborted submission.
+
+Username may remain after authentication failure; password never does.
+
+### 3. Auth is not a side effect
+
+O18 does not authorize independently. Credentials ride with the existing command. No durable client “approved” flag. Wireframe “approve then return to form” is superseded.
+
+### 4. O9 parent chrome
+
+| Action | Title | Secondary | Remove label |
+|---|---|---|---|
+| Price | Change Selling Price | Keep Current Price | Remove Price Override |
+| Discount | Apply Line Discount | Keep Current Discount | Remove Line Discount |
+| Tax | Change Tax Class | Keep Current Tax Class | Restore Original Tax Class |
+
+- Direct policy: Apply / Remove submit immediately.
+- Approval required: Apply / Remove opens O18.
+- Prohibited: cannot open O9 or O18.
+
+### 5. O18 context
+
+Tax-class **names** and formatted money—never internal IDs. Escape/Back closes O18 only; parent non-secret values intact; credentials cleared.
+
+### 6. Cancel transaction
+
+Presenter-authored consequences using **quantities**, not DOM row counts. Include gift-card issuances when present; omit absent components. Do not invent tender reversal; honor existing cancel gates.
+
+### 7. Typed failure classification
+
+Closed vocabulary (no message-prefix UI routing):
+
+```text
+authorization_failed
+authorization_prohibited
+parent_validation_failed
+stale_transaction
+transport_uncertain
+```
+
+Turbo / dialog error exposes `data-overlay-error-kind` and `data-overlay-error-field`. Adapter at workspace response boundary maps domain exceptions.
+
+| Kind | Visible layer | Focus |
+|---|---|---|
+| `authorization_failed` | O18 | Password |
+| `authorization_prohibited` | O18 | Username or safe dismiss |
+| `parent_validation_failed` | Parent (pop O18) | Invalid field |
+| `stale_transaction` | Parent (pop O18) | Local error |
+| `transport_uncertain` | Existing recovery | Retry |
+| Success | Refreshed workspace | Command / selected line |
+
+### 8. Stack transitions
+
+```text
+command → O9 → Escape → command
+O9 (approval required) → O18 → Escape/Back → O9
+unlinked → O18 → Escape/Back → unlinked
+command → cancel destructive → Escape/Keep → command
+Closing parent closes O18 and clears invocation + credentials
+```
+
+## Implementation sequence
+
+1. Packet (this document + manual stub).
+2. Shared frame lifecycle + whitelisted invocation.
+3. Cancel Transaction with presenter consequences.
+4. O9 action-specific content and direct-policy submission.
+5. Controlled-action O18.
+6. Unlinked-return O18.
+7. Typed failure routing, isolation, credential clearing.
+8. Tests, docs, PR; close #88 after merge.
+
+## Tests (required)
+
+Flows plus invocation isolation (direct-policy without O18; prohibited cannot open; cross-parent context/credential isolation; exact form submit; parent close clears invocation; Turbo/disconnect clears credentials; remove direct or O18 per policy; tax-class names in O18; pointer-only; double-submit prevention).
+
+## Explicit non-goals
+
+- Quantity overlay; tender/issuance (5D); Slice 7 confirmations
+- Cash / post-void / session leave confirmations
+- Destructive second step for remove-adjustment
+- New financial/domain mutation model
+- Remapping F6/F7; message-prefix failure routing; open-ended P14 migration

--- a/docs/planning/register-workspace-consolidation/slice5c-manual-verification.md
+++ b/docs/planning/register-workspace-consolidation/slice5c-manual-verification.md
@@ -1,0 +1,25 @@
+# Slice 5C — Manual verification evidence
+
+Status: required for Slice 5C closeout alongside automated system coverage.
+
+Workstation assumptions: Chrome (or Chromium) on a Register-class display; Keyboard Lock optional.
+
+## Checklist
+
+| # | Case | Pass criteria | Result | Notes |
+|---|---|---|---|---|
+| 1 | O9 price open (F6) | Action-specific title; background inert | | |
+| 2 | Direct-policy Apply | Submits without O18 | | |
+| 3 | Approval → O18 → Escape | Parent values restored; password cleared | | |
+| 4 | Auth failure | O18 stays; password cleared; username may remain | | |
+| 5 | Unlinked → O18 → Authorize | Atomic add; ancestry cleared | | |
+| 6 | Cross-parent O18 | Unlinked context after price O18; no leftover credentials | | |
+| 7 | Cancel transaction | Presenter consequence copy; Keep restores command | | |
+| 8 | F10 while O9 or O18 open | Menu does not open | | |
+
+## Sign-off
+
+- Date:
+- Browser / OS:
+- Verified by:
+- Follow-ups (if any):

--- a/docs/planning/register-workspace-consolidation/test-matrix.md
+++ b/docs/planning/register-workspace-consolidation/test-matrix.md
@@ -60,14 +60,16 @@ F10 working-basket preservation is already covered in [test/system/pos_register_
 | `test/services/pos/workspace_presenter_test.rb` | Summary formula, tax groups, settlement DTOs, mismatch fallback, non-summary chrome | Slice 4 |
 | `test/integration/pos_register_test.rb` | `#pos_tenders` sibling of `#pos_totals`; Merchandise / no Sales | Slice 4 DOM |
 | Financial/domain POS suites | Signing / settlement unchanged under provisional tax persistence | Slice 4 regression |
-| `test/system/pos_register_workspace_test.rb` | Keyboard, F10→menu, overlays, scan; Slice 5A lookup stack/inert/async/pointer/open-price; Slice 5B return Escape ladder / chooser stack / linked add | Slice 5A–5B |
+| `test/system/pos_register_workspace_test.rb` | Keyboard, F10→menu, overlays, scan; Slice 5A lookup stack/inert/async/pointer/open-price; Slice 5B return Escape ladder / chooser stack / linked add; Slice 5C O9/O18 nesting, cancel consequence, invocation isolation | Slice 5A–5C |
 | Slice 5A cases in workspace system suite | Root/nested inert; Escape restores parent stage; pointer Choose Product / Attach Customer / Add Pickup; Escape-during-fetch ignores late response; zero open-price select-all | [#86](https://github.com/BankEncore/ShelfSense-v1/issues/86) |
 | Slice 5B return overlay cases | Chooser parent stack; linked Escape ladder; Escape during lines fetch ignores late response; prohibited unlinked disabled in chooser; linked add clears ancestry; unlinked failure preserves fields/clears password; nested picker Cancel aborts; unlinked variant Back to Item Lookup | [#87](https://github.com/BankEncore/ShelfSense-v1/issues/87) |
+| Slice 5C controlled-action / confirmation cases | O9 action titles; direct-policy Apply; O18 nest Escape restores parent; auth failure typed feedback; cross-parent O18 isolation; cancel presenter consequence | [#88](https://github.com/BankEncore/ShelfSense-v1/issues/88) |
 | `test/system/pos_register_shell_test.rb` | Shell zoom, F10 lifecycle on all compositions | Slice 3 |
 | `test/system/pos_linked_return_test.rb` | F10 menu then Transactions & Receipts | Slice 3 |
 | `test/system/pos_mixed_return_test.rb` | F10 menu then Transactions & Receipts; Escape restores chooser then command | Slice 3 / 5B |
 | `test/services/pos/register_menu_test.rb` | Menu capability keys | Slice 3 |
-| `test/system/pos_unlinked_return_test.rb` | Unlinked chrome, nested picker, approval failure while chooser parent inert | [#87](https://github.com/BankEncore/ShelfSense-v1/issues/87) |
+| `test/system/pos_unlinked_return_test.rb` | Unlinked chrome, nested picker; Slice 5C O18 authorization failure while parents inert | [#87](https://github.com/BankEncore/ShelfSense-v1/issues/87) / [#88](https://github.com/BankEncore/ShelfSense-v1/issues/88) |
+| `test/services/pos/overlay_failure_test.rb` | Typed OverlayFailure vocabulary | [#88](https://github.com/BankEncore/ShelfSense-v1/issues/88) |
 | `test/system/pos_close_z_test.rb` | Interaction | Preserve |
 
 ## Gap characterization (this slice)

--- a/test/integration/pos_register_test.rb
+++ b/test/integration/pos_register_test.rb
@@ -564,7 +564,7 @@ class PosRegisterTest < ActionDispatch::IntegrationTest
     }
     assert_response :success
     assert_equal 1999, line.reload.selling_unit_price_cents
-    assert_match(/approver credentials/, response.body)
+    assert_match(/Manager credentials were not accepted/, response.body)
     assert_equal associate.id, User.find_by!(username: "clerk_ui").id
 
     post pos_register_controlled_action_path, params: {
@@ -608,8 +608,9 @@ class PosRegisterTest < ActionDispatch::IntegrationTest
 
     assert_response :unprocessable_entity
     assert_equal 1999, line.reload.selling_unit_price_cents
-    assert_match(/approver credentials/, response.body)
-    assert_includes response.body, 'target="pos-control-feedback"'
+    assert_match(/Manager credentials were not accepted/, response.body)
+    assert_includes response.body, 'target="pos-approval-feedback"'
+    assert_includes response.body, 'data-overlay-error-kind="authorization_failed"'
     refute_includes response.body, 'target="pos_workspace"'
     refute_includes response.body, "wrong-password-secret"
   end

--- a/test/integration/pos_register_test.rb
+++ b/test/integration/pos_register_test.rb
@@ -615,7 +615,9 @@ class PosRegisterTest < ActionDispatch::IntegrationTest
     refute_includes response.body, "wrong-password-secret"
   end
 
-  test "stale overlay submission still replaces the workspace" do
+  test "stale overlay submission replaces the workspace per amended packet" do
+    # Packet: proposed values against a changed lock_version are unsafe — clear overlays
+    # and require the cashier to reopen the action on the refreshed workspace.
     post pos_register_enter_path, params: enter_params
     follow_redirect!
     transaction = PosTransaction.working.find_by!(register: @register)
@@ -634,6 +636,8 @@ class PosRegisterTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes response.body, 'target="pos_workspace"'
     assert_match(/This sale was changed/, response.body)
+    refute_includes response.body, 'target="pos-control-feedback"'
+    refute_includes response.body, 'target="pos-approval-feedback"'
   end
 
   test "discount apply ignores a leftover malformed selling_price" do

--- a/test/integration/pos_unlinked_return_workspace_test.rb
+++ b/test/integration/pos_unlinked_return_workspace_test.rb
@@ -82,7 +82,7 @@ class PosUnlinkedReturnWorkspaceTest < ActionDispatch::IntegrationTest
       return_price: "19.99"
     }
     assert_response :success
-    assert_match "approver credentials are required", response.body
+    assert_match "Manager credentials were not accepted", response.body
     assert_equal 0, transaction.reload.pos_transaction_lines.count
 
     post pos_register_unlinked_return_path, params: {

--- a/test/services/pos/controlled_actions_test.rb
+++ b/test/services/pos/controlled_actions_test.rb
@@ -87,8 +87,8 @@ class PosControlledActionsTest < ActiveSupport::TestCase
         approver_password: "correct-horse-battery"
       )
     end
-    assert_equal :authorization_failed, error.kind
-    assert_match(/Manager credentials were not accepted/, error.message)
+    assert_equal :authorization_prohibited, error.kind
+    assert_match(/You cannot approve your own action/, error.message)
     assert_equal 1999, line.reload.selling_unit_price_cents
     assert AuditEvent.exists?(action: "pos.controlled_action.denied")
   end

--- a/test/services/pos/controlled_actions_test.rb
+++ b/test/services/pos/controlled_actions_test.rb
@@ -76,7 +76,7 @@ class PosControlledActionsTest < ActiveSupport::TestCase
   test "self-approval is rejected" do
     transaction, line = start_sale(@associate)
 
-    error = assert_raises(Pos::Error) do
+    error = assert_raises(Pos::OverlayFailure) do
       apply_action(
         transaction, line, @associate,
         action_type: "price_override",
@@ -87,7 +87,8 @@ class PosControlledActionsTest < ActiveSupport::TestCase
         approver_password: "correct-horse-battery"
       )
     end
-    assert_match(/performer/, error.message)
+    assert_equal :authorization_failed, error.kind
+    assert_match(/Manager credentials were not accepted/, error.message)
     assert_equal 1999, line.reload.selling_unit_price_cents
     assert AuditEvent.exists?(action: "pos.controlled_action.denied")
   end
@@ -97,7 +98,7 @@ class PosControlledActionsTest < ActiveSupport::TestCase
     other = pos_store_manager(store: east, assigned_by: @admin, username: "eastmgr")
     transaction, line = start_sale(@associate)
 
-    error = assert_raises(Pos::Error) do
+    error = assert_raises(Pos::OverlayFailure) do
       apply_action(
         transaction, line, @associate,
         action_type: "price_override",
@@ -108,7 +109,8 @@ class PosControlledActionsTest < ActiveSupport::TestCase
         approver_password: "correct-horse-battery"
       )
     end
-    assert_match(/not authorized at this store/, error.message)
+    assert_equal :authorization_prohibited, error.kind
+    assert_match(/This manager cannot authorize/, error.message)
     assert_equal other.username, "eastmgr"
     assert_equal 0, line.reload.pos_controlled_actions.count
   end

--- a/test/services/pos/execute_unlinked_return_test.rb
+++ b/test/services/pos/execute_unlinked_return_test.rb
@@ -294,7 +294,7 @@ class PosExecuteUnlinkedReturnTest < ActiveSupport::TestCase
 
   test "denied approver produces no line and audits the working transaction" do
     transaction = start_transaction(@associate)
-    error = assert_raises(Pos::Error) do
+    error = assert_raises(Pos::OverlayFailure) do
       add_unlinked!(
         transaction,
         @associate,
@@ -302,7 +302,8 @@ class PosExecuteUnlinkedReturnTest < ActiveSupport::TestCase
         approver_password: "wrong-password"
       )
     end
-    assert_match(/approver credentials are invalid/, error.message)
+    assert_equal :authorization_failed, error.kind
+    assert_match(/Manager credentials were not accepted/, error.message)
     assert_equal 0, transaction.reload.pos_transaction_lines.count
     assert_equal 0, PosControlledAction.where(pos_transaction_id: transaction.id).count
 

--- a/test/services/pos/overlay_failure_test.rb
+++ b/test/services/pos/overlay_failure_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PosOverlayFailureTest < ActiveSupport::TestCase
+  test "from_denied maps credential failures" do
+    failure = Pos::OverlayFailure.from_denied(Pos::Denied.new("approver credentials are invalid"))
+    assert_equal :authorization_failed, failure.kind
+    assert_equal :approver_password, failure.field
+    assert_match(/Manager credentials were not accepted/, failure.message)
+  end
+
+  test "from_denied maps unauthorized approver" do
+    failure = Pos::OverlayFailure.from_denied(Pos::Denied.new("approver is not authorized at this store"))
+    assert_equal :authorization_prohibited, failure.kind
+    assert_equal :approver_username, failure.field
+  end
+
+  test "from_denied ignores unrelated denials" do
+    assert_nil Pos::OverlayFailure.from_denied(Pos::Denied.new("not authorized to perform this action"))
+  end
+
+  test "rejects unknown kinds" do
+    assert_raises(ArgumentError) { Pos::OverlayFailure.new(kind: :nope, message: "x") }
+  end
+end

--- a/test/services/pos/overlay_failure_test.rb
+++ b/test/services/pos/overlay_failure_test.rb
@@ -3,21 +3,41 @@
 require "test_helper"
 
 class PosOverlayFailureTest < ActiveSupport::TestCase
-  test "from_denied maps credential failures" do
-    failure = Pos::OverlayFailure.from_denied(Pos::Denied.new("approver credentials are invalid"))
+  test "maps authentication failures by class" do
+    failure = Pos::OverlayFailure.from_approver_error(
+      Pos::ApproverAuthenticationFailed.new("approver credentials are invalid")
+    )
     assert_equal :authorization_failed, failure.kind
     assert_equal :approver_password, failure.field
-    assert_match(/Manager credentials were not accepted/, failure.message)
+    assert_equal "Manager credentials were not accepted.", failure.message
   end
 
-  test "from_denied maps unauthorized approver" do
-    failure = Pos::OverlayFailure.from_denied(Pos::Denied.new("approver is not authorized at this store"))
+  test "maps self-approval separately from credential failure" do
+    failure = Pos::OverlayFailure.from_approver_error(
+      Pos::SelfApprovalProhibited.new("approver cannot be the performer")
+    )
     assert_equal :authorization_prohibited, failure.kind
     assert_equal :approver_username, failure.field
+    assert_equal "You cannot approve your own action.", failure.message
   end
 
-  test "from_denied ignores unrelated denials" do
-    assert_nil Pos::OverlayFailure.from_denied(Pos::Denied.new("not authorized to perform this action"))
+  test "maps unauthorized approver by class" do
+    failure = Pos::OverlayFailure.from_approver_error(
+      Pos::ApproverNotAuthorized.new("approver is not authorized at this store")
+    )
+    assert_equal :authorization_prohibited, failure.kind
+    assert_equal :approver_username, failure.field
+    assert_equal "This manager cannot authorize that action.", failure.message
+  end
+
+  test "ignores unrelated denials" do
+    assert_nil Pos::OverlayFailure.from_approver_error(Pos::Denied.new("not authorized to perform this action"))
+  end
+
+  test "does not route by English copy of a generic denial" do
+    assert_nil Pos::OverlayFailure.from_approver_error(
+      Pos::Denied.new("approver credentials are invalid")
+    )
   end
 
   test "rejects unknown kinds" do

--- a/test/services/pos/workspace_presenter_test.rb
+++ b/test/services/pos/workspace_presenter_test.rb
@@ -33,6 +33,13 @@ class PosWorkspacePresenterTest < ActiveSupport::TestCase
     assert_equal "text", result.command_inputmode
     assert result.close_session_available
     refute result.completion_recovery
+    assert_equal "All working content will be discarded.", result.cancel_consequence
+  end
+
+  test "cancel consequence lists sale quantities" do
+    transaction = start_sale
+    result = present(transaction, ui_mode: "sale_entry")
+    assert_equal "1 item for sale will be discarded.", result.cancel_consequence
   end
 
   test "quantity mode labels the selected line" do

--- a/test/services/pos/workspace_presenter_test.rb
+++ b/test/services/pos/workspace_presenter_test.rb
@@ -162,6 +162,7 @@ class PosWorkspacePresenterTest < ActiveSupport::TestCase
     assert_equal 2500, issuance_row.signed_cents
     assert_empty result.tender_rows
     assert result.issuance_remove_available
+    assert_equal "1 gift card activation will be discarded.", result.cancel_consequence
   end
 
   test "multiple tax groups group and order stably" do

--- a/test/system/pos_register_workspace_test.rb
+++ b/test/system/pos_register_workspace_test.rb
@@ -129,11 +129,12 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
 
     click_on "Price (F6)"
     assert_selector "#pos_control_overlay", visible: true
-    fill_in "Selling price", with: "15.00"
+    fill_in "New selling price", with: "15.00"
     select "Damaged", from: "Reason"
     find("#pos-control-price").send_keys :enter
 
-    assert_selector "#pos_control_overlay", visible: true
+    assert_selector "#pos_approval_overlay", visible: true
+    assert_selector "#pos_control_overlay[inert]", visible: :all
     assert_equal "pos-approver-username", page.evaluate_script("document.activeElement && document.activeElement.id")
     line = PosTransaction.working.find_by!(register: @register).pos_transaction_lines.first
     assert_equal line.reference_unit_price_cents, line.selling_unit_price_cents
@@ -142,13 +143,13 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     username.fill_in with: "mgr_scan"
     username.send_keys :enter
 
-    assert_selector "#pos_control_overlay", visible: true
+    assert_selector "#pos_approval_overlay", visible: true
     assert_equal "pos-approver-password", page.evaluate_script("document.activeElement && document.activeElement.id")
     line.reload
     assert_equal line.reference_unit_price_cents, line.selling_unit_price_cents
   end
 
-  test "rejected approver credentials stay in the price overlay" do
+  test "rejected approver credentials stay in authorization overlay" do
     pos_transacting_user(store: @store, assigned_by: @actor, username: "clerk_retry")
     pos_store_manager(store: @store, assigned_by: @actor, username: "mgr_retry")
     visit new_session_path
@@ -164,15 +165,18 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
 
     click_on "Price (F6)"
     assert_selector "#pos_control_overlay", visible: true
-    fill_in "Selling price", with: "15.00"
+    fill_in "New selling price", with: "15.00"
     select "Damaged", from: "Reason"
+    click_on "Apply"
+    assert_selector "#pos_approval_overlay", visible: true
     fill_in "Approver username", with: "mgr_retry"
     find("#pos-approver-password").fill_in with: "typoooo"
     find("#pos-approver-password").send_keys :enter
 
+    assert_selector "#pos_approval_overlay", visible: true
+    assert_selector "#pos-approval-feedback", text: /Manager credentials were not accepted/
     assert_selector "#pos_control_overlay", visible: true
-    assert_selector "#pos-control-feedback", text: /approver credentials/
-    assert_field "Selling price", with: "15.00"
+    assert_field "New selling price", with: "15.00"
     assert_field "Approver username", with: "mgr_retry"
     assert_equal "", find("#pos-approver-password").value
     assert_equal "pos-approver-password", page.evaluate_script("document.activeElement && document.activeElement.id")
@@ -181,6 +185,7 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
 
     find("#pos-approver-password").fill_in with: "correct-horse-battery"
     find("#pos-approver-password").send_keys :enter
+    assert_no_selector "#pos_approval_overlay", visible: true
     assert_no_selector "#pos_control_overlay", visible: true
     assert_equal 1500, line.reload.selling_unit_price_cents
   end
@@ -191,7 +196,8 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
 
     click_on "Price (F6)"
     assert_selector "#pos_control_overlay", visible: true
-    fill_in "Selling price", with: "15.00"
+    assert_selector "#pos-control-title", text: "Change Selling Price"
+    fill_in "New selling price", with: "15.00"
     select "Damaged", from: "Reason"
     find("#pos-control-price").send_keys :enter
 
@@ -225,19 +231,19 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
 
     send_keys :f6
     assert_selector "#pos_control_overlay", visible: true
-    assert_selector "#pos-control-title", text: "Price override"
+    assert_selector "#pos-control-title", text: "Change Selling Price"
     send_keys :escape
     assert_no_selector "#pos_control_overlay", visible: true
 
     send_keys :f7
     assert_selector "#pos_control_overlay", visible: true
-    assert_selector "#pos-control-title", text: "Line discount"
+    assert_selector "#pos-control-title", text: "Apply Line Discount"
     send_keys :escape
     assert_no_selector "#pos_control_overlay", visible: true
 
     click_on "Tax Class"
     assert_selector "#pos_control_overlay", visible: true
-    assert_selector "#pos-control-title", text: "Tax Class override"
+    assert_selector "#pos-control-title", text: "Change Tax Class"
     send_keys :escape
     assert_no_selector "#pos_control_overlay", visible: true
   end
@@ -370,12 +376,84 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     add_current_sku
     send_keys :f9
     assert_text "Cancel this transaction?"
+    assert_text "1 item for sale will be discarded"
+    assert_text "No receipt, inventory movement, or stored-value issuance will be completed"
     send_keys :enter
     assert_text "Cancel this transaction?"
     assert_text "Example Book"
     send_keys :f9
     assert_text "SALE ENTRY"
     assert_no_text "Example Book"
+  end
+
+  test "authorization escape restores control parent without credentials" do
+    pos_transacting_user(store: @store, assigned_by: @actor, username: "clerk_esc5c")
+    pos_store_manager(store: @store, assigned_by: @actor, username: "mgr_esc5c")
+    visit new_session_path
+    fill_in "session_username", with: "clerk_esc5c"
+    fill_in "session_password", with: "correct-horse-battery"
+    find_field("session_password").send_keys :enter
+    assert_text "Signed in successfully"
+    visit pos_register_enter_path(register_id: @register.id)
+    fill_in "Opening float", with: "0.00"
+    click_on "Open register"
+    assert_text "SALE ENTRY"
+    add_current_sku
+
+    click_on "Price (F6)"
+    fill_in "New selling price", with: "15.00"
+    select "Damaged", from: "Reason"
+    click_on "Apply"
+    assert_selector "#pos_approval_overlay", visible: true
+    fill_in "Approver username", with: "mgr_esc5c"
+    find("#pos-approver-password").fill_in with: "temp-secret"
+    send_keys :escape
+    assert_no_selector "#pos_approval_overlay", visible: true
+    assert_selector "#pos_control_overlay", visible: true
+    assert_field "New selling price", with: "15.00"
+    assert_equal "", find("#pos-approver-password", visible: :all).value
+    assert_equal "", find("#pos-approver-username", visible: :all).value
+  end
+
+  test "closing control parent clears prior authorization invocation before unlinked" do
+    pos_transacting_user(store: @store, assigned_by: @actor, username: "clerk_iso5c")
+    pos_store_manager(store: @store, assigned_by: @actor, username: "mgr_iso5c")
+    visit new_session_path
+    fill_in "session_username", with: "clerk_iso5c"
+    fill_in "session_password", with: "correct-horse-battery"
+    find_field("session_password").send_keys :enter
+    assert_text "Signed in successfully"
+    visit pos_register_enter_path(register_id: @register.id)
+    fill_in "Opening float", with: "0.00"
+    click_on "Open register"
+    assert_text "SALE ENTRY"
+    add_current_sku
+
+    click_on "Price (F6)"
+    fill_in "New selling price", with: "15.00"
+    select "Damaged", from: "Reason"
+    click_on "Apply"
+    assert_selector "#pos_approval_overlay", visible: true
+    assert_text "Price change"
+    click_on "Back to Price Change"
+    click_on "Keep Current Price"
+
+    click_on "Return (-)"
+    send_keys :arrow_down
+    send_keys :enter
+    assert_selector "#pos_unlinked_overlay", visible: true
+    identifier = find("#pos-unlinked-identifier")
+    identifier.fill_in with: @variant.sku
+    identifier.send_keys :enter
+    assert_text "Example Book", wait: 5
+    fill_in "Return unit price", with: "18.00"
+    select "Defective", from: "Return reason"
+    click_on "Add Unlinked Return"
+    assert_selector "#pos_approval_overlay", visible: true
+    assert_text "Unlinked return"
+    assert_no_text "Price change"
+    assert_equal "", find("#pos-approver-username").value
+    assert_equal "", find("#pos-approver-password").value
   end
 
   test "completed receipt enter is a no-op and workspace without a working sale returns to enter" do

--- a/test/system/pos_register_workspace_test.rb
+++ b/test/system/pos_register_workspace_test.rb
@@ -190,6 +190,30 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     assert_equal 1500, line.reload.selling_unit_price_cents
   end
 
+  test "incomplete price overlay does not open authorization" do
+    pos_transacting_user(store: @store, assigned_by: @actor, username: "clerk_ready5c")
+    pos_store_manager(store: @store, assigned_by: @actor, username: "mgr_ready5c")
+    visit new_session_path
+    fill_in "session_username", with: "clerk_ready5c"
+    fill_in "session_password", with: "correct-horse-battery"
+    find_field("session_password").send_keys :enter
+    assert_text "Signed in successfully"
+    visit pos_register_enter_path(register_id: @register.id)
+    fill_in "Opening float", with: "0.00"
+    click_on "Open register"
+    assert_text "SALE ENTRY"
+    add_current_sku
+
+    click_on "Price (F6)"
+    assert_selector "#pos_control_overlay", visible: true
+    fill_in "New selling price", with: "15.00"
+    click_on "Apply"
+    assert_no_selector "#pos_approval_overlay", visible: true
+    assert_selector "#pos_control_overlay", visible: true
+    assert_selector "#pos-control-feedback", text: /Choose a reason/
+    assert_equal "pos-control-reason", page.evaluate_script("document.activeElement && document.activeElement.id")
+  end
+
   test "enter from a direct price field applies the override" do
     open_register
     add_current_sku

--- a/test/system/pos_unlinked_return_test.rb
+++ b/test/system/pos_unlinked_return_test.rb
@@ -38,11 +38,13 @@ class PosUnlinkedReturnTest < ApplicationSystemTestCase
 
     fill_in "Return unit price", with: "18.00"
     select "Defective", from: "Return reason"
-    find("#pos-unlinked-approver-username", visible: true).fill_in with: "mgr_sys65c"
-    password = find("#pos-unlinked-approver-password", visible: :all)
+    click_on "Add Unlinked Return"
+    assert_selector "#pos_approval_overlay", visible: true
+    fill_in "Approver username", with: "mgr_sys65c"
+    password = find("#pos-approver-password", visible: :all)
     scroll_to password
     password.fill_in with: "correct-horse-battery"
-    click_on "Add Unlinked Return"
+    click_on "Authorize and Add Return"
 
     assert_text "RETURN", wait: 10
     assert_text "Unlinked return"
@@ -163,20 +165,24 @@ class PosUnlinkedReturnTest < ApplicationSystemTestCase
     assert_text "Example Book", wait: 5
     fill_in "Return unit price", with: "18.00"
     select "Defective", from: "Return reason"
-    find("#pos-unlinked-approver-username", visible: true).fill_in with: "mgr_sys65c"
-    password = find("#pos-unlinked-approver-password", visible: :all)
+    click_on "Add Unlinked Return"
+    assert_selector "#pos_approval_overlay", visible: true
+    fill_in "Approver username", with: "mgr_sys65c"
+    password = find("#pos-approver-password", visible: :all)
     scroll_to password
     password.fill_in with: "wrong-password"
-    click_on "Add Unlinked Return"
+    click_on "Authorize and Add Return"
 
-    assert_selector "#pos-unlinked-feedback", text: /approver/i, wait: 10
+    assert_selector "#pos-approval-feedback", text: /Manager credentials were not accepted/, wait: 10
+    assert_selector "#pos_approval_overlay", visible: true
     assert_selector "#pos_unlinked_overlay", visible: true
     assert_selector "#pos_return_chooser", visible: :all
     assert page.evaluate_script("document.querySelector('#pos_return_chooser').inert === true")
+    assert page.evaluate_script("document.querySelector('#pos_unlinked_overlay').inert === true")
     assert_equal "18.00", find("#pos-unlinked-price").value
     assert_equal "defective", find("#pos-unlinked-reason").value
-    assert_equal "mgr_sys65c", find("#pos-unlinked-approver-username").value
-    assert_equal "", find("#pos-unlinked-approver-password", visible: :all).value
+    assert_equal "mgr_sys65c", find("#pos-approver-username").value
+    assert_equal "", find("#pos-approver-password", visible: :all).value
   end
 
   test "pointer Back on nested product picker restores unlinked overlay" do


### PR DESCRIPTION
## Summary
- Nest manager authorization (O18) for controlled actions and unlinked returns; credentials copy onto the existing command form for one-shot submit (no separate approval side effect).
- O9 action-specific chrome with direct-policy Apply/Remove; remove inline approver wraps; cancel transaction uses presenter-authored consequence quantities.
- Typed `Pos::OverlayFailure` at the workspace response boundary (`data-overlay-error-kind` / field) for dialog recovery without message-prefix routing.

## Test plan
- [x] `./dev/rails-docker bin/rails test` — overlay failure, presenter, controlled actions, unlinked return, register/unlinked integration
- [x] `./dev/rails-docker bin/rails test test/system/pos_register_workspace_test.rb test/system/pos_unlinked_return_test.rb test/system/pos_mixed_return_test.rb`
- [ ] Manual checklist in `docs/planning/register-workspace-consolidation/slice5c-manual-verification.md`
- [ ] After merge to `register-workspace-consolidation`, close [#88](https://github.com/BankEncore/ShelfSense-v1/issues/88) manually (non-default base)


Made with [Cursor](https://cursor.com)