### PR TITLE
Slice 7: complete tender lifecycle inventory

### DIFF
--- a/docs/planning/register-workspace-consolidation/README.md
+++ b/docs/planning/register-workspace-consolidation/README.md
@@ -37,6 +37,7 @@ This program **replaces** the current POS presentation. It does not run a parall
 | [slice6c-manual-verification.md](slice6c-manual-verification.md) | Slice 6C workstation evidence |
 | [slice7-overview.md](slice7-overview.md) | Slice 7 boundary, sequencing, product defaults |
 | [slice7-keyboard-contract.md](slice7-keyboard-contract.md) | Slice 7.0 accepted SALE/TENDER keyboard contract (docs; runtime in 7C) |
+| [slice7-tender-lifecycle-inventory.md](slice7-tender-lifecycle-inventory.md) | Code-backed tender/issuance dispositions; gates 7A/7B packets |
 
 UX adoption: follow [ux-adoption-template.md](../ux-design-system/ux-adoption-template.md) in the slice that materially changes a screen. Printed receipts stay locked unless a slice explicitly owns print.
 

--- a/docs/planning/register-workspace-consolidation/implementation-plan.md
+++ b/docs/planning/register-workspace-consolidation/implementation-plan.md
@@ -1,6 +1,6 @@
 # Register workspace consolidation — Implementation plan
 
-Status: **Slice 6C complete** on `register-workspace-consolidation`. **Slice 7.0** keyboard contract documentation ([slice7-overview.md](slice7-overview.md), [slice7-keyboard-contract.md](slice7-keyboard-contract.md)) is the **[#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) docs gate** (PR [#112](https://github.com/BankEncore/ShelfSense-v1/pull/112); branch name may still read `93-…` historically — **does not implement or close [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93)**). Inventory and 7A–7C implementation packets follow.
+Status: **Slice 6C complete** on `register-workspace-consolidation`. **Slice 7.0** keyboard contract docs merged ([#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) / PR [#112](https://github.com/BankEncore/ShelfSense-v1/pull/112)). **Tender lifecycle inventory complete** ([slice7-tender-lifecycle-inventory.md](slice7-tender-lifecycle-inventory.md)). Next: lock `slice7a-tender-review-plan.md` then implement 7A ([#93](https://github.com/BankEncore/ShelfSense-v1/issues/93)).
 
 Authority: [plan.md](plan.md), [routing-and-authority.md](routing-and-authority.md).
 
@@ -31,8 +31,9 @@ This program uses a long-lived integration branch because an incomplete Register
 | 6A Customer-service surfaces | **Complete** on integration ([#90](https://github.com/BankEncore/ShelfSense-v1/issues/90) / PRs [#104](https://github.com/BankEncore/ShelfSense-v1/pull/104)–[#106](https://github.com/BankEncore/ShelfSense-v1/pull/106)) | [#90](https://github.com/BankEncore/ShelfSense-v1/issues/90) |
 | 6B Till and session detail | **Complete** on integration ([#91](https://github.com/BankEncore/ShelfSense-v1/issues/91) / PR [#108](https://github.com/BankEncore/ShelfSense-v1/pull/108)) | [#91](https://github.com/BankEncore/ShelfSense-v1/issues/91) |
 | 6C Reporting-period surfaces | **Complete** on integration ([#92](https://github.com/BankEncore/ShelfSense-v1/issues/92) / PR [#109](https://github.com/BankEncore/ShelfSense-v1/pull/109)) | [#92](https://github.com/BankEncore/ShelfSense-v1/issues/92) |
-| 7.0 Keyboard contract amendment | **Docs** via PR [#112](https://github.com/BankEncore/ShelfSense-v1/pull/112) ([slice7-keyboard-contract.md](slice7-keyboard-contract.md)); **#95 gate** — does not close #93; runtime unchanged until 7C | [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) (contract) |
-| 7A Tender-review framework | Gated on 7.0 + tender lifecycle inventory | [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) |
+| 7.0 Keyboard contract amendment | **Docs** merged PR [#112](https://github.com/BankEncore/ShelfSense-v1/pull/112) ([slice7-keyboard-contract.md](slice7-keyboard-contract.md)); runtime unchanged until 7C | [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) (contract) |
+| Inventory (7A/7B gate) | **Complete** ([slice7-tender-lifecycle-inventory.md](slice7-tender-lifecycle-inventory.md)) | — |
+| 7A Tender-review framework | Gated on locking `slice7a-tender-review-plan.md` (inventory met) | [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) |
 | 7B Stored-value / issuance / Quick Customer | Gated on 7A | [#94](https://github.com/BankEncore/ShelfSense-v1/issues/94) |
 | 7C Keyboard dispatcher | Gated on 7A–7B; implements 7.0 contract | [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) |
 

--- a/docs/planning/register-workspace-consolidation/slice7-overview.md
+++ b/docs/planning/register-workspace-consolidation/slice7-overview.md
@@ -62,7 +62,7 @@ Until 7C ships the dispatcher, **runtime** key behavior remains Phase 6.7 as sta
 | Completed tenders | Immutable; correction via post-void / refund only |
 | `+1`–`+9` sequences | **Omitted** from the accepted contract |
 | Customer Lookup | Semantic action `open-customer-lookup` only; **no 7.0 key**; **F2 remains Card Tender** |
-| Quick Customer | In scope for **7B.2**; inventory complete — extract `Customers::Create` for shared admin/Register path; authorize with `customers.manage`; must not invent a Register-only create path or repurpose F2 |
+| Quick Customer | In scope for **7B.2**; extract `Customers::Create`; authorize Register with **`customers.create`** (add permission); admin create continues under `customers.manage`; idempotent create; must not invent a Register-only create path or repurpose F2 |
 | Ambiguous external / activation outcome | Recovery surface; never ordinary retry |
 
 ## Speculative wireframe remap rejected

--- a/docs/planning/register-workspace-consolidation/slice7-overview.md
+++ b/docs/planning/register-workspace-consolidation/slice7-overview.md
@@ -1,8 +1,8 @@
 # Slice 7 — Overview
 
-Status: **7.0 keyboard contract accepted as documentation** (PR toward `register-workspace-consolidation`; **[#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) docs gate** — does not implement or close [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93)). Tender lifecycle inventory and 7A–7C implementation packets follow. Issues [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93)–[#95](https://github.com/BankEncore/ShelfSense-v1/issues/95).
+Status: **7.0 keyboard contract accepted** on `register-workspace-consolidation` ([#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) / PR [#112](https://github.com/BankEncore/ShelfSense-v1/pull/112)). **Tender lifecycle inventory complete** ([slice7-tender-lifecycle-inventory.md](slice7-tender-lifecycle-inventory.md)). Next: lock 7A–7C implementation packets. Issues [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93)–[#95](https://github.com/BankEncore/ShelfSense-v1/issues/95).
 
-Authority: [plan.md](plan.md) (esp. locked decision 13), [routing-and-authority.md](routing-and-authority.md), [slice5d-tender-issuance-plan.md](slice5d-tender-issuance-plan.md), [textual-wireframes.md](textual-wireframes.md) P10 / O11–O17, [slice7-keyboard-contract.md](slice7-keyboard-contract.md). Historical thinking: [slice-7-draft.md](../../drafts/phase-10-followup-pos-transaction-workspace/slice-7-draft.md) (superseded for implementation; do not implement from the draft).
+Authority: [plan.md](plan.md) (esp. locked decision 13), [routing-and-authority.md](routing-and-authority.md), [slice5d-tender-issuance-plan.md](slice5d-tender-issuance-plan.md), [textual-wireframes.md](textual-wireframes.md) P10 / O11–O17, [slice7-keyboard-contract.md](slice7-keyboard-contract.md), [slice7-tender-lifecycle-inventory.md](slice7-tender-lifecycle-inventory.md). Historical thinking: [slice-7-draft.md](../../drafts/phase-10-followup-pos-transaction-workspace/slice-7-draft.md) (superseded for implementation; do not implement from the draft).
 
 ## Boundary statement
 
@@ -19,8 +19,8 @@ Decision 13 requires Slice 7’s **first merge** to establish the replacement ke
 ## Sequencing
 
 ```text
-7.0 Keyboard contract amendment (docs-only)   ← this step
-  → Tender lifecycle inventory
+7.0 Keyboard contract amendment (docs-only)   ✓
+  → Tender lifecycle inventory                 ✓
   → 7A Tender Review (ordinary tender correction)
   → 7B Stored value, issuance, and Quick Customer
   → 7C Dispatcher implementation and obsolete-handler deletion
@@ -28,8 +28,8 @@ Decision 13 requires Slice 7’s **first merge** to establish the replacement ke
 
 | Step | Artifact | Issue |
 |---|---|---|
-| 7.0 | [slice7-keyboard-contract.md](slice7-keyboard-contract.md) | [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) (contract); shared Slice 7 gate |
-| Inventory | `slice7-tender-lifecycle-inventory.md` (next) | gates 7A/7B lock |
+| 7.0 | [slice7-keyboard-contract.md](slice7-keyboard-contract.md) | [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) (contract) |
+| Inventory | [slice7-tender-lifecycle-inventory.md](slice7-tender-lifecycle-inventory.md) (**Complete**) | gates 7A/7B lock |
 | 7A | `slice7a-tender-review-plan.md` | [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) |
 | 7B | `slice7b-stored-value-issuance-plan.md` | [#94](https://github.com/BankEncore/ShelfSense-v1/issues/94) |
 | 7C | `slice7c-keyboard-dispatcher-plan.md` + implement contract | [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) |
@@ -55,14 +55,14 @@ Until 7C ships the dispatcher, **runtime** key behavior remains Phase 6.7 as sta
 |---|---|
 | Keyboard first merge | Docs-only 7.0 ([slice7-keyboard-contract.md](slice7-keyboard-contract.md)) |
 | Ordinary edit | Cash, check, and configured manual-reference tenders via atomic replace; externally authorized **card** = remove + re-authorize (no field edit of external auth) |
-| Working tender persistence | Inventory decides durable supersession vs audited destroy against current `pos_tenders`; no second ledger |
+| Working tender persistence | **Audited destroy + add** under one txn lock ([slice7-tender-lifecycle-inventory.md](slice7-tender-lifecycle-inventory.md)); no supersession schema |
 | Return to Sale | Atomic remove of all reversible working tenders, or change nothing; not Cancel Transaction |
 | Confirmations | Destructive / reversal yes; ordinary field edits no |
 | SV cap | Auto-apply with prominent feedback; requested amount is prompt / audit context only |
 | Completed tenders | Immutable; correction via post-void / refund only |
 | `+1`–`+9` sequences | **Omitted** from the accepted contract |
 | Customer Lookup | Semantic action `open-customer-lookup` only; **no 7.0 key**; **F2 remains Card Tender** |
-| Quick Customer | In scope for **7B.2** as one child of the shared Register Customer Lookup family — reachable from ordinary Sale customer lookup **and** from customer-required stored-value / refund flows. Inventory validates reuse of the existing customer domain only; must not invent a second create path or repurpose F2 |
+| Quick Customer | In scope for **7B.2**; inventory complete — extract `Customers::Create` for shared admin/Register path; authorize with `customers.manage`; must not invent a Register-only create path or repurpose F2 |
 | Ambiguous external / activation outcome | Recovery surface; never ordinary retry |
 
 ## Speculative wireframe remap rejected

--- a/docs/planning/register-workspace-consolidation/slice7-tender-lifecycle-inventory.md
+++ b/docs/planning/register-workspace-consolidation/slice7-tender-lifecycle-inventory.md
@@ -1,0 +1,133 @@
+# Slice 7 — Tender lifecycle inventory
+
+Status: **Complete — dispositions assigned.** Working-tender persistence: **audited destroy + add** (no supersession schema). Quick Customer product decision unchanged (**7B.2**); create-path extraction required. Gates locking of 7A/7B packets. Does **not** implement [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) or [#94](https://github.com/BankEncore/ShelfSense-v1/issues/94).
+
+Authority: [slice7-overview.md](slice7-overview.md), [slice7-keyboard-contract.md](slice7-keyboard-contract.md). Verified against POS tender/issuance services, `Pos::CompleteTransaction` / `Pos::CompleteStoredValue`, customer admin create, and attach services (2026-08-30).
+
+## Disposition key
+
+| Disposition | Meaning |
+|---|---|
+| **7A** | Ordinary tender select / remove / atomic replace in Tender Review |
+| **7B** | SV tender / issuance / capping / completion revalidation / customer-required flows / Quick Customer |
+| **7A inspect-only** | Row selectable in 7A; Edit/Remove withheld until 7B (code may already allow destroy) |
+| **N/A** | Type not cashier-enabled under current seed/config (e.g. check refund when `allows_refund: false`) |
+
+## Cross-cutting code facts
+
+| Topic | Reality |
+|---|---|
+| When value moves | Working tenders/issuances are rows only. Settlement and SV ledger post in `Pos::CompleteTransaction` → `settle_tenders!` / `Pos::CompleteStoredValue` (`app/services/pos/complete_transaction.rb`, `complete_stored_value.rb`). |
+| Working remove | `Pos::RemoveWorkingTender`, `Pos::AbandonTender`, `Pos::Support.clear_working_tenders!` — **destroy**; SV detail cascades (`PosTender` dependent destroy). **No** `StoredValue::Reverse` while working (nothing posted yet). |
+| Cash upsert | `Pos::TenderCash` upserts the single cash **payment** row in place. Cash **refund** upserts via cash branch of `Pos::AddRefundTender`. |
+| Ordinary non-cash | `Pos::AddTender` / `Pos::AddRefundTender` append new rows (optional `external_reference`). |
+| SV add | `Pos::AddStoredValueTender`, `Pos::AddStoredValueRefundTender` — balance/capacity checks; no ledger post. |
+| Issuance | `Pos::AddStoredValueIssuance` / `Pos::RemoveStoredValueIssuance` — working rows; **clears tenders** on add/remove; activate/reload at complete. |
+| Replace orchestration | **`Pos::ReplaceTender` does not exist** — 7A introduces it for ordinary families only. |
+| Completed immutability | Completed tenders/issuances are commercially readonly; correction via post-void / new refund. Posted SV reverse: `Pos::PostVoidStoredValue` / `StoredValue::Reverse`. |
+| Completion idempotency | `Pos::OperationLease` on complete; nested SV keys under completion operation id. Tender **add** has no idempotency key today. |
+| Locks | Working mutations: `lock_working_transaction!` + optimistic `lock_version`. SV account `lock` at post time. |
+
+Controller dispatch today: `Pos::WorkspacesController` tender / remove_tender / abandon_tender / stored_value_issuance actions.
+
+---
+
+## Lifecycle matrix
+
+| Type | Add service | When value moves | Removable now | Editable now | Working reversal | Locks | Idempotency | Disposition |
+|---|---|---|---|---|---|---|---|---|
+| Cash payment | `Pos::TenderCash` (`tender_cash.rb`) | Working row + presented/change; applied/change re-settled at complete | Yes — destroy paths | Upsert — re-call `TenderCash` | Destroy | Txn `lock!` + `lock_version` | None on add; complete lease | **7A** |
+| Cash refund | `Pos::AddRefundTender` (cash) | Working refund row | Yes — destroy | Upsert — re-call for cash | Destroy | Same | None on add; complete lease | **7A** |
+| Card payment | `Pos::AddTender` | Working row + optional reference; no processor post | Yes — destroy | None (append) | Destroy | Same | None on add; complete lease | **7A** (remove + re-authorize; no field-edit of external auth) |
+| Card refund | `Pos::AddRefundTender` | Working refund + optional reference | Yes — destroy | None | Destroy | Same | None on add; complete lease | **7A** (same family) |
+| Check payment | `Pos::AddTender` | Working row + optional reference | Yes — destroy | None (append); replace via 7A orchestration | Destroy | Same | None on add; complete lease | **7A** |
+| Check refund | `Pos::AddRefundTender` | Same if type allows refund | Yes if row exists | None | Destroy | Same | None on add; complete lease | **N/A** by default seed (`allows_refund: false`); **7A** when enabled |
+| Other payment | `Pos::AddTender` (`behavioral_category: other`) | Working row + reference per type policy | Yes — destroy | None (append); configured manual-reference types editable via 7A replace | Destroy | Same | None on add; complete lease | **7A** |
+| Other refund | `Pos::AddRefundTender` (if `allows_refund`) | Working refund | Yes — destroy | None | Destroy | Same | None on add; complete lease | **7A** when enabled |
+| Gift-card payment | `Pos::AddStoredValueTender` | Redeem at `CompleteStoredValue#post_tender!` | Yes while working — destroy | None | Destroy (**not** SV reverse) | Txn lock; account lock at post | Nested tender key at post | **7A inspect-only** → **7B** mutate |
+| Store-credit payment | same (`store_credit`) | Redeem at complete | Yes — destroy | None | Destroy | Same | Nested tender key | **7A inspect-only** → **7B** mutate |
+| Trade-credit payment | same (`trade_credit`) | Redeem at complete | Yes — destroy | None | Destroy | Same | Nested tender key | **7A inspect-only** → **7B** mutate |
+| Gift-card refund (existing account) | `Pos::AddStoredValueRefundTender` (`existing_account`) | Credit at complete | Yes — destroy | None | Destroy | Txn + capacity; account lock at post | Nested tender key | **7A inspect-only** → **7B** mutate |
+| Gift-card refund (new card) | same (`new_gift_card`) | Provision + credit at complete | Yes — destroy | None | Destroy | Same + program checks | Nested tender key | **7A inspect-only** → **7B** mutate |
+| Store-credit refund | same (`existing_account` / `customer_store_credit`) | Ensure account + credit at complete | Yes — destroy | None | Destroy | Same | Nested tender key | **7A inspect-only** → **7B** mutate |
+| Trade-credit refund | same (`existing_account`; original-account constrained) | Credit at complete | Yes — destroy | None | Destroy | Same | Nested tender key | **7A inspect-only** → **7B** mutate |
+| Gift-card issuance (activate/reload) | `Pos::AddStoredValueIssuance` / `RemoveStoredValueIssuance` | Activate/reload at `post_issuance!`; clears tenders on add/remove | Yes — remove issuance service | None today | Destroy issuance (not SV reverse while working) | Txn lock; card/account lock at post | Nested issuance key at post | **7B** (edit/replace while unactivated) |
+
+---
+
+## Working-tender persistence decision
+
+**Lock:** Working correction uses **audited destroy + add under one transaction lock**, not a durable supersession relationship on `pos_tenders`.
+
+**Rationale:** No `superseded_by` / supersession columns exist; destroy is the current working model; inventing supersession schema is out of Slice 7 scope. No second ledger.
+
+**Audit** on replace/remove must capture safe facts: tender type, amounts (and cash presented/change when applicable), actor, reason, source and idempotency identifiers. Do **not** audit full card numbers or full stored-value instrument numbers.
+
+### `Pos::ReplaceTender` (7A target)
+
+```text
+authorize → lock transaction → verify working membership
+  → validate replacement family/support
+  → remove original (destroy) → add replacement
+  → recalc settlement → commit
+```
+
+On any failure after lock: leave the original tender unchanged. Cash may keep upsert semantics inside the orchestration where behaviorally equivalent. Card: remove + re-authorize only (no field edit of external auth).
+
+### Return to Sale
+
+Atomic clear of all reversible working tenders via `clear_working_tenders!` (or equivalent orchestration), **or** change nothing if any tender cannot be reversed under 7A/7B rules. Not synonymous with Cancel Transaction.
+
+---
+
+## Capability vs UI law (7A)
+
+| Layer | SV / issuance working rows |
+|---|---|
+| **Code today** | `RemoveWorkingTender` / issuance remove already destroy them without ledger reverse |
+| **7A product / UI** | Select and inspect allowed; **Edit / Remove unavailable** until 7B, with a concise reason |
+| **7B** | Capping, remove/replace, completion revalidation, issuance edit while unactivated, customer-required flows |
+
+Do not confuse destroy capability with 7A permission to expose mutation.
+
+---
+
+## Quick Customer reuse checklist
+
+Product decision unchanged: Quick Customer remains **7B.2** (child of shared Register Customer Lookup; Sale + customer-required SV/refund; no F2 key — see [slice7-keyboard-contract.md](slice7-keyboard-contract.md) `open-customer-lookup`).
+
+| Item | Verdict |
+|---|---|
+| Authoritative create | **Gap:** admin only — `Admin::CustomersController#create` + `create_and_audit!` (`admin/customers_controller.rb`, `admin/base_controller.rb`). **No** `Customers::Create` service. |
+| Reusable now | `Customers::NormalizeContact`, `Customers::SuggestDuplicates`, `Customers::Search`, `Pos::AttachCustomer` |
+| Permission | Catalog: `customers.manage` / `customers.view`. Draft `customers.create` **permission key does not exist**. Audit action string is `customers.create`. |
+| Fields | `display_name` required; email/phone optional on bare `Customer`. Email ∨ phone as a **contextual** Quick Customer / credit rule does **not** contradict Phase 8 bare-create policy (contact required on requests, not bare identity). |
+| Canonical / merge | ADR-023; create yields active canonical; duplicates warn + acknowledge; no auto-merge. Attach requires active canonical. |
+| Idempotency | None on customer create today (merge has keys; create does not). |
+
+### Implementation boundary (not product deferral)
+
+7B.2’s first work extracts **`Customers::Create`** (validate → duplicate gate → persist → audit action `customers.create`) and has **admin + Quick Customer** call it. Authorize create with **`customers.manage`** (align draft wording to the catalog) unless a later ADR adds a distinct `customers.create` permission.
+
+If extraction cannot land without duplicating Customer domain logic, stop with a documented blocker issue. **Do not** invent a Register-only create path.
+
+---
+
+## Notes for later packets
+
+| Topic | Owner |
+|---|---|
+| Tender Review selection, ordinary remove/replace, Return to Sale (O15–O17) | **7A** |
+| Nested customer lookup, attach, change-customer guards | **7B.1** |
+| Quick Customer + `Customers::Create` extraction | **7B.2** |
+| SV capping; working SV remove/replace; issuance edit while unactivated; completion revalidation that fails recoverably (no silent tender shrink) | **7B.3** |
+| Activated / completed issuance or tender edit from workspace | **Out** — recovery / post-void only |
+| Keyboard dispatcher binding | **7C** (implements 7.0 contract) |
+
+## Packet readiness
+
+| Packet | Inventory gate |
+|---|---|
+| 7A | **Met** — ordinary dispositions and persistence decision locked |
+| 7B | **Met** — SV/issuance dispositions and Quick Customer boundary locked; create extraction called out |
+| 7C | Uses 7.0 contract; no further inventory gate |

--- a/docs/planning/register-workspace-consolidation/slice7-tender-lifecycle-inventory.md
+++ b/docs/planning/register-workspace-consolidation/slice7-tender-lifecycle-inventory.md
@@ -1,8 +1,8 @@
 # Slice 7 — Tender lifecycle inventory
 
-Status: **Complete — dispositions assigned.** Working-tender persistence: **audited destroy + add** (no supersession schema). Quick Customer product decision unchanged (**7B.2**); create-path extraction required. Gates locking of 7A/7B packets. Does **not** implement [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) or [#94](https://github.com/BankEncore/ShelfSense-v1/issues/94).
+Status: **Complete — dispositions assigned** (including idempotency, issuance-with-tenders, Quick Customer permission, and stored-value capping/revalidation). Gates locking of 7A/7B packets. Does **not** implement [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) or [#94](https://github.com/BankEncore/ShelfSense-v1/issues/94).
 
-Authority: [slice7-overview.md](slice7-overview.md), [slice7-keyboard-contract.md](slice7-keyboard-contract.md). Verified against POS tender/issuance services, `Pos::CompleteTransaction` / `Pos::CompleteStoredValue`, customer admin create, and attach services (2026-08-30).
+Authority: [slice7-overview.md](slice7-overview.md), [slice7-keyboard-contract.md](slice7-keyboard-contract.md). Verified against POS tender/issuance services, `Pos::CompleteTransaction` / `Pos::CompleteStoredValue`, `Pos::OperationLease`, customer admin create, and attach services (2026-08-30).
 
 ## Disposition key
 
@@ -13,70 +13,142 @@ Authority: [slice7-overview.md](slice7-overview.md), [slice7-keyboard-contract.m
 | **7A inspect-only** | Row selectable in 7A; Edit/Remove withheld until 7B (code may already allow destroy) |
 | **N/A** | Type not cashier-enabled under current seed/config (e.g. check refund when `allows_refund: false`) |
 
+## Core boundary (normative)
+
+```text
+Working tender / issuance  → database row only (no stored-value ledger movement)
+Transaction completion     → settle tenders + CompleteStoredValue ledger posting
+Post-void / recovery       → posted-value reversal (outside ordinary workspace editing)
+```
+
+Therefore 7B must **not** describe working tender or issuance correction as an “exact-once stored-value reversal.”
+
+Use:
+
+- **idempotent working removal**
+- **atomic working replacement**
+- **completion-time stored-value posting and revalidation**
+- **posted-value reversal** only for post-void / recovery outside ordinary workspace editing
+
+Creating compensating ledger entries for an **unposted** working tender would be wrong.
+
+---
+
 ## Cross-cutting code facts
 
 | Topic | Reality |
 |---|---|
-| When value moves | Working tenders/issuances are rows only. Settlement and SV ledger post in `Pos::CompleteTransaction` → `settle_tenders!` / `Pos::CompleteStoredValue` (`app/services/pos/complete_transaction.rb`, `complete_stored_value.rb`). |
-| Working remove | `Pos::RemoveWorkingTender`, `Pos::AbandonTender`, `Pos::Support.clear_working_tenders!` — **destroy**; SV detail cascades (`PosTender` dependent destroy). **No** `StoredValue::Reverse` while working (nothing posted yet). |
-| Cash upsert | `Pos::TenderCash` upserts the single cash **payment** row in place. Cash **refund** upserts via cash branch of `Pos::AddRefundTender`. |
+| When value moves | Working tenders/issuances are rows only. Settlement and SV ledger post in `Pos::CompleteTransaction` → `settle_tenders!` / `Pos::CompleteStoredValue`. |
+| Working removal | `Pos::RemoveWorkingTender`, `Pos::AbandonTender`, `Pos::Support.clear_working_tenders!` — **destroy**; SV detail cascades. **No** `StoredValue::Reverse` while working. |
+| Cash upsert | `Pos::TenderCash` upserts the single cash **payment** row. Cash **refund** upserts via cash branch of `Pos::AddRefundTender`. |
 | Ordinary non-cash | `Pos::AddTender` / `Pos::AddRefundTender` append new rows (optional `external_reference`). |
-| SV add | `Pos::AddStoredValueTender`, `Pos::AddStoredValueRefundTender` — balance/capacity checks; no ledger post. |
-| Issuance | `Pos::AddStoredValueIssuance` / `Pos::RemoveStoredValueIssuance` — working rows; **clears tenders** on add/remove; activate/reload at complete. |
-| Replace orchestration | **`Pos::ReplaceTender` does not exist** — 7A introduces it for ordinary families only. |
+| Issuance | `Pos::AddStoredValueIssuance` / `RemoveStoredValueIssuance` — working rows; **clears all working tenders** on add and on remove. |
+| Replace orchestration | **`Pos::ReplaceTender` does not exist** — 7A introduces it for ordinary families; 7B for SV/issuance. |
 | Completed immutability | Completed tenders/issuances are commercially readonly; correction via post-void / new refund. Posted SV reverse: `Pos::PostVoidStoredValue` / `StoredValue::Reverse`. |
-| Completion idempotency | `Pos::OperationLease` on complete; nested SV keys under completion operation id. Tender **add** has no idempotency key today. |
-| Locks | Working mutations: `lock_working_transaction!` + optimistic `lock_version`. SV account `lock` at post time. |
-
-Controller dispatch today: `Pos::WorkspacesController` tender / remove_tender / abandon_tender / stored_value_issuance actions.
+| Add idempotency today | Tender/issuance **add has no idempotency key**. Completion uses `Pos::OperationLease` (`command_type: pos.complete_transaction`). Nested SV post keys under completion operation id. |
 
 ---
 
 ## Lifecycle matrix
 
-| Type | Add service | When value moves | Removable now | Editable now | Working reversal | Locks | Idempotency | Disposition |
+| Type | Add service | When value moves | Removable now | Editable now | Working removal/correction | Locks | Idempotency today | Disposition |
 |---|---|---|---|---|---|---|---|---|
-| Cash payment | `Pos::TenderCash` (`tender_cash.rb`) | Working row + presented/change; applied/change re-settled at complete | Yes — destroy paths | Upsert — re-call `TenderCash` | Destroy | Txn `lock!` + `lock_version` | None on add; complete lease | **7A** |
+| Cash payment | `Pos::TenderCash` | Working row + presented/change; applied/change re-settled at complete | Yes — destroy | Upsert — re-call `TenderCash` | Destroy | Txn `lock!` + `lock_version` | None on add; complete lease | **7A** |
 | Cash refund | `Pos::AddRefundTender` (cash) | Working refund row | Yes — destroy | Upsert — re-call for cash | Destroy | Same | None on add; complete lease | **7A** |
-| Card payment | `Pos::AddTender` | Working row + optional reference; no processor post | Yes — destroy | None (append) | Destroy | Same | None on add; complete lease | **7A** (remove + re-authorize; no field-edit of external auth) |
+| Card payment | `Pos::AddTender` | Working row + optional reference; **no processor post in ShelfSense** | Yes — destroy | None (append) | Destroy | Same | None on add; complete lease | **7A** — remove working row, perform any required **external** reauthorization outside/currently supported by ShelfSense, then record replacement authorization/reference |
 | Card refund | `Pos::AddRefundTender` | Working refund + optional reference | Yes — destroy | None | Destroy | Same | None on add; complete lease | **7A** (same family) |
 | Check payment | `Pos::AddTender` | Working row + optional reference | Yes — destroy | None (append); replace via 7A orchestration | Destroy | Same | None on add; complete lease | **7A** |
 | Check refund | `Pos::AddRefundTender` | Same if type allows refund | Yes if row exists | None | Destroy | Same | None on add; complete lease | **N/A** by default seed (`allows_refund: false`); **7A** when enabled |
-| Other payment | `Pos::AddTender` (`behavioral_category: other`) | Working row + reference per type policy | Yes — destroy | None (append); configured manual-reference types editable via 7A replace | Destroy | Same | None on add; complete lease | **7A** |
+| Other payment | `Pos::AddTender` | Working row + reference per type policy | Yes — destroy | None (append); configured manual-reference types via 7A replace | Destroy | Same | None on add; complete lease | **7A** |
 | Other refund | `Pos::AddRefundTender` (if `allows_refund`) | Working refund | Yes — destroy | None | Destroy | Same | None on add; complete lease | **7A** when enabled |
 | Gift-card payment | `Pos::AddStoredValueTender` | Redeem at `CompleteStoredValue#post_tender!` | Yes while working — destroy | None | Destroy (**not** SV reverse) | Txn lock; account lock at post | Nested tender key at post | **7A inspect-only** → **7B** mutate |
 | Store-credit payment | same (`store_credit`) | Redeem at complete | Yes — destroy | None | Destroy | Same | Nested tender key | **7A inspect-only** → **7B** mutate |
 | Trade-credit payment | same (`trade_credit`) | Redeem at complete | Yes — destroy | None | Destroy | Same | Nested tender key | **7A inspect-only** → **7B** mutate |
-| Gift-card refund (existing account) | `Pos::AddStoredValueRefundTender` (`existing_account`) | Credit at complete | Yes — destroy | None | Destroy | Txn + capacity; account lock at post | Nested tender key | **7A inspect-only** → **7B** mutate |
+| Gift-card refund (existing) | `Pos::AddStoredValueRefundTender` | Credit at complete | Yes — destroy | None | Destroy | Txn + capacity; account lock at post | Nested tender key | **7A inspect-only** → **7B** mutate |
 | Gift-card refund (new card) | same (`new_gift_card`) | Provision + credit at complete | Yes — destroy | None | Destroy | Same + program checks | Nested tender key | **7A inspect-only** → **7B** mutate |
-| Store-credit refund | same (`existing_account` / `customer_store_credit`) | Ensure account + credit at complete | Yes — destroy | None | Destroy | Same | Nested tender key | **7A inspect-only** → **7B** mutate |
-| Trade-credit refund | same (`existing_account`; original-account constrained) | Credit at complete | Yes — destroy | None | Destroy | Same | Nested tender key | **7A inspect-only** → **7B** mutate |
-| Gift-card issuance (activate/reload) | `Pos::AddStoredValueIssuance` / `RemoveStoredValueIssuance` | Activate/reload at `post_issuance!`; clears tenders on add/remove | Yes — remove issuance service | None today | Destroy issuance (not SV reverse while working) | Txn lock; card/account lock at post | Nested issuance key at post | **7B** (edit/replace while unactivated) |
+| Store-credit refund | same | Ensure account + credit at complete | Yes — destroy | None | Destroy | Same | Nested tender key | **7A inspect-only** → **7B** mutate |
+| Trade-credit refund | same (original-account constrained) | Credit at complete | Yes — destroy | None | Destroy | Same | Nested tender key | **7A inspect-only** → **7B** mutate |
+| Gift-card issuance (activate/reload) | `AddStoredValueIssuance` / `RemoveStoredValueIssuance` | Activate/reload at `post_issuance!`; **clears tenders** on add/remove | Yes — remove issuance | None today | Destroy issuance (not SV reverse while working) | Txn lock; card/account lock at post | Nested issuance key at post | **7B** (see issuance-with-tenders) |
 
 ---
 
 ## Working-tender persistence decision
 
-**Lock:** Working correction uses **audited destroy + add under one transaction lock**, not a durable supersession relationship on `pos_tenders`.
-
-**Rationale:** No `superseded_by` / supersession columns exist; destroy is the current working model; inventing supersession schema is out of Slice 7 scope. No second ledger.
-
-**Audit** on replace/remove must capture safe facts: tender type, amounts (and cash presented/change when applicable), actor, reason, source and idempotency identifiers. Do **not** audit full card numbers or full stored-value instrument numbers.
-
-### `Pos::ReplaceTender` (7A target)
+**Lock:** Working correction uses **audited destroy + add inside one database transaction under the transaction lock**, not a durable supersession relationship on `pos_tenders`.
 
 ```text
-authorize → lock transaction → verify working membership
-  → validate replacement family/support
-  → remove original (destroy) → add replacement
-  → recalc settlement → commit
+transaction lock
+  ├── validate complete replacement
+  ├── prepare removal/replacement audit context
+  ├── destroy original
+  ├── add replacement
+  ├── write audit in the same DB transaction as the successful mutation
+  └── commit everything together
 ```
 
-On any failure after lock: leave the original tender unchanged. Cash may keep upsert semantics inside the orchestration where behaviorally equivalent. Card: remove + re-authorize only (no field edit of external auth).
+The audit event must **not** survive a rolled-back replacement. A successful financial mutation must **not** commit without its required audit record.
 
-### Return to Sale
+**Rationale:** No supersession columns exist; destroy is the current working model; inventing supersession schema is out of Slice 7 scope.
 
-Atomic clear of all reversible working tenders via `clear_working_tenders!` (or equivalent orchestration), **or** change nothing if any tender cannot be reversed under 7A/7B rules. Not synonymous with Cancel Transaction.
+### `Pos::ReplaceTender` (7A ordinary / 7B SV)
+
+Authorize → lock txn → verify working membership → validate replacement → destroy original → add replacement → recalc settlement → commit; on failure leave original unchanged. Cash may keep upsert semantics inside the orchestration where behaviorally equivalent.
+
+Card: remove the working row, perform any required **external** reauthorization outside/currently supported by ShelfSense, then record the replacement authorization/reference. ShelfSense does **not** currently operate an integrated card authorization-reversal service for working tenders.
+
+---
+
+## Mutation idempotency (normative)
+
+Recording an idempotency key only in an audit event does **not** make a mutation idempotent. Do not add `idempotency_key` parameters that are merely logged.
+
+| Mutation | Required 7A/7B behavior |
+|---|---|
+| Remove working tender | Same key returns the original successful outcome |
+| Replace working tender | Same key returns the same replacement, not another tender |
+| Return to Sale | Retry does not create duplicate audit events or partially repeat clearing |
+| Quick Customer create | Retry does not create a second customer |
+| Issuance replacement | Retry returns the same resulting issuance |
+
+**Chosen mechanism:** Reuse existing **`Pos::OperationLease` / `PosOperation`** infrastructure with **distinct `command_type` values** for working mutations (the lease already accepts `command_type`; completion uses `pos.complete_transaction`, post-void uses `pos.post_void_transaction`). Register-scoped `source_id`, canonical payload hash, in-flight / completed / failed replay rules apply.
+
+**Quick Customer / `Customers::Create`:** reuse the same class of idempotency pattern used elsewhere for domain commands (e.g. `Idempotency::OperationService` as in `StoredValue::Post`), scoped so a double-submit or lost response cannot create two customers.
+
+Optimistic `lock_version` remains required concurrency protection; it is **not** a substitute for replay-safe idempotency after a lost successful response.
+
+---
+
+## Issuance replacement when tenders exist (normative)
+
+Code fact: adding or removing an issuance **clears all working tenders**.
+
+**Locked behavior:**
+
+```text
+No tenders applied
+  → edit/remove issuance directly (7B)
+
+Tenders applied
+  → explain that changing issuance changes the transaction total
+  → confirm Return to Sale / clear all tenders (O17-class)
+  → replace issuance and clear tenders atomically
+  → or change nothing
+```
+
+Do **not** allow an issuance editor to silently clear tenders.
+
+**Required tests (7B):** issuance edit with no tenders; with ordinary tenders; with stored-value tenders; failure after tender clearing begins; concurrent issuance/tender change; idempotent retry.
+
+---
+
+## Return to Sale during staged delivery (normative)
+
+| Stage | Behavior |
+|---|---|
+| **7A** | Ordinary tenders only → clear atomically. **Any stored-value tender present** → refuse Return to Sale with an explanation that SV correction lands in 7B. Do not expose underlying SV destroy through Return to Sale before 7B. |
+| **7B** | All supported working tenders (including SV) can be cleared atomically, or change nothing if any cannot be reversed under policy. |
+
+Not synonymous with Cancel Transaction.
 
 ---
 
@@ -84,32 +156,45 @@ Atomic clear of all reversible working tenders via `clear_working_tenders!` (or 
 
 | Layer | SV / issuance working rows |
 |---|---|
-| **Code today** | `RemoveWorkingTender` / issuance remove already destroy them without ledger reverse |
-| **7A product / UI** | Select and inspect allowed; **Edit / Remove unavailable** until 7B, with a concise reason |
-| **7B** | Capping, remove/replace, completion revalidation, issuance edit while unactivated, customer-required flows |
+| **Code today** | Destroy paths already remove them without ledger reverse |
+| **7A product / UI** | Select and inspect allowed; **Edit / Remove / Return-to-Sale clearing unavailable** until 7B |
+| **7B** | Idempotent working removal, atomic replacement, capping, completion revalidation, issuance edit with tender-clear confirm |
 
-Do not confuse destroy capability with 7A permission to expose mutation.
+---
+
+## Stored-value add vs completion (code inventory)
+
+Current code does **not** auto-cap. Overview product lock for 7B remains **auto-apply with prominent feedback**; that is a deliberate change from today’s reject-on-over-balance.
+
+| Question | Current code answer | 7B disposition |
+|---|---|---|
+| Request exceeds available payment balance | **Rejects** (`stored-value balance is insufficient`) — no cap | Change to **auto-cap** to `min(requested, available, remaining due)` with prominent feedback; persist only applied amount |
+| Request exceeds remaining transaction balance | **Rejects** (`amount is greater than remaining due`) | **Keep reject** (do not apply above remainder) |
+| Refund exceeds account/program capacity | Detected at **add** (`assert_gift_card_credit_within_maximum!` / capacity remaining) and again at **complete** (`StoredValueRefundCapacity.assert_working_allocation!`) | Keep dual assert; fail recoverably |
+| Balance changes after working tender is added | Completion **re-checks** balance; raises if insufficient — **does not** silently shrink the tender | Keep recoverable failure; no silent shrink |
+| Account becomes suspended/closed | Completion `resolve_tender_account!` requires `account.active?`; raises if not available | Keep recoverable failure |
+| Completion fails after some SV operations post | `CompleteStoredValue` runs inside `CompleteTransaction`’s DB transaction; raise aborts completion (txn stays working). Nested `StoredValue::Post` has its own idempotency — **7B must test** mid-completion failure / sticky nested ops | Require enclosing rollback of POS completion; verify nested replay safety in tests |
+| Multiple SV tenders on one account | **Rejected at add** for payments (`duplicate_account?`) | Keep one payment tender per account; post locks accounts in **sorted id** order |
+| New-card refund provisioning fails | Raises in `provision_refund_card!`; aborts `CompleteStoredValue` | Whole completion fails; no partial completed txn |
+| Stored-value posting replay | Nested key `Pos::Support.nested_stored_value_idempotency_key(completion_operation_id, "tender"\|"issuance", id)`; skip if `stored_value_operation_id` already set | Retain nested keys; completion lease remains outer authority |
 
 ---
 
 ## Quick Customer reuse checklist
 
-Product decision unchanged: Quick Customer remains **7B.2** (child of shared Register Customer Lookup; Sale + customer-required SV/refund; no F2 key — see [slice7-keyboard-contract.md](slice7-keyboard-contract.md) `open-customer-lookup`).
+Product decision unchanged: Quick Customer remains **7B.2** (child of shared Register Customer Lookup; Sale + customer-required SV/refund; `open-customer-lookup`; **F2 remains Card**).
 
 | Item | Verdict |
 |---|---|
-| Authoritative create | **Gap:** admin only — `Admin::CustomersController#create` + `create_and_audit!` (`admin/customers_controller.rb`, `admin/base_controller.rb`). **No** `Customers::Create` service. |
-| Reusable now | `Customers::NormalizeContact`, `Customers::SuggestDuplicates`, `Customers::Search`, `Pos::AttachCustomer` |
-| Permission | Catalog: `customers.manage` / `customers.view`. Draft `customers.create` **permission key does not exist**. Audit action string is `customers.create`. |
-| Fields | `display_name` required; email/phone optional on bare `Customer`. Email ∨ phone as a **contextual** Quick Customer / credit rule does **not** contradict Phase 8 bare-create policy (contact required on requests, not bare identity). |
-| Canonical / merge | ADR-023; create yields active canonical; duplicates warn + acknowledge; no auto-merge. Attach requires active canonical. |
-| Idempotency | None on customer create today (merge has keys; create does not). |
+| Authoritative create | **Gap:** admin only — `Admin::CustomersController#create` + `create_and_audit!`. **No** `Customers::Create` service. |
+| Reusable now | `Customers::NormalizeContact`, `SuggestDuplicates`, `Search`, `Pos::AttachCustomer` |
+| Permission (locked) | Add **`customers.create`** for Quick Customer. Keep **`customers.manage`** for full customer management. Inquiry: `customers.view` / existing POS authority. Attach existing: existing POS attach authority. |
+| Service authorization | `Customers::Create` is presentation-neutral. **Admin caller** authorizes `customers.manage`. **Register Quick Customer caller** authorizes `customers.create`. |
+| Fields | `display_name` required; email/phone optional on bare `Customer`. Email ∨ phone as **contextual** Quick Customer / credit rule OK without changing base model. |
+| Canonical / merge | ADR-023; create yields canonical; duplicates warn + acknowledge; no auto-merge. |
+| Idempotency | **Required** on create (see mutation idempotency); none today. |
 
-### Implementation boundary (not product deferral)
-
-7B.2’s first work extracts **`Customers::Create`** (validate → duplicate gate → persist → audit action `customers.create`) and has **admin + Quick Customer** call it. Authorize create with **`customers.manage`** (align draft wording to the catalog) unless a later ADR adds a distinct `customers.create` permission.
-
-If extraction cannot land without duplicating Customer domain logic, stop with a documented blocker issue. **Do not** invent a Register-only create path.
+**Implementation boundary:** 7B.2 extracts `Customers::Create` and has admin + Quick Customer call it. If extraction cannot land without duplicating domain logic, stop with a documented blocker — do **not** invent a Register-only create path. Do **not** grant ordinary cashiers `customers.manage` solely to enable Quick Customer.
 
 ---
 
@@ -117,17 +202,17 @@ If extraction cannot land without duplicating Customer domain logic, stop with a
 
 | Topic | Owner |
 |---|---|
-| Tender Review selection, ordinary remove/replace, Return to Sale (O15–O17) | **7A** |
+| Tender Review selection; ordinary remove/replace; Return to Sale (ordinary-only) | **7A** |
 | Nested customer lookup, attach, change-customer guards | **7B.1** |
-| Quick Customer + `Customers::Create` extraction | **7B.2** |
-| SV capping; working SV remove/replace; issuance edit while unactivated; completion revalidation that fails recoverably (no silent tender shrink) | **7B.3** |
+| Quick Customer + `Customers::Create` + `customers.create` seed | **7B.2** |
+| SV capping (auto); idempotent working SV remove/replace; issuance edit with tender-clear confirm; completion revalidation | **7B.3** |
 | Activated / completed issuance or tender edit from workspace | **Out** — recovery / post-void only |
-| Keyboard dispatcher binding | **7C** (implements 7.0 contract) |
+| Keyboard dispatcher | **7C** |
 
 ## Packet readiness
 
 | Packet | Inventory gate |
 |---|---|
-| 7A | **Met** — ordinary dispositions and persistence decision locked |
-| 7B | **Met** — SV/issuance dispositions and Quick Customer boundary locked; create extraction called out |
+| 7A | **Met** |
+| 7B | **Met** |
 | 7C | Uses 7.0 contract; no further inventory gate |

--- a/docs/planning/register-workspace-consolidation/user-stories.md
+++ b/docs/planning/register-workspace-consolidation/user-stories.md
@@ -90,7 +90,7 @@ Gated on 7.0 + tender lifecycle inventory. Tender Review mode, semantic selectio
 
 ## Slice 7B — Stored-value, issuance, and Quick Customer
 
-Gated on 7A. Nested customer-required SV lookup (7B.1), Quick Customer (7B.2), capping / working correction / completion revalidation / issuance edit (7B.3).
+Gated on 7A. Nested customer-required SV lookup (7B.1), Quick Customer with `customers.create` (7B.2), auto-capping / idempotent working removal / atomic replacement / completion revalidation / issuance edit with tender-clear confirm (7B.3).
 
 ## Slice 7C — Keyboard dispatcher
 


### PR DESCRIPTION
## Summary
- Code-backed tender/issuance lifecycle inventory with 7A/7B dispositions.
- Locks audited destroy+add, OperationLease-backed working-mutation idempotency, issuance-with-tenders confirm, `customers.create` for Quick Customer, and SV reject-vs-cap / completion revalidation facts.
- Updates overview, README, implementation plan, and user-stories wording.

## Tracker
Inventory gate for #93/#94 only. Does not implement 7A or close #93.

## Test plan
- [ ] Read inventory dispositions and normative sections.
- [ ] Confirm no application code change (docs-only).


Made with [Cursor](https://cursor.com)