### PR TITLE
Close out Slice 7A documentation

### DIFF
--- a/docs/planning/register-workspace-consolidation/README.md
+++ b/docs/planning/register-workspace-consolidation/README.md
@@ -38,8 +38,8 @@ This program **replaces** the current POS presentation. It does not run a parall
 | [slice7-overview.md](slice7-overview.md) | Slice 7 boundary, sequencing, product defaults |
 | [slice7-keyboard-contract.md](slice7-keyboard-contract.md) | Slice 7.0 accepted SALE/TENDER keyboard contract (docs; runtime in 7C) |
 | [slice7-tender-lifecycle-inventory.md](slice7-tender-lifecycle-inventory.md) | Code-backed tender/issuance dispositions; gates 7A/7B packets |
-| [slice7a-tender-review-plan.md](slice7a-tender-review-plan.md) | Slice 7A Fully locked; Tender Review / ordinary remove-replace |
-| [slice7a-manual-verification.md](slice7a-manual-verification.md) | Slice 7A workstation evidence |
+| [slice7a-tender-review-plan.md](slice7a-tender-review-plan.md) | Slice 7A **Complete**; Tender Review / ordinary remove-replace |
+| [slice7a-manual-verification.md](slice7a-manual-verification.md) | Slice 7A evidence (signed off) |
 
 UX adoption: follow [ux-adoption-template.md](../ux-design-system/ux-adoption-template.md) in the slice that materially changes a screen. Printed receipts stay locked unless a slice explicitly owns print.
 

--- a/docs/planning/register-workspace-consolidation/implementation-plan.md
+++ b/docs/planning/register-workspace-consolidation/implementation-plan.md
@@ -1,6 +1,6 @@
 # Register workspace consolidation — Implementation plan
 
-Status: **Slice 6C complete** on `register-workspace-consolidation`. **Slice 7.0** + tender lifecycle inventory complete. **Slice 7A Tender Review implemented** under [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93).
+Status: **Slice 6C complete** on `register-workspace-consolidation`. **Slice 7.0** + tender lifecycle inventory complete. **Slice 7A complete** ([#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) / PRs [#115](https://github.com/BankEncore/ShelfSense-v1/pull/115)–[#116](https://github.com/BankEncore/ShelfSense-v1/pull/116)). Next: 7B.
 
 Authority: [plan.md](plan.md), [routing-and-authority.md](routing-and-authority.md).
 
@@ -33,7 +33,7 @@ This program uses a long-lived integration branch because an incomplete Register
 | 6C Reporting-period surfaces | **Complete** on integration ([#92](https://github.com/BankEncore/ShelfSense-v1/issues/92) / PR [#109](https://github.com/BankEncore/ShelfSense-v1/pull/109)) | [#92](https://github.com/BankEncore/ShelfSense-v1/issues/92) |
 | 7.0 Keyboard contract amendment | **Docs** merged PR [#112](https://github.com/BankEncore/ShelfSense-v1/pull/112) ([slice7-keyboard-contract.md](slice7-keyboard-contract.md)); runtime unchanged until 7C | [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) (contract) |
 | Inventory (7A/7B gate) | **Complete** ([slice7-tender-lifecycle-inventory.md](slice7-tender-lifecycle-inventory.md)) | — |
-| 7A Tender-review framework | **Implemented** ([slice7a-tender-review-plan.md](slice7a-tender-review-plan.md)) | [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) |
+| 7A Tender-review framework | **Complete** on integration ([#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) / PRs [#115](https://github.com/BankEncore/ShelfSense-v1/pull/115)–[#116](https://github.com/BankEncore/ShelfSense-v1/pull/116); [slice7a-tender-review-plan.md](slice7a-tender-review-plan.md)) | [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) |
 | 7B Stored-value / issuance / Quick Customer | Gated on 7A | [#94](https://github.com/BankEncore/ShelfSense-v1/issues/94) |
 | 7C Keyboard dispatcher | Gated on 7A–7B; implements 7.0 contract | [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) |
 

--- a/docs/planning/register-workspace-consolidation/slice6c-manual-verification.md
+++ b/docs/planning/register-workspace-consolidation/slice6c-manual-verification.md
@@ -25,4 +25,4 @@ Workstation assumptions: Chrome (or Chromium) on a Register-class display; print
 - Date: 2026-08-30
 - Browser / OS: Automated Docker/Chromium system suite + PR CI
 - Verified by: Project owner (automated evidence)
-- Follow-ups (if any): Slice 7A tender-review framework (#93) remains gated on 2–6. Workstation print-preview spot-check optional.
+- Follow-ups (if any): Slice 7A complete (#93 / #115–#116). Next: 7B (#94). Workstation print-preview spot-check optional.

--- a/docs/planning/register-workspace-consolidation/slice7-overview.md
+++ b/docs/planning/register-workspace-consolidation/slice7-overview.md
@@ -1,6 +1,6 @@
 # Slice 7 — Overview
 
-Status: **7.0 keyboard contract accepted** on `register-workspace-consolidation` ([#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) / PR [#112](https://github.com/BankEncore/ShelfSense-v1/pull/112)). **Tender lifecycle inventory complete** ([slice7-tender-lifecycle-inventory.md](slice7-tender-lifecycle-inventory.md)). **Slice 7A Tender Review implemented** under [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93). Issues [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93)–[#95](https://github.com/BankEncore/ShelfSense-v1/issues/95).
+Status: **7.0 keyboard contract accepted** on `register-workspace-consolidation` ([#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) / PR [#112](https://github.com/BankEncore/ShelfSense-v1/pull/112)). **Tender lifecycle inventory complete** ([slice7-tender-lifecycle-inventory.md](slice7-tender-lifecycle-inventory.md)). **Slice 7A complete** ([#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) / PRs [#115](https://github.com/BankEncore/ShelfSense-v1/pull/115)–[#116](https://github.com/BankEncore/ShelfSense-v1/pull/116)). Next: 7B ([#94](https://github.com/BankEncore/ShelfSense-v1/issues/94)), then 7C ([#95](https://github.com/BankEncore/ShelfSense-v1/issues/95)).
 
 Authority: [plan.md](plan.md) (esp. locked decision 13), [routing-and-authority.md](routing-and-authority.md), [slice5d-tender-issuance-plan.md](slice5d-tender-issuance-plan.md), [textual-wireframes.md](textual-wireframes.md) P10 / O11–O17, [slice7-keyboard-contract.md](slice7-keyboard-contract.md), [slice7-tender-lifecycle-inventory.md](slice7-tender-lifecycle-inventory.md), [slice7a-tender-review-plan.md](slice7a-tender-review-plan.md). Historical thinking: [slice-7-draft.md](../../drafts/phase-10-followup-pos-transaction-workspace/slice-7-draft.md) (superseded for implementation; do not implement from the draft).
 
@@ -30,7 +30,7 @@ Decision 13 requires Slice 7’s **first merge** to establish the replacement ke
 |---|---|---|
 | 7.0 | [slice7-keyboard-contract.md](slice7-keyboard-contract.md) | [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) (contract) |
 | Inventory | [slice7-tender-lifecycle-inventory.md](slice7-tender-lifecycle-inventory.md) (**Complete**) | gates 7A/7B lock |
-| 7A | [slice7a-tender-review-plan.md](slice7a-tender-review-plan.md) (**Implemented**) | [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) |
+| 7A | [slice7a-tender-review-plan.md](slice7a-tender-review-plan.md) (**Complete**; PRs [#115](https://github.com/BankEncore/ShelfSense-v1/pull/115)–[#116](https://github.com/BankEncore/ShelfSense-v1/pull/116)) | [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) |
 | 7B | `slice7b-stored-value-issuance-plan.md` | [#94](https://github.com/BankEncore/ShelfSense-v1/issues/94) |
 | 7C | `slice7c-keyboard-dispatcher-plan.md` + implement contract | [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) |
 

--- a/docs/planning/register-workspace-consolidation/slice7-tender-lifecycle-inventory.md
+++ b/docs/planning/register-workspace-consolidation/slice7-tender-lifecycle-inventory.md
@@ -43,7 +43,7 @@ Creating compensating ledger entries for an **unposted** working tender would be
 | Cash upsert | `Pos::TenderCash` upserts the single cash **payment** row. Cash **refund** upserts via cash branch of `Pos::AddRefundTender`. |
 | Ordinary non-cash | `Pos::AddTender` / `Pos::AddRefundTender` append new rows (optional `external_reference`). |
 | Issuance | `Pos::AddStoredValueIssuance` / `RemoveStoredValueIssuance` — working rows; **clears all working tenders** on add and on remove. |
-| Replace orchestration | **`Pos::ReplaceTender` does not exist** — 7A introduces it for ordinary families; 7B for SV/issuance. |
+| Replace orchestration | **`Pos::ReplaceTender`** exists for ordinary families (cash / check / other; card refused — remove + external reauth). 7B extends for SV/issuance. |
 | Completed immutability | Completed tenders/issuances are commercially readonly; correction via post-void / new refund. Posted SV reverse: `Pos::PostVoidStoredValue` / `StoredValue::Reverse`. |
 | Add idempotency today | Tender/issuance **add has no idempotency key**. Completion uses `Pos::OperationLease` (`command_type: pos.complete_transaction`). Nested SV post keys under completion operation id. |
 

--- a/docs/planning/register-workspace-consolidation/slice7a-manual-verification.md
+++ b/docs/planning/register-workspace-consolidation/slice7a-manual-verification.md
@@ -1,6 +1,6 @@
 # Slice 7A — Manual verification evidence
 
-Status: **automated coverage landed** with 7A.1–7A.3 (presenter, mutation services, integration, system). Workstation sign-off optional for residual UX. Packet: [slice7a-tender-review-plan.md](slice7a-tender-review-plan.md).
+Status: **Complete** on `register-workspace-consolidation`. Implementation [#115](https://github.com/BankEncore/ShelfSense-v1/pull/115); remediation [#116](https://github.com/BankEncore/ShelfSense-v1/pull/116) (card remove-only, arrow scope, selection persistence, O15–O17 Enter/Escape). Issue [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) closed. Packet: [slice7a-tender-review-plan.md](slice7a-tender-review-plan.md).
 
 Workstation assumptions: Chrome (or Chromium) on a Register-class display; print not required for 7A.
 
@@ -8,21 +8,21 @@ Workstation assumptions: Chrome (or Chromium) on a Register-class display; print
 
 | # | Case | Pass criteria | Result | Notes |
 |---|---|---|---|---|
-| 1 | Enter Tender Review | ≥1 tender → review chrome; settlement label correct | automated | presenter + system |
-| 2 | Selection | One selected; `aria-selected`; survives Turbo; nearest after remove | automated | integration/system |
-| 3 | Ordinary remove (O16) | Confirm; tender gone; lease replay safe | automated | service + system |
-| 4 | Cash replace (O15) | Presented/applied/change; failure keeps original | automated | service |
-| 5 | Card / check / other replace | Per family rules; card is remove + re-record | automated | service |
-| 6 | SV inspect-only | Select/inspect; no Edit/Remove; reason shown | automated | presenter + service refuse |
-| 7 | Return to Sale ordinary | O17 clears ordinary tenders atomically | automated | service + system |
-| 8 | Return to Sale with SV | Refused with explanation | automated | service |
-| 9 | F10 round-trip | Working basket/tenders preserved | prior coverage | unchanged by 7A |
-| 10 | Pointer + keyboard | Tab/Enter/pointer can select and open actions | automated | system selection/arrows |
-| 11 | No new global shortcuts | No temporary document-level key maps | reviewed | Phase 6.7 + existing `+` only |
+| 1 | Enter Tender Review | ≥1 tender → review chrome; settlement label correct | pass | presenter + system |
+| 2 | Selection | One selected; `aria-selected`; survives Turbo; nearest after remove | pass | integration (incl. tender-add) + system |
+| 3 | Ordinary remove (O16) | Confirm; tender gone; lease replay safe | pass | service + system Enter/Escape |
+| 4 | Cash / check / other replace (O15) | Presented/applied/change where applicable; failure keeps original | pass | service + system (check) |
+| 5 | Card | Edit withheld; Remove available; forged replace refused | pass | presenter + service + integration/system (#116) |
+| 6 | SV inspect-only | Select/inspect; no Edit/Remove; reason shown | pass | presenter + service refuse |
+| 7 | Return to Sale ordinary | O17 clears ordinary tenders atomically | pass | service + system |
+| 8 | Return to Sale with SV | Refused with explanation | pass | service |
+| 9 | F10 round-trip | Working basket/tenders preserved | pass | prior coverage; unchanged by 7A |
+| 10 | Pointer + keyboard | Tab/Enter/pointer select; arrows scoped to tender listbox | pass | system (#116) |
+| 11 | No new global shortcuts | No temporary document-level key maps | pass | Phase 6.7 + existing `+`; arrows not global |
 
 ## Sign-off
 
 - Date: 2026-08-30
-- Browser / OS: CI Chromium system tests + focused Docker suite
-- Verified by: automated 7A suite
-- Follow-ups (if any): optional live Register workstation pass before closeout to `main`
+- Browser / OS: CI Chromium system tests + focused Docker suite; manual code review on #115/#116
+- Verified by: automated 7A suite + CI green + code review
+- Follow-ups (if any): Slice 7B ([#94](https://github.com/BankEncore/ShelfSense-v1/issues/94))

--- a/docs/planning/register-workspace-consolidation/slice7a-tender-review-plan.md
+++ b/docs/planning/register-workspace-consolidation/slice7a-tender-review-plan.md
@@ -1,6 +1,6 @@
 # Slice 7A — Tender Review (ordinary tender correction)
 
-Status: **Fully locked.** Inventory gate met ([slice7-tender-lifecycle-inventory.md](slice7-tender-lifecycle-inventory.md)). Implementation may proceed as 7A.1 → 7A.2 → 7A.3 on branches under [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93). PR target: `register-workspace-consolidation`.
+Status: **Complete** on `register-workspace-consolidation` ([#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) / PRs [#115](https://github.com/BankEncore/ShelfSense-v1/pull/115), remediation [#116](https://github.com/BankEncore/ShelfSense-v1/pull/116)). Inventory gate was met ([slice7-tender-lifecycle-inventory.md](slice7-tender-lifecycle-inventory.md)). Evidence: [slice7a-manual-verification.md](slice7a-manual-verification.md).
 
 Authority: [plan.md](plan.md), [implementation-plan.md](implementation-plan.md), [slice7-overview.md](slice7-overview.md), [slice7-tender-lifecycle-inventory.md](slice7-tender-lifecycle-inventory.md), [slice7-keyboard-contract.md](slice7-keyboard-contract.md), [slice5a-lookup-overlays-plan.md](slice5a-lookup-overlays-plan.md) (overlay lifecycle), [slice5d-tender-issuance-plan.md](slice5d-tender-issuance-plan.md) (O11 add path unchanged), [textual-wireframes.md](textual-wireframes.md) P10 / **O15–O17**, [user-stories.md](user-stories.md), [routing-and-authority.md](routing-and-authority.md).
 
@@ -180,4 +180,4 @@ Reporting periods; sessions; completed transactions; posted tenders; stored-valu
 
 ## Full-lock criterion
 
-Met when this packet is on `register-workspace-consolidation` with inventory already complete. Implementation PRs follow 7A.1 → 7A.2 → 7A.3.
+Met when this packet is on `register-workspace-consolidation` with inventory already complete. Implementation landed as [#115](https://github.com/BankEncore/ShelfSense-v1/pull/115) (7A.1–7A.3 together) with remediation [#116](https://github.com/BankEncore/ShelfSense-v1/pull/116).

--- a/docs/planning/register-workspace-consolidation/user-stories.md
+++ b/docs/planning/register-workspace-consolidation/user-stories.md
@@ -2,7 +2,7 @@
 
 GitHub issues should usually be one focused PR. Slice 1 is this packet (no separate implementation issue required after merge).
 
-Tracker: [milestone Register workspace consolidation](https://github.com/BankEncore/ShelfSense-v1/milestone/7) — [#83](https://github.com/BankEncore/ShelfSense-v1/issues/83) Slice 2, [#84](https://github.com/BankEncore/ShelfSense-v1/issues/84) Slice 3, [#85](https://github.com/BankEncore/ShelfSense-v1/issues/85) Slice 4, [#86](https://github.com/BankEncore/ShelfSense-v1/issues/86) 5A, [#87](https://github.com/BankEncore/ShelfSense-v1/issues/87) 5B, [#88](https://github.com/BankEncore/ShelfSense-v1/issues/88) 5C, [#89](https://github.com/BankEncore/ShelfSense-v1/issues/89) 5D, [#90](https://github.com/BankEncore/ShelfSense-v1/issues/90) 6A, [#91](https://github.com/BankEncore/ShelfSense-v1/issues/91) 6B, [#92](https://github.com/BankEncore/ShelfSense-v1/issues/92) 6C, [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) 7A (gated), [#94](https://github.com/BankEncore/ShelfSense-v1/issues/94) 7B (gated), [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) 7C (gated).
+Tracker: [milestone Register workspace consolidation](https://github.com/BankEncore/ShelfSense-v1/milestone/7) — [#83](https://github.com/BankEncore/ShelfSense-v1/issues/83) Slice 2, [#84](https://github.com/BankEncore/ShelfSense-v1/issues/84) Slice 3, [#85](https://github.com/BankEncore/ShelfSense-v1/issues/85) Slice 4, [#86](https://github.com/BankEncore/ShelfSense-v1/issues/86) 5A, [#87](https://github.com/BankEncore/ShelfSense-v1/issues/87) 5B, [#88](https://github.com/BankEncore/ShelfSense-v1/issues/88) 5C, [#89](https://github.com/BankEncore/ShelfSense-v1/issues/89) 5D, [#90](https://github.com/BankEncore/ShelfSense-v1/issues/90) 6A, [#91](https://github.com/BankEncore/ShelfSense-v1/issues/91) 6B, [#92](https://github.com/BankEncore/ShelfSense-v1/issues/92) 6C, [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) 7A (complete), [#94](https://github.com/BankEncore/ShelfSense-v1/issues/94) 7B (gated), [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) 7C (gated).
 
 ## Slice 2 — Shell and state routing
 
@@ -86,7 +86,7 @@ Till Activity, cash activity detail, Session Details, Active Sessions, reversal 
 
 ## Slice 7A — Tender-review framework
 
-**Implemented** on integration via [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93): Tender Review selection, ordinary remove/replace with OperationLease, Return to Sale (ordinary-only; refuse when SV present). No temporary global shortcuts. SV mutate deferred to 7B. Packet: [slice7a-tender-review-plan.md](slice7a-tender-review-plan.md).
+**Complete** on integration ([#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) / PRs [#115](https://github.com/BankEncore/ShelfSense-v1/pull/115)–[#116](https://github.com/BankEncore/ShelfSense-v1/pull/116)): Tender Review selection; ordinary remove/replace with OperationLease; card remove-only (external reauth); Return to Sale ordinary-only (refuse when SV present). No temporary global shortcuts. SV mutate deferred to 7B. Packet: [slice7a-tender-review-plan.md](slice7a-tender-review-plan.md). Evidence: [slice7a-manual-verification.md](slice7a-manual-verification.md).
 
 ## Slice 7B — Stored-value, issuance, and Quick Customer
 


### PR DESCRIPTION
## Summary
- Mark Slice 7A **Complete** across planning docs with PRs [#115](https://github.com/BankEncore/ShelfSense-v1/pull/115)–[#116](https://github.com/BankEncore/ShelfSense-v1/pull/116) and closed [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93).
- Sign off [slice7a-manual-verification.md](docs/planning/register-workspace-consolidation/slice7a-manual-verification.md); note `Pos::ReplaceTender` exists for ordinary families in the tender inventory.
- Point next work at Slice 7B (#94).

## Test plan
- [x] Docs-only review
- [ ] Merge to `register-workspace-consolidation`


Made with [Cursor](https://cursor.com)