### PR TITLE
Slice 6A.1: RegisterShellContext + Transactions & Receipts

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -2316,6 +2316,18 @@ input[type="submit"]:disabled,
   margin: var(--space-6) auto;
 }
 
+.pos-history__title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.pos-history__title-row h1 {
+  margin: 0;
+}
+
 .pos-history__nav {
   display: flex;
   gap: var(--space-4);

--- a/app/controllers/pos/base_controller.rb
+++ b/app/controllers/pos/base_controller.rb
@@ -131,6 +131,24 @@ module Pos
       end
     end
 
+    def prepare_inquiry_shell!(surface:)
+      prepare_register_shell!
+      @shell_context = Pos::RegisterShellContext.call(
+        store: current_store,
+        actor: current_user,
+        state: @state,
+        surface: surface,
+        can_view_expected_cash: can_view_expected_cash?
+      )
+    end
+
+    def inquiry_register_params
+      return {} if @register.blank?
+
+      { register_id: @register.id }
+    end
+    helper_method :inquiry_register_params
+
     def cashier_open_sessions
       PosSession.open.where(store: current_store, cashier_user: current_user)
     end

--- a/app/controllers/pos/transactions_controller.rb
+++ b/app/controllers/pos/transactions_controller.rb
@@ -3,10 +3,11 @@
 module Pos
   class TransactionsController < BaseController
     def index
+      prepare_inquiry_shell!(surface: :transaction_history)
       @search = Pos::CompletedTransactionSearch.call(
         store: current_store,
         transaction_reference: params[:transaction_reference],
-        register_id: params[:register_id],
+        register_id: params[:filter_register_id],
         receipt_sequence: params[:receipt_sequence],
         business_date: params[:business_date],
         page: params[:page]
@@ -15,6 +16,7 @@ module Pos
     end
 
     def show
+      prepare_inquiry_shell!(surface: :transaction_history)
       @transaction = PosTransaction.completed
                                    .includes(
                                      :post_void_of,

--- a/app/helpers/pos_helper.rb
+++ b/app/helpers/pos_helper.rb
@@ -116,7 +116,7 @@ module PosHelper
   def pos_history_query_params(search)
     {
       transaction_reference: search.transaction_reference,
-      register_id: search.register_id,
+      filter_register_id: search.register_id,
       receipt_sequence: search.receipt_sequence,
       business_date: search.business_date
     }.compact_blank

--- a/app/helpers/pos_register_shell_helper.rb
+++ b/app/helpers/pos_register_shell_helper.rb
@@ -133,8 +133,21 @@ module PosRegisterShellHelper
   def register_menu_surface
     return :switch_register if @switch_register
     return :workspace if controller_path == "pos/workspaces"
+    return @shell_context.menu_surface if @shell_context.respond_to?(:menu_surface)
 
     :state_landing
+  end
+
+  def register_inquiry_return_path
+    return @shell_context.return_path if @shell_context.respond_to?(:return_path)
+
+    pos_resume_register_path
+  end
+
+  def register_inquiry_return_label
+    return @shell_context.return_label if @shell_context.respond_to?(:return_label)
+
+    "Close"
   end
 
   def register_menu_permissions
@@ -144,7 +157,7 @@ module PosRegisterShellHelper
   def register_menu_item(key)
     case key
     when :transactions
-      { key:, label: "Transactions & Receipts", href: pos_transactions_path }
+      { key:, label: "Transactions & Receipts", href: pos_transactions_path(inquiry_register_params) }
     when :gift_card_cash_out
       { key:, label: "Gift-card cash-out", href: new_pos_cash_out_path }
     when :paid_in

--- a/app/services/pos/register_menu.rb
+++ b/app/services/pos/register_menu.rb
@@ -9,6 +9,7 @@ module Pos
     SWITCH_SUPPRESSED = (
       TILL_KEYS + %i[switch_register x_report close_session open_register open_session finalize_z]
     ).freeze
+    INQUIRY_SUPPRESSED = %i[open_register open_session finalize_z close_session].freeze
 
     def self.call(...)
       new(...).call
@@ -37,7 +38,10 @@ module Pos
     end
 
     def suppressed?(key)
-      @surface == :switch_register && SWITCH_SUPPRESSED.include?(key)
+      return true if @surface == :switch_register && SWITCH_SUPPRESSED.include?(key)
+      return true if @surface == :inquiry && INQUIRY_SUPPRESSED.include?(key)
+
+      false
     end
 
     def customer_service_keys

--- a/app/services/pos/register_shell_context.rb
+++ b/app/services/pos/register_shell_context.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module Pos
+  # Read-only DTO for Register shell inquiry and detail surfaces.
+  # Does not create records, read cookies/session, or reimplement RegisterMenu.
+  class RegisterShellContext
+    Result = Struct.new(
+      :surface,
+      :kind,
+      :register,
+      :session,
+      :gate,
+      :owned_sessions,
+      :menu_surface,
+      :return_path,
+      :return_label,
+      :can_view_expected_cash,
+      keyword_init: true
+    )
+
+    SURFACES = %i[
+      transaction_history
+      stored_value_inquiry
+      customer_summary
+      pickup_queue
+      till_activity
+      session_detail
+      active_sessions
+      x_report
+      z_period
+      cash_operation
+    ].freeze
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(store:, actor:, state:, surface:, can_view_expected_cash:)
+      @store = store
+      @actor = actor
+      @state = state
+      @surface = surface.to_sym
+      @can_view_expected_cash = !!can_view_expected_cash
+    end
+
+    def call
+      raise ArgumentError, "unknown Register shell surface: #{@surface}" unless SURFACES.include?(@surface)
+
+      Result.new(
+        surface: @surface,
+        kind: @state.kind,
+        register: @state.register,
+        session: session_for(@state),
+        gate: @state.gate,
+        owned_sessions: Array(@state.owned_sessions),
+        menu_surface: :inquiry,
+        return_path: return_path_for(@state),
+        return_label: return_label_for(@state),
+        can_view_expected_cash: @can_view_expected_cash
+      )
+    end
+
+    private
+
+    def session_for(state)
+      return unless state.gate.respond_to?(:session)
+
+      state.gate.session
+    end
+
+    def return_path_for(state)
+      register = state.register
+      case state.kind
+      when "own_session"
+        return Rails.application.routes.url_helpers.pos_register_workspace_path(register_id: register.id) if register
+
+        Rails.application.routes.url_helpers.pos_path
+      when "closed", "between_sessions", "occupied"
+        if register
+          Rails.application.routes.url_helpers.pos_path(register_id: register.id)
+        else
+          Rails.application.routes.url_helpers.pos_path
+        end
+      else
+        Rails.application.routes.url_helpers.pos_path
+      end
+    end
+
+    def return_label_for(state)
+      case state.kind
+      when "own_session"
+        "Return to Register"
+      when "occupied"
+        "Return to Register"
+      when "closed", "between_sessions"
+        "Close"
+      else
+        "Close"
+      end
+    end
+  end
+end

--- a/app/views/pos/transactions/index.html.erb
+++ b/app/views/pos/transactions/index.html.erb
@@ -1,77 +1,85 @@
-<% content_for :title, "Transactions" %>
+<% content_for :title, "Transactions & Receipts" %>
+<%= render layout: "pos/shell/frame" do %>
+  <%= render "pos/shell/feedback" %>
+  <div class="pos-register-shell__body">
+    <main class="pos-history">
+      <div class="pos-history__title-row pos-no-print">
+        <h1>Transactions &amp; Receipts</h1>
+        <%= link_to register_inquiry_return_label, register_inquiry_return_path, class: "btn btn--ghost" %>
+      </div>
 
-<main class="pos-history">
-  <%= render "pos/transactions/chrome" %>
-
-  <h1>Transactions</h1>
-
-  <%= form_with url: pos_transactions_path, method: :get, local: true, class: "pos-history__filters" do %>
-    <div class="form-field">
-      <%= label_tag :transaction_reference, "Receipt reference" %>
-      <%= text_field_tag :transaction_reference, @search.transaction_reference, autocomplete: "off" %>
-    </div>
-    <div class="form-field">
-      <%= label_tag :register_id, "Register" %>
-      <%= select_tag :register_id,
-            options_for_select([["Any register", ""]] + @registers.map { |register| [register.admin_label, register.id] }, @search.register_id) %>
-    </div>
-    <div class="form-field">
-      <%= label_tag :receipt_sequence, "Transaction #" %>
-      <%= text_field_tag :receipt_sequence, @search.receipt_sequence, inputmode: "numeric", autocomplete: "off" %>
-    </div>
-    <div class="form-field">
-      <%= label_tag :business_date, "Business date" %>
-      <%= date_field_tag :business_date, @search.business_date %>
-    </div>
-    <div class="form-field">
-      <%= submit_tag "Find", class: "btn" %>
-    </div>
-  <% end %>
-
-  <% if @search.records.empty? && !@search.filtered %>
-    <p class="muted">No completed transactions yet.</p>
-  <% elsif @search.records.empty? %>
-    <p class="muted">No matching transactions.</p>
-  <% else %>
-    <div class="table-scroll">
-    <table class="pos-history__table">
-      <thead>
-        <tr>
-          <th>Receipt</th>
-          <th>Business date</th>
-          <th>Completed</th>
-          <th>Register</th>
-          <th>Cashier</th>
-          <th class="numeric">Net</th>
-          <th>Tender</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @search.records.each do |transaction| %>
-          <tr>
-            <td><%= link_to transaction.transaction_reference, pos_transaction_path(transaction) %></td>
-            <td><%= transaction.business_date.iso8601 %></td>
-            <td><%= format_store_timestamp(transaction.completed_at, current_store) %></td>
-            <td><%= pos_padded_register_snapshot(transaction.register_number_snapshot) %></td>
-            <td><%= pos_cashier_name(transaction) %></td>
-            <td class="numeric"><%= format_signed_money_cents(transaction.signed_net_cents) %></td>
-            <td><%= pos_tender_summary(transaction) %></td>
-          </tr>
+      <%= form_with url: pos_transactions_path, method: :get, local: true, class: "pos-history__filters" do %>
+        <% inquiry_register_params.each do |key, value| %>
+          <%= hidden_field_tag key, value %>
         <% end %>
-      </tbody>
-    </table>
-    </div>
+        <div class="form-field">
+          <%= label_tag :transaction_reference, "Receipt reference" %>
+          <%= text_field_tag :transaction_reference, @search.transaction_reference, autocomplete: "off" %>
+        </div>
+        <div class="form-field">
+          <%= label_tag :filter_register_id, "Register" %>
+          <%= select_tag :filter_register_id,
+                options_for_select([["Any register", ""]] + @registers.map { |register| [register.admin_label, register.id] }, @search.register_id) %>
+        </div>
+        <div class="form-field">
+          <%= label_tag :receipt_sequence, "Transaction #" %>
+          <%= text_field_tag :receipt_sequence, @search.receipt_sequence, inputmode: "numeric", autocomplete: "off" %>
+        </div>
+        <div class="form-field">
+          <%= label_tag :business_date, "Business date" %>
+          <%= date_field_tag :business_date, @search.business_date %>
+        </div>
+        <div class="form-field">
+          <%= submit_tag "Find", class: "btn" %>
+        </div>
+      <% end %>
 
-    <div class="pagination">
-      <span class="muted">
-        Page <%= @search.page %> of <%= @search.total_pages %> · <%= @search.total_count %> total
-      </span>
-      <% if @search.page > 1 %>
-        <%= link_to "Previous", pos_transactions_path(pos_history_query_params(@search).merge(page: @search.page - 1)), class: "btn btn--ghost" %>
+      <% if @search.records.empty? && !@search.filtered %>
+        <p class="muted">No completed transactions yet.</p>
+      <% elsif @search.records.empty? %>
+        <p class="muted">No matching transactions.</p>
+      <% else %>
+        <div class="table-scroll">
+        <table class="pos-history__table">
+          <thead>
+            <tr>
+              <th>Receipt</th>
+              <th>Business date</th>
+              <th>Completed</th>
+              <th>Register</th>
+              <th>Cashier</th>
+              <th class="numeric">Net</th>
+              <th>Tender</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @search.records.each do |transaction| %>
+              <tr>
+                <td><%= link_to transaction.transaction_reference, pos_transaction_path(transaction, inquiry_register_params) %></td>
+                <td><%= transaction.business_date.iso8601 %></td>
+                <td><%= format_store_timestamp(transaction.completed_at, current_store) %></td>
+                <td><%= pos_padded_register_snapshot(transaction.register_number_snapshot) %></td>
+                <td><%= pos_cashier_name(transaction) %></td>
+                <td class="numeric"><%= format_signed_money_cents(transaction.signed_net_cents) %></td>
+                <td><%= pos_tender_summary(transaction) %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+        </div>
+
+        <div class="pagination">
+          <span class="muted">
+            Page <%= @search.page %> of <%= @search.total_pages %> · <%= @search.total_count %> total
+          </span>
+          <% if @search.page > 1 %>
+            <%= link_to "Previous", pos_transactions_path(pos_history_query_params(@search).merge(page: @search.page - 1).merge(inquiry_register_params)), class: "btn btn--ghost" %>
+          <% end %>
+          <% if @search.page < @search.total_pages %>
+            <%= link_to "Next", pos_transactions_path(pos_history_query_params(@search).merge(page: @search.page + 1).merge(inquiry_register_params)), class: "btn btn--ghost" %>
+          <% end %>
+        </div>
       <% end %>
-      <% if @search.page < @search.total_pages %>
-        <%= link_to "Next", pos_transactions_path(pos_history_query_params(@search).merge(page: @search.page + 1)), class: "btn btn--ghost" %>
-      <% end %>
-    </div>
-  <% end %>
-</main>
+    </main>
+  </div>
+<% end %>

--- a/app/views/pos/transactions/show.html.erb
+++ b/app/views/pos/transactions/show.html.erb
@@ -1,95 +1,101 @@
 <% content_for :title, "Transaction #{@transaction.transaction_reference}" %>
+<%= render layout: "pos/shell/frame" do %>
+  <%= render "pos/shell/feedback" %>
+  <div class="pos-register-shell__body">
+    <main class="pos-history pos-receipt" data-controller="pos-receipt" data-action="keydown@document->pos-receipt#onKeydown">
+      <div class="pos-history__title-row pos-no-print">
+        <h1>Receipt  <%= @transaction.transaction_reference %></h1>
+        <%= link_to register_inquiry_return_label, register_inquiry_return_path, class: "btn btn--ghost" %>
+      </div>
 
-<main class="pos-history pos-receipt" data-controller="pos-receipt" data-action="keydown@document->pos-receipt#onKeydown">
-  <%= render "pos/transactions/chrome" %>
-
-  <div class="pos-history__detail pos-no-print">
-    <h1>Receipt  <%= @transaction.transaction_reference %></h1>
-    <%= render "pos/receipts/post_void_banner", transaction: @transaction, linked: true %>
-    <dl class="pos-history__header">
-      <div><dt>Business date</dt><dd><%= @transaction.business_date.iso8601 %></dd></div>
-      <div><dt>Completed</dt><dd><%= format_store_timestamp(@transaction.completed_at, @transaction.store) %></dd></div>
-      <div><dt>Register</dt><dd><%= pos_padded_register_snapshot(@transaction.register_number_snapshot) %></dd></div>
-      <div><dt>Cashier</dt><dd><%= pos_cashier_name(@transaction) %></dd></div>
-      <% if @transaction.customer %>
-        <div><dt>Customer</dt><dd><%= @transaction.customer.display_name %></dd></div>
-      <% end %>
-    </dl>
-
-    <dl class="pos-history__header">
-      <%= render "pos/receipts/directional_totals", transaction: @transaction %>
-    </dl>
-
-    <div class="actions pos-history__actions">
-      <% if @returnable %>
-        <%= action_link_to(
-              "Return items",
-              pos_transaction_return_items_path(@transaction),
-              style: :outline,
-              intent: :neutral
-            ) %>
-      <% end %>
-      <% if @post_void_eligible %>
-        <%= action_link_to(
-              "Post-void",
-              pos_transaction_post_void_path(@transaction),
-              style: :outline,
-              intent: :danger
-            ) %>
-      <% end %>
-    </div>
-
-    <% @transaction.pos_controlled_actions.select { |action| action.action_type == "post_void" }.each do |action| %>
-      <section aria-label="post void">
-        <h2>Post-void</h2>
+      <div class="pos-history__detail pos-no-print">
+        <%= render "pos/receipts/post_void_banner", transaction: @transaction, linked: true %>
         <dl class="pos-history__header">
-          <div><dt>Performed by</dt><dd><%= action.performed_by_name_snapshot %></dd></div>
-          <% if action.approved_by_name_snapshot.present? %>
-            <div><dt>Approved by</dt><dd><%= action.approved_by_name_snapshot %></dd></div>
-          <% end %>
-          <div><dt>Reason</dt><dd><%= action.reason_name_snapshot %></dd></div>
-          <% if action.reason_note.present? %>
-            <div><dt>Note</dt><dd><%= action.reason_note %></dd></div>
+          <div><dt>Business date</dt><dd><%= @transaction.business_date.iso8601 %></dd></div>
+          <div><dt>Completed</dt><dd><%= format_store_timestamp(@transaction.completed_at, @transaction.store) %></dd></div>
+          <div><dt>Register</dt><dd><%= pos_padded_register_snapshot(@transaction.register_number_snapshot) %></dd></div>
+          <div><dt>Cashier</dt><dd><%= pos_cashier_name(@transaction) %></dd></div>
+          <% if @transaction.customer %>
+            <div><dt>Customer</dt><dd><%= @transaction.customer.display_name %></dd></div>
           <% end %>
         </dl>
-      </section>
-    <% end %>
 
-    <section aria-label="Lines">
-      <% @lines.each do |line| %>
-        <%= render "pos/transactions/line", line: line, summary: @summaries[line.id] %>
-      <% end %>
-    </section>
+        <dl class="pos-history__header">
+          <%= render "pos/receipts/directional_totals", transaction: @transaction %>
+        </dl>
 
-    <section aria-label="Tenders">
-      <h2>Tenders</h2>
-      <% @tenders.each do |tender| %>
-        <div class="pos-history__tender">
-          <div>
-            <%= tender.tender_number %>
-            <%= pos_tender_label(tender) %>
-            <%= format_money_cents(tender.amount_cents) %>
-          </div>
-          <% if pos_cash_payment?(tender) %>
-            <div>Presented  <%= format_money_cents(tender.amount_presented_cents) %></div>
-            <div>Change  <%= format_money_cents(tender.change_cents) %></div>
-          <% elsif tender.external_reference.present? %>
-            <div>Reference  <%= tender.external_reference %></div>
+        <div class="actions pos-history__actions">
+          <% if @returnable %>
+            <%= action_link_to(
+                  "Return items",
+                  pos_transaction_return_items_path(@transaction, inquiry_register_params),
+                  style: :outline,
+                  intent: :neutral
+                ) %>
+          <% end %>
+          <% if @post_void_eligible %>
+            <%= action_link_to(
+                  "Post-void",
+                  pos_transaction_post_void_path(@transaction, inquiry_register_params),
+                  style: :outline,
+                  intent: :danger
+                ) %>
           <% end %>
         </div>
-      <% end %>
-    </section>
-  </div>
 
-  <%= render "pos/receipts/print", transaction: @transaction, tenders: @tenders, reprint: true %>
+        <% @transaction.pos_controlled_actions.select { |action| action.action_type == "post_void" }.each do |action| %>
+          <section aria-label="post void">
+            <h2>Post-void</h2>
+            <dl class="pos-history__header">
+              <div><dt>Performed by</dt><dd><%= action.performed_by_name_snapshot %></dd></div>
+              <% if action.approved_by_name_snapshot.present? %>
+                <div><dt>Approved by</dt><dd><%= action.approved_by_name_snapshot %></dd></div>
+              <% end %>
+              <div><dt>Reason</dt><dd><%= action.reason_name_snapshot %></dd></div>
+              <% if action.reason_note.present? %>
+                <div><dt>Note</dt><dd><%= action.reason_note %></dd></div>
+              <% end %>
+            </dl>
+          </section>
+        <% end %>
 
-  <div class="pos-receipt__actions pos-no-print">
-    <% receipt = Pos::CustomerReceipt.build(@transaction) %>
-    <% if receipt.printable? %>
-      <%= action_button("Reprint receipt", style: :outline, intent: :neutral, data: { action: "pos-receipt#print" }) %>
-    <% else %>
-      <p class="pos-enter__alert" role="alert"><%= receipt.error %></p>
-    <% end %>
-    <%= action_link_to("Back to transactions", pos_transactions_path, style: :ghost, intent: :neutral) %>
+        <section aria-label="Lines">
+          <% @lines.each do |line| %>
+            <%= render "pos/transactions/line", line: line, summary: @summaries[line.id] %>
+          <% end %>
+        </section>
+
+        <section aria-label="Tenders">
+          <h2>Tenders</h2>
+          <% @tenders.each do |tender| %>
+            <div class="pos-history__tender">
+              <div>
+                <%= tender.tender_number %>
+                <%= pos_tender_label(tender) %>
+                <%= format_money_cents(tender.amount_cents) %>
+              </div>
+              <% if pos_cash_payment?(tender) %>
+                <div>Presented  <%= format_money_cents(tender.amount_presented_cents) %></div>
+                <div>Change  <%= format_money_cents(tender.change_cents) %></div>
+              <% elsif tender.external_reference.present? %>
+                <div>Reference  <%= tender.external_reference %></div>
+              <% end %>
+            </div>
+          <% end %>
+        </section>
+      </div>
+
+      <%= render "pos/receipts/print", transaction: @transaction, tenders: @tenders, reprint: true %>
+
+      <div class="pos-receipt__actions pos-no-print">
+        <% receipt = Pos::CustomerReceipt.build(@transaction) %>
+        <% if receipt.printable? %>
+          <%= action_button("Reprint receipt", style: :outline, intent: :neutral, data: { action: "pos-receipt#print" }) %>
+        <% else %>
+          <p class="pos-enter__alert" role="alert"><%= receipt.error %></p>
+        <% end %>
+        <%= action_link_to("Back to transactions", pos_transactions_path(inquiry_register_params), style: :ghost, intent: :neutral) %>
+      </div>
+    </main>
   </div>
-</main>
+<% end %>

--- a/docs/planning/register-workspace-consolidation/README.md
+++ b/docs/planning/register-workspace-consolidation/README.md
@@ -27,6 +27,8 @@ This program **replaces** the current POS presentation. It does not run a parall
 | [slice5c-manual-verification.md](slice5c-manual-verification.md) | Slice 5C workstation evidence |
 | [slice5d-tender-issuance-plan.md](slice5d-tender-issuance-plan.md) | Locked Slice 5D tender selection / issuance Add contracts |
 | [slice5d-manual-verification.md](slice5d-manual-verification.md) | Slice 5D workstation evidence |
+| [slice6a-customer-service-plan.md](slice6a-customer-service-plan.md) | Locked Slice 6A shell context / S12–S16 contracts (6A.1–6A.3) |
+| [slice6a-manual-verification.md](slice6a-manual-verification.md) | Slice 6A workstation evidence |
 
 UX adoption: follow [ux-adoption-template.md](../ux-design-system/ux-adoption-template.md) in the slice that materially changes a screen. Printed receipts stay locked unless a slice explicitly owns print.
 

--- a/docs/planning/register-workspace-consolidation/implementation-plan.md
+++ b/docs/planning/register-workspace-consolidation/implementation-plan.md
@@ -1,6 +1,6 @@
 # Register workspace consolidation — Implementation plan
 
-Status: **Slice 5D complete** on `register-workspace-consolidation` ([#89](https://github.com/BankEncore/ShelfSense-v1/issues/89) / PR [#102](https://github.com/BankEncore/ShelfSense-v1/pull/102); remediation PR [#103](https://github.com/BankEncore/ShelfSense-v1/pull/103)). Next: Slice 6 inquiry surfaces.
+Status: **Slice 6A in implementation** on `register-workspace-consolidation` ([#90](https://github.com/BankEncore/ShelfSense-v1/issues/90); packet [slice6a-customer-service-plan.md](slice6a-customer-service-plan.md)). Prior: Slice 5D complete ([#89](https://github.com/BankEncore/ShelfSense-v1/issues/89) / PR [#102](https://github.com/BankEncore/ShelfSense-v1/pull/102); remediation PR [#103](https://github.com/BankEncore/ShelfSense-v1/pull/103)).
 
 Authority: [plan.md](plan.md), [routing-and-authority.md](routing-and-authority.md).
 
@@ -28,7 +28,7 @@ This program uses a long-lived integration branch because an incomplete Register
 | 5B Return overlays | Merged to integration ([#87](https://github.com/BankEncore/ShelfSense-v1/issues/87) / PR [#100](https://github.com/BankEncore/ShelfSense-v1/pull/100)) | [#87](https://github.com/BankEncore/ShelfSense-v1/issues/87) |
 | 5C Controlled-action overlays | Merged to integration ([#88](https://github.com/BankEncore/ShelfSense-v1/issues/88) / PR [#101](https://github.com/BankEncore/ShelfSense-v1/pull/101)) | [#88](https://github.com/BankEncore/ShelfSense-v1/issues/88) |
 | 5D Tender/issuance overlays | Complete on integration ([#89](https://github.com/BankEncore/ShelfSense-v1/issues/89) / PR [#102](https://github.com/BankEncore/ShelfSense-v1/pull/102); remediation PR [#103](https://github.com/BankEncore/ShelfSense-v1/pull/103)) | [#89](https://github.com/BankEncore/ShelfSense-v1/issues/89) |
-| 6A Customer-service surfaces | Not started | [#90](https://github.com/BankEncore/ShelfSense-v1/issues/90) |
+| 6A Customer-service surfaces | In implementation (packet locked; 6A.1–6A.3 PRs) | [#90](https://github.com/BankEncore/ShelfSense-v1/issues/90) |
 | 6B Till and session detail | Not started | [#91](https://github.com/BankEncore/ShelfSense-v1/issues/91) |
 | 6C Reporting-period surfaces | Not started | [#92](https://github.com/BankEncore/ShelfSense-v1/issues/92) |
 | 7A Tender-review framework | Gated on 2–6 | [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) |

--- a/docs/planning/register-workspace-consolidation/routing-and-authority.md
+++ b/docs/planning/register-workspace-consolidation/routing-and-authority.md
@@ -105,11 +105,13 @@ Hide **before-count** expected till/session totals unless `Authorization::Permis
 
 ## Stored-value inquiry (Slice 6A)
 
-Three labeled find paths — not one field that might accept a complete number or prefix + last four.
+Locked in [slice6a-customer-service-plan.md](slice6a-customer-service-plan.md). Three labeled find paths — not one field that might accept a complete number or prefix + last four.
 
 1. **Exact number** — `GiftCards::Lookup` / digest possession. May lead to eligible reload, tender, cash-out.
 2. **Customer store credit** — customer identity → account relationship. Not a card possession test.
 3. **Prefix + last four** — `GiftCards::AdminInquiry` (or equivalent), `gift_cards.view`, masked candidates. Must not call the possession path, feed scan routing, or start redeem/reload/cash-out/completion ([ADR-026](../../adr/ADR-026-gift-card-number-protection.md), [ADR-027](../../adr/ADR-027-admin-gift-card-prefix-last-four-inquiry.md)).
+
+Packaging: one `Pos::StoredValueInquiriesController` with **separate POST actions** per path. No full numbers in GET. Continuations invoke existing workspace/cash-out flows; inquiry never mutates solely because a card was found.
 
 ## Current route disposition
 

--- a/docs/planning/register-workspace-consolidation/slice6a-customer-service-plan.md
+++ b/docs/planning/register-workspace-consolidation/slice6a-customer-service-plan.md
@@ -1,0 +1,177 @@
+# Slice 6A — Customer-service surfaces
+
+Status: **In implementation** on `register-workspace-consolidation` ([#90](https://github.com/BankEncore/ShelfSense-v1/issues/90)). Delivery: one packet; three PRs (**6A.1** / **6A.2** / **6A.3**). Close #90 after all three merge.
+
+Authority: [plan.md](plan.md), [implementation-plan.md](implementation-plan.md), [routing-and-authority.md](routing-and-authority.md), [user-stories.md](user-stories.md), [textual-wireframes.md](textual-wireframes.md) S12–S16 / P1–P5, [closeout-plan.md](closeout-plan.md), ADR-026 / ADR-027.
+
+Issue: [#90](https://github.com/BankEncore/ShelfSense-v1/issues/90). Branch: `90-customer-service-surfaces`. PR target: `register-workspace-consolidation` (not `main`).
+
+## Outcome
+
+Compose read-only customer-service inquiry into the shared Register shell: Transactions & Receipts (S12/S13), Stored Value Inquiry (S14), Customer Summary (S15), and Pickup Queue (S16 view-only). Establish shared `Pos::RegisterShellContext` for header, menu policy input, return navigation, ownership, and expected-cash visibility. Do not duplicate transaction, stored-value, pickup, cash, or finalization mutations.
+
+## Boundary statement
+
+> Slice 6A consolidates customer-service inquiry into the Register shell. It may bridge back to existing workspace or cash-out workflows when operational context makes continuations legal, but it does not duplicate those mutation services. Every surface has explicit Register-state eligibility, direct-URL authorization, read-only GET behavior, and expected-cash protection. S16 Add to Transaction and Assisted Close stay out.
+
+## Scope
+
+| In | Out |
+|---|---|
+| `Pos::RegisterShellContext` (6A.1) | Till / session detail (6B) |
+| S12 Transactions & Receipts + S13 detail in shell | Reporting / X / Z / P13 (6C) |
+| Post-void / linked-return **entry chrome** only | Assisted Close |
+| S14 three labeled SV find paths | S16 Add to Transaction bridge |
+| S15 Customer Summary (read-only) | Customer create / merge / edit; attach from S15 |
+| S16 Pickup Queue (view-only) | Prefix+last-four as possession |
+| F10-only Keyboard Lock on inquiry | F1–F9 claims; SALE/TENDER remaps (7C) |
+| Expected-cash gating on these surfaces | New cash types; duplicating mutation services |
+| Menu items + `register_id` preservation | Slice 7 |
+
+## Locked decisions
+
+| Decision | Choice |
+|---|---|
+| Sequencing within Slice 6 | **6A → 6B → 6C** |
+| 6A delivery | **One packet; three PRs** (6A.1 / 6A.2 / 6A.3) |
+| Composition | Inside Register shell (P1–P5). Working basket preserved across F10 inquiry |
+| Shell context | Shared read-only `Pos::RegisterShellContext` in **6A.1** |
+| Keyboard | Inquiry pages: **F10-only** Keyboard Lock. No F1–F9 |
+| S16 bridge | **Out of 6A** — view-only Pickup Queue |
+| Assisted Close | Out of 6A–6C |
+| S14 packaging | One `Pos::StoredValueInquiriesController` with **separate actions** per path — not three controllers, not one `mode=` |
+
+## Surface / state eligibility matrix (packet law)
+
+Hiding a menu item is not authorization. Every destination enforces the same rules on **direct URL**.
+
+| Surface | Closed | Between sessions | Own session | Occupied | Selector / no Register |
+|---|---|---|---|---|---|
+| Transactions & Receipts | View | View | View / return entry | View if permitted | View |
+| Stored Value Inquiry | View | View | View; contextual actions only per S14 table | View | View |
+| Customer Summary | View | View | View | View | View |
+| Pickup Queue | View | View | View only (6A) | View | View |
+
+GET must not create a period, session, transaction, or cash record.
+
+## Shared `Pos::RegisterShellContext` (6A.1)
+
+```ruby
+Pos::RegisterShellContext.call(
+  store:,
+  actor:,
+  register:,
+  session:,
+  surface:,
+  state: # RegisterStateResolver result (or equivalent facts)
+)
+```
+
+Surfaces include at least: `:transaction_history`, `:stored_value_inquiry`, `:customer_summary`, `:pickup_queue` (and later `:till_activity`, `:session_detail`, `:active_sessions`, `:x_report`, `:z_period`, `:cash_operation`).
+
+**Supplies:** header facts, status copy, F10 / menu policy input (`menu_surface: :inquiry`), return destination, `surface:`, Register/session ownership, expected-cash visibility.
+
+**Must not:** read cookies/Rails session directly; create durable records; reimplement mutation services or RegisterMenu groups.
+
+### Return navigation (exact)
+
+```text
+Own session        → existing workspace for that owned session/Register
+Closed / between   → /pos?register_id=...
+Occupied           → occupied Register state (never the other cashier’s workspace)
+Selector / none    → /pos selector
+```
+
+Preserve `register_id` through inquiry links and forms. If the actor owns multiple sessions, do not silently choose one for return when the resolver already surfaced selector/custody warnings.
+
+### Menu surface `:inquiry`
+
+Suppress state-landing proxies (`open_register`, `open_session`, `finalize_z`) and workspace-only `close_session`. Customer-service items remain. Till / X / Z / active-sessions / switch / leave follow existing RegisterMenu permission and kind rules unless a later packet narrows them.
+
+## Expected-cash protection (Slice 6 law; applied on 6A surfaces)
+
+Without `cash.view_expected_before_count`, expected till totals are absent from shell chrome, inquiry pages, Turbo fragments, and direct URLs that these surfaces render. 6A surfaces do not introduce new expected-cash displays; they must not leak totals through reused partials.
+
+## S12 / S13 — Transactions & Receipts (6A.1)
+
+- Wrap index and show in `pos/shell/frame`.
+- Replace orphan `_chrome` / history mini-nav with shell Close / Return using `RegisterShellContext#return_path`.
+- Keep existing search and detail behavior; preserve filter `register_id` separately from shell register resolution when both are present (shell context uses resolver register; search filter remains a query param).
+- Post-void and Begin Linked Return remain **entry chrome** to existing routes — no workflow redesign.
+- Print receipt output must not include F10 / Return / shell status strips (existing print templates / `pos-no-print`; verify).
+
+## S14 — Stored Value Inquiry (6A.2)
+
+Inquiry first; continuation only when legal.
+
+| Action | Required context |
+|---|---|
+| View balance/activity | Any authorized Register state |
+| Tender with card | Own active session, working transaction, payment due |
+| Reload | Own active session and explicit issuance flow |
+| Cash-out | Own active session, eligible card/account, existing cash-out rules |
+| Store-credit use | Correct customer/account context and payment due |
+
+Inquiry never mutates merely because an exact card was found. Continuations **return to / invoke** existing workspace or cash-out workflows — no duplicated tender/issuance/cash-out services inside S14.
+
+**Prefix/last-four:** masked inquiry only; never exposes continuation actions; never populates O10, tender fields, cash-out forms, or scan routing.
+
+### Card-number protection
+
+- No full numbers in GET query strings; **POST** for exact-number and prefix/last-four
+- Filter card parameters from logs
+- Never render full numbers after lookup
+- Do not persist searched numbers in presenters longer than necessary
+- Exact-number possession does **not** grant `gift_cards.view`
+- Audit administrative prefix/last-four inquiry (existing `GiftCards::AdminInquiry` audits)
+- Test browser history, redirect URLs, and rendered HTML for number leakage
+- **Separate actions/commands** per path (no shared `mode=` that can cross possession/admin)
+
+### Controller shape
+
+```text
+GET  /pos/stored_value_inquiry          → show (blank form; three labeled paths)
+POST /pos/stored_value_inquiry/exact    → exact_number (GiftCards::Lookup)
+POST /pos/stored_value_inquiry/store_credit → store_credit (customer → account)
+POST /pos/stored_value_inquiry/admin    → admin_prefix_last_four (GiftCards::AdminInquiry; gift_cards.view)
+```
+
+## S15 — Customer Summary (6A.3)
+
+Read-only: identity/contact; recent transactions; open requests/pickups; store-credit balance/activity; link to full Customer workspace when authorized. **No** edit, merge, or attach from S15.
+
+## S16 — Pickup Queue (6A.3)
+
+View-only: ready/eligible pickups; customer/request identity; location/status/expiration; fulfillment blockers. **Add to Transaction deferred** (explicit Out).
+
+## Delivery split
+
+| PR | Scope |
+|---|---|
+| **6A.1** | `RegisterShellContext` + return-nav + Transactions & Receipts / detail (+ post-void/return entry chrome) in shell; replace orphan history chrome for those pages |
+| **6A.2** | S14 three-path SV inquiry + menu item + card-number protection + audits/tests |
+| **6A.3** | S15 + S16 view-only + menu items; close #90 after merge |
+
+## Primary touch points
+
+- `app/services/pos/register_menu.rb`, `app/helpers/pos_register_shell_helper.rb`, `app/views/pos/shell/`
+- New: `Pos::RegisterShellContext` (+ tests)
+- `app/controllers/pos/transactions_controller.rb`, `app/views/pos/transactions/*`
+- New: `Pos::StoredValueInquiriesController` + presenters; `GiftCards::Lookup` / `GiftCards::AdminInquiry`
+- New: customer summary + pickup queue controllers/views/presenters
+- Replace `app/views/pos/transactions/_chrome.html.erb` usage as history migrates
+
+## Tests (minimum)
+
+- `RegisterShellContext` return paths for own / closed / between / occupied / selector
+- Menu `:inquiry` suppresses open/finalize/close proxies
+- Transactions index/show render inside shell; GET creates no session/period
+- Direct URL eligibility matches matrix (all View for 6A surfaces)
+- S14: separate POSTs; no card number in GET/redirect/HTML; Lookup vs AdminInquiry isolation; prefix path has no continuation actions
+- S15/S16: read-only; no attach / no Add to Transaction
+- Expected-cash helper still gates any reused cash fragments
+- Update [test-matrix.md](test-matrix.md) with 6A rows
+
+## Manual verification
+
+[slice6a-manual-verification.md](slice6a-manual-verification.md)

--- a/docs/planning/register-workspace-consolidation/slice6a-manual-verification.md
+++ b/docs/planning/register-workspace-consolidation/slice6a-manual-verification.md
@@ -1,0 +1,32 @@
+# Slice 6A — Manual verification evidence
+
+Status: **pending** until 6A.1–6A.3 land and workstation/CI evidence is recorded.
+
+Workstation assumptions: Chrome (or Chromium) on a Register-class display; Keyboard Lock optional (F10-only on inquiry).
+
+## Checklist
+
+| # | Case | Pass criteria | Result | Notes |
+|---|---|---|---|---|
+| 1 | F10 → Transactions & Receipts | Opens inside shell; Close returns per ownership rules | | |
+| 2 | History without open session | View OK; GET creates no session/period | | |
+| 3 | Occupied Register → history Close | Returns to occupied state; never other cashier workspace | | |
+| 4 | Own session → history → Close | Returns to owned workspace; basket preserved | | |
+| 5 | Receipt detail entry chrome | Post-void / Return items link to existing flows | | |
+| 6 | Print / reprint receipt | No F10, Return, or shell status in print output | | |
+| 7 | S14 exact-number POST | Balance/activity; no full number in URL/HTML/history | | |
+| 8 | S14 store credit | Customer path; no possession Lookup | | |
+| 9 | S14 prefix/last-four | Masked only; no tender/reload/cash-out actions | | |
+| 10 | S14 continuations | Tender/reload/cash-out only when context legal; invoke existing flows | | |
+| 11 | S15 Customer Summary | Read-only; Open Customer when authorized; no attach | | |
+| 12 | S16 Pickup Queue | View-only; no Add to Transaction | | |
+| 13 | Inquiry Keyboard Lock | F10 only; F1–F9 not claimed | | |
+| 14 | Menu register_id | Inquiry links preserve register context | | |
+| 15 | Expected cash | No before-count expected totals without permission | | |
+
+## Sign-off
+
+- Date:
+- Browser / OS:
+- Verified by:
+- Follow-ups (if any):

--- a/test/integration/pos_transaction_history_test.rb
+++ b/test/integration/pos_transaction_history_test.rb
@@ -194,7 +194,7 @@ class PosTransactionHistoryTest < ActionDispatch::IntegrationTest
     )
     other_register.update_column(:active, false)
 
-    get pos_transactions_path, params: { register_id: other_register.id }
+    get pos_transactions_path, params: { filter_register_id: other_register.id }
     assert_response :success
     assert_select "a", text: sale.transaction_reference
     assert_select "option[value='#{other_register.id}']"
@@ -215,14 +215,15 @@ class PosTransactionHistoryTest < ActionDispatch::IntegrationTest
     assert_select ".pos-receipt__print", text: /Description unavailable/
   end
 
-  test "history register link resumes the bound session when the cashier has several open" do
+  test "history return control follows shell ownership and never invents a workspace under ambiguity" do
     other_register = Register.create!(store: @store, register_number: 2, name: "Back")
     pos_open_context(store: @store, actor: @actor, register: other_register)
     assert_equal 2, PosSession.open.where(store: @store, cashier_user: @actor).count
 
     get pos_transactions_path
     assert_response :success
-    assert_select "a[href='#{pos_path}']", text: "Resume"
+    assert_select ".pos-register-shell"
+    assert_select "a[href='#{pos_path}']", text: "Close"
 
     post pos_register_enter_path, params: {
       register_id: other_register.id,
@@ -231,10 +232,10 @@ class PosTransactionHistoryTest < ActionDispatch::IntegrationTest
     }
     assert_equal other_register.id.to_s, session[:pos_register_id].to_s
 
-    get pos_transactions_path
+    get pos_transactions_path, params: { register_id: other_register.id }
     assert_response :success
-    assert_select "a[href='#{pos_register_workspace_path(register_id: other_register.id)}']", text: "Resume"
-    assert_select "a[href='#{pos_register_workspace_path(register_id: @register.id)}']", text: "Resume", count: 0
+    assert_select "a[href='#{pos_register_workspace_path(register_id: other_register.id)}']", text: "Return to Register"
+    assert_select "a[href='#{pos_register_workspace_path(register_id: @register.id)}']", text: "Return to Register", count: 0
   end
 
   test "transaction history index exposes search landmarks for workflow layer" do
@@ -242,7 +243,8 @@ class PosTransactionHistoryTest < ActionDispatch::IntegrationTest
     get pos_transactions_path
     assert_response :success
     assert_select "main"
-    assert_select "h1", text: /Transactions/i
+    assert_select "h1", text: /Transactions & Receipts/i
+    assert_select ".pos-register-shell"
     assert_select "form[action='#{pos_transactions_path}']"
     assert_select "a", text: transaction.transaction_reference
   end

--- a/test/services/pos/register_menu_test.rb
+++ b/test/services/pos/register_menu_test.rb
@@ -108,11 +108,28 @@ class PosRegisterMenuTest < ActiveSupport::TestCase
 
   test "never emits reverse cash" do
     %w[selector closed between_sessions own_session occupied].each do |kind|
-      %i[state_landing workspace switch_register].each do |surface|
+      %i[state_landing workspace switch_register inquiry].each do |surface|
         keys = keys_for(kind:, surface:, permissions: ALL_PERMISSIONS)
         refute_includes keys, :reverse_cash
       end
     end
+  end
+
+  test "inquiry suppresses open finalize and close proxies" do
+    gate = Struct.new(:can_finalize_period?).new(true)
+    closed = keys_for(kind: "closed", surface: :inquiry, permissions: ALL_PERMISSIONS)
+    assert_includes closed, :transactions
+    refute_includes closed, :open_register
+    refute_includes closed, :close_session
+
+    between = keys_for(kind: "between_sessions", surface: :inquiry, permissions: ALL_PERMISSIONS, gate: gate)
+    refute_includes between, :open_session
+    refute_includes between, :finalize_z
+
+    own = keys_for(kind: "own_session", surface: :inquiry, permissions: ALL_PERMISSIONS)
+    assert_includes own, :transactions
+    assert_includes own, :drop
+    refute_includes own, :close_session
   end
 
   test "empty groups are omitted" do

--- a/test/services/pos/register_shell_context_test.rb
+++ b/test/services/pos/register_shell_context_test.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PosRegisterShellContextTest < ActiveSupport::TestCase
+  include Rails.application.routes.url_helpers
+
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    @register = Register.create!(store: @store, register_number: 3, name: "Shell")
+  end
+
+  test "own session returns to the owned workspace" do
+    context = pos_open_context(store: @store, actor: @actor, register: @register)
+    state = state_for(register: @register, owned: [ context[:session] ])
+    result = Pos::RegisterShellContext.call(
+      store: @store,
+      actor: @actor,
+      state: state,
+      surface: :transaction_history,
+      can_view_expected_cash: true
+    )
+
+    assert_equal :transaction_history, result.surface
+    assert_equal "own_session", result.kind
+    assert_equal :inquiry, result.menu_surface
+    assert_equal true, result.can_view_expected_cash
+    assert_equal pos_register_workspace_path(register_id: @register.id), result.return_path
+    assert_equal "Return to Register", result.return_label
+    assert_equal context[:session], result.session
+  end
+
+  test "closed and between sessions return to pos with register_id" do
+    %w[closed between_sessions].each do |kind|
+      state = fake_state(kind: kind, register: @register)
+      result = call_context(state:)
+      assert_equal pos_path(register_id: @register.id), result.return_path, kind
+      assert_equal "Close", result.return_label, kind
+    end
+  end
+
+  test "occupied returns to occupied register state never workspace" do
+    state = fake_state(kind: "occupied", register: @register)
+    result = call_context(state:)
+    assert_equal pos_path(register_id: @register.id), result.return_path
+    refute_match %r{/pos/register}, result.return_path
+  end
+
+  test "selector returns to pos without inventing a register" do
+    state = fake_state(kind: "selector", register: nil)
+    result = call_context(state:)
+    assert_equal pos_path, result.return_path
+    assert_equal "Close", result.return_label
+  end
+
+  test "rejects unknown surfaces" do
+    state = fake_state(kind: "selector", register: nil)
+    assert_raises(ArgumentError) do
+      call_context(state:, surface: :not_a_surface)
+    end
+  end
+
+  test "expected cash flag is boolean and does not invent visibility" do
+    state = fake_state(kind: "selector", register: nil)
+    refute call_context(state:, can_view_expected_cash: false).can_view_expected_cash
+    assert call_context(state:, can_view_expected_cash: true).can_view_expected_cash
+  end
+
+  private
+
+  def call_context(state:, surface: :transaction_history, can_view_expected_cash: false)
+    Pos::RegisterShellContext.call(
+      store: @store,
+      actor: @actor,
+      state: state,
+      surface: surface,
+      can_view_expected_cash: can_view_expected_cash
+    )
+  end
+
+  def fake_state(kind:, register:)
+    Struct.new(:kind, :register, :gate, :owned_sessions).new(kind, register, nil, [])
+  end
+
+  def state_for(register:, owned:)
+    Pos::RegisterStateResolver.call(
+      store: @store,
+      actor: @actor,
+      requested_register: register,
+      preferred_register: nil,
+      bound_register_id: nil,
+      owned_open_sessions: owned
+    )
+  end
+end


### PR DESCRIPTION
## Summary
- Lock the Slice 6A packet (eligibility matrix, shell context, S12–S16 contracts, 6A.1–6A.3 split) under #90.
- Add read-only `Pos::RegisterShellContext` with return-nav rules and inquiry menu surface.
- Wrap Transactions & Receipts index/show in the Register shell; replace orphan history chrome.

## Test plan
- [x] `./dev/rails-docker bin/rails test test/services/pos/register_shell_context_test.rb test/services/pos/register_menu_test.rb test/integration/pos_transaction_history_test.rb`
- [ ] Manual: F10 → Transactions → Close returns per ownership (own/occupied/selector)

Closes nothing alone — close #90 after 6A.1–6A.3 merge.


Made with [Cursor](https://cursor.com)