### PR TITLE
Fix 6A inquiry results visibility and receipt print chrome

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -2607,8 +2607,22 @@ input[type="submit"]:disabled,
 
   .pos-no-print,
   .pos-receipt__screen,
-  .pos-receipt__actions {
+  .pos-receipt__actions,
+  .pos-register-shell__announce,
+  .pos-register-menu {
     display: none !important;
+  }
+
+  /* Shell layout is screen-only; print must not keep the viewport chrome. */
+  .pos-register-shell,
+  .pos-register-shell__background,
+  .pos-register-shell__body {
+    display: block !important;
+    height: auto !important;
+    max-height: none !important;
+    min-height: 0 !important;
+    overflow: visible !important;
+    width: 100% !important;
   }
 
   .pos-print-only,

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -2332,7 +2332,21 @@ input[type="submit"]:disabled,
   align-items: flex-end;
 }
 
-.pos-inquiry__result,
+.pos-inquiry__result {
+  margin: 0;
+  padding: var(--space-4);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface, #fff);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.pos-inquiry__result h2,
+.pos-inquiry__result h3 {
+  margin: 0;
+}
+
 .pos-inquiry__matches,
 .pos-inquiry__activity {
   margin: 0;
@@ -2346,8 +2360,15 @@ input[type="submit"]:disabled,
   gap: var(--space-2);
 }
 
+.pos-inquiry__matches .btn {
+  width: 100%;
+  justify-content: flex-start;
+  text-align: left;
+  white-space: normal;
+}
+
 .pos-inquiry__actions {
-  margin-top: var(--space-3);
+  margin-top: var(--space-2);
 }
 
 .pos-inquiry--wide {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1392,6 +1392,8 @@ input[type="submit"]:disabled,
 
 .table-scroll {
   overflow-x: auto;
+  max-width: 100%;
+  min-width: 0;
   border: 1px solid var(--color-border-subtle);
   border-radius: var(--radius);
   background: var(--color-bg-surface);
@@ -2312,8 +2314,12 @@ input[type="submit"]:disabled,
 }
 
 .pos-inquiry {
-  width: min(100% - 2rem, 40rem);
+  width: 100%;
+  max-width: 40rem;
   margin: var(--space-6) auto;
+  padding-inline: 1rem;
+  box-sizing: border-box;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   gap: var(--space-6);
@@ -2372,24 +2378,32 @@ input[type="submit"]:disabled,
 }
 
 .pos-inquiry--wide {
-  width: min(100% - 2rem, 56rem);
+  max-width: 56rem;
 }
 
 .pos-history {
-  width: min(100% - 2rem, 56rem);
+  width: 100%;
+  max-width: 56rem;
   margin: var(--space-6) auto;
+  padding-inline: 1rem;
+  box-sizing: border-box;
+  min-width: 0;
 }
 
 .pos-history__title-row {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   gap: var(--space-3);
   margin-bottom: var(--space-3);
+  min-width: 0;
 }
 
 .pos-history__title-row h1 {
   margin: 0;
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .pos-history__nav {

--- a/app/controllers/pos/stored_value_inquiries_controller.rb
+++ b/app/controllers/pos/stored_value_inquiries_controller.rb
@@ -94,31 +94,41 @@ module Pos
         store: current_store
       )
       @customer_query = params[:customer_query].to_s
+      @inquiry_result_present = false
     end
 
     def restore_inquiry_result!
       payload = flash[:sv_inquiry]
       return if payload.blank?
 
-      if payload["exact_gift_card_id"].present?
-        card = GiftCard.includes(:gift_card_program, :stored_value_account).find_by(id: payload["exact_gift_card_id"])
-        return unless card
+      restore_exact_result!(payload)
+      restore_store_credit_result!(payload)
+      restore_admin_result!(payload)
+      @inquiry_result_present = inquiry_result_present?
+    end
 
-        @exact_card = card
-        @exact_activity = StoredValue::AccountActivity.call(
-          account: card.stored_value_account,
-          actor: current_user,
-          permission_key: "pos.transact",
-          page: 1
-        )
-        @continuations = Pos::StoredValueInquiryContinuations.call(
-          state: @state,
-          actor: current_user,
-          store: current_store,
-          gift_card: card
-        )
-      end
+    def restore_exact_result!(payload)
+      return if payload["exact_gift_card_id"].blank?
 
+      card = GiftCard.includes(:gift_card_program, :stored_value_account).find_by(id: payload["exact_gift_card_id"])
+      return unless card
+
+      @exact_card = card
+      @exact_activity = StoredValue::AccountActivity.call(
+        account: card.stored_value_account,
+        actor: current_user,
+        permission_key: "pos.transact",
+        page: 1
+      )
+      @continuations = Pos::StoredValueInquiryContinuations.call(
+        state: @state,
+        actor: current_user,
+        store: current_store,
+        gift_card: card
+      )
+    end
+
+    def restore_store_credit_result!(payload)
       if payload["store_credit_match_ids"].present?
         ids = Array(payload["store_credit_match_ids"])
         customers = Customer.active.canonical.where(id: ids).index_by(&:id)
@@ -131,56 +141,63 @@ module Pos
         @customer_query = payload["customer_query"].presence || @customer_query
       end
 
-      if payload["store_credit_customer_id"].present?
-        customer = Customer.active.canonical.find_by(id: payload["store_credit_customer_id"])
-        if customer
-          @store_credit_customer = customer
-          @store_credit_account = customer.stored_value_accounts.find_by(account_type: "store_credit")
-          @continuations = Pos::StoredValueInquiryContinuations.call(
-            state: @state,
-            actor: current_user,
-            store: current_store,
-            store_credit_customer: customer
-          )
-        end
+      return if payload["store_credit_customer_id"].blank?
+
+      customer = Customer.active.canonical.find_by(id: payload["store_credit_customer_id"])
+      return unless customer
+
+      @store_credit_customer = customer
+      @store_credit_account = customer.stored_value_accounts.find_by(account_type: "store_credit")
+      @continuations = Pos::StoredValueInquiryContinuations.call(
+        state: @state,
+        actor: current_user,
+        store: current_store,
+        store_credit_customer: customer
+      )
+    end
+
+    def restore_admin_result!(payload)
+      result = Pos::StoredValueAdminInquiryRestore.call(
+        payload: payload,
+        actor: current_user,
+        store: current_store
+      )
+      if result.denied
+        record_gift_cards_view_denied!
+        flash.now[:alert] = "You are not authorized to perform that action."
+        return
       end
 
-      if payload["admin_gift_card_id"].present?
-        card = GiftCard.includes(:gift_card_program, :stored_value_account).find_by(id: payload["admin_gift_card_id"])
-        if card
-          @admin_card = card
-          @admin_activity = StoredValue::AccountActivity.call(
-            account: card.stored_value_account,
-            actor: current_user,
-            permission_key: "gift_cards.view",
-            page: 1
-          )
-        end
+      if result.card
+        @admin_card = result.card
+        @admin_activity = StoredValue::AccountActivity.call(
+          account: result.card.stored_value_account,
+          actor: current_user,
+          permission_key: "gift_cards.view",
+          page: 1
+        )
       end
 
-      if payload["admin_candidate_ids"].present?
-        cards = GiftCard.includes(:gift_card_program, :stored_value_account)
-                        .where(id: payload["admin_candidate_ids"])
-                        .index_by(&:id)
-        @admin_candidates = Array(payload["admin_candidate_ids"]).filter_map do |id|
-          card = cards[id]
-          next unless card
+      @admin_candidates = result.candidates if result.candidates.any?
+    end
 
-          GiftCards::AdminInquiry::Candidate.new(
-            id: card.id,
-            masked_number: card.masked_number,
-            status: card.status,
-            program_name: card.gift_card_program.name,
-            balance_cents: card.balance_cents,
-            activated_at: card.activated_at
-          )
-        end
-      end
+    def inquiry_result_present?
+      @exact_card ||
+        @store_credit_customer ||
+        @store_credit_matches.present? ||
+        @admin_card ||
+        @admin_candidates.present?
     end
 
     def require_gift_cards_view!
       return if @can_admin_inquire
 
+      record_gift_cards_view_denied!
+      redirect_to pos_stored_value_inquiry_path(inquiry_register_params),
+                  alert: "You are not authorized to perform that action."
+    end
+
+    def record_gift_cards_view_denied!
       Audit::Recorder.record!(
         action: "authorization.denied",
         outcome: "denied",
@@ -190,8 +207,6 @@ module Pos
         reason_code: "gift_cards.view",
         metadata: { path: request.fullpath }
       )
-      redirect_to pos_stored_value_inquiry_path(inquiry_register_params),
-                  alert: "You are not authorized to perform that action."
     end
   end
 end

--- a/app/controllers/pos/stored_value_inquiries_controller.rb
+++ b/app/controllers/pos/stored_value_inquiries_controller.rb
@@ -6,69 +6,55 @@ module Pos
     before_action :require_gift_cards_view!, only: :admin_prefix_last_four
 
     def show
+      restore_inquiry_result!
     end
 
     def exact_number
       raw = params[:card_number].to_s
       card = GiftCards::Lookup.by_number(raw)
       if card.nil?
-        flash.now[:alert] = "No gift card matched that number."
-        render :show, status: :unprocessable_entity
+        redirect_to pos_stored_value_inquiry_path(inquiry_register_params),
+                    alert: "No gift card matched that number."
         return
       end
 
-      @exact_card = card
-      @exact_activity = StoredValue::AccountActivity.call(
-        account: card.stored_value_account,
-        actor: current_user,
-        permission_key: "pos.transact",
-        page: 1
-      )
-      @continuations = Pos::StoredValueInquiryContinuations.call(
-        state: @state,
-        actor: current_user,
-        store: current_store,
-        gift_card: card
-      )
-      render :show
+      flash[:sv_inquiry] = { "exact_gift_card_id" => card.id }
+      redirect_to pos_stored_value_inquiry_path(inquiry_register_params)
     end
 
     def store_credit
       if params[:customer_id].present?
         customer = Customer.active.canonical.find_by(id: params[:customer_id])
         unless customer
-          flash.now[:alert] = "Customer not found."
-          render :show, status: :unprocessable_entity
+          redirect_to pos_stored_value_inquiry_path(inquiry_register_params),
+                      alert: "Customer not found."
           return
         end
 
-        @store_credit_customer = customer
-        @store_credit_account = customer.stored_value_accounts.find_by(account_type: "store_credit")
-        @continuations = Pos::StoredValueInquiryContinuations.call(
-          state: @state,
-          actor: current_user,
-          store: current_store,
-          store_credit_customer: customer
-        )
-        render :show
+        flash[:sv_inquiry] = { "store_credit_customer_id" => customer.id }
+        redirect_to pos_stored_value_inquiry_path(inquiry_register_params)
         return
       end
 
       query = params[:customer_query].to_s.strip
       if query.blank?
-        flash.now[:alert] = "Enter a customer name, email, or phone."
-        render :show, status: :unprocessable_entity
+        redirect_to pos_stored_value_inquiry_path(inquiry_register_params),
+                    alert: "Enter a customer name, email, or phone."
         return
       end
 
-      @store_credit_matches = Customers::Search.call(query: query, mode: :operational, limit: 20)
-      if @store_credit_matches.empty?
-        flash.now[:alert] = "No matching customers."
-        render :show, status: :unprocessable_entity
+      matches = Customers::Search.call(query: query, mode: :operational, limit: 20)
+      if matches.empty?
+        redirect_to pos_stored_value_inquiry_path(inquiry_register_params.merge(customer_query: query)),
+                    alert: "No matching customers."
         return
       end
 
-      render :show
+      flash[:sv_inquiry] = {
+        "store_credit_match_ids" => matches.map { |row| row.customer.id },
+        "customer_query" => query
+      }
+      redirect_to pos_stored_value_inquiry_path(inquiry_register_params.merge(customer_query: query))
     end
 
     def admin_prefix_last_four
@@ -80,23 +66,22 @@ module Pos
       )
       case result.status
       when :found
-        @admin_card = result.card
-        @admin_activity = StoredValue::AccountActivity.call(
-          account: result.card.stored_value_account,
-          actor: current_user,
-          permission_key: "gift_cards.view",
-          page: 1
-        )
+        flash[:sv_inquiry] = { "admin_gift_card_id" => result.card.id }
+        redirect_to pos_stored_value_inquiry_path(inquiry_register_params)
       when :ambiguous
-        @admin_candidates = result.candidates
-        flash.now[:alert] = "Several cards share that prefix and last four. Choose a masked candidate."
+        flash[:sv_inquiry] = {
+          "admin_candidate_ids" => result.candidates.map(&:id),
+          "admin_prefix" => params[:number_prefix].to_s,
+          "admin_last_four" => params[:number_last_four].to_s
+        }
+        redirect_to pos_stored_value_inquiry_path(inquiry_register_params),
+                    alert: "Several cards share that prefix and last four. Choose a masked candidate."
       else
-        flash.now[:alert] = GiftCards::GENERIC_INQUIRY_FAILURE
+        redirect_to pos_stored_value_inquiry_path(inquiry_register_params),
+                    alert: GiftCards::GENERIC_INQUIRY_FAILURE
       end
-      render :show, status: result.status == :found ? :ok : :unprocessable_entity
     rescue GiftCards::Error => e
-      flash.now[:alert] = e.message
-      render :show, status: :unprocessable_entity
+      redirect_to pos_stored_value_inquiry_path(inquiry_register_params), alert: e.message
     end
 
     private
@@ -108,6 +93,89 @@ module Pos
         permission_key: "gift_cards.view",
         store: current_store
       )
+      @customer_query = params[:customer_query].to_s
+    end
+
+    def restore_inquiry_result!
+      payload = flash[:sv_inquiry]
+      return if payload.blank?
+
+      if payload["exact_gift_card_id"].present?
+        card = GiftCard.includes(:gift_card_program, :stored_value_account).find_by(id: payload["exact_gift_card_id"])
+        return unless card
+
+        @exact_card = card
+        @exact_activity = StoredValue::AccountActivity.call(
+          account: card.stored_value_account,
+          actor: current_user,
+          permission_key: "pos.transact",
+          page: 1
+        )
+        @continuations = Pos::StoredValueInquiryContinuations.call(
+          state: @state,
+          actor: current_user,
+          store: current_store,
+          gift_card: card
+        )
+      end
+
+      if payload["store_credit_match_ids"].present?
+        ids = Array(payload["store_credit_match_ids"])
+        customers = Customer.active.canonical.where(id: ids).index_by(&:id)
+        @store_credit_matches = ids.filter_map do |id|
+          customer = customers[id]
+          next unless customer
+
+          Customers::Search::Result.new(customer: customer, matched_former_customer: false)
+        end
+        @customer_query = payload["customer_query"].presence || @customer_query
+      end
+
+      if payload["store_credit_customer_id"].present?
+        customer = Customer.active.canonical.find_by(id: payload["store_credit_customer_id"])
+        if customer
+          @store_credit_customer = customer
+          @store_credit_account = customer.stored_value_accounts.find_by(account_type: "store_credit")
+          @continuations = Pos::StoredValueInquiryContinuations.call(
+            state: @state,
+            actor: current_user,
+            store: current_store,
+            store_credit_customer: customer
+          )
+        end
+      end
+
+      if payload["admin_gift_card_id"].present?
+        card = GiftCard.includes(:gift_card_program, :stored_value_account).find_by(id: payload["admin_gift_card_id"])
+        if card
+          @admin_card = card
+          @admin_activity = StoredValue::AccountActivity.call(
+            account: card.stored_value_account,
+            actor: current_user,
+            permission_key: "gift_cards.view",
+            page: 1
+          )
+        end
+      end
+
+      if payload["admin_candidate_ids"].present?
+        cards = GiftCard.includes(:gift_card_program, :stored_value_account)
+                        .where(id: payload["admin_candidate_ids"])
+                        .index_by(&:id)
+        @admin_candidates = Array(payload["admin_candidate_ids"]).filter_map do |id|
+          card = cards[id]
+          next unless card
+
+          GiftCards::AdminInquiry::Candidate.new(
+            id: card.id,
+            masked_number: card.masked_number,
+            status: card.status,
+            program_name: card.gift_card_program.name,
+            balance_cents: card.balance_cents,
+            activated_at: card.activated_at
+          )
+        end
+      end
     end
 
     def require_gift_cards_view!

--- a/app/services/pos/stored_value_admin_inquiry_restore.rb
+++ b/app/services/pos/stored_value_admin_inquiry_restore.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Pos
+  # Restores masked admin inquiry results from a PRG flash payload.
+  # Re-evaluates gift_cards.view for the current actor/store before loading cards.
+  class StoredValueAdminInquiryRestore
+    Result = Data.define(:card, :candidates, :denied)
+
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(payload:, actor:, store:)
+      @payload = payload || {}
+      @actor = actor
+      @store = store
+    end
+
+    def call
+      return empty(denied: false) unless admin_payload?
+
+      unless authorized?
+        return empty(denied: true)
+      end
+
+      Result.new(card: load_card, candidates: load_candidates, denied: false)
+    end
+
+    private
+
+    def admin_payload?
+      @payload["admin_gift_card_id"].present? || Array(@payload["admin_candidate_ids"]).any?
+    end
+
+    def authorized?
+      Authorization::PermissionEvaluator.allowed?(
+        user: @actor,
+        permission_key: "gift_cards.view",
+        store: @store
+      )
+    end
+
+    def load_card
+      id = @payload["admin_gift_card_id"]
+      return nil if id.blank?
+
+      GiftCard.includes(:gift_card_program, :stored_value_account).find_by(id: id)
+    end
+
+    def load_candidates
+      ids = Array(@payload["admin_candidate_ids"])
+      return [] if ids.empty?
+
+      cards = GiftCard.includes(:gift_card_program, :stored_value_account)
+                      .where(id: ids)
+                      .index_by(&:id)
+      ids.filter_map do |id|
+        card = cards[id]
+        next unless card
+
+        GiftCards::AdminInquiry::Candidate.new(
+          id: card.id,
+          masked_number: card.masked_number,
+          status: card.status,
+          program_name: card.gift_card_program.name,
+          balance_cents: card.balance_cents,
+          activated_at: card.activated_at
+        )
+      end
+    end
+
+    def empty(denied:)
+      Result.new(card: nil, candidates: [], denied: denied)
+    end
+  end
+end

--- a/app/views/pos/customer_summaries/show.html.erb
+++ b/app/views/pos/customer_summaries/show.html.erb
@@ -8,31 +8,38 @@
         <%= link_to register_inquiry_return_label, register_inquiry_return_path, class: "btn btn--ghost" %>
       </div>
 
-      <%= form_with url: pos_customer_summary_path, method: :get, local: true, class: "pos-inquiry__form" do %>
+      <%= form_with url: pos_customer_summary_path,
+            method: :get,
+            local: true,
+            data: { turbo: false },
+            class: "pos-inquiry__form" do %>
         <% inquiry_register_params.each do |key, value| %>
           <%= hidden_field_tag key, value %>
         <% end %>
         <div class="form-field">
           <%= label_tag :q, "Search customer" %>
-          <%= text_field_tag :q, params[:q], autocomplete: "off" %>
+          <%= text_field_tag :q, params[:q], autocomplete: "off", autofocus: @customer.blank? && @matches.blank? %>
         </div>
         <%= submit_tag "Search", class: "btn" %>
       <% end %>
 
       <% if @matches.present? %>
-        <ul class="pos-inquiry__matches">
-          <% @matches.each do |row| %>
-            <li>
-              <%= link_to [ row.customer.display_name, row.customer.email, row.customer.phone ].compact.join(" · "),
-                    pos_customer_summary_path(inquiry_register_params.merge(customer_id: row.customer.id)),
-                    class: "btn btn--ghost" %>
-            </li>
-          <% end %>
-        </ul>
+        <section class="pos-inquiry__result" id="customer-summary-result" aria-live="polite">
+          <h2>Matching customers</h2>
+          <ul class="pos-inquiry__matches">
+            <% @matches.each do |row| %>
+              <li>
+                <%= link_to [ row.customer.display_name, row.customer.email, row.customer.phone ].compact.join(" · "),
+                      pos_customer_summary_path(inquiry_register_params.merge(customer_id: row.customer.id)),
+                      class: "btn btn--outline" %>
+              </li>
+            <% end %>
+          </ul>
+        </section>
       <% end %>
 
       <% if @customer %>
-        <section class="pos-inquiry__result" aria-label="Customer summary">
+        <section class="pos-inquiry__result" id="customer-summary-result" aria-label="Customer summary">
           <div class="pos-history__title-row">
             <h2><%= @customer.display_name %></h2>
             <% if @can_open_customer %>

--- a/app/views/pos/shell/_feedback.html.erb
+++ b/app/views/pos/shell/_feedback.html.erb
@@ -1,6 +1,6 @@
 <% if notice.present? %>
-  <p class="pos-feedback" role="status"><%= notice %></p>
+  <p class="pos-feedback pos-no-print" role="status"><%= notice %></p>
 <% end %>
 <% if alert.present? || flash.now[:alert].present? %>
-  <p class="pos-enter__alert" role="alert"><%= alert.presence || flash.now[:alert] %></p>
+  <p class="pos-enter__alert pos-no-print" role="alert"><%= alert.presence || flash.now[:alert] %></p>
 <% end %>

--- a/app/views/pos/shell/_frame.html.erb
+++ b/app/views/pos/shell/_frame.html.erb
@@ -5,5 +5,5 @@
     <%= yield %>
   </div>
   <%= render "pos/shell/menu" %>
-  <p class="pos-register-shell__announce visually-hidden" data-register-shell-target="announce" role="status" aria-live="assertive"></p>
+  <p class="pos-register-shell__announce visually-hidden pos-no-print" data-register-shell-target="announce" role="status" aria-live="assertive"></p>
 </div>

--- a/app/views/pos/shell/_header.html.erb
+++ b/app/views/pos/shell/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="pos-header pos-header--register" data-register-shell-target="header">
+<header class="pos-header pos-header--register pos-no-print" data-register-shell-target="header">
   <div class="pos-header__row">
     <div class="pos-header__facts">
       <span><%= pos_padded_store_number(current_store) %> <%= current_store.name %></span>

--- a/app/views/pos/shell/_menu.html.erb
+++ b/app/views/pos/shell/_menu.html.erb
@@ -1,4 +1,4 @@
-<div class="pos-overlay pos-register-menu"
+<div class="pos-overlay pos-register-menu pos-no-print"
      id="register-menu"
      hidden
      data-register-shell-target="menu"

--- a/app/views/pos/shell/_status.html.erb
+++ b/app/views/pos/shell/_status.html.erb
@@ -1,4 +1,4 @@
-<div data-register-shell-target="status">
+<div class="pos-no-print" data-register-shell-target="status">
 <% if @gate&.occupied? %>
   <div class="pos-banner" role="status">
     <strong>IN USE</strong>

--- a/app/views/pos/stored_value_inquiries/show.html.erb
+++ b/app/views/pos/stored_value_inquiries/show.html.erb
@@ -8,23 +8,10 @@
         <%= link_to register_inquiry_return_label, register_inquiry_return_path, class: "btn btn--ghost" %>
       </div>
 
-      <section class="pos-inquiry__path" aria-labelledby="sv-exact-heading">
-        <h2 id="sv-exact-heading">Scan or enter complete gift-card number</h2>
-        <p class="muted">For balance, reload, redemption, or cash-out eligibility. Uses exact possession-based lookup.</p>
-        <%= form_with url: exact_number_pos_stored_value_inquiry_path, method: :post, local: true, class: "pos-inquiry__form" do %>
-          <% inquiry_register_params.each do |key, value| %>
-            <%= hidden_field_tag key, value %>
-          <% end %>
-          <div class="form-field">
-            <%= label_tag :card_number, "Gift-card number" %>
-            <%= password_field_tag :card_number, nil, autocomplete: "off", inputmode: "numeric" %>
-          </div>
-          <%= submit_tag "Look up card", class: "btn" %>
-        <% end %>
-
-        <% if @exact_card %>
-          <div class="pos-inquiry__result">
-            <h3>Account</h3>
+      <% if @exact_card || @store_credit_customer || @store_credit_matches.present? || @admin_card || @admin_candidates.present? %>
+        <section class="pos-inquiry__result" id="sv-inquiry-result" tabindex="-1" aria-live="polite">
+          <% if @exact_card %>
+            <h2>Gift card</h2>
             <dl class="pos-history__header">
               <div><dt>Program</dt><dd><%= @exact_card.gift_card_program.name %></dd></div>
               <div><dt>Card</dt><dd><%= @exact_card.masked_number %></dd></div>
@@ -56,43 +43,31 @@
                 <% end %>
               </div>
             <% end %>
-          </div>
-        <% end %>
-      </section>
-
-      <section class="pos-inquiry__path" aria-labelledby="sv-credit-heading">
-        <h2 id="sv-credit-heading">Find customer store credit</h2>
-        <p class="muted">Search by customer identity. Not a card possession test.</p>
-        <%= form_with url: store_credit_pos_stored_value_inquiry_path, method: :post, local: true, class: "pos-inquiry__form" do %>
-          <% inquiry_register_params.each do |key, value| %>
-            <%= hidden_field_tag key, value %>
           <% end %>
-          <div class="form-field">
-            <%= label_tag :customer_query, "Customer" %>
-            <%= text_field_tag :customer_query, params[:customer_query], autocomplete: "off" %>
-          </div>
-          <%= submit_tag "Find store credit", class: "btn" %>
-        <% end %>
 
-        <% if @store_credit_matches.present? %>
-          <ul class="pos-inquiry__matches">
-            <% @store_credit_matches.each do |row| %>
-              <li>
-                <%= form_with url: store_credit_pos_stored_value_inquiry_path, method: :post, local: true do %>
-                  <% inquiry_register_params.each do |key, value| %>
-                    <%= hidden_field_tag key, value %>
+          <% if @store_credit_matches.present? %>
+            <h2>Matching customers</h2>
+            <ul class="pos-inquiry__matches">
+              <% @store_credit_matches.each do |row| %>
+                <li>
+                  <%= form_with url: store_credit_pos_stored_value_inquiry_path,
+                        method: :post,
+                        local: true,
+                        data: { turbo: false } do %>
+                    <% inquiry_register_params.each do |key, value| %>
+                      <%= hidden_field_tag key, value %>
+                    <% end %>
+                    <%= hidden_field_tag :customer_id, row.customer.id %>
+                    <%= submit_tag [ row.customer.display_name, row.customer.email, row.customer.phone ].compact.join(" · "),
+                          class: "btn btn--outline" %>
                   <% end %>
-                  <%= hidden_field_tag :customer_id, row.customer.id %>
-                  <%= submit_tag [ row.customer.display_name, row.customer.email, row.customer.phone ].compact.join(" · "), class: "btn btn--ghost" %>
-                <% end %>
-              </li>
-            <% end %>
-          </ul>
-        <% end %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
 
-        <% if @store_credit_customer %>
-          <div class="pos-inquiry__result">
-            <h3>Customer store credit</h3>
+          <% if @store_credit_customer %>
+            <h2>Customer store credit</h2>
             <dl class="pos-history__header">
               <div><dt>Customer</dt><dd><%= @store_credit_customer.display_name %></dd></div>
               <div>
@@ -106,7 +81,7 @@
                 </dd>
               </div>
             </dl>
-            <div class="actions">
+            <div class="actions pos-inquiry__actions">
               <%= link_to "View Customer Summary",
                     pos_customer_summary_path(inquiry_register_params.merge(customer_id: @store_credit_customer.id)),
                     class: "btn btn--outline" %>
@@ -114,30 +89,10 @@
                 <%= link_to "Use as Tender", @continuations.workspace_path, class: "btn btn--outline" %>
               <% end %>
             </div>
-          </div>
-        <% end %>
-      </section>
-
-      <% if @can_admin_inquire %>
-        <section class="pos-inquiry__path" aria-labelledby="sv-admin-heading">
-          <h2 id="sv-admin-heading">Find gift-card history by prefix and last four</h2>
-          <p class="muted">Masked inquiry only; cannot begin a value-moving action. Requires gift_cards.view.</p>
-          <%= form_with url: admin_prefix_last_four_pos_stored_value_inquiry_path, method: :post, local: true, class: "pos-inquiry__form" do %>
-            <% inquiry_register_params.each do |key, value| %>
-              <%= hidden_field_tag key, value %>
-            <% end %>
-            <div class="form-field">
-              <%= label_tag :number_prefix, "Prefix" %>
-              <%= text_field_tag :number_prefix, nil, autocomplete: "off", inputmode: "numeric" %>
-            </div>
-            <div class="form-field">
-              <%= label_tag :number_last_four, "Last four" %>
-              <%= text_field_tag :number_last_four, nil, autocomplete: "off", inputmode: "numeric", maxlength: 4 %>
-            </div>
-            <%= submit_tag "Find masked history", class: "btn" %>
           <% end %>
 
           <% if @admin_candidates.present? %>
+            <h2>Gift-card history (masked)</h2>
             <ul class="pos-inquiry__matches">
               <% @admin_candidates.each do |candidate| %>
                 <li>
@@ -150,16 +105,83 @@
           <% end %>
 
           <% if @admin_card %>
-            <div class="pos-inquiry__result">
-              <h3>Gift-card history (masked)</h3>
-              <dl class="pos-history__header">
-                <div><dt>Card</dt><dd><%= @admin_card.masked_number %></dd></div>
-                <div><dt>Program</dt><dd><%= @admin_card.gift_card_program.name %></dd></div>
-                <div><dt>Status</dt><dd><%= @admin_card.status.humanize %></dd></div>
-                <div><dt>Balance</dt><dd><%= format_money_cents(@admin_card.balance_cents) %></dd></div>
-              </dl>
-              <p class="muted">This find does not prove possession. Use as Tender, Reload, and Cash Out are not offered.</p>
+            <h2>Gift-card history (masked)</h2>
+            <dl class="pos-history__header">
+              <div><dt>Card</dt><dd><%= @admin_card.masked_number %></dd></div>
+              <div><dt>Program</dt><dd><%= @admin_card.gift_card_program.name %></dd></div>
+              <div><dt>Status</dt><dd><%= @admin_card.status.humanize %></dd></div>
+              <div><dt>Balance</dt><dd><%= format_money_cents(@admin_card.balance_cents) %></dd></div>
+            </dl>
+            <p class="muted">This find does not prove possession. Use as Tender, Reload, and Cash Out are not offered.</p>
+          <% end %>
+        </section>
+      <% end %>
+
+      <section class="pos-inquiry__path" aria-labelledby="sv-exact-heading">
+        <h2 id="sv-exact-heading">Scan or enter complete gift-card number</h2>
+        <p class="muted">For balance, reload, redemption, or cash-out eligibility. Uses exact possession-based lookup.</p>
+        <%= form_with url: exact_number_pos_stored_value_inquiry_path,
+              method: :post,
+              local: true,
+              data: { turbo: false },
+              class: "pos-inquiry__form" do %>
+          <% inquiry_register_params.each do |key, value| %>
+            <%= hidden_field_tag key, value %>
+          <% end %>
+          <div class="form-field">
+            <%= label_tag :card_number, "Gift-card number" %>
+            <%= password_field_tag :card_number, nil,
+                  id: "card_number",
+                  autocomplete: "off",
+                  inputmode: "numeric",
+                  autofocus: @exact_card.blank?,
+                  aria: { describedby: "sv-exact-hint" } %>
+          </div>
+          <p id="sv-exact-hint" class="muted">Focus this field, then scan or type the full number and press Enter or Look up card.</p>
+          <%= submit_tag "Look up card", class: "btn" %>
+        <% end %>
+      </section>
+
+      <section class="pos-inquiry__path" aria-labelledby="sv-credit-heading">
+        <h2 id="sv-credit-heading">Find customer store credit</h2>
+        <p class="muted">Search by customer identity. Not a card possession test.</p>
+        <%= form_with url: store_credit_pos_stored_value_inquiry_path,
+              method: :post,
+              local: true,
+              data: { turbo: false },
+              class: "pos-inquiry__form" do %>
+          <% inquiry_register_params.each do |key, value| %>
+            <%= hidden_field_tag key, value %>
+          <% end %>
+          <div class="form-field">
+            <%= label_tag :customer_query, "Customer" %>
+            <%= text_field_tag :customer_query, @customer_query, autocomplete: "off" %>
+          </div>
+          <%= submit_tag "Find store credit", class: "btn" %>
+        <% end %>
+      </section>
+
+      <% if @can_admin_inquire %>
+        <section class="pos-inquiry__path" aria-labelledby="sv-admin-heading">
+          <h2 id="sv-admin-heading">Find gift-card history by prefix and last four</h2>
+          <p class="muted">Masked inquiry only; cannot begin a value-moving action. Requires gift_cards.view.</p>
+          <%= form_with url: admin_prefix_last_four_pos_stored_value_inquiry_path,
+                method: :post,
+                local: true,
+                data: { turbo: false },
+                class: "pos-inquiry__form" do %>
+            <% inquiry_register_params.each do |key, value| %>
+              <%= hidden_field_tag key, value %>
+            <% end %>
+            <div class="form-field">
+              <%= label_tag :number_prefix, "Prefix" %>
+              <%= text_field_tag :number_prefix, nil, autocomplete: "off", inputmode: "numeric" %>
             </div>
+            <div class="form-field">
+              <%= label_tag :number_last_four, "Last four" %>
+              <%= text_field_tag :number_last_four, nil, autocomplete: "off", inputmode: "numeric", maxlength: 4 %>
+            </div>
+            <%= submit_tag "Find masked history", class: "btn" %>
           <% end %>
         </section>
       <% end %>

--- a/app/views/pos/stored_value_inquiries/show.html.erb
+++ b/app/views/pos/stored_value_inquiries/show.html.erb
@@ -8,8 +8,8 @@
         <%= link_to register_inquiry_return_label, register_inquiry_return_path, class: "btn btn--ghost" %>
       </div>
 
-      <% if @exact_card || @store_credit_customer || @store_credit_matches.present? || @admin_card || @admin_candidates.present? %>
-        <section class="pos-inquiry__result" id="sv-inquiry-result" tabindex="-1" aria-live="polite">
+      <% if @inquiry_result_present %>
+        <section class="pos-inquiry__result" id="sv-inquiry-result" tabindex="-1" autofocus aria-live="polite">
           <% if @exact_card %>
             <h2>Gift card</h2>
             <dl class="pos-history__header">
@@ -134,7 +134,7 @@
                   id: "card_number",
                   autocomplete: "off",
                   inputmode: "numeric",
-                  autofocus: @exact_card.blank?,
+                  autofocus: !@inquiry_result_present,
                   aria: { describedby: "sv-exact-hint" } %>
           </div>
           <p id="sv-exact-hint" class="muted">Focus this field, then scan or type the full number and press Enter or Look up card.</p>

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -58,6 +58,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   def choose_register_menu(label)
     open_register_menu
     click_on label
+    assert_no_selector "#register-menu", visible: true
   end
 
   # Slice 5D: empty-field Tender (+) / Refund (+) opens O11; Cash is first in cashier_selectable order.

--- a/test/integration/pos_stored_value_inquiry_test.rb
+++ b/test/integration/pos_stored_value_inquiry_test.rb
@@ -27,7 +27,7 @@ class PosStoredValueInquiryTest < ActionDispatch::IntegrationTest
     refute PosSession.open.exists?
   end
 
-  test "exact number POST shows masked balance and never echoes the full number" do
+  test "exact number POST redirects then shows masked balance and never echoes the full number" do
     card = numbered_card(last_four: "4242")
     GiftCards::Fund.call(gift_card: card, amount_cents: 1_800, store: @store, performed_by: @actor)
 
@@ -35,9 +35,13 @@ class PosStoredValueInquiryTest < ActionDispatch::IntegrationTest
       register_id: @register.id,
       card_number: card.number
     }
+    assert_redirected_to pos_stored_value_inquiry_path(register_id: @register.id)
+    follow_redirect!
     assert_response :success
+    assert_select "#sv-inquiry-result"
     assert_match card.masked_number, response.body
     assert_match format_money_cents(1_800), response.body
+    assert_match "Available balance", response.body
     refute_includes response.body, card.number
     refute_match(/card_number=#{Regexp.escape(card.number)}/, response.body)
     assert_select "a", text: "Use as Tender", count: 0
@@ -55,7 +59,8 @@ class PosStoredValueInquiryTest < ActionDispatch::IntegrationTest
       number_prefix: first.number_prefix,
       number_last_four: "3131"
     }
-    assert_response :unprocessable_entity
+    assert_response :redirect
+    follow_redirect!
     assert_match first.masked_number, response.body
     assert_match second.masked_number, response.body
     refute_includes response.body, first.number
@@ -87,15 +92,7 @@ class PosStoredValueInquiryTest < ActionDispatch::IntegrationTest
       phone: "555-0199"
     )
     account = StoredValue::OpenAccount.call(account_type: "store_credit", customer: customer)
-    reason = StoredValueAdjustmentReason.find_by(code: "goodwill") ||
-             StoredValueAdjustmentReason.create!(
-               code: "goodwill",
-               name: "Goodwill",
-               active: true,
-               applies_to_store_credit: true,
-               applies_to_trade_credit: true,
-               applies_to_gift_card: false
-             )
+    reason = StoredValueAdjustmentReason.find_by!(code: "goodwill")
     StoredValue::Adjust.call(
       account: account,
       direction: "credit",
@@ -111,15 +108,19 @@ class PosStoredValueInquiryTest < ActionDispatch::IntegrationTest
       register_id: @register.id,
       customer_query: "Jane Inquiry"
     }
-    assert_response :success
+    assert_redirected_to pos_stored_value_inquiry_path(register_id: @register.id, customer_query: "Jane Inquiry")
+    follow_redirect!
     assert_match "Jane Inquiry", response.body
+    assert_select "#sv-inquiry-result"
 
     post store_credit_pos_stored_value_inquiry_path, params: {
       register_id: @register.id,
       customer_id: customer.id
     }
-    assert_response :success
+    assert_response :redirect
+    follow_redirect!
     assert_match format_money_cents(500), response.body
+    assert_match "Customer store credit", response.body
   end
 
   test "GET with card_number query does not perform possession lookup" do

--- a/test/integration/pos_stored_value_inquiry_test.rb
+++ b/test/integration/pos_stored_value_inquiry_test.rb
@@ -85,6 +85,48 @@ class PosStoredValueInquiryTest < ActionDispatch::IntegrationTest
     assert_redirected_to pos_stored_value_inquiry_path
   end
 
+  test "admin restore discards flash when gift_cards.view is revoked before GET" do
+    manager = pos_store_manager(store: @store, assigned_by: @actor, username: "sv_mgr_revoke")
+    RoleAssignment.create!(
+      user: manager,
+      role: Role.find_by!(key: "associate"),
+      store: @store,
+      assigned_by: @actor,
+      effective_at: Time.current
+    )
+    delete session_path
+    sign_in_as("sv_mgr_revoke")
+
+    card = numbered_card(last_four: "7171")
+    GiftCards::Fund.call(gift_card: card, amount_cents: 300, store: @store, performed_by: @actor)
+
+    post admin_prefix_last_four_pos_stored_value_inquiry_path, params: {
+      register_id: @register.id,
+      number_prefix: card.number_prefix,
+      number_last_four: "7171"
+    }
+    assert_redirected_to pos_stored_value_inquiry_path(register_id: @register.id)
+
+    assignment = RoleAssignment.effective.find_by!(user: manager, role: Role.find_by!(key: "store_manager"), store: @store)
+    assignment.update!(
+      revoked_at: Time.current,
+      revoked_by: @actor,
+      revocation_reason: "test revoke"
+    )
+
+    follow_redirect!
+    assert_response :success
+    assert_select "#sv-inquiry-result", count: 0
+    refute_match card.masked_number, response.body
+    assert_match(/not authorized/i, response.body)
+    assert AuditEvent.exists?(
+      action: "authorization.denied",
+      outcome: "denied",
+      actor_user: manager,
+      reason_code: "gift_cards.view"
+    )
+  end
+
   test "store credit path finds customer by identity without gift card lookup" do
     customer = Customer.create!(
       display_name: "Jane Inquiry",
@@ -112,6 +154,8 @@ class PosStoredValueInquiryTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_match "Jane Inquiry", response.body
     assert_select "#sv-inquiry-result"
+    assert_select "#sv-inquiry-result[autofocus]"
+    assert_select "input#card_number[autofocus]", count: 0
 
     post store_credit_pos_stored_value_inquiry_path, params: {
       register_id: @register.id,
@@ -121,6 +165,30 @@ class PosStoredValueInquiryTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_match format_money_cents(500), response.body
     assert_match "Customer store credit", response.body
+    assert_select "#sv-inquiry-result[autofocus]"
+    assert_select "input#card_number[autofocus]", count: 0
+  end
+
+  test "admin result panel receives autofocus instead of exact-card field" do
+    card = numbered_card(last_four: "6060")
+    GiftCards::Fund.call(gift_card: card, amount_cents: 150, store: @store, performed_by: @actor)
+
+    post admin_prefix_last_four_pos_stored_value_inquiry_path, params: {
+      register_id: @register.id,
+      number_prefix: card.number_prefix,
+      number_last_four: "6060"
+    }
+    follow_redirect!
+    assert_select "#sv-inquiry-result[autofocus]"
+    assert_match card.masked_number, response.body
+    assert_select "input#card_number[autofocus]", count: 0
+  end
+
+  test "empty inquiry autofocuses the exact-card field" do
+    get pos_stored_value_inquiry_path, params: { register_id: @register.id }
+    assert_response :success
+    assert_select "#sv-inquiry-result", count: 0
+    assert_select "input#card_number[autofocus]"
   end
 
   test "GET with card_number query does not perform possession lookup" do

--- a/test/integration/pos_transaction_history_test.rb
+++ b/test/integration/pos_transaction_history_test.rb
@@ -258,6 +258,19 @@ class PosTransactionHistoryTest < ActionDispatch::IntegrationTest
     assert_match transaction.transaction_reference, response.body
   end
 
+  test "receipt reprint chrome is marked no-print so shell header stays off the ticket" do
+    transaction = complete_cash_sale!
+    get pos_transaction_path(transaction)
+    assert_response :success
+    assert_select ".pos-register-shell"
+    assert_select "header.pos-header.pos-no-print"
+    assert_select "[data-register-shell-target=status].pos-no-print"
+    assert_select ".pos-register-menu.pos-no-print"
+    assert_select ".pos-receipt__print .pos-receipt__reprint", text: "*** REPRINT ***"
+    assert_select ".pos-history__title-row.pos-no-print"
+    assert_select ".pos-history__detail.pos-no-print"
+  end
+
   private
 
   def sign_in_as(username)

--- a/test/services/pos/stored_value_admin_inquiry_restore_test.rb
+++ b/test/services/pos/stored_value_admin_inquiry_restore_test.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PosStoredValueAdminInquiryRestoreTest < ActiveSupport::TestCase
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    GiftCards::Programs.seed!
+    @program = GiftCardProgram.find_by!(code: "generated")
+  end
+
+  test "returns denied without loading cards when gift_cards.view is missing" do
+    clerk = pos_transacting_user(store: @store, assigned_by: @actor, username: "restore_clerk")
+    card = numbered_card(last_four: "1111")
+
+    result = Pos::StoredValueAdminInquiryRestore.call(
+      payload: { "admin_gift_card_id" => card.id },
+      actor: clerk,
+      store: @store
+    )
+
+    assert result.denied
+    assert_nil result.card
+    assert_empty result.candidates
+  end
+
+  test "returns denied for store context without gift_cards.view" do
+    east = Store.create!(
+      store_number: "9",
+      code: "east_restore",
+      name: "East Restore",
+      legal_name: "Example Books LLC",
+      timezone: "America/New_York",
+      country_code: "US"
+    )
+    manager = pos_store_manager(store: @store, assigned_by: @actor, username: "restore_mgr")
+    card = numbered_card(last_four: "3333")
+
+    result = Pos::StoredValueAdminInquiryRestore.call(
+      payload: { "admin_candidate_ids" => [ card.id ] },
+      actor: manager,
+      store: east
+    )
+
+    assert result.denied
+    assert_nil result.card
+    assert_empty result.candidates
+  end
+
+  test "restores masked candidates when authorized" do
+    first = numbered_card(last_four: "2222")
+    second = numbered_card(last_four: "2222")
+
+    result = Pos::StoredValueAdminInquiryRestore.call(
+      payload: { "admin_candidate_ids" => [ first.id, second.id ] },
+      actor: @actor,
+      store: @store
+    )
+
+    refute result.denied
+    assert_nil result.card
+    assert_equal 2, result.candidates.size
+    assert_equal [ first.masked_number, second.masked_number ], result.candidates.map(&:masked_number)
+  end
+
+  test "ignores blank admin payload" do
+    result = Pos::StoredValueAdminInquiryRestore.call(
+      payload: { "exact_gift_card_id" => SecureRandom.uuid_v7 },
+      actor: @actor,
+      store: @store
+    )
+
+    refute result.denied
+    assert_nil result.card
+    assert_empty result.candidates
+  end
+
+  private
+
+  def numbered_card(last_four:)
+    prefix = @program.prefix
+    body_length = @program.number_length - prefix.length - 1
+    50_000.times do |index|
+      body = format("%0#{body_length}d", index)
+      number = "#{prefix}#{body}#{GiftCards::Luhn.check_digit("#{prefix}#{body}")}"
+      next unless number.end_with?(last_four)
+      next if GiftCard.exists?(number_digest: GiftCards::Number.digest(number))
+
+      return GiftCards::ProvisionInstrument.call(program: @program, store: @store, number: number)
+    end
+    raise "unable to allocate a #{prefix} number ending in #{last_four}"
+  end
+end

--- a/test/system/pos_register_workspace_test.rb
+++ b/test/system/pos_register_workspace_test.rb
@@ -706,8 +706,8 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     assert page.evaluate_script("document.activeElement === document.getElementById('pos-command-field')")
 
     choose_register_menu "Transactions & Receipts"
-    assert_text "Transactions"
-    click_on "Register"
+    assert_selector "h1", text: /Transactions/
+    click_on "Return to Register"
     assert_text "Example Book"
     assert_text "SALE ENTRY"
 
@@ -719,8 +719,8 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     assert_selector "#pos_tenders", text: "External Card"
     assert_no_selector "#pos_totals", text: "External Card"
     choose_register_menu "Transactions & Receipts"
-    assert_text "Transactions"
-    click_on "Register"
+    assert_selector "h1", text: /Transactions/
+    click_on "Return to Register"
     assert_selector "#pos_tenders", text: "External Card"
     assert_no_selector "#pos_totals", text: "External Card"
     assert_text "Example Book"

--- a/test/system/pos_stored_value_inquiry_test.rb
+++ b/test/system/pos_stored_value_inquiry_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class PosStoredValueInquirySystemTest < ApplicationSystemTestCase
+  setup do
+    @bootstrap = bootstrap!
+    @store = @bootstrap[:store]
+    @actor = @bootstrap[:administrator]
+    GiftCards::Programs.seed!
+    @program = GiftCardProgram.find_by!(code: "generated")
+    @register = Register.create!(store: @store, register_number: 41, name: "Inquiry")
+  end
+
+  test "customer match results focus the result panel and stay visible at high zoom" do
+    Customer.create!(
+      display_name: "Focus Inquiry Customer",
+      email: "focus.inquiry@example.com",
+      phone: "555-0141"
+    )
+
+    sign_in_admin(actor: @actor)
+    visit pos_stored_value_inquiry_path(register_id: @register.id)
+    assert_text "Stored Value Inquiry"
+
+    fill_in "Customer", with: "Focus Inquiry Customer"
+    click_on "Find store credit"
+
+    assert_selector "#sv-inquiry-result", text: /Matching customers/
+    assert_selector "#sv-inquiry-result input[type=submit][value*='Focus Inquiry Customer']"
+    assert_equal "sv-inquiry-result", page.evaluate_script("document.activeElement && document.activeElement.id")
+    refute_equal "card_number", page.evaluate_script("document.activeElement && document.activeElement.id")
+
+    with_viewport(width: 1280, height: 720, zoom: 2) do
+      result = find("#sv-inquiry-result")
+      assert result.visible?
+      rect = page.evaluate_script(<<~JS)
+        (() => {
+          const el = document.getElementById("sv-inquiry-result");
+          const r = el.getBoundingClientRect();
+          return { top: r.top, bottom: r.bottom, height: window.innerHeight };
+        })()
+      JS
+      assert_operator rect["top"], :<, rect["height"], "result panel should remain in the viewport"
+      assert_operator rect["bottom"], :>, 0
+    end
+  end
+
+  test "masked admin results focus the result panel not the exact-card field" do
+    card = numbered_card(last_four: "5151")
+    GiftCards::Fund.call(gift_card: card, amount_cents: 250, store: @store, performed_by: @actor)
+
+    sign_in_admin(actor: @actor)
+    visit pos_stored_value_inquiry_path(register_id: @register.id)
+    assert_text "Stored Value Inquiry"
+
+    fill_in "Prefix", with: card.number_prefix
+    fill_in "Last four", with: "5151"
+    click_on "Find masked history"
+
+    assert_selector "#sv-inquiry-result", text: card.masked_number
+    assert_equal "sv-inquiry-result", page.evaluate_script("document.activeElement && document.activeElement.id")
+    refute_equal "card_number", page.evaluate_script("document.activeElement && document.activeElement.id")
+  end
+
+  private
+
+  def numbered_card(last_four:)
+    prefix = @program.prefix
+    body_length = @program.number_length - prefix.length - 1
+    50_000.times do |index|
+      body = format("%0#{body_length}d", index)
+      number = "#{prefix}#{body}#{GiftCards::Luhn.check_digit("#{prefix}#{body}")}"
+      next unless number.end_with?(last_four)
+      next if GiftCard.exists?(number_digest: GiftCards::Number.digest(number))
+
+      return GiftCards::ProvisionInstrument.call(program: @program, store: @store, number: number)
+    end
+    raise "unable to allocate a #{prefix} number ending in #{last_four}"
+  end
+end


### PR DESCRIPTION
## Summary
- Restore Stored Value Inquiry / customer lookup results via post-redirect-get, full-page form submits, and a top result panel (lookups were succeeding but not appearing reliably under Turbo).
- Keep Register shell header, status, menu, and feedback out of receipt reprints after history moved into the shell.

## Test plan
- [x] `./dev/rails-docker bin/rails test test/integration/pos_stored_value_inquiry_test.rb test/integration/pos_customer_service_surfaces_test.rb`
- [x] `./dev/rails-docker bin/rails test test/integration/pos_transaction_history_test.rb` (reprint chrome assertions)
- [ ] Manual: F10 → Stored Value Inquiry → look up card / customer → results panel visible
- [ ] Manual: Transactions → receipt → Reprint → no F10 / Return / shell status on the ticket


Made with [Cursor](https://cursor.com)