### PR TITLE
Slice 6A.2: S14 Stored Value Inquiry

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -2311,6 +2311,45 @@ input[type="submit"]:disabled,
   margin-top: var(--space-5);
 }
 
+.pos-inquiry {
+  width: min(100% - 2rem, 40rem);
+  margin: var(--space-6) auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+
+.pos-inquiry__path {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.pos-inquiry__form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  align-items: flex-end;
+}
+
+.pos-inquiry__result,
+.pos-inquiry__matches,
+.pos-inquiry__activity {
+  margin: 0;
+}
+
+.pos-inquiry__matches {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.pos-inquiry__actions {
+  margin-top: var(--space-3);
+}
+
 .pos-history {
   width: min(100% - 2rem, 56rem);
   margin: var(--space-6) auto;

--- a/app/controllers/pos/stored_value_inquiries_controller.rb
+++ b/app/controllers/pos/stored_value_inquiries_controller.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+module Pos
+  class StoredValueInquiriesController < BaseController
+    before_action :prepare_surface
+    before_action :require_gift_cards_view!, only: :admin_prefix_last_four
+
+    def show
+    end
+
+    def exact_number
+      raw = params[:card_number].to_s
+      card = GiftCards::Lookup.by_number(raw)
+      if card.nil?
+        flash.now[:alert] = "No gift card matched that number."
+        render :show, status: :unprocessable_entity
+        return
+      end
+
+      @exact_card = card
+      @exact_activity = StoredValue::AccountActivity.call(
+        account: card.stored_value_account,
+        actor: current_user,
+        permission_key: "pos.transact",
+        page: 1
+      )
+      @continuations = Pos::StoredValueInquiryContinuations.call(
+        state: @state,
+        actor: current_user,
+        store: current_store,
+        gift_card: card
+      )
+      render :show
+    end
+
+    def store_credit
+      if params[:customer_id].present?
+        customer = Customer.active.canonical.find_by(id: params[:customer_id])
+        unless customer
+          flash.now[:alert] = "Customer not found."
+          render :show, status: :unprocessable_entity
+          return
+        end
+
+        @store_credit_customer = customer
+        @store_credit_account = customer.stored_value_accounts.find_by(account_type: "store_credit")
+        @continuations = Pos::StoredValueInquiryContinuations.call(
+          state: @state,
+          actor: current_user,
+          store: current_store,
+          store_credit_customer: customer
+        )
+        render :show
+        return
+      end
+
+      query = params[:customer_query].to_s.strip
+      if query.blank?
+        flash.now[:alert] = "Enter a customer name, email, or phone."
+        render :show, status: :unprocessable_entity
+        return
+      end
+
+      @store_credit_matches = Customers::Search.call(query: query, mode: :operational, limit: 20)
+      if @store_credit_matches.empty?
+        flash.now[:alert] = "No matching customers."
+        render :show, status: :unprocessable_entity
+        return
+      end
+
+      render :show
+    end
+
+    def admin_prefix_last_four
+      result = GiftCards::AdminInquiry.call(
+        prefix: params[:number_prefix],
+        last_four: params[:number_last_four],
+        actor: current_user,
+        store: current_store
+      )
+      case result.status
+      when :found
+        @admin_card = result.card
+        @admin_activity = StoredValue::AccountActivity.call(
+          account: result.card.stored_value_account,
+          actor: current_user,
+          permission_key: "gift_cards.view",
+          page: 1
+        )
+      when :ambiguous
+        @admin_candidates = result.candidates
+        flash.now[:alert] = "Several cards share that prefix and last four. Choose a masked candidate."
+      else
+        flash.now[:alert] = GiftCards::GENERIC_INQUIRY_FAILURE
+      end
+      render :show, status: result.status == :found ? :ok : :unprocessable_entity
+    rescue GiftCards::Error => e
+      flash.now[:alert] = e.message
+      render :show, status: :unprocessable_entity
+    end
+
+    private
+
+    def prepare_surface
+      prepare_inquiry_shell!(surface: :stored_value_inquiry)
+      @can_admin_inquire = Authorization::PermissionEvaluator.allowed?(
+        user: current_user,
+        permission_key: "gift_cards.view",
+        store: current_store
+      )
+    end
+
+    def require_gift_cards_view!
+      return if @can_admin_inquire
+
+      Audit::Recorder.record!(
+        action: "authorization.denied",
+        outcome: "denied",
+        actor_user: current_user,
+        actor_label: current_user.display_name,
+        store: current_store,
+        reason_code: "gift_cards.view",
+        metadata: { path: request.fullpath }
+      )
+      redirect_to pos_stored_value_inquiry_path(inquiry_register_params),
+                  alert: "You are not authorized to perform that action."
+    end
+  end
+end

--- a/app/helpers/pos_register_shell_helper.rb
+++ b/app/helpers/pos_register_shell_helper.rb
@@ -158,6 +158,8 @@ module PosRegisterShellHelper
     case key
     when :transactions
       { key:, label: "Transactions & Receipts", href: pos_transactions_path(inquiry_register_params) }
+    when :stored_value_inquiry
+      { key:, label: "Stored Value Inquiry", href: pos_stored_value_inquiry_path(inquiry_register_params) }
     when :gift_card_cash_out
       { key:, label: "Gift-card cash-out", href: new_pos_cash_out_path }
     when :paid_in

--- a/app/services/pos/register_menu.rb
+++ b/app/services/pos/register_menu.rb
@@ -45,7 +45,7 @@ module Pos
     end
 
     def customer_service_keys
-      [ :transactions ]
+      %i[transactions stored_value_inquiry]
     end
 
     def till_keys

--- a/app/services/pos/stored_value_inquiry_continuations.rb
+++ b/app/services/pos/stored_value_inquiry_continuations.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Pos
+  # Contextual continuation affordances for S14 exact-number and store-credit results.
+  # Continuations link to existing workspace / cash-out flows; they do not mutate.
+  class StoredValueInquiryContinuations
+    Result = Struct.new(
+      :can_tender,
+      :can_reload,
+      :can_cash_out,
+      :cash_out_amount_cents,
+      :workspace_path,
+      :cash_out_path,
+      keyword_init: true
+    )
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(state:, actor:, store:, gift_card: nil, store_credit_customer: nil)
+      @state = state
+      @actor = actor
+      @store = store
+      @gift_card = gift_card
+      @store_credit_customer = store_credit_customer
+    end
+
+    def call
+      own = @state.kind == "own_session" && @state.register.present?
+      workspace = own ? Rails.application.routes.url_helpers.pos_register_workspace_path(register_id: @state.register.id) : nil
+      working = working_transaction
+      payment_due = working.present? && Pos::Support.remaining_payment_cents(working).positive?
+
+      cash_out = cash_out_eligibility
+      can_cash_out = own && cash_out&.eligible &&
+                     Authorization::PermissionEvaluator.allowed?(
+                       user: @actor,
+                       permission_key: "gift_cards.cash_out",
+                       store: @store
+                     )
+
+      Result.new(
+        can_tender: own && payment_due && (@gift_card.present? || @store_credit_customer.present?),
+        can_reload: own && @gift_card.present? && @gift_card.active?,
+        can_cash_out: can_cash_out,
+        cash_out_amount_cents: cash_out&.amount_cents,
+        workspace_path: workspace,
+        cash_out_path: can_cash_out ? Rails.application.routes.url_helpers.new_pos_cash_out_path : nil
+      )
+    end
+
+    private
+
+    def working_transaction
+      session_record = @state.gate&.session
+      return if session_record.blank?
+
+      session_record.pos_transactions.working.first
+    end
+
+    def cash_out_eligibility
+      return unless @gift_card
+
+      GiftCards::CashOutEligibility.call(@gift_card)
+    end
+  end
+end

--- a/app/views/pos/stored_value_inquiries/show.html.erb
+++ b/app/views/pos/stored_value_inquiries/show.html.erb
@@ -1,0 +1,165 @@
+<% content_for :title, "Stored Value Inquiry" %>
+<%= render layout: "pos/shell/frame" do %>
+  <%= render "pos/shell/feedback" %>
+  <div class="pos-register-shell__body">
+    <main class="pos-inquiry">
+      <div class="pos-history__title-row pos-no-print">
+        <h1>Stored Value Inquiry</h1>
+        <%= link_to register_inquiry_return_label, register_inquiry_return_path, class: "btn btn--ghost" %>
+      </div>
+
+      <section class="pos-inquiry__path" aria-labelledby="sv-exact-heading">
+        <h2 id="sv-exact-heading">Scan or enter complete gift-card number</h2>
+        <p class="muted">For balance, reload, redemption, or cash-out eligibility. Uses exact possession-based lookup.</p>
+        <%= form_with url: exact_number_pos_stored_value_inquiry_path, method: :post, local: true, class: "pos-inquiry__form" do %>
+          <% inquiry_register_params.each do |key, value| %>
+            <%= hidden_field_tag key, value %>
+          <% end %>
+          <div class="form-field">
+            <%= label_tag :card_number, "Gift-card number" %>
+            <%= password_field_tag :card_number, nil, autocomplete: "off", inputmode: "numeric" %>
+          </div>
+          <%= submit_tag "Look up card", class: "btn" %>
+        <% end %>
+
+        <% if @exact_card %>
+          <div class="pos-inquiry__result">
+            <h3>Account</h3>
+            <dl class="pos-history__header">
+              <div><dt>Program</dt><dd><%= @exact_card.gift_card_program.name %></dd></div>
+              <div><dt>Card</dt><dd><%= @exact_card.masked_number %></dd></div>
+              <div><dt>Status</dt><dd><%= @exact_card.status.humanize %></dd></div>
+              <div><dt>Available balance</dt><dd><%= format_money_cents(@exact_card.balance_cents) %></dd></div>
+            </dl>
+            <% if @exact_activity && @exact_activity.rows.any? %>
+              <h3>Recent activity</h3>
+              <ul class="pos-inquiry__activity">
+                <% @exact_activity.rows.first(5).each do |row| %>
+                  <li>
+                    <%= row.business_date %>
+                    <%= row.operation_label %>
+                    <%= format_signed_money_cents(row.amount_cents) %>
+                  </li>
+                <% end %>
+              </ul>
+            <% end %>
+            <% if @continuations %>
+              <div class="actions pos-inquiry__actions">
+                <% if @continuations.can_tender && @continuations.workspace_path %>
+                  <%= link_to "Use as Tender", @continuations.workspace_path, class: "btn btn--outline" %>
+                <% end %>
+                <% if @continuations.can_reload && @continuations.workspace_path %>
+                  <%= link_to "Reload", @continuations.workspace_path, class: "btn btn--outline" %>
+                <% end %>
+                <% if @continuations.can_cash_out && @continuations.cash_out_path %>
+                  <%= link_to "Cash Out Eligible Balance", @continuations.cash_out_path, class: "btn btn--outline" %>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </section>
+
+      <section class="pos-inquiry__path" aria-labelledby="sv-credit-heading">
+        <h2 id="sv-credit-heading">Find customer store credit</h2>
+        <p class="muted">Search by customer identity. Not a card possession test.</p>
+        <%= form_with url: store_credit_pos_stored_value_inquiry_path, method: :post, local: true, class: "pos-inquiry__form" do %>
+          <% inquiry_register_params.each do |key, value| %>
+            <%= hidden_field_tag key, value %>
+          <% end %>
+          <div class="form-field">
+            <%= label_tag :customer_query, "Customer" %>
+            <%= text_field_tag :customer_query, params[:customer_query], autocomplete: "off" %>
+          </div>
+          <%= submit_tag "Find store credit", class: "btn" %>
+        <% end %>
+
+        <% if @store_credit_matches.present? %>
+          <ul class="pos-inquiry__matches">
+            <% @store_credit_matches.each do |row| %>
+              <li>
+                <%= form_with url: store_credit_pos_stored_value_inquiry_path, method: :post, local: true do %>
+                  <% inquiry_register_params.each do |key, value| %>
+                    <%= hidden_field_tag key, value %>
+                  <% end %>
+                  <%= hidden_field_tag :customer_id, row.customer.id %>
+                  <%= submit_tag [ row.customer.display_name, row.customer.email, row.customer.phone ].compact.join(" · "), class: "btn btn--ghost" %>
+                <% end %>
+              </li>
+            <% end %>
+          </ul>
+        <% end %>
+
+        <% if @store_credit_customer %>
+          <div class="pos-inquiry__result">
+            <h3>Customer store credit</h3>
+            <dl class="pos-history__header">
+              <div><dt>Customer</dt><dd><%= @store_credit_customer.display_name %></dd></div>
+              <div>
+                <dt>Available</dt>
+                <dd>
+                  <% if @store_credit_account %>
+                    <%= format_money_cents(@store_credit_account.balance_cents) %>
+                  <% else %>
+                    No store-credit account
+                  <% end %>
+                </dd>
+              </div>
+            </dl>
+            <div class="actions">
+              <% if @continuations&.can_tender && @continuations.workspace_path %>
+                <%= link_to "Use as Tender", @continuations.workspace_path, class: "btn btn--outline" %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </section>
+
+      <% if @can_admin_inquire %>
+        <section class="pos-inquiry__path" aria-labelledby="sv-admin-heading">
+          <h2 id="sv-admin-heading">Find gift-card history by prefix and last four</h2>
+          <p class="muted">Masked inquiry only; cannot begin a value-moving action. Requires gift_cards.view.</p>
+          <%= form_with url: admin_prefix_last_four_pos_stored_value_inquiry_path, method: :post, local: true, class: "pos-inquiry__form" do %>
+            <% inquiry_register_params.each do |key, value| %>
+              <%= hidden_field_tag key, value %>
+            <% end %>
+            <div class="form-field">
+              <%= label_tag :number_prefix, "Prefix" %>
+              <%= text_field_tag :number_prefix, nil, autocomplete: "off", inputmode: "numeric" %>
+            </div>
+            <div class="form-field">
+              <%= label_tag :number_last_four, "Last four" %>
+              <%= text_field_tag :number_last_four, nil, autocomplete: "off", inputmode: "numeric", maxlength: 4 %>
+            </div>
+            <%= submit_tag "Find masked history", class: "btn" %>
+          <% end %>
+
+          <% if @admin_candidates.present? %>
+            <ul class="pos-inquiry__matches">
+              <% @admin_candidates.each do |candidate| %>
+                <li>
+                  <%= candidate.masked_number %> · <%= candidate.status.humanize %> ·
+                  <%= format_money_cents(candidate.balance_cents) %> · <%= candidate.program_name %>
+                </li>
+              <% end %>
+            </ul>
+            <p class="muted">This find does not prove possession. Use as Tender, Reload, and Cash Out are not offered.</p>
+          <% end %>
+
+          <% if @admin_card %>
+            <div class="pos-inquiry__result">
+              <h3>Gift-card history (masked)</h3>
+              <dl class="pos-history__header">
+                <div><dt>Card</dt><dd><%= @admin_card.masked_number %></dd></div>
+                <div><dt>Program</dt><dd><%= @admin_card.gift_card_program.name %></dd></div>
+                <div><dt>Status</dt><dd><%= @admin_card.status.humanize %></dd></div>
+                <div><dt>Balance</dt><dd><%= format_money_cents(@admin_card.balance_cents) %></dd></div>
+              </dl>
+              <p class="muted">This find does not prove possession. Use as Tender, Reload, and Cash Out are not offered.</p>
+            </div>
+          <% end %>
+        </section>
+      <% end %>
+    </main>
+  </div>
+<% end %>

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -5,5 +5,5 @@
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += [
   :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc,
-  :isbndb_api_key, :card_number, :pending_card_number, :gift_card_number
+  :isbndb_api_key, :card_number, :pending_card_number, :gift_card_number, :number_prefix, :number_last_four
 ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -203,6 +203,11 @@ Rails.application.routes.draw do
     get "active_sessions", to: "active_sessions#index", as: :active_sessions
     get "reports", to: "reports#index", as: :reports
     resources :transactions, only: %i[index show]
+    resource :stored_value_inquiry, only: :show, controller: "stored_value_inquiries" do
+      post :exact_number
+      post :store_credit
+      post :admin_prefix_last_four
+    end
     get "register/enter", to: "enters#show", as: :register_enter
     post "register/enter", to: "enters#create"
     resources :cash_outs, only: %i[new create show] do

--- a/test/integration/pos_stored_value_inquiry_test.rb
+++ b/test/integration/pos_stored_value_inquiry_test.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PosStoredValueInquiryTest < ActionDispatch::IntegrationTest
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    GiftCards::Programs.seed!
+    @program = GiftCardProgram.find_by!(code: "generated")
+    @register = Register.create!(store: @store, register_number: 1, name: "Front")
+    sign_in_as("admin")
+  end
+
+  test "show renders three labeled paths inside the shell without creating a session" do
+    get pos_stored_value_inquiry_path, params: { register_id: @register.id }
+    assert_response :success
+    assert_select ".pos-register-shell"
+    assert_select "h1", text: "Stored Value Inquiry"
+    assert_select "h2", text: /complete gift-card number/i
+    assert_select "h2", text: /store credit/i
+    assert_select "h2", text: /prefix and last four/i
+    assert_select "form[action='#{exact_number_pos_stored_value_inquiry_path}'][method='post']"
+    assert_select "form[action='#{store_credit_pos_stored_value_inquiry_path}'][method='post']"
+    assert_select "form[action='#{admin_prefix_last_four_pos_stored_value_inquiry_path}'][method='post']"
+    refute PosSession.open.exists?
+  end
+
+  test "exact number POST shows masked balance and never echoes the full number" do
+    card = numbered_card(last_four: "4242")
+    GiftCards::Fund.call(gift_card: card, amount_cents: 1_800, store: @store, performed_by: @actor)
+
+    post exact_number_pos_stored_value_inquiry_path, params: {
+      register_id: @register.id,
+      card_number: card.number
+    }
+    assert_response :success
+    assert_match card.masked_number, response.body
+    assert_match format_money_cents(1_800), response.body
+    refute_includes response.body, card.number
+    refute_match(/card_number=#{Regexp.escape(card.number)}/, response.body)
+    assert_select "a", text: "Use as Tender", count: 0
+    assert_select "a", text: "Reload", count: 0
+  end
+
+  test "admin prefix path shows masked candidates without continuation actions" do
+    first = numbered_card(last_four: "3131")
+    second = numbered_card(last_four: "3131")
+    GiftCards::Fund.call(gift_card: first, amount_cents: 100, store: @store, performed_by: @actor)
+    GiftCards::Fund.call(gift_card: second, amount_cents: 200, store: @store, performed_by: @actor)
+
+    post admin_prefix_last_four_pos_stored_value_inquiry_path, params: {
+      register_id: @register.id,
+      number_prefix: first.number_prefix,
+      number_last_four: "3131"
+    }
+    assert_response :unprocessable_entity
+    assert_match first.masked_number, response.body
+    assert_match second.masked_number, response.body
+    refute_includes response.body, first.number
+    assert_select "a", text: "Use as Tender", count: 0
+    assert_select "a", text: "Cash Out Eligible Balance", count: 0
+    assert AuditEvent.exists?(action: "gift_cards.inquiry", outcome: "succeeded", actor_user: @actor)
+  end
+
+  test "admin path requires gift_cards.view" do
+    clerk = pos_transacting_user(store: @store, assigned_by: @actor, username: "sv_clerk")
+    delete session_path
+    sign_in_as("sv_clerk")
+
+    get pos_stored_value_inquiry_path
+    assert_response :success
+    assert_select "h2", text: /prefix and last four/i, count: 0
+
+    post admin_prefix_last_four_pos_stored_value_inquiry_path, params: {
+      number_prefix: "801",
+      number_last_four: "0001"
+    }
+    assert_redirected_to pos_stored_value_inquiry_path
+  end
+
+  test "store credit path finds customer by identity without gift card lookup" do
+    customer = Customer.create!(
+      display_name: "Jane Inquiry",
+      email: "jane.inquiry@example.com",
+      phone: "555-0199"
+    )
+    account = StoredValue::OpenAccount.call(account_type: "store_credit", customer: customer)
+    reason = StoredValueAdjustmentReason.find_by(code: "goodwill") ||
+             StoredValueAdjustmentReason.create!(
+               code: "goodwill",
+               name: "Goodwill",
+               active: true,
+               applies_to_store_credit: true,
+               applies_to_trade_credit: true,
+               applies_to_gift_card: false
+             )
+    StoredValue::Adjust.call(
+      account: account,
+      direction: "credit",
+      amount_cents: 500,
+      reason: reason,
+      store: @store,
+      performed_by: @actor,
+      source_id: account.id,
+      idempotency_key: SecureRandom.uuid_v7
+    )
+
+    post store_credit_pos_stored_value_inquiry_path, params: {
+      register_id: @register.id,
+      customer_query: "Jane Inquiry"
+    }
+    assert_response :success
+    assert_match "Jane Inquiry", response.body
+
+    post store_credit_pos_stored_value_inquiry_path, params: {
+      register_id: @register.id,
+      customer_id: customer.id
+    }
+    assert_response :success
+    assert_match format_money_cents(500), response.body
+  end
+
+  test "GET with card_number query does not perform possession lookup" do
+    card = numbered_card(last_four: "9999")
+    GiftCards::Fund.call(gift_card: card, amount_cents: 100, store: @store, performed_by: @actor)
+
+    get pos_stored_value_inquiry_path, params: { card_number: card.number }
+    assert_response :success
+    refute_match card.masked_number, response.body
+    refute_includes response.body, card.number
+  end
+
+  private
+
+  def sign_in_as(username)
+    post session_path, params: { session: { username: username, password: "correct-horse-battery" } }
+  end
+
+  def format_money_cents(cents)
+    format("$%d.%02d", cents / 100, cents % 100)
+  end
+
+  def numbered_card(last_four:)
+    prefix = @program.prefix
+    body_length = @program.number_length - prefix.length - 1
+    50_000.times do |index|
+      body = format("%0#{body_length}d", index)
+      number = "#{prefix}#{body}#{GiftCards::Luhn.check_digit("#{prefix}#{body}")}"
+      next unless number.end_with?(last_four)
+      next if GiftCard.exists?(number_digest: GiftCards::Number.digest(number))
+
+      return GiftCards::ProvisionInstrument.call(program: @program, store: @store, number: number)
+    end
+    raise "unable to allocate a #{prefix} number ending in #{last_four}"
+  end
+end

--- a/test/services/pos/register_menu_test.rb
+++ b/test/services/pos/register_menu_test.rb
@@ -7,7 +7,7 @@ class PosRegisterMenuTest < ActiveSupport::TestCase
 
   test "selector includes transactions session z switch and return" do
     keys = keys_for(kind: "selector", surface: :state_landing, permissions: ALL_PERMISSIONS)
-    assert_equal %i[transactions session_z_reports active_sessions switch_register return_to_shelfsense], keys
+    assert_equal %i[transactions stored_value_inquiry session_z_reports active_sessions switch_register return_to_shelfsense], keys
     refute_includes keys, :x_report
     refute_includes keys, :close_session
     refute_includes keys, :drop
@@ -85,7 +85,7 @@ class PosRegisterMenuTest < ActiveSupport::TestCase
 
   test "switch register suppresses switch till x close and in-page mutations" do
     keys = keys_for(kind: "own_session", surface: :switch_register, permissions: ALL_PERMISSIONS)
-    assert_equal %i[transactions session_z_reports active_sessions return_to_shelfsense], keys
+    assert_equal %i[transactions stored_value_inquiry session_z_reports active_sessions return_to_shelfsense], keys
     refute_includes keys, :switch_register
     refute_includes keys, :x_report
     refute_includes keys, :drop


### PR DESCRIPTION
## Summary
- Add three labeled SV inquiry paths via one `Pos::StoredValueInquiriesController` with separate POST actions.
- Exact possession uses `GiftCards::Lookup`; admin prefix/last-four uses `GiftCards::AdminInquiry` with `gift_cards.view`.
- No full card numbers in GET/redirects/HTML; continuations only link existing workspace/cash-out flows.

## Test plan
- [x] `./dev/rails-docker bin/rails test test/integration/pos_stored_value_inquiry_test.rb test/services/pos/register_menu_test.rb`
- [ ] Manual: exact / store-credit / prefix paths; confirm no number leakage in history or HTML

Depends on 6A.1. Stacked on `90-6a1-shell-history`.


Made with [Cursor](https://cursor.com)