### PR TITLE
Slice 6A.3: Customer Summary + Pickup Queue; lock 6B/6C packets

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -2350,6 +2350,10 @@ input[type="submit"]:disabled,
   margin-top: var(--space-3);
 }
 
+.pos-inquiry--wide {
+  width: min(100% - 2rem, 56rem);
+}
+
 .pos-history {
   width: min(100% - 2rem, 56rem);
   margin: var(--space-6) auto;

--- a/app/controllers/pos/customer_summaries_controller.rb
+++ b/app/controllers/pos/customer_summaries_controller.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Pos
+  class CustomerSummariesController < BaseController
+    def show
+      prepare_inquiry_shell!(surface: :customer_summary)
+      @can_open_customer = Authorization::PermissionEvaluator.allowed?(
+        user: current_user,
+        permission_key: "customers.view",
+        store: current_store
+      )
+
+      if params[:customer_id].present?
+        @customer = Customer.active.canonical.find_by(id: params[:customer_id])
+        unless @customer
+          flash.now[:alert] = "Customer not found."
+          return
+        end
+
+        load_customer_summary!(@customer)
+        return
+      end
+
+      query = params[:q].to_s.strip
+      return if query.blank?
+
+      @matches = Customers::Search.call(query: query, mode: :operational, limit: 20)
+      flash.now[:alert] = "No matching customers." if @matches.empty?
+    end
+
+    private
+
+    def load_customer_summary!(customer)
+      @store_credit_account = customer.stored_value_accounts.find_by(account_type: "store_credit")
+      @open_requests = customer.customer_requests
+                               .for_store(current_store)
+                               .where(status: CustomerRequest::ACTIVE_STATUSES)
+                               .includes(:product_variant, :customer_request_allocations)
+                               .admin_ordered
+                               .limit(20)
+      @ready_pickups = @open_requests.select(&:available?)
+      @recent_transactions = PosTransaction.completed
+                                           .where(store_id: current_store.id, customer_id: customer.id)
+                                           .order(completed_at: :desc)
+                                           .limit(10)
+    end
+  end
+end

--- a/app/controllers/pos/pickup_queues_controller.rb
+++ b/app/controllers/pos/pickup_queues_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Pos
+  class PickupQueuesController < BaseController
+    def index
+      prepare_inquiry_shell!(surface: :pickup_queue)
+      @query = params[:q].to_s.strip
+      @status = params[:status].presence_in(%w[available all]) || "available"
+
+      scope = CustomerRequest.for_store(current_store)
+                             .includes(
+                               :customer,
+                               product_variant: [ :product, :merchandise_condition ],
+                               customer_request_allocations: :inventory_unit
+                             )
+
+      scope = if @status == "available"
+        scope.available
+      else
+        scope.where(status: CustomerRequest::ACTIVE_STATUSES)
+      end
+
+      if @query.present?
+        rows = Pos::SearchAvailableCustomerRequests.call(store: current_store, query: @query)
+        ids = rows.map { |row| row.customer_request.id }
+        scope = scope.where(id: ids)
+      end
+
+      @requests = scope.admin_ordered.limit(50)
+      @selected = @requests.find { |request| request.id.to_s == params[:request_id].to_s } if params[:request_id].present?
+      @selected ||= @requests.first
+      @can_view_request = Authorization::PermissionEvaluator.allowed?(
+        user: current_user,
+        permission_key: "customers.view",
+        store: current_store
+      )
+    end
+  end
+end

--- a/app/helpers/pos_register_shell_helper.rb
+++ b/app/helpers/pos_register_shell_helper.rb
@@ -160,6 +160,10 @@ module PosRegisterShellHelper
       { key:, label: "Transactions & Receipts", href: pos_transactions_path(inquiry_register_params) }
     when :stored_value_inquiry
       { key:, label: "Stored Value Inquiry", href: pos_stored_value_inquiry_path(inquiry_register_params) }
+    when :customer_summary
+      { key:, label: "Customer Summary", href: pos_customer_summary_path(inquiry_register_params) }
+    when :pickup_queue
+      { key:, label: "Pickup Queue", href: pos_pickup_queue_path(inquiry_register_params) }
     when :gift_card_cash_out
       { key:, label: "Gift-card cash-out", href: new_pos_cash_out_path }
     when :paid_in

--- a/app/services/pos/register_menu.rb
+++ b/app/services/pos/register_menu.rb
@@ -45,7 +45,7 @@ module Pos
     end
 
     def customer_service_keys
-      %i[transactions stored_value_inquiry]
+      %i[transactions stored_value_inquiry customer_summary pickup_queue]
     end
 
     def till_keys

--- a/app/views/pos/customer_summaries/show.html.erb
+++ b/app/views/pos/customer_summaries/show.html.erb
@@ -1,0 +1,101 @@
+<% content_for :title, "Customer Summary" %>
+<%= render layout: "pos/shell/frame" do %>
+  <%= render "pos/shell/feedback" %>
+  <div class="pos-register-shell__body">
+    <main class="pos-inquiry">
+      <div class="pos-history__title-row pos-no-print">
+        <h1>Customer Summary</h1>
+        <%= link_to register_inquiry_return_label, register_inquiry_return_path, class: "btn btn--ghost" %>
+      </div>
+
+      <%= form_with url: pos_customer_summary_path, method: :get, local: true, class: "pos-inquiry__form" do %>
+        <% inquiry_register_params.each do |key, value| %>
+          <%= hidden_field_tag key, value %>
+        <% end %>
+        <div class="form-field">
+          <%= label_tag :q, "Search customer" %>
+          <%= text_field_tag :q, params[:q], autocomplete: "off" %>
+        </div>
+        <%= submit_tag "Search", class: "btn" %>
+      <% end %>
+
+      <% if @matches.present? %>
+        <ul class="pos-inquiry__matches">
+          <% @matches.each do |row| %>
+            <li>
+              <%= link_to [ row.customer.display_name, row.customer.email, row.customer.phone ].compact.join(" · "),
+                    pos_customer_summary_path(inquiry_register_params.merge(customer_id: row.customer.id)),
+                    class: "btn btn--ghost" %>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+
+      <% if @customer %>
+        <section class="pos-inquiry__result" aria-label="Customer summary">
+          <div class="pos-history__title-row">
+            <h2><%= @customer.display_name %></h2>
+            <% if @can_open_customer %>
+              <%= link_to "Open Customer", admin_customer_path(@customer), class: "btn btn--outline" %>
+            <% end %>
+          </div>
+          <p class="muted"><%= [ @customer.email, @customer.phone ].compact.join(" · ") %></p>
+
+          <dl class="pos-history__header">
+            <div>
+              <dt>Store credit</dt>
+              <dd>
+                <% if @store_credit_account %>
+                  <%= format_money_cents(@store_credit_account.balance_cents) %> available
+                <% else %>
+                  None
+                <% end %>
+              </dd>
+            </div>
+            <div>
+              <dt>Pickups &amp; requests</dt>
+              <dd><%= @ready_pickups.size %> ready · <%= @open_requests.size %> open</dd>
+            </div>
+          </dl>
+
+          <% if @ready_pickups.any? %>
+            <p>
+              <%= link_to "View ready pickups",
+                    pos_pickup_queue_path(inquiry_register_params.merge(q: @customer.display_name, status: "available")),
+                    class: "btn btn--outline" %>
+            </p>
+          <% end %>
+
+          <h3>Recent transactions</h3>
+          <% if @recent_transactions.empty? %>
+            <p class="muted">No completed transactions for this customer at this store.</p>
+          <% else %>
+            <ul class="pos-inquiry__activity">
+              <% @recent_transactions.each do |transaction| %>
+                <li>
+                  <%= transaction.business_date %> ·
+                  <%= link_to transaction.transaction_reference, pos_transaction_path(transaction, inquiry_register_params) %> ·
+                  <%= format_signed_money_cents(transaction.signed_net_cents) %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+
+          <h3>Open requests</h3>
+          <% if @open_requests.empty? %>
+            <p class="muted">No open requests at this store.</p>
+          <% else %>
+            <ul class="pos-inquiry__activity">
+              <% @open_requests.each do |request| %>
+                <li>
+                  #<%= request.number %> · <%= request.status.humanize %> ·
+                  <%= request.product_variant&.product&.name || "Merchandise" %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+        </section>
+      <% end %>
+    </main>
+  </div>
+<% end %>

--- a/app/views/pos/pickup_queues/index.html.erb
+++ b/app/views/pos/pickup_queues/index.html.erb
@@ -1,0 +1,87 @@
+<% content_for :title, "Pickup Queue" %>
+<%= render layout: "pos/shell/frame" do %>
+  <%= render "pos/shell/feedback" %>
+  <div class="pos-register-shell__body">
+    <main class="pos-inquiry pos-inquiry--wide">
+      <div class="pos-history__title-row pos-no-print">
+        <h1>Pickup Queue</h1>
+        <%= link_to register_inquiry_return_label, register_inquiry_return_path, class: "btn btn--ghost" %>
+      </div>
+      <p class="muted">View only. Add to Transaction is not available from this surface in Slice 6A.</p>
+
+      <%= form_with url: pos_pickup_queue_path, method: :get, local: true, class: "pos-inquiry__form" do %>
+        <% inquiry_register_params.each do |key, value| %>
+          <%= hidden_field_tag key, value %>
+        <% end %>
+        <div class="form-field">
+          <%= label_tag :status, "Status" %>
+          <%= select_tag :status, options_for_select([["Ready", "available"], ["All open", "all"]], @status) %>
+        </div>
+        <div class="form-field">
+          <%= label_tag :q, "Search" %>
+          <%= text_field_tag :q, @query, autocomplete: "off" %>
+        </div>
+        <%= submit_tag "Filter", class: "btn" %>
+      <% end %>
+
+      <% if @requests.empty? %>
+        <p class="muted">No matching pickups.</p>
+      <% else %>
+        <div class="table-scroll">
+          <table class="pos-history__table">
+            <thead>
+              <tr>
+                <th>Request</th>
+                <th>Customer</th>
+                <th>Items</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @requests.each do |request| %>
+                <tr class="<%= "is-selected" if @selected&.id == request.id %>">
+                  <td>
+                    <%= link_to "##{request.number}",
+                          pos_pickup_queue_path(inquiry_register_params.merge(q: @query, status: @status, request_id: request.id)) %>
+                  </td>
+                  <td><%= request.customer.display_name %></td>
+                  <td>
+                    <% variant = request.product_variant %>
+                    <%= [ variant&.product&.name, variant&.sku ].compact.join(" · ") %>
+                  </td>
+                  <td><%= request.status.humanize %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+
+        <% if @selected %>
+          <section class="pos-inquiry__result" aria-label="Selected pickup">
+            <h2>Request #<%= @selected.number %> · <%= @selected.customer.display_name %></h2>
+            <% variant = @selected.product_variant %>
+            <dl class="pos-history__header">
+              <div><dt>Merchandise</dt><dd><%= [ variant&.product&.name, variant&.sku ].compact.join(" · ") %></dd></div>
+              <div><dt>Status</dt><dd><%= @selected.status.humanize %></dd></div>
+              <% allocation = @selected.active_allocation %>
+              <% if allocation %>
+                <div><dt>Allocation</dt><dd><%= allocation.allocation_type.humanize %></dd></div>
+                <% if allocation.inventory_unit %>
+                  <div><dt>Unit</dt><dd><%= allocation.inventory_unit.unit_identifier %></dd></div>
+                <% end %>
+              <% end %>
+            </dl>
+            <div class="actions">
+              <% if @can_view_request %>
+                <%= link_to "View Request", admin_customer_request_path(@selected), class: "btn btn--outline" %>
+              <% end %>
+              <%= link_to "Customer Summary",
+                    pos_customer_summary_path(inquiry_register_params.merge(customer_id: @selected.customer_id)),
+                    class: "btn btn--outline" %>
+            </div>
+          </section>
+        <% end %>
+      <% end %>
+    </main>
+  </div>
+<% end %>

--- a/app/views/pos/stored_value_inquiries/show.html.erb
+++ b/app/views/pos/stored_value_inquiries/show.html.erb
@@ -107,6 +107,9 @@
               </div>
             </dl>
             <div class="actions">
+              <%= link_to "View Customer Summary",
+                    pos_customer_summary_path(inquiry_register_params.merge(customer_id: @store_credit_customer.id)),
+                    class: "btn btn--outline" %>
               <% if @continuations&.can_tender && @continuations.workspace_path %>
                 <%= link_to "Use as Tender", @continuations.workspace_path, class: "btn btn--outline" %>
               <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -208,6 +208,8 @@ Rails.application.routes.draw do
       post :store_credit
       post :admin_prefix_last_four
     end
+    resource :customer_summary, only: :show, controller: "customer_summaries"
+    get "pickup_queue", to: "pickup_queues#index", as: :pickup_queue
     get "register/enter", to: "enters#show", as: :register_enter
     post "register/enter", to: "enters#create"
     resources :cash_outs, only: %i[new create show] do

--- a/docs/planning/register-workspace-consolidation/README.md
+++ b/docs/planning/register-workspace-consolidation/README.md
@@ -29,6 +29,10 @@ This program **replaces** the current POS presentation. It does not run a parall
 | [slice5d-manual-verification.md](slice5d-manual-verification.md) | Slice 5D workstation evidence |
 | [slice6a-customer-service-plan.md](slice6a-customer-service-plan.md) | Locked Slice 6A shell context / S12–S16 contracts (6A.1–6A.3) |
 | [slice6a-manual-verification.md](slice6a-manual-verification.md) | Slice 6A workstation evidence |
+| [slice6b-till-session-plan.md](slice6b-till-session-plan.md) | Locked Slice 6B till / session / reverse-from-original contracts |
+| [slice6b-manual-verification.md](slice6b-manual-verification.md) | Slice 6B workstation evidence |
+| [slice6c-reporting-period-plan.md](slice6c-reporting-period-plan.md) | Locked Slice 6C reporting / P13 / print chrome contracts |
+| [slice6c-manual-verification.md](slice6c-manual-verification.md) | Slice 6C workstation evidence |
 
 UX adoption: follow [ux-adoption-template.md](../ux-design-system/ux-adoption-template.md) in the slice that materially changes a screen. Printed receipts stay locked unless a slice explicitly owns print.
 

--- a/docs/planning/register-workspace-consolidation/implementation-plan.md
+++ b/docs/planning/register-workspace-consolidation/implementation-plan.md
@@ -28,9 +28,9 @@ This program uses a long-lived integration branch because an incomplete Register
 | 5B Return overlays | Merged to integration ([#87](https://github.com/BankEncore/ShelfSense-v1/issues/87) / PR [#100](https://github.com/BankEncore/ShelfSense-v1/pull/100)) | [#87](https://github.com/BankEncore/ShelfSense-v1/issues/87) |
 | 5C Controlled-action overlays | Merged to integration ([#88](https://github.com/BankEncore/ShelfSense-v1/issues/88) / PR [#101](https://github.com/BankEncore/ShelfSense-v1/pull/101)) | [#88](https://github.com/BankEncore/ShelfSense-v1/issues/88) |
 | 5D Tender/issuance overlays | Complete on integration ([#89](https://github.com/BankEncore/ShelfSense-v1/issues/89) / PR [#102](https://github.com/BankEncore/ShelfSense-v1/pull/102); remediation PR [#103](https://github.com/BankEncore/ShelfSense-v1/pull/103)) | [#89](https://github.com/BankEncore/ShelfSense-v1/issues/89) |
-| 6A Customer-service surfaces | In implementation (packet locked; 6A.1–6A.3 PRs) | [#90](https://github.com/BankEncore/ShelfSense-v1/issues/90) |
-| 6B Till and session detail | Not started | [#91](https://github.com/BankEncore/ShelfSense-v1/issues/91) |
-| 6C Reporting-period surfaces | Not started | [#92](https://github.com/BankEncore/ShelfSense-v1/issues/92) |
+| 6A Customer-service surfaces | Implemented on `90-customer-service-surfaces` (awaiting merge) | [#90](https://github.com/BankEncore/ShelfSense-v1/issues/90) |
+| 6B Till and session detail | Packet locked | [#91](https://github.com/BankEncore/ShelfSense-v1/issues/91) |
+| 6C Reporting-period surfaces | Packet locked | [#92](https://github.com/BankEncore/ShelfSense-v1/issues/92) |
 | 7A Tender-review framework | Gated on 2–6 | [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) |
 | 7B Stored-value/issuance completion | Gated on 7A | [#94](https://github.com/BankEncore/ShelfSense-v1/issues/94) |
 | 7C Keyboard supersession | Gated on 7A–7B packet amendment | [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) |

--- a/docs/planning/register-workspace-consolidation/slice6a-customer-service-plan.md
+++ b/docs/planning/register-workspace-consolidation/slice6a-customer-service-plan.md
@@ -1,6 +1,6 @@
 # Slice 6A — Customer-service surfaces
 
-Status: **In implementation** on `register-workspace-consolidation` ([#90](https://github.com/BankEncore/ShelfSense-v1/issues/90)). Delivery: one packet; three PRs (**6A.1** / **6A.2** / **6A.3**). Close #90 after all three merge.
+Status: **Implemented on branch** `90-customer-service-surfaces` ([#90](https://github.com/BankEncore/ShelfSense-v1/issues/90)). Delivery: one packet; three commits/PRs (**6A.1** / **6A.2** / **6A.3**). Close #90 after all three merge to `register-workspace-consolidation`.
 
 Authority: [plan.md](plan.md), [implementation-plan.md](implementation-plan.md), [routing-and-authority.md](routing-and-authority.md), [user-stories.md](user-stories.md), [textual-wireframes.md](textual-wireframes.md) S12–S16 / P1–P5, [closeout-plan.md](closeout-plan.md), ADR-026 / ADR-027.
 

--- a/docs/planning/register-workspace-consolidation/slice6b-manual-verification.md
+++ b/docs/planning/register-workspace-consolidation/slice6b-manual-verification.md
@@ -1,0 +1,25 @@
+# Slice 6B — Manual verification evidence
+
+Status: **pending** until Slice 6B implementation lands.
+
+Workstation assumptions: Chrome (or Chromium) on a Register-class display; Keyboard Lock optional (F10-only on inquiry).
+
+## Checklist
+
+| # | Case | Pass criteria | Result | Notes |
+|---|---|---|---|---|
+| 1 | Till Activity own session | Current till; expected cash gated | | |
+| 2 | Till Activity historical | Between/closed shows history without inventing till | | |
+| 3 | Reverse from original only | No reverse on reversal; confirm shows effect | | |
+| 4 | Reverse commit revalidation | Custody + cash availability; idempotent | | |
+| 5 | Generic reverse launcher gone | No menu/route UI; service remains | | |
+| 6 | Cash forms in shell | Paid-in/out/drop/replenish/cash-out fit | | |
+| 7 | Session Details / Active Sessions | Permission + ownership rules | | |
+| 8 | Print/detail expected cash | No before-count leak without permission | | |
+
+## Sign-off
+
+- Date:
+- Browser / OS:
+- Verified by:
+- Follow-ups (if any):

--- a/docs/planning/register-workspace-consolidation/slice6b-till-session-plan.md
+++ b/docs/planning/register-workspace-consolidation/slice6b-till-session-plan.md
@@ -1,0 +1,61 @@
+# Slice 6B — Till and session detail
+
+Status: **Packet locked** (not started). Depends on Slice 6A shell context and eligibility law.
+
+Authority: [plan.md](plan.md), [implementation-plan.md](implementation-plan.md), [routing-and-authority.md](routing-and-authority.md), [slice6a-customer-service-plan.md](slice6a-customer-service-plan.md) (shared `RegisterShellContext`, eligibility matrix, expected-cash), [textual-wireframes.md](textual-wireframes.md) S17–S19 / S21–S23, [user-stories.md](user-stories.md).
+
+Issue: [#91](https://github.com/BankEncore/ShelfSense-v1/issues/91). Branch: `91-till-session-detail`. PR target: `register-workspace-consolidation`.
+
+## Outcome
+
+Compose Till Activity, Session Details, Active Sessions enhancements, and cash operation detail into the Register shell. Shell-wrap existing paid-in/out, drop, replenish, and gift-card cash-out forms (S21/S22). Enable reverse-from-original on cash activity detail; delete the generic reverse launcher in the same PR.
+
+## Boundary statement
+
+> Slice 6B wraps till and session inquiry and existing cash forms in the shared shell. It does not invent new cash types or duplicate reverse services. Reverse is only from an eligible original; confirmation uses a distinct overlay ID assigned before markup (not O10).
+
+## Scope
+
+| In | Out |
+|---|---|
+| S17 Till Activity | Reporting / X / Z / P13 (6C) |
+| S18 Session Details | Assisted Close |
+| S19 Active Sessions enhancements | New cash types |
+| S21/S22 shell wrap of existing cash forms | Redesigning cash mutation services |
+| S23 cash activity detail + reverse-from-original | Generic reverse launcher (delete) |
+| Expected-cash gating on these surfaces | Slice 7 |
+| Distinct reverse confirmation overlay ID | Using O10 for reverse confirm |
+
+## Reverse-from-original (packet law)
+
+- Only an eligible original exposes Reverse
+- Cannot reverse a reversal; cannot reverse twice
+- Revalidate authorization and session/register custody at commit
+- Revalidate cash availability when reversal removes session cash
+- Confirmation shows original operation, amount, direction, performer, time, resulting effect
+- Existing reverse service; idempotent
+- Detail page reflects reversal relationship immediately
+- Generic launcher + obsolete tests deleted in the **same PR**
+- Distinct confirmation overlay ID assigned **before** markup (not O10)
+
+## Eligibility (from Slice 6 matrix)
+
+| Surface | Closed | Between sessions | Own session | Occupied | Selector / no Register |
+|---|---|---|---|---|---|
+| Till Activity | No current till | Historical | Current session | Permission-controlled view | No |
+| Session Details | Historical only | Historical | Current | `pos.sessions.view` | No |
+| Active Sessions | Permission | Permission | Permission | Permission | Permission |
+
+GET must not create a period, session, transaction, or cash record.
+
+## Default for S21/S22
+
+Shell wrap of existing cash forms (no new cash types; layout refresh only if required for shell fit).
+
+## Shared context
+
+Reuse `Pos::RegisterShellContext` surfaces `:till_activity`, `:session_detail`, `:active_sessions`, `:cash_operation`. Menu surface `:inquiry` (or cash-specific if needed) — no open/finalize/close proxies.
+
+## Manual verification
+
+Add `slice6b-manual-verification.md` when implementation starts.

--- a/docs/planning/register-workspace-consolidation/slice6c-manual-verification.md
+++ b/docs/planning/register-workspace-consolidation/slice6c-manual-verification.md
@@ -1,0 +1,25 @@
+# Slice 6C — Manual verification evidence
+
+Status: **pending** until Slice 6C implementation lands.
+
+Workstation assumptions: Chrome (or Chromium) on a Register-class display; print preview available.
+
+## Checklist
+
+| # | Case | Pass criteria | Result | Notes |
+|---|---|---|---|---|
+| 1 | X in shell | Session-scoped; expected cash gated | | |
+| 2 | Closed session detail | Snapshot facts; shell return | | |
+| 3 | Z status | Cumulative projection; view rules | | |
+| 4 | Finalize GET | Read-only blockers; no mutate | | |
+| 5 | Finalize POST | Revalidates; locks; once only | | |
+| 6 | P13 consistency | X / closed / Z reconcile to facts | | |
+| 7 | Print X/Z | No F10, Return, status strips | | |
+| 8 | Print receipt/voucher | No interactive shell chrome | | |
+
+## Sign-off
+
+- Date:
+- Browser / OS:
+- Verified by:
+- Follow-ups (if any):

--- a/docs/planning/register-workspace-consolidation/slice6c-reporting-period-plan.md
+++ b/docs/planning/register-workspace-consolidation/slice6c-reporting-period-plan.md
@@ -1,0 +1,67 @@
+# Slice 6C — Reporting-period surfaces
+
+Status: **Packet locked** (not started). Depends on Slice 6A shell context and Slice 6B till/session patterns where shared.
+
+Authority: [plan.md](plan.md), [implementation-plan.md](implementation-plan.md), [routing-and-authority.md](routing-and-authority.md), [slice6a-customer-service-plan.md](slice6a-customer-service-plan.md), [textual-wireframes.md](textual-wireframes.md) S9–S11 / S20 / P13, [user-stories.md](user-stories.md).
+
+Issue: [#92](https://github.com/BankEncore/ShelfSense-v1/issues/92). Branch: `92-reporting-period-surfaces`. PR target: `register-workspace-consolidation`.
+
+## Outcome
+
+Compose X Report, Session / Z Reports, closed-session detail, and Z status/finalize into the Register shell. Introduce **P13** as a shared projection over existing facts (not a second report calculator). Ensure print/X/Z/receipt/voucher output omits interactive shell chrome.
+
+## Boundary statement
+
+> Slice 6C consolidates reporting-period inquiry and finalize into the Register shell. P13 projects existing session and period facts; presenters do not persist totals. Finalize revalidates blockers on POST. Print views must not include F10, Return to Register, status strips, or interactive navigation.
+
+## Scope
+
+| In | Out |
+|---|---|
+| S9–S11 reporting destinations in shell | Assisted Close |
+| S20 closed-session detail | New financial ledgers |
+| P13 shared totals projection | Recalculating sales outside existing facts |
+| Finalize Z GET blockers / POST once | Bypassing blockers via earlier GET |
+| Print chrome absence tests | Slice 7 |
+| Expected-cash gating on X/Z/session/print | Changing finalized snapshot authority |
+
+## P13 / financial authority
+
+P13 is a **shared projection over existing facts**, not another report calculation.
+
+- X = session-scoped; closed-session = one session snapshot; Z = reporting-period cumulative
+- Sale/return signs and tender totals reconcile to completed transactions
+- Cash operations separate from sales/tenders
+- Stored-value issuance and redemption not conflated
+- Presenters do not persist totals; finalized reports use immutable snapshots where available
+
+## Finalize
+
+```text
+GET  → read-only blockers / confirmation
+POST → revalidate blockers, lock, finalize once
+```
+
+No open session, working transaction, incomplete closing snapshot, or stale eligibility bypass via an earlier confirmation GET.
+
+## Print
+
+Screen reports use Register shell. Print-specific X/Z, receipts, vouchers **must not** print F10, Return to Register, shell status strips, or interactive navigation. Print CSS or dedicated print templates; test chrome absence.
+
+## Eligibility (from Slice 6 matrix)
+
+| Surface | Closed | Between sessions | Own session | Occupied | Selector / no Register |
+|---|---|---|---|---|---|
+| X Report | No current X | Prior/closed reports | Current X | `pos.sessions.view` | No |
+| Z status | Historical | Current period | View only | Permission-controlled | No |
+| Finalize Z | No | When eligible | No | No | No |
+
+GET must not create a period, session, transaction, or cash record.
+
+## Shared context
+
+Reuse `Pos::RegisterShellContext` surfaces `:x_report`, `:z_period`, and session detail as applicable.
+
+## Manual verification
+
+Add `slice6c-manual-verification.md` when implementation starts.

--- a/docs/planning/register-workspace-consolidation/test-matrix.md
+++ b/docs/planning/register-workspace-consolidation/test-matrix.md
@@ -43,11 +43,15 @@ F10 working-basket preservation is already covered in [test/system/pos_register_
 | `test/services/pos/cash_accountability_test.rb` | Domain | Preserve |
 | `test/services/cash/*` | Domain | Preserve |
 | `test/services/gift_cards/cash_out_test.rb` | Domain | Preserve |
-| `test/services/gift_cards/*` inquiry/admin | Domain; prefix/last-four vs possession | Preserve; extend in 6A |
+| `test/services/gift_cards/*` inquiry/admin | Domain; prefix/last-four vs possession | Preserve; POS S14 in 6A.2 |
 | `test/models/pos_schema_test.rb` | Domain | Preserve |
 | `test/integration/pos_register_test.rb` | Request still required (enter, occupied, resume) | Preserve; retarget paths if `/pos` semantics change |
 | `test/integration/pos_home_test.rb` | Mixed: GET immutability / auth (keep); `h1` POS Home and Home link lists (replace Slice 2); workspace “POS Home” chrome (replace Slice 2–3); F10 not covered here | Replace Home-specific assertions in Slice 2 |
-| `test/integration/pos_transaction_history_test.rb` | Request still required | Preserve; Slice 3/6A may change chrome |
+| `test/integration/pos_transaction_history_test.rb` | Request still required; shell wrap + return ownership | Slice 6A.1 |
+| `test/services/pos/register_shell_context_test.rb` | Return paths / inquiry menu surface / expected-cash flag | Slice 6A.1 |
+| `test/integration/pos_stored_value_inquiry_test.rb` | S14 three POST paths; no GET number leakage; admin isolation | Slice 6A.2 |
+| `test/integration/pos_customer_service_surfaces_test.rb` | S15/S16 read-only shell surfaces | Slice 6A.3 |
+| `test/services/pos/register_menu_test.rb` | Menu capability keys; inquiry suppresses proxies; 6A customer-service items | Slice 3 / 6A |
 | `test/integration/pos_return_items_test.rb` | Request still required | Preserve |
 | `test/integration/pos_post_void_workspace_test.rb` | Request still required | Preserve |
 | `test/integration/pos_*_return_workspace_test.rb` | Request still required | Preserve |

--- a/test/integration/pos_customer_service_surfaces_test.rb
+++ b/test/integration/pos_customer_service_surfaces_test.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PosCustomerServiceSurfacesTest < ActionDispatch::IntegrationTest
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    @register = Register.create!(store: @store, register_number: 1, name: "Front")
+    @tax = tax_class(code: "physical_book", name: "Physical book")
+    @variant = pos_sellable_variant(actor: @actor, tax_class: @tax)
+    sign_in_as("admin")
+  end
+
+  test "customer summary is read-only inside the shell" do
+    customer = Customer.create!(display_name: "Summary Customer", email: "summary@example.com", phone: "555-0144")
+    account = StoredValue::OpenAccount.call(account_type: "store_credit", customer: customer)
+    reason = StoredValueAdjustmentReason.find_by!(code: "goodwill")
+    StoredValue::Adjust.call(
+      account: account,
+      direction: "credit",
+      amount_cents: 1_800,
+      reason: reason,
+      store: @store,
+      performed_by: @actor,
+      source_id: account.id,
+      idempotency_key: SecureRandom.uuid_v7
+    )
+
+    get pos_customer_summary_path, params: { register_id: @register.id, customer_id: customer.id }
+    assert_response :success
+    assert_select ".pos-register-shell"
+    assert_select "h1", text: "Customer Summary"
+    assert_match "Summary Customer", response.body
+    assert_match format_money_cents(1_800), response.body
+    assert_select "a", text: "Open Customer"
+    refute_match(/Attach/i, response.body)
+    refute_match(/Merge/i, response.body)
+    refute_match(/Edit customer/i, response.body)
+  end
+
+  test "customer summary search lists matches without mutation controls" do
+    Customer.create!(display_name: "Alpha Search", email: "alpha.search@example.com")
+    get pos_customer_summary_path, params: { q: "Alpha Search" }
+    assert_response :success
+    assert_match "Alpha Search", response.body
+    assert_select "form[method='post']", count: 0
+  end
+
+  test "pickup queue is view-only and lists available requests" do
+    customer = Customer.create!(display_name: "Pickup Customer", phone: "555-0188")
+    request = create_available_request!(customer:)
+
+    get pos_pickup_queue_path, params: { register_id: @register.id }
+    assert_response :success
+    assert_select ".pos-register-shell"
+    assert_select "h1", text: "Pickup Queue"
+    assert_match(/##{request.number}/, response.body)
+    assert_match "Pickup Customer", response.body
+    assert_match "View only", response.body
+    assert_select "a", text: /Add .* Transaction/i, count: 0
+    assert_select "form[action*='pickup'][method='post']", count: 0
+  end
+
+  test "pickup queue and customer summary do not create sessions on GET" do
+    get pos_customer_summary_path
+    get pos_pickup_queue_path
+    assert_response :success
+    refute PosSession.open.exists?
+    refute PosReportingPeriod.exists?
+  end
+
+  private
+
+  def sign_in_as(username)
+    post session_path, params: { session: { username: username, password: "correct-horse-battery" } }
+  end
+
+  def format_money_cents(cents)
+    format("$%d.%02d", cents / 100, cents % 100)
+  end
+
+  def create_available_request!(customer:)
+    open_quantity_stock(store: @store, variant: @variant, actor: @actor, quantity: 2)
+    request = CustomerRequest.create!(
+      store: @store,
+      customer: customer,
+      product_variant: @variant,
+      number: (CustomerRequest.where(store: @store).maximum(:number) || 0) + 1,
+      status: "available",
+      requested_quantity: 1
+    )
+    CustomerRequestAllocation.create!(
+      customer_request: request,
+      allocation_type: "standard_quantity",
+      status: "reserved",
+      quantity: 1
+    )
+    request
+  end
+end

--- a/test/services/pos/register_menu_test.rb
+++ b/test/services/pos/register_menu_test.rb
@@ -7,7 +7,7 @@ class PosRegisterMenuTest < ActiveSupport::TestCase
 
   test "selector includes transactions session z switch and return" do
     keys = keys_for(kind: "selector", surface: :state_landing, permissions: ALL_PERMISSIONS)
-    assert_equal %i[transactions stored_value_inquiry session_z_reports active_sessions switch_register return_to_shelfsense], keys
+    assert_equal %i[transactions stored_value_inquiry customer_summary pickup_queue session_z_reports active_sessions switch_register return_to_shelfsense], keys
     refute_includes keys, :x_report
     refute_includes keys, :close_session
     refute_includes keys, :drop
@@ -85,7 +85,7 @@ class PosRegisterMenuTest < ActiveSupport::TestCase
 
   test "switch register suppresses switch till x close and in-page mutations" do
     keys = keys_for(kind: "own_session", surface: :switch_register, permissions: ALL_PERMISSIONS)
-    assert_equal %i[transactions stored_value_inquiry session_z_reports active_sessions return_to_shelfsense], keys
+    assert_equal %i[transactions stored_value_inquiry customer_summary pickup_queue session_z_reports active_sessions return_to_shelfsense], keys
     refute_includes keys, :switch_register
     refute_includes keys, :x_report
     refute_includes keys, :drop


### PR DESCRIPTION
## Summary
- Add S15 Customer Summary and S16 Pickup Queue as view-only Register shell surfaces (no attach / no Add to Transaction).
- Update test-matrix and menu customer-service items.
- Lock Slice 6B and 6C planning packets for the next implementation wave.

## Test plan
- [x] `./dev/rails-docker bin/rails test test/integration/pos_customer_service_surfaces_test.rb test/integration/pos_stored_value_inquiry_test.rb test/services/pos/register_menu_test.rb`
- [ ] Manual: Customer Summary read-only; Pickup Queue view-only

Depends on 6A.2. After this merges through to `register-workspace-consolidation`, close #90.


Made with [Cursor](https://cursor.com)