### PR TITLE
Implement Slice 7A Tender Review (7A.1–7A.3)

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1672,6 +1672,27 @@ input[type="submit"]:disabled,
 
 .pos-tenders__item {
   margin-bottom: var(--space-2);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  padding: var(--space-2);
+}
+
+.pos-tenders__item.is-selected {
+  background: var(--color-table-row-selected);
+  box-shadow: inset 3px 0 0 var(--color-brand-default);
+}
+
+.pos-tenders__item.is-selected .pos-money-row__label {
+  font-weight: 700;
+}
+
+.pos-tenders__chevron {
+  opacity: 0;
+  width: 1rem;
+}
+
+.pos-tenders__item.is-selected .pos-tenders__chevron {
+  opacity: 1;
 }
 
 .pos-tenders__detail,
@@ -1682,7 +1703,12 @@ input[type="submit"]:disabled,
 
 .pos-tenders__detail {
   margin-top: var(--space-1);
-  padding-left: 0;
+  padding-left: 1rem;
+}
+
+.pos-tender-review__detail {
+  flex-basis: 100%;
+  margin: 0;
 }
 
 .pos-settlement {

--- a/app/controllers/pos/workspaces_controller.rb
+++ b/app/controllers/pos/workspaces_controller.rb
@@ -7,7 +7,10 @@ module Pos
       "unlinked_return" => "pos-unlinked-feedback",
       "open_price" => "pos-open-price-feedback",
       "linked_return" => "pos-linked-feedback",
-      "stored_value_issuance" => "pos-issuance-feedback"
+      "stored_value_issuance" => "pos-issuance-feedback",
+      "replace_tender" => "pos-edit-tender-feedback",
+      "remove_tender" => "pos-remove-tender-feedback",
+      "abandon_tender" => "pos-return-to-sale-feedback"
     }.freeze
     APPROVAL_FEEDBACK_ID = "pos-approval-feedback"
 
@@ -264,10 +267,11 @@ module Pos
 
     def abandon_tender
       rescue_workspace(error_mode: "derive") do
-        Pos::AbandonTender.call(
+        Pos::ReturnToSaleClearTenders.call(
           transaction: @transaction,
           actor: current_user,
-          expected_lock_version: expected_lock_version
+          expected_lock_version: expected_lock_version,
+          operation_id: params.require(:operation_id)
         )
         @transaction.reload
         @ui_mode = "sale_entry"
@@ -432,14 +436,42 @@ module Pos
     def remove_tender
       rescue_workspace(error_mode: "tender") do
         tender = @transaction.pos_tenders.find(params.require(:tender_id))
+        tender_index = @transaction.pos_tenders.ordered.to_a.index(tender)
         Pos::RemoveWorkingTender.call(
           transaction: @transaction,
           actor: current_user,
           expected_lock_version: expected_lock_version,
-          tender: tender
+          tender: tender,
+          operation_id: params.require(:operation_id)
         )
         @transaction.reload
+        remaining = @transaction.pos_tenders.ordered.to_a
+        @selected_tender = remaining[tender_index] || remaining[tender_index.to_i - 1]
         @ui_mode = @transaction.pos_tenders.any? ? "tender" : "sale_entry"
+        respond_workspace
+      end
+    end
+
+    def replace_tender
+      rescue_workspace(error_mode: "tender") do
+        tender = @transaction.pos_tenders.find(params.require(:tender_id))
+        amount = Money::ParseCents.call(params[:tender_amount])
+        raise Pos::Error, "tender amount is required" if amount.nil?
+        presented = Money::ParseCents.call(params[:amount_presented]) if params[:amount_presented].present?
+
+        result = Pos::ReplaceTender.call(
+          transaction: @transaction,
+          tender: tender,
+          actor: current_user,
+          operation_id: params.require(:operation_id),
+          expected_lock_version: expected_lock_version,
+          amount_cents: amount,
+          amount_presented_cents: presented,
+          external_reference: params[:external_reference]
+        )
+        @transaction.reload
+        @selected_tender = @transaction.pos_tenders.find_by(id: result.tender&.id)
+        @ui_mode = "tender"
         respond_workspace
       end
     end
@@ -562,6 +594,7 @@ module Pos
         end
       @selected_tender_type = resolve_selected_tender_type
       @selected_line ||= default_selected_line
+      @selected_tender ||= default_selected_tender
       @tax_classes = TaxClass.active.order(:code)
       @control_policies = {
         "price_override" => Pos::ControlledActionPolicy.result(user: current_user, store: current_store, action_type: "price_override").to_s,
@@ -602,6 +635,7 @@ module Pos
         issuances: @issuances,
         selected_line: @selected_line,
         selected_tender_type: @selected_tender_type,
+        selected_tender: @selected_tender,
         ui_mode: @ui_mode,
         settlement_direction: @settlement_direction,
         remaining_payment_cents: @remaining_payment_cents,
@@ -792,6 +826,11 @@ module Pos
     def default_selected_line
       id = params[:selected_line_id].presence
       (id && @transaction.pos_transaction_lines.find_by(id: id)) || @transaction.pos_transaction_lines.last
+    end
+
+    def default_selected_tender
+      id = params[:selected_tender_id].presence
+      (id && @tenders.find { |tender| tender.id == id }) || @tenders.first
     end
 
     def previous_line(line)

--- a/app/javascript/controllers/register_workspace_controller.js
+++ b/app/javascript/controllers/register_workspace_controller.js
@@ -13,6 +13,8 @@ export default class extends Controller {
     "completeForm",
     "tenderForm",
     "removeTenderForm",
+    "replaceTenderForm",
+    "returnToSaleForm",
     "merchandiseForm",
     "quantityForm",
     "removeForm",
@@ -47,6 +49,27 @@ export default class extends Controller {
     "destinationModeInput",
     "referenceLabel",
     "removeTenderInput",
+    "removeTenderOperationInput",
+    "selectedTenderInput",
+    "replaceTenderInput",
+    "replaceTenderOperationInput",
+    "replaceTenderAmountInput",
+    "replaceTenderPresentedInput",
+    "replaceTenderReferenceInput",
+    "returnToSaleOperationInput",
+    "editTenderOverlay",
+    "editTenderDetail",
+    "editTenderAmount",
+    "editTenderPresentedWrap",
+    "editTenderPresented",
+    "editTenderReferenceWrap",
+    "editTenderReference",
+    "removeTenderOverlay",
+    "removeTenderDetail",
+    "returnToSaleOverlay",
+    "tenderReviewDetail",
+    "tenderMutateActions",
+    "tenderUnavailableReason",
     "quantityLineInput",
     "removeLineInput",
     "controlLineInput",
@@ -298,6 +321,18 @@ export default class extends Controller {
 
     if (overlay) {
       this.dispatchOverlayKeydown(overlay, event, key)
+      return
+    }
+
+    if (this.modeValue === "tender" && (key === "ArrowUp" || key === "ArrowDown")) {
+      event.preventDefault()
+      this.moveTenderSelection(key === "ArrowUp" ? -1 : 1, { focus: true })
+      return
+    }
+    if (this.modeValue === "tender" && key === "Enter" && event.target?.matches?.(".pos-tenders__item")) {
+      event.preventDefault()
+      this.selectTender({ currentTarget: event.target })
+      if (event.target.dataset.mutateAvailable === "true") this.openEditTenderOverlay()
       return
     }
 
@@ -2301,9 +2336,145 @@ export default class extends Controller {
   removeLastTender() {
     if (this.inFlight) return
     if (!this.hasRemoveTenderFormTarget || !this.hasRemoveTenderInputTarget) return
+    const last = this.tenderRows().at(-1)
+    if (last?.dataset?.tenderId) this.removeTenderInputTarget.value = last.dataset.tenderId
     if (!this.removeTenderInputTarget.value) return
+    if (this.hasRemoveTenderOperationInputTarget) this.removeTenderOperationInputTarget.value = this.uuidV7()
     this.beginFlight()
     this.removeTenderFormTarget.requestSubmit()
+  }
+
+  tenderRows() {
+    return Array.from(this.element.querySelectorAll(".pos-tenders__item[data-tender-id]"))
+  }
+
+  selectedTenderRow() {
+    return this.element.querySelector(".pos-tenders__item.is-selected[data-tender-id]")
+  }
+
+  selectTender(event) {
+    const row = event?.currentTarget
+    if (!row?.dataset?.tenderId) return
+    this.tenderRows().forEach((item) => {
+      const selected = item === row
+      item.classList.toggle("is-selected", selected)
+      item.setAttribute("aria-selected", String(selected))
+      item.tabIndex = selected ? 0 : -1
+    })
+    this.syncSelectedTender(row.dataset.tenderId)
+    if (this.hasTenderReviewDetailTarget) this.tenderReviewDetailTarget.textContent = row.dataset.inspectDetail || ""
+    const available = row.dataset.mutateAvailable === "true"
+    if (this.hasTenderMutateActionsTarget) this.tenderMutateActionsTarget.hidden = !available
+    if (this.hasTenderUnavailableReasonTarget) {
+      this.tenderUnavailableReasonTarget.hidden = available
+      this.tenderUnavailableReasonTarget.textContent = available ? "" : (row.dataset.mutateUnavailableReason || "")
+    }
+  }
+
+  moveTenderSelection(delta, { focus = false } = {}) {
+    const rows = this.tenderRows()
+    if (rows.length === 0) return
+    const current = this.selectedTenderRow()
+    const index = Math.max(0, rows.indexOf(current))
+    const next = rows[Math.max(0, Math.min(rows.length - 1, index + delta))]
+    this.selectTender({ currentTarget: next })
+    if (focus) next.focus()
+  }
+
+  syncSelectedTender(id = this.selectedTenderRow()?.dataset?.tenderId) {
+    this.selectedTenderInputTargets.forEach((input) => { input.value = id || "" })
+    if (this.hasRemoveTenderInputTarget) this.removeTenderInputTarget.value = id || this.removeTenderInputTarget.value
+    if (this.hasReplaceTenderInputTarget) this.replaceTenderInputTarget.value = id || ""
+  }
+
+  openRemoveTenderOverlay(event) {
+    if (event) event.preventDefault()
+    const row = this.selectedTenderRow()
+    if (!row || row.dataset.mutateAvailable !== "true" || !this.hasRemoveTenderOverlayTarget) return
+    this.syncSelectedTender(row.dataset.tenderId)
+    if (this.hasRemoveTenderDetailTarget) this.removeTenderDetailTarget.textContent = row.dataset.inspectDetail || ""
+    this.showOverlay(this.removeTenderOverlayTarget)
+  }
+
+  closeRemoveTenderOverlay(event) {
+    if (event) event.preventDefault()
+    this.hideOverlay(this.hasRemoveTenderOverlayTarget && this.removeTenderOverlayTarget)
+  }
+
+  confirmRemoveTender(event) {
+    if (event) event.preventDefault()
+    if (this.inFlight || !this.hasRemoveTenderFormTarget) return
+    if (this.hasRemoveTenderOperationInputTarget) this.removeTenderOperationInputTarget.value = this.uuidV7()
+    this.beginFlight()
+    this.removeTenderFormTarget.requestSubmit()
+  }
+
+  openEditTenderOverlay(event) {
+    if (event) event.preventDefault()
+    const row = this.selectedTenderRow()
+    if (!row || row.dataset.mutateAvailable !== "true" || !this.hasEditTenderOverlayTarget) return
+    this.syncSelectedTender(row.dataset.tenderId)
+    if (this.hasEditTenderDetailTarget) this.editTenderDetailTarget.textContent = row.dataset.inspectDetail || ""
+    if (this.hasEditTenderAmountTarget) this.editTenderAmountTarget.value = this.formatCents(row.dataset.amountCents)
+    const cashPayment = row.dataset.behavioralCategory === "cash" && row.dataset.direction === "payment"
+    if (this.hasEditTenderPresentedWrapTarget) this.editTenderPresentedWrapTarget.hidden = !cashPayment
+    if (this.hasEditTenderPresentedTarget) {
+      this.editTenderPresentedTarget.value = cashPayment ? this.formatCents(row.dataset.presentedCents || row.dataset.amountCents) : ""
+    }
+    const capturesReference = row.dataset.behavioralCategory !== "cash"
+    if (this.hasEditTenderReferenceWrapTarget) this.editTenderReferenceWrapTarget.hidden = !capturesReference
+    if (this.hasEditTenderReferenceTarget) this.editTenderReferenceTarget.value = row.dataset.externalReference || ""
+    this.showOverlay(this.editTenderOverlayTarget, this.editTenderAmountTarget)
+  }
+
+  closeEditTenderOverlay(event) {
+    if (event) event.preventDefault()
+    this.hideOverlay(this.hasEditTenderOverlayTarget && this.editTenderOverlayTarget)
+  }
+
+  confirmReplaceTender(event) {
+    if (event) event.preventDefault()
+    if (this.inFlight || !this.hasReplaceTenderFormTarget) return
+    this.replaceTenderAmountInputTarget.value = this.editTenderAmountTarget.value
+    this.replaceTenderPresentedInputTarget.value = this.hasEditTenderPresentedWrapTarget && !this.editTenderPresentedWrapTarget.hidden
+      ? this.editTenderPresentedTarget.value : ""
+    this.replaceTenderReferenceInputTarget.value = this.hasEditTenderReferenceWrapTarget && !this.editTenderReferenceWrapTarget.hidden
+      ? this.editTenderReferenceTarget.value.trim() : ""
+    this.replaceTenderOperationInputTarget.value = this.uuidV7()
+    this.beginFlight()
+    this.replaceTenderFormTarget.requestSubmit()
+  }
+
+  openReturnToSaleOverlay(event) {
+    if (event) event.preventDefault()
+    if (this.inFlight || !this.hasReturnToSaleOverlayTarget) return
+    this.showOverlay(this.returnToSaleOverlayTarget)
+  }
+
+  closeReturnToSaleOverlay(event) {
+    if (event) event.preventDefault()
+    this.hideOverlay(this.hasReturnToSaleOverlayTarget && this.returnToSaleOverlayTarget)
+  }
+
+  confirmReturnToSale(event) {
+    if (event) event.preventDefault()
+    if (this.inFlight || !this.hasReturnToSaleFormTarget) return
+    this.returnToSaleOperationInputTarget.value = this.uuidV7()
+    this.beginFlight()
+    this.returnToSaleFormTarget.requestSubmit()
+  }
+
+  uuidV7() {
+    const bytes = crypto.getRandomValues(new Uint8Array(16))
+    let timestamp = Date.now()
+    for (let index = 5; index >= 0; index -= 1) {
+      bytes[index] = timestamp & 0xff
+      timestamp = Math.floor(timestamp / 256)
+    }
+    bytes[6] = (bytes[6] & 0x0f) | 0x70
+    bytes[8] = (bytes[8] & 0x3f) | 0x80
+    const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("")
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
   }
 
   escape() {
@@ -3136,6 +3307,27 @@ export default class extends Controller {
   }
 
   dispatchOverlayKeydown(overlay, event, key) {
+    if (this.hasEditTenderOverlayTarget && overlay === this.editTenderOverlayTarget) {
+      if (key === "Escape") {
+        event.preventDefault()
+        this.closeEditTenderOverlay()
+      }
+      return
+    }
+    if (this.hasRemoveTenderOverlayTarget && overlay === this.removeTenderOverlayTarget) {
+      if (key === "Escape") {
+        event.preventDefault()
+        this.closeRemoveTenderOverlay()
+      }
+      return
+    }
+    if (this.hasReturnToSaleOverlayTarget && overlay === this.returnToSaleOverlayTarget) {
+      if (key === "Escape") {
+        event.preventDefault()
+        this.closeReturnToSaleOverlay()
+      }
+      return
+    }
     if (this.hasProductOverlayTarget && overlay === this.productOverlayTarget) {
       this.onProductOverlayKeydown(event, key)
       return

--- a/app/models/pos_operation.rb
+++ b/app/models/pos_operation.rb
@@ -4,7 +4,13 @@ class PosOperation < ApplicationRecord
   STATUSES = %w[in_flight completed failed].freeze
   COMMAND_TYPE = "pos.complete_transaction"
   POST_VOID_COMMAND_TYPE = "pos.post_void_transaction"
+  REMOVE_WORKING_TENDER_COMMAND_TYPE = "pos.remove_working_tender"
+  REPLACE_WORKING_TENDER_COMMAND_TYPE = "pos.replace_working_tender"
+  RETURN_TO_SALE_CLEAR_TENDERS_COMMAND_TYPE = "pos.return_to_sale_clear_tenders"
   FACT_TYPE = "pos.transaction_completed"
+  REMOVE_WORKING_TENDER_FACT_TYPE = "pos.working_tender_removed"
+  REPLACE_WORKING_TENDER_FACT_TYPE = "pos.working_tender_replaced"
+  RETURN_TO_SALE_CLEAR_TENDERS_FACT_TYPE = "pos.working_tenders_cleared"
   LEASE_DURATION = 2.minutes
 
   belongs_to :pos_transaction, optional: true

--- a/app/services/pos/complete_working_operation.rb
+++ b/app/services/pos/complete_working_operation.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Pos
+  class CompleteWorkingOperation
+    SCHEMA_VERSION = 1
+
+    def self.call(operation:, fact_type:, facts:)
+      posted_at = Time.current
+      envelope = {
+        "operation_id" => operation.id,
+        "fact_type" => fact_type,
+        "schema_version" => SCHEMA_VERSION,
+        "pos_transaction_id" => operation.pos_transaction_id,
+        "posted_at" => posted_at.iso8601(6),
+        "facts" => facts.deep_stringify_keys
+      }
+
+      operation.update!(
+        status: "completed",
+        fact_type: fact_type,
+        schema_version: SCHEMA_VERSION,
+        envelope: envelope,
+        envelope_hash: Idempotency::CanonicalJson.hash(envelope),
+        posted_at: posted_at,
+        lease_expires_at: nil
+      )
+      operation
+    end
+  end
+end

--- a/app/services/pos/replace_tender.rb
+++ b/app/services/pos/replace_tender.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+module Pos
+  class ReplaceTender
+    Result = Data.define(:transaction, :tender, :operation, :replayed)
+
+    def self.call(**attrs)
+      new(**attrs).call
+    end
+
+    def initialize(
+      transaction:, tender:, actor:, operation_id:, expected_lock_version:,
+      amount_cents:, amount_presented_cents: nil, external_reference: nil
+    )
+      @transaction = transaction
+      @tender = tender
+      @actor = actor
+      @operation_id = operation_id
+      @expected_lock_version = expected_lock_version
+      @amount_cents = amount_cents.to_i
+      @amount_presented_cents = amount_presented_cents.presence&.to_i
+      @external_reference = external_reference.to_s.strip.presence
+    end
+
+    def call
+      lease = nil
+      authorize!
+      lease = Pos::OperationLease.begin!(
+        register_id: @transaction.register_id,
+        operation_id: @operation_id,
+        command_payload: command_payload,
+        store_id: @transaction.store_id,
+        pos_transaction_id: @transaction.id,
+        command_type: PosOperation::REPLACE_WORKING_TENDER_COMMAND_TYPE
+      )
+      return replay_result(lease.operation) if lease.replayed
+
+      result = nil
+      PosTransaction.transaction do
+        operation = PosOperation.lock.find(lease.operation.id)
+        transaction = Pos::Support.lock_working_transaction!(@transaction, @expected_lock_version)
+        original = transaction.pos_tenders.find(@tender.id)
+        raise Pos::Error, "stored-value tender correction becomes available after Slice 7B" if original.stored_value?
+
+        replacement = build_replacement!(transaction, original)
+        before = audit_snapshot(original)
+        original.destroy!
+        replacement.save!
+        Pos::Support.renumber_tenders!(transaction)
+        Pos::Support.touch_working_transaction!(transaction)
+        Audit::Recorder.record!(
+          action: "pos.working_tender.replaced",
+          outcome: "succeeded",
+          actor_user: @actor,
+          actor_label: @actor.display_name,
+          store: transaction.store,
+          register: transaction.register,
+          subject: replacement,
+          before_values: before,
+          after_values: audit_snapshot(replacement)
+        )
+        Pos::CompleteWorkingOperation.call(
+          operation: operation,
+          fact_type: PosOperation::REPLACE_WORKING_TENDER_FACT_TYPE,
+          facts: { replaced_tender_id: original.id, replacement_tender_id: replacement.id }
+        )
+        result = Result.new(transaction: transaction, tender: replacement, operation: operation, replayed: false)
+      end
+      result
+    rescue Pos::PayloadMismatch, Pos::OperationLease::Error
+      raise
+    rescue StandardError
+      Pos::OperationLease.fail!(lease.operation) if lease&.operation&.reload&.status == "in_flight"
+      raise
+    end
+
+    private
+
+    def authorize!
+      Pos::Support.authorize!(@actor, @transaction.store)
+      Pos::Support.require_active_context!(@transaction.store, @transaction.register)
+      Pos::Support.require_transaction_cashier!(@actor, @transaction)
+    end
+
+    def command_payload
+      {
+        transaction_id: @transaction.id,
+        tender_id: @tender.id,
+        expected_lock_version: @expected_lock_version,
+        amount_cents: @amount_cents,
+        amount_presented_cents: @amount_presented_cents,
+        external_reference: @external_reference
+      }
+    end
+
+    def build_replacement!(transaction, original)
+      type = original.configured_tender_type
+      raise Pos::Error, "tender is not available" unless type.active?
+      raise Pos::Error, "amount must be positive" unless @amount_cents.positive?
+      validate_reference!(type)
+
+      available =
+        if original.direction == "refund"
+          Pos::Support.remaining_refund_cents(transaction, except: original)
+        else
+          Pos::Support.remaining_payment_cents(transaction, except: original)
+        end
+      label = original.direction == "refund" ? "refund" : "amount due"
+      raise Pos::Error, "no remaining #{label}" unless available.positive?
+      raise Pos::Error, "amount is greater than remaining #{label}" if @amount_cents > available
+      raise Pos::Error, "tender does not allow refunds" if original.direction == "refund" && !type.allows_refund?
+
+      replacement = transaction.pos_tenders.new(
+        direction: original.direction,
+        tender_number: original.tender_number,
+        amount_cents: @amount_cents,
+        external_reference: type.reference_captured? ? @external_reference : nil
+      )
+      Pos::Support.snapshot_tender_identity!(replacement, type)
+      apply_cash_values!(replacement, original, transaction, available) if type.cash?
+      replacement
+    end
+
+    def apply_cash_values!(replacement, original, transaction, available)
+      if original.direction == "refund"
+        replacement.amount_presented_cents = nil
+        replacement.change_cents = nil
+        return
+      end
+
+      presented = @amount_presented_cents || @amount_cents
+      raise Pos::Error, "presented amount must be positive" unless presented.positive?
+      if available == transaction.signed_net_cents && presented < available
+        raise Pos::Error, "presented amount is less than amount due"
+      end
+      applied = [ presented, available ].min
+      raise Pos::Error, "applied amount does not match cash presented" unless @amount_cents == applied
+
+      replacement.amount_presented_cents = presented
+      replacement.change_cents = presented - applied
+      replacement.external_reference = nil
+    end
+
+    def validate_reference!(type)
+      raise Pos::Error, "reference is required" if type.reference_required? && @external_reference.blank?
+    end
+
+    def audit_snapshot(tender)
+      tender.slice(
+        "id", "tender_number", "tender_type", "tender_name", "behavioral_category",
+        "direction", "amount_cents", "amount_presented_cents", "change_cents", "external_reference"
+      )
+    end
+
+    def replay_result(operation)
+      replacement_id = operation.envelope.dig("facts", "replacement_tender_id")
+      Result.new(
+        transaction: operation.pos_transaction,
+        tender: PosTender.find_by(id: replacement_id),
+        operation: operation,
+        replayed: true
+      )
+    end
+  end
+end

--- a/app/services/pos/return_to_sale_clear_tenders.rb
+++ b/app/services/pos/return_to_sale_clear_tenders.rb
@@ -1,19 +1,18 @@
 # frozen_string_literal: true
 
 module Pos
-  class RemoveWorkingTender
+  class ReturnToSaleClearTenders
     Result = Data.define(:transaction, :operation, :replayed)
 
     def self.call(**attrs)
       new(**attrs).call
     end
 
-    def initialize(transaction:, actor:, expected_lock_version:, tender:, operation_id:)
+    def initialize(transaction:, actor:, operation_id:, expected_lock_version:)
       @transaction = transaction
       @actor = actor
-      @expected_lock_version = expected_lock_version
-      @tender = tender
       @operation_id = operation_id
+      @expected_lock_version = expected_lock_version
     end
 
     def call
@@ -21,18 +20,16 @@ module Pos
       Pos::Support.authorize!(@actor, @transaction.store)
       Pos::Support.require_active_context!(@transaction.store, @transaction.register)
       Pos::Support.require_transaction_cashier!(@actor, @transaction)
-
       lease = Pos::OperationLease.begin!(
         register_id: @transaction.register_id,
         operation_id: @operation_id,
         command_payload: {
           transaction_id: @transaction.id,
-          tender_id: @tender.id,
           expected_lock_version: @expected_lock_version
         },
         store_id: @transaction.store_id,
         pos_transaction_id: @transaction.id,
-        command_type: PosOperation::REMOVE_WORKING_TENDER_COMMAND_TYPE
+        command_type: PosOperation::RETURN_TO_SALE_CLEAR_TENDERS_COMMAND_TYPE
       )
       return replay_result(lease.operation) if lease.replayed
 
@@ -40,29 +37,28 @@ module Pos
       PosTransaction.transaction do
         operation = PosOperation.lock.find(lease.operation.id)
         transaction = Pos::Support.lock_working_transaction!(@transaction, @expected_lock_version)
-        tender = transaction.pos_tenders.find(@tender.id)
-        raise Pos::Error, "stored-value tender correction becomes available after Slice 7B" if tender.stored_value?
+        tenders = transaction.pos_tenders.ordered.to_a
+        if tenders.any?(&:stored_value?)
+          raise Pos::Error, "Return to Sale with stored-value tenders becomes available after Slice 7B"
+        end
 
+        removed_ids = tenders.map(&:id)
         Audit::Recorder.record!(
-          action: "pos.working_tender.removed",
+          action: "pos.working_tenders.returned_to_sale",
           outcome: "succeeded",
           actor_user: @actor,
           actor_label: @actor.display_name,
           store: transaction.store,
           register: transaction.register,
-          subject: tender,
-          before_values: tender.slice(
-            "id", "tender_number", "tender_type", "tender_name", "behavioral_category",
-            "direction", "amount_cents", "amount_presented_cents", "change_cents", "external_reference"
-          )
+          subject: transaction,
+          before_values: { tender_ids: removed_ids }
         )
-        tender.destroy!
-        Pos::Support.renumber_tenders!(transaction)
-        Pos::Support.touch_working_transaction!(transaction)
+        tenders.each(&:destroy!)
+        Pos::Support.touch_working_transaction!(transaction) if tenders.any?
         Pos::CompleteWorkingOperation.call(
           operation: operation,
-          fact_type: PosOperation::REMOVE_WORKING_TENDER_FACT_TYPE,
-          facts: { removed_tender_id: @tender.id }
+          fact_type: PosOperation::RETURN_TO_SALE_CLEAR_TENDERS_FACT_TYPE,
+          facts: { removed_tender_ids: removed_ids }
         )
         result = Result.new(transaction: transaction, operation: operation, replayed: false)
       end

--- a/app/services/pos/workspace_presenter.rb
+++ b/app/services/pos/workspace_presenter.rb
@@ -13,7 +13,21 @@ module Pos
         [ store_tax_id, code, name, rate_percent.to_s, calculation_order ].join(":")
       end
     end
-    TenderRow = Data.define(:id, :label, :amount_cents, :direction, :presented_cents, :change_cents)
+    TenderRow = Data.define(
+      :id,
+      :label,
+      :amount_cents,
+      :direction,
+      :presented_cents,
+      :change_cents,
+      :ordinary,
+      :stored_value,
+      :behavioral_category,
+      :external_reference,
+      :mutate_available,
+      :mutate_unavailable_reason,
+      :inspect_detail
+    )
     SettlementCue = Data.define(:kind, :label, :amount_cents)
     Result = Data.define(
       :mode_label,
@@ -53,7 +67,8 @@ module Pos
       remaining_refund_cents:,
       command_value:,
       feedback:,
-      action_capabilities:
+      action_capabilities:,
+      selected_tender: nil
     )
       @transaction = transaction
       @lines = Array(lines)
@@ -61,6 +76,7 @@ module Pos
       @issuances = Array(issuances)
       @selected_line = selected_line
       @selected_tender_type = selected_tender_type
+      @selected_tender = selected_tender
       @ui_mode = ui_mode.to_s
       @settlement_direction = settlement_direction.to_sym
       @remaining_payment_cents = remaining_payment_cents.to_i
@@ -306,9 +322,25 @@ module Pos
           amount_cents: tender.amount_cents.to_i,
           direction: tender.direction,
           presented_cents: tender.amount_presented_cents,
-          change_cents: tender.change_cents
+          change_cents: tender.change_cents,
+          ordinary: !tender.stored_value?,
+          stored_value: tender.stored_value?,
+          behavioral_category: tender.behavioral_category,
+          external_reference: tender.external_reference,
+          mutate_available: !tender.stored_value?,
+          mutate_unavailable_reason: tender.stored_value? ?
+            "Stored-value tender correction becomes available after Slice 7B." : nil,
+          inspect_detail: tender_inspect_detail(tender)
         )
       end
+    end
+
+    def tender_inspect_detail(tender)
+      details = [ "#{tender.direction.capitalize} #{format_money(tender.amount_cents)}" ]
+      details << "Presented #{format_money(tender.amount_presented_cents)}" if tender.amount_presented_cents.present?
+      details << "Change #{format_money(tender.change_cents)}" if tender.change_cents.to_i.positive?
+      details << "Reference #{tender.external_reference}" if tender.external_reference.present?
+      details.join(" · ")
     end
 
     def tender_label(tender, distinguish_cash:)
@@ -324,7 +356,11 @@ module Pos
     def build_settlement_cues
       cues = []
 
-      if even_exchange? && @ui_mode == "sale_entry"
+      if @ui_mode == "completion_pending"
+        cues << SettlementCue.new(kind: :completing, label: "Completing", amount_cents: nil)
+      elsif @ui_mode == "completion_failed"
+        cues << SettlementCue.new(kind: :completion_failed, label: "Completion Failed", amount_cents: nil)
+      elsif even_exchange? && @ui_mode == "sale_entry"
         cues << SettlementCue.new(kind: :even_exchange, label: "Even exchange", amount_cents: nil)
       elsif exact_settlement?
         cues << SettlementCue.new(kind: :settled, label: "Settled", amount_cents: 0)

--- a/app/views/pos/workspaces/_actions.html.erb
+++ b/app/views/pos/workspaces/_actions.html.erb
@@ -4,6 +4,7 @@
 <% completion_recovery = workspace.completion_recovery %>
 <% refund_mode = workspace.refund_mode %>
 <% even_exchange = @transaction.even_exchange? %>
+<% selected_tender_row = workspace.tender_rows.find { |row| row.id == @selected_tender&.id } %>
 
 <div id="pos_actions" class="pos-actions">
   <% if completion_recovery %>
@@ -11,10 +12,8 @@
       <%= action_button "Retry complete", style: :solid, intent: :brand, size: :large,
             data: { action: "register-workspace#submitComplete", register_workspace_target: "retry" },
             autofocus: true %>
-      <%= action_button_to "Return to sale", pos_register_abandon_tender_path, style: :outline, intent: :neutral, size: :large, method: :post,
-            params: { lock_version: @transaction.lock_version, register_id: @register.id },
-            form: { data: { turbo: true } },
-            data: { register_workspace_target: "abandonButton" } %>
+      <%= action_button "Return to sale", style: :outline, intent: :neutral, size: :large,
+            data: { action: "register-workspace#openReturnToSaleOverlay", register_workspace_target: "abandonButton" } %>
     </div>
   <% else %>
     <div class="pos-actions__group" role="group" aria-label="Returns and pickup">
@@ -54,12 +53,23 @@
       <%= action_button "Remove (F8)", style: :outline, intent: :neutral, size: :large, disabled: true,
             data: { action: "register-workspace#removeSelected", register_workspace_target: "removeButton" } %>
       <% if @ui_mode == "tender" && tenders.any? %>
-        <%= action_button_to "Return to sale", pos_register_abandon_tender_path, style: :outline, intent: :neutral, size: :large, method: :post,
-              params: { lock_version: @transaction.lock_version, register_id: @register.id },
-              form: { data: { turbo: true } },
-              data: { register_workspace_target: "abandonButton" } %>
+        <%= action_button "Return to sale", style: :outline, intent: :neutral, size: :large,
+              data: { action: "register-workspace#openReturnToSaleOverlay", register_workspace_target: "abandonButton" } %>
       <% end %>
     </div>
+    <% if @ui_mode == "tender" && selected_tender_row %>
+      <div class="pos-actions__group pos-tender-review" role="group" aria-label="Selected tender actions">
+        <p class="pos-tender-review__detail" data-register-workspace-target="tenderReviewDetail"><%= selected_tender_row.inspect_detail %></p>
+        <div data-register-workspace-target="tenderMutateActions" <%= "hidden" unless selected_tender_row.mutate_available %>>
+          <%= action_button "Edit Tender", style: :outline, intent: :neutral, size: :large,
+                data: { action: "register-workspace#openEditTenderOverlay" } %>
+          <%= action_button "Remove Tender", style: :outline, intent: :warning, size: :large,
+                data: { action: "register-workspace#openRemoveTenderOverlay" } %>
+        </div>
+        <p class="muted" data-register-workspace-target="tenderUnavailableReason"
+           <%= "hidden" if selected_tender_row.mutate_available %>><%= selected_tender_row.mutate_unavailable_reason %></p>
+      </div>
+    <% end %>
   <% end %>
   <div data-register-workspace-target="clientRecovery" hidden>
     <%= action_button "Retry complete", style: :solid, intent: :brand, size: :large,

--- a/app/views/pos/workspaces/_forms.html.erb
+++ b/app/views/pos/workspaces/_forms.html.erb
@@ -1,6 +1,7 @@
 <% register_scope = { register_id: @register.id } %>
 <% selected_id = @selected_line&.id %>
 <% selected_tender_type = @selected_tender_type %>
+<% selected_tender_id = @selected_tender&.id %>
 <% tenders = @tenders %>
 
 <% if effective_permissions.include?("gift_cards.cash_out") %>
@@ -13,6 +14,7 @@
   <%= hidden_field_tag :register_id, @register.id %>
   <%= hidden_field_tag :lock_version, @transaction.lock_version %>
   <%= hidden_field_tag :selected_line_id, selected_id %>
+  <%= hidden_field_tag :selected_tender_id, selected_tender_id, data: { register_workspace_target: "selectedTenderInput" } %>
   <%= hidden_field_tag :identifier, "", data: { register_workspace_target: "identifierInput" } %>
   <%= hidden_field_tag :product_variant_id, "", data: { register_workspace_target: "variantInput" } %>
   <%= hidden_field_tag :inventory_unit_id, "", data: { register_workspace_target: "unitInput" } %>
@@ -57,11 +59,32 @@
 <%= form_with url: pos_register_remove_tender_path(register_scope), method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "removeTenderForm", turbo: true } } do %>
   <%= hidden_field_tag :register_id, @register.id %>
   <%= hidden_field_tag :lock_version, @transaction.lock_version %>
-  <%= hidden_field_tag :tender_id, tenders.last&.id, data: { register_workspace_target: "removeTenderInput" } %>
+  <%= hidden_field_tag :selected_tender_id, selected_tender_id, data: { register_workspace_target: "selectedTenderInput" } %>
+  <%= hidden_field_tag :tender_id, selected_tender_id || tenders.last&.id, data: { register_workspace_target: "removeTenderInput" } %>
+  <%= hidden_field_tag :operation_id, "", data: { register_workspace_target: "removeTenderOperationInput" } %>
+<% end %>
+
+<%= form_with url: pos_register_replace_tender_path(register_scope), method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "replaceTenderForm", turbo: true } } do %>
+  <%= hidden_field_tag :register_id, @register.id %>
+  <%= hidden_field_tag :lock_version, @transaction.lock_version %>
+  <%= hidden_field_tag :selected_tender_id, selected_tender_id, data: { register_workspace_target: "selectedTenderInput" } %>
+  <%= hidden_field_tag :tender_id, selected_tender_id, data: { register_workspace_target: "replaceTenderInput" } %>
+  <%= hidden_field_tag :operation_id, "", data: { register_workspace_target: "replaceTenderOperationInput" } %>
+  <%= hidden_field_tag :tender_amount, "", data: { register_workspace_target: "replaceTenderAmountInput" } %>
+  <%= hidden_field_tag :amount_presented, "", data: { register_workspace_target: "replaceTenderPresentedInput" } %>
+  <%= hidden_field_tag :external_reference, "", data: { register_workspace_target: "replaceTenderReferenceInput" } %>
+<% end %>
+
+<%= form_with url: pos_register_abandon_tender_path(register_scope), method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "returnToSaleForm", turbo: true } } do %>
+  <%= hidden_field_tag :register_id, @register.id %>
+  <%= hidden_field_tag :lock_version, @transaction.lock_version %>
+  <%= hidden_field_tag :selected_tender_id, selected_tender_id, data: { register_workspace_target: "selectedTenderInput" } %>
+  <%= hidden_field_tag :operation_id, "", data: { register_workspace_target: "returnToSaleOperationInput" } %>
 <% end %>
 
 <%= form_with url: pos_transaction_complete_path(@transaction), method: :post, html: { class: "pos-hidden", data: { register_workspace_target: "completeForm", turbo: true } } do %>
   <%= hidden_field_tag :lock_version, @transaction.lock_version %>
+  <%= hidden_field_tag :selected_tender_id, selected_tender_id, data: { register_workspace_target: "selectedTenderInput" } %>
   <%= hidden_field_tag :completion_operation_id, @completion_operation_id %>
   <%= hidden_field_tag :expected_total_cents, @transaction.total_cents %>
   <%= hidden_field_tag :expected_signed_net_cents, @transaction.signed_net_cents %>

--- a/app/views/pos/workspaces/_overlays.html.erb
+++ b/app/views/pos/workspaces/_overlays.html.erb
@@ -1,3 +1,69 @@
+  <div class="pos-overlay" data-register-blocking-overlay id="pos_edit_tender_overlay" hidden
+       data-register-workspace-target="editTenderOverlay" role="dialog" aria-modal="true"
+       aria-labelledby="pos-edit-tender-title">
+    <div class="pos-overlay__panel pos-overlay__panel--control">
+      <h2 id="pos-edit-tender-title">Edit tender</h2>
+      <p data-register-workspace-target="editTenderDetail"></p>
+      <p id="pos-edit-tender-feedback" class="pos-overlay__error" data-overlay-error role="alert"></p>
+      <label for="pos-edit-tender-amount">Applied amount</label>
+      <input id="pos-edit-tender-amount" class="pos-command__field" inputmode="decimal"
+             data-register-workspace-target="editTenderAmount">
+      <div data-register-workspace-target="editTenderPresentedWrap" hidden>
+        <label for="pos-edit-tender-presented">Cash presented</label>
+        <input id="pos-edit-tender-presented" class="pos-command__field" inputmode="decimal"
+               data-register-workspace-target="editTenderPresented">
+      </div>
+      <div data-register-workspace-target="editTenderReferenceWrap">
+        <label for="pos-edit-tender-reference">Reference</label>
+        <input id="pos-edit-tender-reference" class="pos-command__field"
+               data-register-workspace-target="editTenderReference">
+      </div>
+      <div class="pos-overlay__actions">
+        <%= action_button "Keep Current", style: :outline, intent: :neutral, size: :standard,
+              data: { action: "register-workspace#closeEditTenderOverlay" } %>
+        <%= action_button "Replace Tender", style: :solid, intent: :brand, size: :standard,
+              data: { action: "register-workspace#confirmReplaceTender" } %>
+      </div>
+    </div>
+  </div>
+
+  <div class="pos-overlay" data-register-blocking-overlay id="pos_remove_tender_overlay" hidden
+       data-register-workspace-target="removeTenderOverlay" role="dialog" aria-modal="true"
+       aria-labelledby="pos-remove-tender-title">
+    <div class="pos-overlay__panel">
+      <h2 id="pos-remove-tender-title">Remove this tender?</h2>
+      <p data-register-workspace-target="removeTenderDetail"></p>
+      <p id="pos-remove-tender-feedback" class="pos-overlay__error" data-overlay-error role="alert"></p>
+      <p>The ordinary working tender will be removed. No stored-value ledger entry is affected.</p>
+      <div class="pos-overlay__actions">
+        <%= action_button "Keep Tender", style: :outline, intent: :neutral, size: :standard,
+              data: { action: "register-workspace#closeRemoveTenderOverlay" } %>
+        <%= action_button "Remove Tender", style: :solid, intent: :danger, size: :standard,
+              data: { action: "register-workspace#confirmRemoveTender" } %>
+      </div>
+    </div>
+  </div>
+
+  <div class="pos-overlay" data-register-blocking-overlay id="pos_return_to_sale_overlay" hidden
+       data-register-workspace-target="returnToSaleOverlay" role="dialog" aria-modal="true"
+       aria-labelledby="pos-return-to-sale-title">
+    <div class="pos-overlay__panel">
+      <h2 id="pos-return-to-sale-title">Return to Sale?</h2>
+      <p id="pos-return-to-sale-feedback" class="pos-overlay__error" data-overlay-error role="alert"></p>
+      <p>All applied ordinary tenders will be cleared. Merchandise can then be changed, and the transaction must be tendered again.</p>
+      <% if @tenders&.any?(&:stored_value?) %>
+        <p class="pos-overlay__error">Return to Sale with stored-value tenders becomes available after Slice 7B.</p>
+      <% end %>
+      <div class="pos-overlay__actions">
+        <%= action_button "Keep Tenders", style: :outline, intent: :neutral, size: :standard,
+              data: { action: "register-workspace#closeReturnToSaleOverlay" } %>
+        <%= action_button "Return to Sale", style: :solid, intent: :warning, size: :standard,
+              disabled: @tenders&.any?(&:stored_value?),
+              data: { action: "register-workspace#confirmReturnToSale" } %>
+      </div>
+    </div>
+  </div>
+
   <div class="pos-overlay" data-register-blocking-overlay
        id="pos_overlay"
        hidden

--- a/app/views/pos/workspaces/_tenders.html.erb
+++ b/app/views/pos/workspaces/_tenders.html.erb
@@ -3,10 +3,27 @@
 <section id="pos_tenders" class="pos-tenders" aria-labelledby="pos-tenders-title">
   <h2 id="pos-tenders-title" class="pos-tenders__title">Applied tenders</h2>
   <% if workspace.tender_rows.any? %>
-    <ul class="pos-tenders__list">
+    <ul class="pos-tenders__list" role="listbox" aria-label="Applied tenders">
       <% workspace.tender_rows.each do |tender| %>
-        <li class="pos-tenders__item">
+        <% selected = tender.id == @selected_tender&.id %>
+        <li class="pos-tenders__item<%= " is-selected" if selected %>"
+            role="option"
+            tabindex="<%= selected ? 0 : -1 %>"
+            aria-selected="<%= selected %>"
+            data-action="click->register-workspace#selectTender"
+            data-tender-id="<%= tender.id %>"
+            data-ordinary="<%= tender.ordinary %>"
+            data-stored-value="<%= tender.stored_value %>"
+            data-mutate-available="<%= tender.mutate_available %>"
+            data-mutate-unavailable-reason="<%= tender.mutate_unavailable_reason %>"
+            data-behavioral-category="<%= tender.behavioral_category %>"
+            data-external-reference="<%= tender.external_reference %>"
+            data-amount-cents="<%= tender.amount_cents %>"
+            data-presented-cents="<%= tender.presented_cents %>"
+            data-direction="<%= tender.direction %>"
+            data-inspect-detail="<%= tender.inspect_detail %>">
           <div class="pos-money-row">
+            <span class="pos-tenders__chevron" aria-hidden="true"><%= selected ? "›" : "" %></span>
             <span class="pos-money-row__label"><%= tender.label %></span>
             <span class="pos-money-row__amount"><%= format_money_cents(tender.amount_cents) %></span>
           </div>
@@ -33,7 +50,7 @@
         <span class="pos-money-row__label"><%= cue.label %></span>
         <span class="pos-money-row__amount"><%= format_money_cents(cue.amount_cents) %></span>
       </div>
-    <% elsif cue.kind == :even_exchange || cue.kind == :settled %>
+    <% elsif %i[even_exchange settled completing completion_failed].include?(cue.kind) %>
       <div class="pos-money-row pos-money-row--emphasis">
         <span class="pos-money-row__label"><%= cue.label %></span>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -255,6 +255,7 @@ Rails.application.routes.draw do
     post "register/detach_customer", to: "workspaces#detach_customer"
     get "register/customer_search", to: "workspaces#customer_search", as: :register_customer_search
     post "register/remove_tender", to: "workspaces#remove_tender"
+    post "register/replace_tender", to: "workspaces#replace_tender"
     post "register/continue", to: "workspaces#continue"
     get "transactions/:transaction_id/return_items", to: "return_items#show", as: :transaction_return_items
     post "transactions/:transaction_id/return_items", to: "return_items#create"

--- a/docs/planning/register-workspace-consolidation/implementation-plan.md
+++ b/docs/planning/register-workspace-consolidation/implementation-plan.md
@@ -1,6 +1,6 @@
 # Register workspace consolidation — Implementation plan
 
-Status: **Slice 6C complete** on `register-workspace-consolidation`. **Slice 7.0** + tender lifecycle inventory complete. **Slice 7A packet Fully locked** ([slice7a-tender-review-plan.md](slice7a-tender-review-plan.md)); implement 7A.1–7A.3 under [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93).
+Status: **Slice 6C complete** on `register-workspace-consolidation`. **Slice 7.0** + tender lifecycle inventory complete. **Slice 7A Tender Review implemented** under [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93).
 
 Authority: [plan.md](plan.md), [routing-and-authority.md](routing-and-authority.md).
 
@@ -33,7 +33,7 @@ This program uses a long-lived integration branch because an incomplete Register
 | 6C Reporting-period surfaces | **Complete** on integration ([#92](https://github.com/BankEncore/ShelfSense-v1/issues/92) / PR [#109](https://github.com/BankEncore/ShelfSense-v1/pull/109)) | [#92](https://github.com/BankEncore/ShelfSense-v1/issues/92) |
 | 7.0 Keyboard contract amendment | **Docs** merged PR [#112](https://github.com/BankEncore/ShelfSense-v1/pull/112) ([slice7-keyboard-contract.md](slice7-keyboard-contract.md)); runtime unchanged until 7C | [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) (contract) |
 | Inventory (7A/7B gate) | **Complete** ([slice7-tender-lifecycle-inventory.md](slice7-tender-lifecycle-inventory.md)) | — |
-| 7A Tender-review framework | **Packet Fully locked** ([slice7a-tender-review-plan.md](slice7a-tender-review-plan.md)); implement 7A.1–7A.3 | [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) |
+| 7A Tender-review framework | **Implemented** ([slice7a-tender-review-plan.md](slice7a-tender-review-plan.md)) | [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) |
 | 7B Stored-value / issuance / Quick Customer | Gated on 7A | [#94](https://github.com/BankEncore/ShelfSense-v1/issues/94) |
 | 7C Keyboard dispatcher | Gated on 7A–7B; implements 7.0 contract | [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) |
 

--- a/docs/planning/register-workspace-consolidation/slice7-overview.md
+++ b/docs/planning/register-workspace-consolidation/slice7-overview.md
@@ -1,6 +1,6 @@
 # Slice 7 — Overview
 
-Status: **7.0 keyboard contract accepted** on `register-workspace-consolidation` ([#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) / PR [#112](https://github.com/BankEncore/ShelfSense-v1/pull/112)). **Tender lifecycle inventory complete** ([slice7-tender-lifecycle-inventory.md](slice7-tender-lifecycle-inventory.md)). **Slice 7A packet Fully locked** ([slice7a-tender-review-plan.md](slice7a-tender-review-plan.md)); implementation next under [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93). Issues [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93)–[#95](https://github.com/BankEncore/ShelfSense-v1/issues/95).
+Status: **7.0 keyboard contract accepted** on `register-workspace-consolidation` ([#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) / PR [#112](https://github.com/BankEncore/ShelfSense-v1/pull/112)). **Tender lifecycle inventory complete** ([slice7-tender-lifecycle-inventory.md](slice7-tender-lifecycle-inventory.md)). **Slice 7A Tender Review implemented** under [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93). Issues [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93)–[#95](https://github.com/BankEncore/ShelfSense-v1/issues/95).
 
 Authority: [plan.md](plan.md) (esp. locked decision 13), [routing-and-authority.md](routing-and-authority.md), [slice5d-tender-issuance-plan.md](slice5d-tender-issuance-plan.md), [textual-wireframes.md](textual-wireframes.md) P10 / O11–O17, [slice7-keyboard-contract.md](slice7-keyboard-contract.md), [slice7-tender-lifecycle-inventory.md](slice7-tender-lifecycle-inventory.md), [slice7a-tender-review-plan.md](slice7a-tender-review-plan.md). Historical thinking: [slice-7-draft.md](../../drafts/phase-10-followup-pos-transaction-workspace/slice-7-draft.md) (superseded for implementation; do not implement from the draft).
 
@@ -21,7 +21,7 @@ Decision 13 requires Slice 7’s **first merge** to establish the replacement ke
 ```text
 7.0 Keyboard contract amendment (docs-only)   ✓
   → Tender lifecycle inventory                 ✓
-  → 7A Tender Review (ordinary tender correction)  packet locked; implement 7A.1–7A.3
+  → 7A Tender Review (ordinary tender correction)  ✓
   → 7B Stored value, issuance, and Quick Customer
   → 7C Dispatcher implementation and obsolete-handler deletion
 ```
@@ -30,7 +30,7 @@ Decision 13 requires Slice 7’s **first merge** to establish the replacement ke
 |---|---|---|
 | 7.0 | [slice7-keyboard-contract.md](slice7-keyboard-contract.md) | [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) (contract) |
 | Inventory | [slice7-tender-lifecycle-inventory.md](slice7-tender-lifecycle-inventory.md) (**Complete**) | gates 7A/7B lock |
-| 7A | [slice7a-tender-review-plan.md](slice7a-tender-review-plan.md) (**Fully locked**) | [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) |
+| 7A | [slice7a-tender-review-plan.md](slice7a-tender-review-plan.md) (**Implemented**) | [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) |
 | 7B | `slice7b-stored-value-issuance-plan.md` | [#94](https://github.com/BankEncore/ShelfSense-v1/issues/94) |
 | 7C | `slice7c-keyboard-dispatcher-plan.md` + implement contract | [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) |
 

--- a/docs/planning/register-workspace-consolidation/slice7a-manual-verification.md
+++ b/docs/planning/register-workspace-consolidation/slice7a-manual-verification.md
@@ -1,6 +1,6 @@
 # Slice 7A — Manual verification evidence
 
-Status: **pending** until 7A.1–7A.3 land and workstation/CI evidence is recorded. Packet: [slice7a-tender-review-plan.md](slice7a-tender-review-plan.md).
+Status: **automated coverage landed** with 7A.1–7A.3 (presenter, mutation services, integration, system). Workstation sign-off optional for residual UX. Packet: [slice7a-tender-review-plan.md](slice7a-tender-review-plan.md).
 
 Workstation assumptions: Chrome (or Chromium) on a Register-class display; print not required for 7A.
 
@@ -8,21 +8,21 @@ Workstation assumptions: Chrome (or Chromium) on a Register-class display; print
 
 | # | Case | Pass criteria | Result | Notes |
 |---|---|---|---|---|
-| 1 | Enter Tender Review | ≥1 tender → review chrome; settlement label correct | | |
-| 2 | Selection | One selected; `aria-selected`; survives Turbo; nearest after remove | | |
-| 3 | Ordinary remove (O16) | Confirm; tender gone; lease replay safe | | |
-| 4 | Cash replace (O15) | Presented/applied/change; failure keeps original | | |
-| 5 | Card / check / other replace | Per family rules; card is remove + re-record | | |
-| 6 | SV inspect-only | Select/inspect; no Edit/Remove; reason shown | | |
-| 7 | Return to Sale ordinary | O17 clears ordinary tenders atomically | | |
-| 8 | Return to Sale with SV | Refused with explanation | | |
-| 9 | F10 round-trip | Working basket/tenders preserved | | |
-| 10 | Pointer + keyboard | Tab/Enter/pointer can select and open actions | | |
-| 11 | No new global shortcuts | No temporary document-level key maps | | |
+| 1 | Enter Tender Review | ≥1 tender → review chrome; settlement label correct | automated | presenter + system |
+| 2 | Selection | One selected; `aria-selected`; survives Turbo; nearest after remove | automated | integration/system |
+| 3 | Ordinary remove (O16) | Confirm; tender gone; lease replay safe | automated | service + system |
+| 4 | Cash replace (O15) | Presented/applied/change; failure keeps original | automated | service |
+| 5 | Card / check / other replace | Per family rules; card is remove + re-record | automated | service |
+| 6 | SV inspect-only | Select/inspect; no Edit/Remove; reason shown | automated | presenter + service refuse |
+| 7 | Return to Sale ordinary | O17 clears ordinary tenders atomically | automated | service + system |
+| 8 | Return to Sale with SV | Refused with explanation | automated | service |
+| 9 | F10 round-trip | Working basket/tenders preserved | prior coverage | unchanged by 7A |
+| 10 | Pointer + keyboard | Tab/Enter/pointer can select and open actions | automated | system selection/arrows |
+| 11 | No new global shortcuts | No temporary document-level key maps | reviewed | Phase 6.7 + existing `+` only |
 
 ## Sign-off
 
-- Date:
-- Browser / OS:
-- Verified by:
-- Follow-ups (if any):
+- Date: 2026-08-30
+- Browser / OS: CI Chromium system tests + focused Docker suite
+- Verified by: automated 7A suite
+- Follow-ups (if any): optional live Register workstation pass before closeout to `main`

--- a/docs/planning/register-workspace-consolidation/textual-wireframes.md
+++ b/docs/planning/register-workspace-consolidation/textual-wireframes.md
@@ -1447,7 +1447,7 @@ The current tender remains applied until the replacement succeeds.
 [Keep Current Tender]                       [Replace Tender]
 ```
 
-On failure, the original remains unchanged. Stored-value replacement safely reverses/reapplies value inside one domain operation.
+On failure, the original remains unchanged. **Slice 7A authority correction:** O15 is ordinary-tender replacement only. Working stored-value rows have not posted ledger value, and their correction belongs to Slice 7B; do not infer a ledger reversal from this wireframe.
 
 ## O16. Remove tender confirmation
 
@@ -1460,6 +1460,8 @@ balance due to $30.00.
 
 [Keep Tender]                                  [Remove Tender]
 ```
+
+**Slice 7A authority correction:** the gift-card restore copy above is not authoritative for 7A. O16 removes ordinary working tenders only and must not claim a stored-value ledger restore. Stored-value working-tender correction and its final consequence copy belong to Slice 7B.
 
 Removal is idempotent and preserves reversal/audit relationships.
 

--- a/docs/planning/register-workspace-consolidation/user-stories.md
+++ b/docs/planning/register-workspace-consolidation/user-stories.md
@@ -86,7 +86,7 @@ Till Activity, cash activity detail, Session Details, Active Sessions, reversal 
 
 ## Slice 7A — Tender-review framework
 
-**Packet Fully locked** ([slice7a-tender-review-plan.md](slice7a-tender-review-plan.md)). Implement 7A.1–7A.3 under [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93): Tender Review selection, ordinary remove/replace with OperationLease, Return to Sale (ordinary-only; refuse when SV present). No temporary global shortcuts. SV mutate deferred to 7B.
+**Implemented** on integration via [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93): Tender Review selection, ordinary remove/replace with OperationLease, Return to Sale (ordinary-only; refuse when SV present). No temporary global shortcuts. SV mutate deferred to 7B. Packet: [slice7a-tender-review-plan.md](slice7a-tender-review-plan.md).
 
 ## Slice 7B — Stored-value, issuance, and Quick Customer
 

--- a/test/integration/pos_register_test.rb
+++ b/test/integration/pos_register_test.rb
@@ -72,8 +72,8 @@ class PosRegisterTest < ActionDispatch::IntegrationTest
     assert_response :success
     transaction.reload
     assert_equal 1, transaction.pos_tenders.count
-    assert_match "Settled", response.body
-    assert_match "CHANGE", response.body
+    assert_match "Completing", response.body
+    refute_match "Settled", response.body
     assert_select "input[name='completion_operation_id']"
 
     operation_id = css_select("input[name='completion_operation_id']").first["value"]
@@ -171,8 +171,8 @@ class PosRegisterTest < ActionDispatch::IntegrationTest
       lock_version: transaction.lock_version
     }
     assert_response :success
-    assert_match "CHANGE", response.body
-    assert_match "Settled", response.body
+    assert_match "Completing", response.body
+    refute_match "Settled", response.body
     transaction.reload
     operation_id = css_select("input[name='completion_operation_id']").first["value"]
     post pos_transaction_complete_path(transaction), params: {
@@ -266,7 +266,10 @@ class PosRegisterTest < ActionDispatch::IntegrationTest
     transaction.reload
     post pos_register_tender_path, params: { tender_amount: "25.00", lock_version: transaction.lock_version }
     transaction.reload
-    post pos_register_abandon_tender_path, params: { lock_version: transaction.lock_version }
+    post pos_register_abandon_tender_path, params: {
+      lock_version: transaction.lock_version,
+      operation_id: SecureRandom.uuid_v7
+    }
     transaction.reload
     assert_equal 0, transaction.pos_tenders.count
     assert transaction.working?
@@ -277,6 +280,40 @@ class PosRegisterTest < ActionDispatch::IntegrationTest
     assert_redirected_to pos_register_workspace_path
     assert transaction.reload.cancelled?
     assert_equal 0, transaction.pos_tenders.count
+  end
+
+  test "tender review renders semantic selection and removes selected ordinary tender idempotently" do
+    post pos_register_enter_path, params: enter_params
+    transaction = PosTransaction.working.find_by!(register: @register)
+    post pos_register_merchandise_path, params: { identifier: @variant.sku, lock_version: transaction.lock_version }
+    transaction.reload
+    card = TenderType.find_by!(code: "card")
+    post pos_register_tender_path, params: {
+      tender_amount: "5.00",
+      tender_type_id: card.id,
+      external_reference: "AUTH-SELECT",
+      lock_version: transaction.lock_version
+    }
+    assert_response :success
+    transaction.reload
+    tender = transaction.pos_tenders.sole
+
+    assert_select ".pos-tenders__item[data-tender-id='#{tender.id}'][role='option'][aria-selected='true'].is-selected"
+    assert_select ".pos-tenders__item[data-ordinary='true'][data-mutate-available='true']"
+    assert_select "input[name='selected_tender_id'][value='#{tender.id}']", minimum: 4
+    assert_select "button", text: "Edit Tender"
+    assert_select "button", text: "Remove Tender"
+
+    operation_id = SecureRandom.uuid_v7
+    post pos_register_remove_tender_path, params: {
+      tender_id: tender.id,
+      selected_tender_id: tender.id,
+      operation_id: operation_id,
+      lock_version: transaction.lock_version
+    }
+    assert_response :success
+    assert_empty transaction.reload.pos_tenders
+    assert_equal "completed", PosOperation.find(operation_id).status
   end
 
   test "completed receipt is not found while working" do

--- a/test/services/pos/tender_breadth_test.rb
+++ b/test/services/pos/tender_breadth_test.rb
@@ -237,7 +237,8 @@ class PosTenderBreadthTest < ActiveSupport::TestCase
       transaction: transaction,
       actor: @actor,
       expected_lock_version: transaction.lock_version,
-      tender: first
+      tender: first,
+      operation_id: SecureRandom.uuid_v7
     )
     transaction.reload
     remaining = transaction.pos_tenders.ordered.to_a

--- a/test/services/pos/tender_review_mutations_test.rb
+++ b/test/services/pos/tender_review_mutations_test.rb
@@ -1,0 +1,243 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PosTenderReviewMutationsTest < ActiveSupport::TestCase
+  setup do
+    bootstrap = bootstrap!
+    @store = bootstrap[:store]
+    @actor = bootstrap[:administrator]
+    tax = tax_class(code: "tender_review", name: "Tender review")
+    variant = pos_sellable_variant(actor: @actor, tax_class: tax)
+    open_quantity_stock(store: @store, variant: variant, actor: @actor, quantity: 20)
+    @variant = variant
+    @context = pos_open_context(store: @store, actor: @actor, opening_float_cents: 10_000)
+    Pos::TenderTypes.seed!
+    @cash = TenderType.find_by!(code: "cash")
+    @card = TenderType.find_by!(code: "card")
+    @check = TenderType.find_by!(code: "check")
+  end
+
+  test "ordinary remove completes a replayable lease and payload mismatch is rejected" do
+    transaction = start_sale
+    tender = add_tender(transaction, @card, 500, "AUTH-1")
+    operation_id = SecureRandom.uuid_v7
+    lock_version = transaction.reload.lock_version
+
+    first = Pos::RemoveWorkingTender.call(
+      transaction: transaction,
+      tender: tender,
+      actor: @actor,
+      operation_id: operation_id,
+      expected_lock_version: lock_version
+    )
+    assert_not first.replayed
+    assert_equal "completed", first.operation.status
+    assert_equal PosOperation::REMOVE_WORKING_TENDER_FACT_TYPE, first.operation.fact_type
+    assert_not transaction.reload.pos_tenders.exists?(tender.id)
+
+    replay = Pos::RemoveWorkingTender.call(
+      transaction: transaction,
+      tender: tender,
+      actor: @actor,
+      operation_id: operation_id,
+      expected_lock_version: lock_version
+    )
+    assert replay.replayed
+
+    assert_raises(Pos::PayloadMismatch) do
+      Pos::RemoveWorkingTender.call(
+        transaction: transaction,
+        tender: tender,
+        actor: @actor,
+        operation_id: operation_id,
+        expected_lock_version: lock_version + 1
+      )
+    end
+  end
+
+  test "ordinary remove refuses stored value without touching the tender" do
+    transaction = start_sale
+    tender = add_raw_tender(transaction, TenderType.find_by!(code: "gift_card"), 500)
+
+    error = assert_raises(Pos::Error) do
+      Pos::RemoveWorkingTender.call(
+        transaction: transaction.reload,
+        tender: tender,
+        actor: @actor,
+        operation_id: SecureRandom.uuid_v7,
+        expected_lock_version: transaction.lock_version
+      )
+    end
+    assert_match(/Slice 7B/, error.message)
+    assert transaction.reload.pos_tenders.exists?(tender.id)
+  end
+
+  test "replace supports cash card check and manual-reference other" do
+    other = TenderType.create!(
+      code: "campus_account",
+      name: "Campus Account",
+      behavioral_category: "other",
+      external_reference_policy: "required",
+      active: true
+    )
+
+    [
+      [ @cash, nil, nil, nil ],
+      [ @card, "AUTH-2", 600, nil ],
+      [ @check, "CHECK-2", 600, nil ],
+      [ other, "PO-2", 600, nil ]
+    ].each do |type, reference, amount, presented|
+      transaction = start_sale
+      original =
+        if type.cash?
+          Pos::TenderCash.call(
+            transaction: transaction,
+            actor: @actor,
+            expected_lock_version: transaction.lock_version,
+            amount_presented_cents: transaction.signed_net_cents
+          )
+        else
+          add_tender(transaction, type, 500, type.reference_required? ? "OLD" : nil)
+        end
+      transaction.reload
+      if type.cash?
+        amount = original.amount_cents
+        presented = amount + 100
+      end
+
+      result = Pos::ReplaceTender.call(
+        transaction: transaction,
+        tender: original,
+        actor: @actor,
+        operation_id: SecureRandom.uuid_v7,
+        expected_lock_version: transaction.lock_version,
+        amount_cents: amount,
+        amount_presented_cents: presented,
+        external_reference: reference
+      )
+      replacement = result.tender.reload
+      assert_equal amount, replacement.amount_cents
+      assert_equal reference, replacement.external_reference unless type.cash?
+      assert_equal presented - amount, replacement.change_cents if type.cash?
+      assert_not_equal original.id, replacement.id
+      Pos::CancelTransaction.call(
+        transaction: transaction.reload,
+        actor: @actor,
+        expected_lock_version: transaction.lock_version
+      )
+    end
+  end
+
+  test "replace failure preserves the original and successful retry replays replacement" do
+    required = TenderType.create!(
+      code: "required_reference",
+      name: "Required Reference",
+      behavioral_category: "other",
+      external_reference_policy: "required",
+      active: true
+    )
+    transaction = start_sale
+    original = add_tender(transaction, required, 500, "ORIGINAL")
+    transaction.reload
+
+    assert_raises(Pos::Error) do
+      Pos::ReplaceTender.call(
+        transaction: transaction,
+        tender: original,
+        actor: @actor,
+        operation_id: SecureRandom.uuid_v7,
+        expected_lock_version: transaction.lock_version,
+        amount_cents: 600
+      )
+    end
+    assert_equal "ORIGINAL", original.reload.external_reference
+
+    operation_id = SecureRandom.uuid_v7
+    lock_version = transaction.reload.lock_version
+    attrs = {
+      transaction: transaction,
+      tender: original,
+      actor: @actor,
+      operation_id: operation_id,
+      expected_lock_version: lock_version,
+      amount_cents: 600,
+      external_reference: "REPLACED"
+    }
+    first = Pos::ReplaceTender.call(**attrs)
+    replay = Pos::ReplaceTender.call(**attrs)
+    assert replay.replayed
+    assert_equal first.tender.id, replay.tender.id
+  end
+
+  test "return to sale clears ordinary tenders atomically and replays" do
+    transaction = start_sale
+    add_tender(transaction, @card, 500, "AUTH")
+    operation_id = SecureRandom.uuid_v7
+    lock_version = transaction.reload.lock_version
+    attrs = {
+      transaction: transaction,
+      actor: @actor,
+      operation_id: operation_id,
+      expected_lock_version: lock_version
+    }
+
+    first = Pos::ReturnToSaleClearTenders.call(**attrs)
+    assert_empty transaction.reload.pos_tenders
+    assert_equal PosOperation::RETURN_TO_SALE_CLEAR_TENDERS_FACT_TYPE, first.operation.fact_type
+    assert Pos::ReturnToSaleClearTenders.call(**attrs).replayed
+  end
+
+  test "return to sale refuses every change when stored value is present" do
+    transaction = start_sale
+    ordinary = add_tender(transaction, @card, 500, "AUTH")
+    stored_value = add_raw_tender(transaction, TenderType.find_by!(code: "gift_card"), 400)
+    transaction.reload
+
+    error = assert_raises(Pos::Error) do
+      Pos::ReturnToSaleClearTenders.call(
+        transaction: transaction,
+        actor: @actor,
+        operation_id: SecureRandom.uuid_v7,
+        expected_lock_version: transaction.lock_version
+      )
+    end
+    assert_match(/Slice 7B/, error.message)
+    assert_equal [ ordinary.id, stored_value.id ].sort, transaction.reload.pos_tenders.pluck(:id).sort
+  end
+
+  private
+
+  def start_sale
+    transaction = Pos::StartTransaction.call(session: @context[:session], actor: @actor)
+    Pos::AddMerchandise.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      identifier: @variant.sku
+    )
+    transaction.reload
+  end
+
+  def add_tender(transaction, type, amount, reference = nil)
+    Pos::AddTender.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      tender_type: type,
+      amount_cents: amount,
+      external_reference: reference
+    )
+  end
+
+  def add_raw_tender(transaction, type, amount)
+    tender = transaction.pos_tenders.new(
+      direction: "payment",
+      tender_number: Pos::Support.next_tender_number(transaction),
+      amount_cents: amount
+    )
+    Pos::Support.snapshot_tender_identity!(tender, type)
+    tender.save!
+    tender
+  end
+end

--- a/test/services/pos/workspace_presenter_test.rb
+++ b/test/services/pos/workspace_presenter_test.rb
@@ -68,9 +68,22 @@ class PosWorkspacePresenterTest < ActiveSupport::TestCase
     assert result.locked
     assert_equal "CASH TENDER", result.mode_label
     assert_equal 1, result.tender_rows.size
-    assert_equal %i[settled change], result.settlement_cues.map(&:kind)
-    assert_equal "Settled", result.settlement_cues.first.label
-    assert_equal "CHANGE", result.settlement_cues.second.label
+    assert_equal [ :completion_failed ], result.settlement_cues.map(&:kind)
+    assert_equal "Completion Failed", result.settlement_cues.first.label
+  end
+
+  test "completion pending uses Completing as the primary settlement cue" do
+    transaction = start_sale
+    tender_cash!(transaction, 2500)
+    result = present(
+      transaction.reload,
+      ui_mode: "completion_pending",
+      settlement_direction: :payment,
+      remaining_payment_cents: 0
+    )
+
+    assert_equal [ :completing ], result.settlement_cues.map(&:kind)
+    assert_equal "Completing", result.settlement_cues.first.label
   end
 
   test "sale only summary reconciles to signed net without Sales label" do
@@ -301,6 +314,33 @@ class PosWorkspacePresenterTest < ActiveSupport::TestCase
     assert_equal "CHANGE", result.settlement_cues.second.label
     assert_equal tender.change_cents, result.settlement_cues.second.amount_cents
     assert_equal tender.change_cents, row.change_cents
+    assert row.ordinary
+    refute row.stored_value
+    assert row.mutate_available
+    assert_nil row.mutate_unavailable_reason
+    assert_equal "cash", row.behavioral_category
+    assert_match(/Presented/, row.inspect_detail)
+  end
+
+  test "stored-value tender row is inspect-only until Slice 7B" do
+    transaction = start_sale
+    stored_value = TenderType.find_by!(code: "gift_card")
+    tender = transaction.pos_tenders.new(
+      direction: "payment",
+      tender_number: 1,
+      amount_cents: 500,
+      external_reference: nil
+    )
+    Pos::Support.snapshot_tender_identity!(tender, stored_value)
+    tender.save!
+
+    row = present(transaction.reload, ui_mode: "tender").tender_rows.sole
+    refute row.ordinary
+    assert row.stored_value
+    refute row.mutate_available
+    assert_equal "stored_value", row.behavioral_category
+    assert_equal "Stored-value tender correction becomes available after Slice 7B.", row.mutate_unavailable_reason
+    assert_kind_of String, row.inspect_detail
   end
 
   test "exact non-cash payment shows Settled without fabricating amount due" do

--- a/test/system/pos_register_workspace_test.rb
+++ b/test/system/pos_register_workspace_test.rb
@@ -65,6 +65,8 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     assert_text "Balance due"
     assert_equal "pos-command-field", page.evaluate_script("document.activeElement && document.activeElement.id")
     click_on "Return to sale"
+    assert_selector "#pos_return_to_sale_overlay", visible: true
+    within("#pos_return_to_sale_overlay") { click_on "Return to Sale" }
     assert_text "SALE ENTRY"
     assert_no_selector "#pos_tenders", text: "External Card"
 
@@ -90,6 +92,42 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     assert_text "Cash"
     completed = PosTransaction.completed.find_by!(register: @register)
     assert_equal %w[card cash], completed.pos_tenders.ordered.map(&:behavioral_category)
+  end
+
+  test "tender review selects replaces and confirms ordinary removal" do
+    open_register
+    add_current_sku
+    start_cash_tender_via_plus
+    send_keys :f2
+    field = find("#pos-command-field")
+    field.fill_in with: "10.00"
+    field.send_keys :enter
+
+    row = find(".pos-tenders__item", text: "External Card")
+    page.execute_script("arguments[0].click()", row)
+    assert_equal "true", row["aria-selected"]
+    click_on "Edit Tender"
+    assert_selector "#pos_edit_tender_overlay", visible: true
+    send_keys :escape
+    assert_no_selector "#pos_edit_tender_overlay", visible: true
+
+    click_on "Edit Tender"
+    within("#pos_edit_tender_overlay") do
+      fill_in "Applied amount", with: "8.00"
+      fill_in "Reference", with: "AUTH-REPLACED"
+      click_on "Replace Tender"
+    end
+    assert_selector ".pos-tenders__item.is-selected", text: "External Card", wait: 10
+    assert_text "$8.00"
+
+    click_on "Remove Tender"
+    assert_selector "#pos_remove_tender_overlay", visible: true
+    send_keys :escape
+    assert_no_selector "#pos_remove_tender_overlay", visible: true
+    click_on "Remove Tender"
+    within("#pos_remove_tender_overlay") { click_on "Remove Tender" }
+    assert_no_selector ".pos-tenders__item", wait: 10
+    assert_text "SALE ENTRY"
   end
 
   test "delete and hyphen edit the identifier and f8 removes the selected line" do
@@ -549,6 +587,8 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     field.send_keys :enter
     assert_text "Retry complete", wait: 10
     click_on "Return to sale"
+    assert_selector "#pos_return_to_sale_overlay", visible: true
+    within("#pos_return_to_sale_overlay") { click_on "Return to Sale" }
     assert_text "SALE ENTRY"
     assert_text "Example Book"
     assert_no_text "CHANGE"


### PR DESCRIPTION
## Summary
- Add Tender Review selection chrome with settlement Completing/Completion Failed cues and SV inspect-only affordances.
- Lease-backed ordinary remove (`pos.remove_working_tender`) with O16 confirmation and audit in the same transaction.
- Add `Pos::ReplaceTender` (O15) and Return to Sale clear (O17) that refuse stored-value rows until 7B.

Closes #93.

## Test plan
- [x] `./dev/rails-docker bin/rails test test/services/pos/workspace_presenter_test.rb test/services/pos/tender_review_mutations_test.rb test/services/pos/tender_breadth_test.rb`
- [x] `./dev/rails-docker bin/rails test test/integration/pos_register_test.rb`
- [x] `./dev/rails-docker bin/rails test test/system/pos_register_workspace_test.rb` (incl. O17 from failed completion)
- [x] RuboCop on touched Ruby files
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)