### PR TITLE
Slice 7C.2 — Keyboard dispatcher cutover

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1857,6 +1857,11 @@ input[type="submit"]:disabled,
   margin-top: var(--space-2);
 }
 
+.pos-command__hint {
+  margin: var(--space-2) 0 0;
+  font-size: 0.875rem;
+}
+
 .pos-actions {
   display: flex;
   flex-wrap: wrap;

--- a/app/javascript/controllers/register_workspace_controller.js
+++ b/app/javascript/controllers/register_workspace_controller.js
@@ -4,8 +4,7 @@ import {
   classifyFocusZone,
   classifyMode,
   resolveBinding,
-  isEditableControl,
-  REPEAT_IGNORED_ACTIONS
+  isEditableControl
 } from "register_keyboard_dispatcher"
 
 export default class extends Controller {
@@ -352,136 +351,41 @@ export default class extends Controller {
   }
 
   onKeydown(event) {
-    const functionKey = this.functionKey(event)
-    const key = functionKey || event.key
-    if (key === "F10") return
-    if (this.claimedFunctionKey(functionKey)) this.claimFunctionKey(event)
+    const key = normalizeKey(event)
+    if (key === "F10" || key == null) return
+    if (this.claimedFunctionKey(key)) this.claimFunctionKey(event)
 
-    const overlay = this.activeOverlayElement()
-    if (overlay && key === "Tab") {
-      this.trapTabInOverlay(overlay, event)
-      return
-    }
+    const binding = resolveBinding(this.keyboardContext(event, key))
 
-    if (overlay) {
+    if (binding.kind === "delegate_overlay") {
+      const overlay = this.activeOverlayElement()
+      if (!overlay) return
+      if (key === "Tab") {
+        this.trapTabInOverlay(overlay, event)
+        return
+      }
       this.dispatchOverlayKeydown(overlay, event, key)
       return
     }
 
-    if (this.modeValue === "tender" && (key === "ArrowUp" || key === "ArrowDown") && this.tenderListKeyTarget(event.target)) {
-      event.preventDefault()
-      this.moveTenderSelection(key === "ArrowUp" ? -1 : 1, { focus: true })
-      return
-    }
-    if (this.modeValue === "tender" && key === "Enter" && event.target?.matches?.(".pos-tenders__item")) {
-      event.preventDefault()
-      this.selectTender({ currentTarget: event.target })
-      if (event.target.dataset.editAvailable === "true") this.openEditTenderOverlay()
+    if (binding.kind === "native_control") return
+
+    if (binding.kind === "literal") {
+      this.redirectPrintableToCommandField(event)
       return
     }
 
-    this.redirectPrintableToCommandField(event)
-
-    if (this.inFlight || this.modeValue === "completion_pending") {
-      if (key === "Enter" && this.isActionableControl(event.target)) return
-      if (key === "Enter" || key === "F9") event.preventDefault()
-      return
-    }
-
-    if (this.modeValue === "completion_failed") {
-      if (key === "Enter") {
-        if (this.isActionableControl(event.target)) return
+    if (binding.kind === "none") {
+      if (key === "Escape" && this.modeValue === "completion_failed") event.preventDefault()
+      if ((this.inFlight || this.modeValue === "completion_pending") && (key === "Enter" || key === "F9")) {
         event.preventDefault()
-        this.submitComplete()
-      }
-      if (key === "F9") {
-        event.preventDefault()
-        this.openOverlay()
-      }
-      if (key === "Escape") event.preventDefault()
-      return
-    }
-
-    if (key === "Enter") {
-      if (this.isActionableControl(event.target)) return
-      event.preventDefault()
-      this.submitMode()
-      return
-    }
-    if (key === "Escape") {
-      event.preventDefault()
-      this.escape()
-      return
-    }
-    if (key === "F9") {
-      event.preventDefault()
-      this.openOverlay()
-      return
-    }
-    if (this.modeValue !== "sale_entry" && this.modeValue !== "tender") return
-
-    if (key === "F1") {
-      event.preventDefault()
-      this.chooseCash()
-      return
-    }
-    if (key === "F2") {
-      event.preventDefault()
-      this.chooseCard()
-      return
-    }
-    if (key === "F3") {
-      event.preventDefault()
-      this.chooseCheck()
-      return
-    }
-    if (key === "F4") {
-      event.preventDefault()
-      this.chooseOther()
-      return
-    }
-    if (key === "F5") {
-      event.preventDefault()
-      this.chooseStoredValue()
-      return
-    }
-
-    if (this.modeValue === "tender") {
-      if (key === "F8") {
-        event.preventDefault()
-        this.removeLastTender()
       }
       return
     }
 
-    const fieldEmpty = this.commandFieldEmpty()
-    if (key === "*" && fieldEmpty) {
+    if (binding.kind === "action") {
       event.preventDefault()
-      this.enterQuantity()
-    } else if (key === "+" && fieldEmpty) {
-      event.preventDefault()
-      this.enterTender()
-    } else if (key === "/" && fieldEmpty) {
-      event.preventDefault()
-      this.openSearchOverlay()
-    } else if (key === "." && fieldEmpty && this.pickupAllowedValue) {
-      event.preventDefault()
-      this.openPickupOverlay()
-    } else if ((key === "-" || event.code === "Minus") && fieldEmpty) {
-      event.preventDefault()
-      this.openReturnChooser()
-    } else if (key === "F6") {
-      event.preventDefault()
-      this.openPriceOverride()
-    } else if (key === "F7") {
-      event.preventDefault()
-      this.openLineDiscount()
-    } else if (key === "F8") {
-      event.preventDefault()
-      this.removeSelected()
-    } else if (key === "ArrowUp" || key === "ArrowDown") {
-      event.preventDefault()
-      this.moveSelection(key === "ArrowUp" ? -1 : 1)
+      this.performSemanticAction(binding.action, { announceUnavailable: true })
     }
   }
 
@@ -746,6 +650,10 @@ export default class extends Controller {
       case "open-product-lookup":
         return run(() => this.openSearchOverlay())
       case "open-pickup-lookup":
+        if (!this.pickupAllowedValue) {
+          this.showFeedback("No pickup can be added in the current transaction state.")
+          return false
+        }
         return run(() => this.openPickupOverlay())
       case "open-return-chooser":
         return run(() => this.openReturnChooser())
@@ -2841,17 +2749,6 @@ export default class extends Controller {
     if (!show && this.hasReferenceFieldTarget) this.referenceFieldTarget.value = ""
   }
 
-  removeLastTender() {
-    if (this.inFlight) return
-    if (!this.hasRemoveTenderFormTarget || !this.hasRemoveTenderInputTarget) return
-    const last = this.tenderRows().at(-1)
-    if (last?.dataset?.tenderId) this.removeTenderInputTarget.value = last.dataset.tenderId
-    if (!this.removeTenderInputTarget.value) return
-    if (this.hasRemoveTenderOperationInputTarget) this.removeTenderOperationInputTarget.value = this.uuidV7()
-    this.beginFlight()
-    this.removeTenderFormTarget.requestSubmit()
-  }
-
   tenderRows() {
     return Array.from(this.element.querySelectorAll(".pos-tenders__item[data-tender-id]"))
   }
@@ -4387,27 +4284,18 @@ export default class extends Controller {
   }
 
   isCommandSurfaceInput(target) {
-    if (!target) return false
-    if (this.hasFieldTarget && target === this.fieldTarget) return true
-    if (this.hasReferenceFieldTarget && target === this.referenceFieldTarget) return true
-    if (this.hasGiftCardNumberFieldTarget && target === this.giftCardNumberFieldTarget) return true
-    return false
-  }
-
-  reservedCommandGlyph(key, event) {
-    return key === "*" || key === "+" || key === "/" || key === "." || key === "-" || event.code === "Minus"
+    return isEditableControl(target)
   }
 
   redirectPrintableToCommandField(event) {
     if (event.defaultPrevented) return
     if (!this.hasFieldTarget || this.fieldTarget.disabled) return
     if (this.overlayOpen() && this.topOverlay()?.contains(event.target)) return
-    if (this.isCommandSurfaceInput(event.target)) return
+    if (isEditableControl(event.target)) return
     if (event.isComposing) return
     if (event.metaKey || event.ctrlKey || event.altKey) return
-    const key = event.key
+    const key = normalizeKey(event)
     if (typeof key !== "string" || key.length !== 1 || key === " ") return
-    if (this.commandFieldEmpty() && this.reservedCommandGlyph(key, event)) return
 
     event.preventDefault()
     const field = this.fieldTarget

--- a/app/javascript/controllers/register_workspace_controller.js
+++ b/app/javascript/controllers/register_workspace_controller.js
@@ -335,7 +335,7 @@ export default class extends Controller {
     }
     this.enableReadyActions()
     this.restoreFocus()
-    this.scrollSelectedRowIntoView()
+    this.scheduleScrollSelectedRowIntoView()
     if (this.hasFeedbackTarget && /customer is required/i.test(this.feedbackTarget.textContent || "")) {
       this.openCustomerOverlay()
     }
@@ -371,7 +371,7 @@ export default class extends Controller {
     if (binding.kind === "native_control") return
 
     if (binding.kind === "literal") {
-      this.redirectPrintableToCommandField(event)
+      this.redirectPrintableToCommandField(event, binding.key)
       return
     }
 
@@ -603,173 +603,346 @@ export default class extends Controller {
   }
 
   chooseCash() {
-    this.performSemanticAction("tender-cash")
+    this.performSemanticAction("tender-cash", { announceUnavailable: true })
   }
 
   chooseCard() {
-    this.performSemanticAction("tender-card")
+    this.performSemanticAction("tender-card", { announceUnavailable: true })
   }
 
   chooseCheck() {
-    this.performSemanticAction("tender-check")
+    this.performSemanticAction("tender-check", { announceUnavailable: true })
   }
 
   chooseOther() {
-    this.performSemanticAction("tender-other")
+    this.performSemanticAction("tender-other", { announceUnavailable: true })
   }
 
   chooseStoredValue() {
-    this.performSemanticAction("tender-stored-value")
+    this.performSemanticAction("tender-stored-value", { announceUnavailable: true })
   }
 
   /**
    * Slice 7C semantic action executor. Keyboard and visible controls converge here.
-   * Eligibility remains in the underlying methods / live control state.
    */
   performSemanticAction(action, { announceUnavailable = false } = {}) {
     if (!action) return false
-
-    const run = (fn) => {
-      fn.call(this)
-      return true
+    if (!this.invokeSemanticAction(action)) {
+      if (announceUnavailable) {
+        const reason = this.semanticActionUnavailableReason(action)
+        if (reason) this.showFeedback(reason)
+      }
+      return false
     }
+    return true
+  }
 
+  invokeSemanticAction(action) {
     switch (action) {
       case "tender-cash":
-        return run(() => this.chooseTenderCategory("cash"))
+        return this.invokeTenderCategory("cash")
       case "tender-card":
-        return run(() => this.chooseTenderCategory("card"))
+        return this.invokeTenderCategory("card")
       case "tender-check":
-        return run(() => this.chooseTenderCategory("check"))
+        return this.invokeTenderCategory("check")
       case "tender-other":
-        return run(() => this.executeTenderOther())
+        return this.invokeTenderOther()
       case "tender-stored-value":
-        return run(() => this.executeTenderStoredValue())
+        return this.invokeTenderStoredValue()
       case "open-tender-selection":
-        return run(() => this.enterTender())
+        return this.invokeEnterTender()
       case "open-product-lookup":
-        return run(() => this.openSearchOverlay())
+        if (this.inFlight || this.overlayOpen()) return false
+        this.openSearchOverlay()
+        return true
       case "open-pickup-lookup":
-        if (!this.pickupAllowedValue) {
-          this.showFeedback("No pickup can be added in the current transaction state.")
-          return false
-        }
-        return run(() => this.openPickupOverlay())
+        if (this.inFlight || this.overlayOpen()) return false
+        if (!this.pickupAllowedValue) return false
+        this.openPickupOverlay()
+        return true
       case "open-return-chooser":
-        return run(() => this.openReturnChooser())
+        if (this.inFlight || this.overlayOpen()) return false
+        this.openReturnChooser()
+        return true
       case "open-customer-lookup":
-        return run(() => this.openCustomerOverlay())
+        if (this.inFlight) return false
+        this.openCustomerOverlay()
+        return true
       case "open-quick-customer":
-        return run(() => this.openQuickCustomerOverlay())
+        if (this.inFlight) return false
+        this.openQuickCustomerOverlay()
+        return true
       case "set-quantity":
-        return run(() => this.enterQuantity())
+        return this.invokeEnterQuantity()
       case "edit-price":
-        return run(() => this.openPriceOverride())
+        return this.invokeOpenPriceOverride()
       case "edit-discount":
-        return run(() => this.openLineDiscount())
+        return this.invokeOpenLineDiscount()
       case "remove-selected-record":
-        return run(() => this.removeSelected())
+        return this.invokeRemoveSelectedLine()
       case "remove-selected-tender":
-        return run(() => this.executeRemoveSelectedTender())
+        return this.invokeRemoveSelectedTender()
       case "open-selected-tender-actions":
-        return run(() => this.executeOpenSelectedTenderActions())
+        return this.invokeOpenSelectedTenderActions()
       case "return-to-sale":
-        return run(() => this.openReturnToSaleOverlay())
+        if (this.inFlight) return false
+        this.openReturnToSaleOverlay()
+        return true
       case "cancel-transaction":
-        return run(() => this.openOverlay())
+        if (this.inFlight) return false
+        this.openOverlay()
+        return true
       case "submit-command":
-        return run(() => this.submitMode())
+        if (this.inFlight) return false
+        this.submitMode()
+        return true
       case "submit-complete":
-        return run(() => this.submitComplete())
+        if (this.inFlight) return false
+        this.submitComplete()
+        return true
       case "escape":
-        return run(() => this.escape())
+        if (this.inFlight) return false
+        this.escape()
+        return true
       case "move-basket-selection-up":
-        return run(() => this.moveSelection(-1))
+        if (this.inFlight) return false
+        this.moveSelection(-1)
+        return true
       case "move-basket-selection-down":
-        return run(() => this.moveSelection(1))
+        if (this.inFlight) return false
+        this.moveSelection(1)
+        return true
       case "move-tender-selection-up":
-        return run(() => this.moveTenderSelection(-1, { focus: true }))
+        if (this.inFlight) return false
+        this.moveTenderSelection(-1, { focus: true })
+        return true
       case "move-tender-selection-down":
-        return run(() => this.moveTenderSelection(1, { focus: true }))
+        if (this.inFlight) return false
+        this.moveTenderSelection(1, { focus: true })
+        return true
       default:
-        if (announceUnavailable) {
-          this.showFeedback(`Action "${action}" is not available.`)
-        }
         return false
     }
   }
 
-  executeTenderOther() {
-    if (this.inFlight) return
-    if (this.modeValue !== "sale_entry" && this.modeValue !== "tender") return
-    if (!this.ensureTenderable()) return
-    const types = this.otherTypes()
-    if (types.length === 0) {
-      this.showFeedback("No Other tender types are configured.")
-      return
+  semanticActionUnavailableReason(action) {
+    switch (action) {
+      case "set-quantity":
+        if (this.modeValue !== "sale_entry") return "Quantity is only available during sale entry."
+        if (!this.selectedRow()) return "Select a quantity-tracked sale line first."
+        if (this.selectedUnitLine()) return "Quantity is not available on individually tracked units."
+        if (this.selectedQuantityBlocked()) return "Remove the price override or discount before changing quantity."
+        return "Quantity is not available."
+      case "edit-price":
+        if (this.modeValue !== "sale_entry") return "Price is only available during sale entry."
+        if (!this.selectedRow()) return "Select a sale line first."
+        if (this.selectedReturnLine()) return "Price is not available on a return line."
+        if (this.policyFor("price_override") === "prohibited") return "Price change is not available."
+        if (this.selectedRow()?.dataset?.discounted === "true" && this.selectedRow()?.dataset?.pricingMethodSnapshot === "open_price") {
+          return "Remove the line discount before changing the price."
+        }
+        return "Price is not available."
+      case "edit-discount":
+        if (this.modeValue !== "sale_entry") return "Discount is only available during sale entry."
+        if (!this.selectedRow()) return "Select a sale line first."
+        if (this.selectedReturnLine()) return "Discount is not available on a return line."
+        if (this.policyFor("line_discount") === "prohibited") return "Line discount is not available."
+        return "Discount is not available."
+      case "open-pickup-lookup":
+        return "No pickup can be added in the current transaction state."
+      case "remove-selected-record":
+        if (this.modeValue !== "sale_entry") return "Remove is only available during sale entry."
+        if (!this.selectedRow()) return "Select a sale line first."
+        return "Remove is not available."
+      case "open-tender-selection":
+        if (this.modeValue !== "sale_entry" && this.modeValue !== "tender") return "Tender is not available in the current mode."
+        if (!this.hasCommercialContent()) return "Add merchandise before taking a tender."
+        if (this.settlementValue === "none") return null
+        if (this.cashierTenderTypes().length === 0) {
+          return this.settlementValue === "refund" ? "No refund tender types are available." : "No tender types are available."
+        }
+        return "Tender is not available."
+      case "tender-cash":
+      case "tender-card":
+      case "tender-check":
+      case "tender-other":
+      case "tender-stored-value":
+        return this.tenderFamilyUnavailableReason(action)
+      case "remove-selected-tender":
+        if (this.modeValue !== "tender") return "Select a tender in Tender Review first."
+        if (!this.selectedTenderRow()) return "Select a tender before removing."
+        if (this.selectedTenderRow()?.dataset?.removeAvailable === "false") {
+          return this.selectedTenderRow().dataset.removeUnavailableReason || "This tender cannot be removed."
+        }
+        return "Remove is not available for the selected tender."
+      case "open-selected-tender-actions":
+        if (this.modeValue !== "tender") return "Select a tender in Tender Review first."
+        if (!this.selectedTenderRow()) return "Select a tender first."
+        return this.selectedTenderRow()?.dataset?.editUnavailableReason ||
+          this.selectedTenderRow()?.dataset?.removeUnavailableReason ||
+          "No actions are available for the selected tender."
+      default:
+        return null
     }
+  }
+
+  tenderFamilyUnavailableReason(action) {
+    if (this.modeValue !== "sale_entry" && this.modeValue !== "tender") {
+      return "Tender is not available in the current mode."
+    }
+    if (this.modeValue === "sale_entry" && !this.hasCommercialContent()) {
+      return "Add merchandise before taking a tender."
+    }
+    const category = {
+      "tender-cash": "cash",
+      "tender-card": "card",
+      "tender-check": "check",
+      "tender-other": "other",
+      "tender-stored-value": "stored_value"
+    }[action]
+    const label = this.categoryLabel(category)
+    const types = category === "other" ? this.otherTypes() : this.typesForCategory(category)
+    if (types.length > 0) return null
+    if (category === "other") return "No Other tender types are configured."
+    if (category === "stored_value") return "Stored-value tender is not available."
+    if (this.settlementValue === "refund") return `${label} refunds are not enabled.`
+    return `${label} tender is not available.`
+  }
+
+  invokeEnterQuantity() {
+    if (this.inFlight) return false
+    if (this.modeValue !== "sale_entry" || !this.selectedRow()) return false
+    if (this.selectedUnitLine() || this.selectedQuantityBlocked()) return false
+    this.enterQuantity()
+    return true
+  }
+
+  invokeOpenPriceOverride() {
+    if (this.inFlight) return false
+    if (this.modeValue !== "sale_entry") return false
+    const row = this.selectedRow()
+    if (!row) return false
+    if (this.selectedReturnLine()) return false
+    if (this.policyFor("price_override") === "prohibited") return false
+    if (row.dataset.discounted === "true" && row.dataset.pricingMethodSnapshot === "open_price") return false
+    this.openPriceOverride()
+    return true
+  }
+
+  invokeOpenLineDiscount() {
+    if (this.inFlight) return false
+    if (this.modeValue !== "sale_entry") return false
+    if (!this.selectedRow()) return false
+    if (this.selectedReturnLine()) return false
+    if (this.policyFor("line_discount") === "prohibited") return false
+    this.openLineDiscount()
+    return true
+  }
+
+  invokeRemoveSelectedLine() {
+    if (this.inFlight) return false
+    if (this.modeValue !== "sale_entry" || !this.selectedRow()) return false
+    this.removeSelected()
+    return true
+  }
+
+  invokeEnterTender() {
+    if (this.inFlight) return false
+    if (this.modeValue !== "sale_entry" && this.modeValue !== "tender") return false
+    if (this.modeValue === "sale_entry") {
+      if (!this.hasCommercialContent()) return false
+      if (this.settlementValue === "none") {
+        this.submitComplete()
+        return true
+      }
+      if (this.cashierTenderTypes().length === 0) return false
+    }
+    this.enterTender()
+    return true
+  }
+
+  invokeTenderCategory(category) {
+    if (this.inFlight) return false
+    if (this.modeValue !== "sale_entry" && this.modeValue !== "tender") return false
+    if (this.modeValue === "sale_entry") {
+      if (!this.hasCommercialContent()) return false
+      if (this.settlementValue === "none") {
+        this.submitComplete()
+        return true
+      }
+    }
+    const types = category === "other" ? this.otherTypes() : this.typesForCategory(category)
+    if (types.length === 0) return false
+    this.beginTenderMode()
+    this.applyTenderType(types[0])
+    this.prefillRemaining()
+    return true
+  }
+
+  invokeTenderOther() {
+    if (this.inFlight) return false
+    if (this.modeValue !== "sale_entry" && this.modeValue !== "tender") return false
+    if (this.modeValue === "sale_entry") {
+      if (!this.hasCommercialContent()) return false
+      if (this.settlementValue === "none") {
+        this.submitComplete()
+        return true
+      }
+    }
+    const types = this.otherTypes()
+    if (types.length === 0) return false
     if (types.length === 1) {
       this.beginTenderMode()
       this.applyTenderType(types[0])
       this.prefillRemaining()
-      return
+      return true
     }
     this.openTenderPicker(types, { source: "other_key" })
+    return true
   }
 
-  executeTenderStoredValue() {
-    if (this.inFlight) return
-    if (this.modeValue !== "sale_entry" && this.modeValue !== "tender") return
-    if (!this.ensureTenderable()) return
-    const types = this.typesForCategory("stored_value")
-    if (types.length === 0) {
-      this.showFeedback("Stored-value tender is not available.")
-      return
+  invokeTenderStoredValue() {
+    if (this.inFlight) return false
+    if (this.modeValue !== "sale_entry" && this.modeValue !== "tender") return false
+    if (this.modeValue === "sale_entry") {
+      if (!this.hasCommercialContent()) return false
+      if (this.settlementValue === "none") {
+        this.submitComplete()
+        return true
+      }
     }
+    const types = this.typesForCategory("stored_value")
+    if (types.length === 0) return false
     if (types.length === 1) {
       this.beginTenderMode()
       this.applyTenderType(types[0])
       this.prefillRemaining()
-      return
+      return true
     }
     this.openTenderPicker(types, { source: "stored_value_key" })
+    return true
   }
 
-  executeRemoveSelectedTender() {
-    if (this.inFlight) return
-    if (this.modeValue !== "tender") return
+  invokeRemoveSelectedTender() {
+    if (this.inFlight) return false
+    if (this.modeValue !== "tender") return false
     const selected = this.selectedTenderRow()
-    if (!selected) {
-      this.showFeedback("Select a tender before removing.")
-      return
-    }
-    if (selected.dataset.removeAvailable === "false") {
-      this.showFeedback(selected.dataset.removeUnavailableReason || "This tender cannot be removed.")
-      return
-    }
+    if (!selected) return false
+    if (selected.dataset.removeAvailable === "false") return false
     this.openRemoveTenderOverlay()
+    return true
   }
 
-  executeOpenSelectedTenderActions() {
-    if (this.modeValue !== "tender") return
+  invokeOpenSelectedTenderActions() {
+    if (this.modeValue !== "tender") return false
     const selected = this.selectedTenderRow()
-    if (!selected) {
-      this.showFeedback("Select a tender first.")
-      return
-    }
+    if (!selected) return false
     this.selectTender({ currentTarget: selected })
     if (selected.dataset.editAvailable === "true") {
       this.openEditTenderOverlay()
-      return
+      return true
     }
-    if (this.hasTenderReviewDetailTarget) {
-      // Detail region already visible for selection; surface unavailability when present.
-    }
-    if (selected.dataset.editUnavailableReason) {
-      this.showFeedback(selected.dataset.editUnavailableReason)
-    } else if (selected.dataset.removeUnavailableReason) {
-      this.showFeedback(selected.dataset.removeUnavailableReason)
-    }
+    return false
   }
 
   keyboardFocusZone(target) {
@@ -3770,13 +3943,40 @@ export default class extends Controller {
     })
     this.syncSelectedLine()
     this.enableReadyActions()
-    this.scrollSelectedRowIntoView()
+    this.scheduleScrollSelectedRowIntoView()
+  }
+
+  scheduleScrollSelectedRowIntoView() {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => this.scrollSelectedRowIntoView())
+    })
   }
 
   scrollSelectedRowIntoView() {
     const row = this.selectedRow()
-    if (!row || typeof row.scrollIntoView !== "function") return
-    row.scrollIntoView({ block: "nearest", inline: "nearest" })
+    if (!row) return
+    const basket = document.getElementById("pos_basket")
+    if (!basket) {
+      if (typeof row.scrollIntoView === "function") {
+        row.scrollIntoView({ block: "nearest", inline: "nearest" })
+      }
+      return
+    }
+
+    const rowTop = row.getBoundingClientRect().top - basket.getBoundingClientRect().top + basket.scrollTop
+    const rowBottom = rowTop + row.offsetHeight
+    const maxScroll = Math.max(0, basket.scrollHeight - basket.clientHeight)
+    let nextScroll = basket.scrollTop
+
+    if (row.offsetHeight >= basket.clientHeight) {
+      nextScroll = rowTop
+    } else if (rowTop < basket.scrollTop) {
+      nextScroll = rowTop
+    } else if (rowBottom > basket.scrollTop + basket.clientHeight) {
+      nextScroll = rowBottom - basket.clientHeight
+    }
+
+    basket.scrollTop = Math.max(0, Math.min(maxScroll, nextScroll))
   }
 
   overlayOpen() {
@@ -4228,6 +4428,7 @@ export default class extends Controller {
       this.setActionEnabled("removeButton", hasSelection)
       this.setActionEnabled("cancelButton", hasLines)
       this.enableTenderIdentityButtons()
+      this.scheduleScrollSelectedRowIntoView()
       return
     }
     if (this.modeValue === "tender") {
@@ -4287,14 +4488,16 @@ export default class extends Controller {
     return isEditableControl(target)
   }
 
-  redirectPrintableToCommandField(event) {
+  redirectPrintableToCommandField(event, normalizedKey = null) {
     if (event.defaultPrevented) return
     if (!this.hasFieldTarget || this.fieldTarget.disabled) return
     if (this.overlayOpen() && this.topOverlay()?.contains(event.target)) return
     if (isEditableControl(event.target)) return
     if (event.isComposing) return
     if (event.metaKey || event.ctrlKey || event.altKey) return
-    const key = normalizeKey(event)
+    const key = (typeof event.key === "string" && event.key.length === 1)
+      ? event.key
+      : (normalizedKey || normalizeKey(event))
     if (typeof key !== "string" || key.length !== 1 || key === " ") return
 
     event.preventDefault()

--- a/app/javascript/register_keyboard_dispatcher.js
+++ b/app/javascript/register_keyboard_dispatcher.js
@@ -15,8 +15,10 @@ export const FOCUS_ZONES = Object.freeze({
 export const MODES = Object.freeze({
   sale: "sale",
   tender: "tender",
+  quantity: "quantity",
   completion_pending: "completion_pending",
-  completion_failed: "completion_failed"
+  completion_failed: "completion_failed",
+  restricted: "restricted"
 })
 
 /** Actions that ignore event.repeat (packet lock). */
@@ -37,6 +39,20 @@ export const REPEAT_IGNORED_ACTIONS = new Set([
   "tender-check",
   "tender-other",
   "tender-stored-value"
+])
+
+const COMMAND_FIELD_NATIVE_KEYS = new Set([
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowUp",
+  "ArrowDown",
+  "Home",
+  "End",
+  "Backspace",
+  "Delete",
+  "Tab",
+  "PageUp",
+  "PageDown"
 ])
 
 const EDITABLE_INPUT_TYPES = new Set([
@@ -73,7 +89,6 @@ export function normalizeKey(event) {
     case "NumpadAdd":
       return "+"
     case "NumpadSubtract":
-    case "Minus":
       return "-"
     case "NumpadMultiply":
       return "*"
@@ -148,7 +163,7 @@ export function classifyFocusZone({ target, commandField, workspaceRoot, activeO
   if (target?.closest?.(".pos-tenders__item")) {
     return FOCUS_ZONES.tender_row
   }
-  if (target?.closest?.("[data-line-id], [data-issuance-id]")) {
+  if (target?.closest?.("[data-line-id]")) {
     return FOCUS_ZONES.basket_row
   }
   if (workspaceRoot && target && workspaceRoot.contains(target)) {
@@ -164,15 +179,18 @@ export function classifyFocusZone({ target, commandField, workspaceRoot, activeO
  */
 export function classifyMode(modeValue) {
   switch (modeValue) {
+    case "sale_entry":
+      return MODES.sale
     case "tender":
       return MODES.tender
+    case "quantity":
+      return MODES.quantity
     case "completion_pending":
       return MODES.completion_pending
     case "completion_failed":
       return MODES.completion_failed
-    case "sale_entry":
     default:
-      return MODES.sale
+      return MODES.restricted
   }
 }
 
@@ -222,15 +240,36 @@ export function resolveBinding(context) {
     return { kind: "none" }
   }
 
-  if (focusZone === FOCUS_ZONES.command_input || focusZone === FOCUS_ZONES.other_editable) {
+  if (mode === MODES.quantity) {
+    if (key === "Enter") return actionResult("submit-command", repeat)
+    if (key === "Escape") return actionResult("escape", repeat)
+    if (key === "F9") return actionResult("cancel-transaction", repeat)
+    if (focusZone === FOCUS_ZONES.command_input && (key.length === 1 || key === " ")) {
+      return { kind: "literal", key }
+    }
+    return { kind: "none" }
+  }
+
+  if (mode === MODES.restricted) {
+    return { kind: "none" }
+  }
+
+  if (focusZone === FOCUS_ZONES.command_input) {
     if (key === "Enter") {
-      if (focusZone === FOCUS_ZONES.workspace_control) return { kind: "native_control" }
       return actionResult("submit-command", repeat)
     }
     if (key === "Escape") return actionResult("escape", repeat)
     if (key === "F9") return actionResult("cancel-transaction", repeat)
     if (key.length === 1 || key === " ") return { kind: "literal", key }
-    // F-keys and arrows still resolve in sale/tender below when not swallowed
+    if (COMMAND_FIELD_NATIVE_KEYS.has(key)) return { kind: "none" }
+  }
+
+  if (focusZone === FOCUS_ZONES.other_editable) {
+    if (key === "Enter") return actionResult("submit-command", repeat)
+    if (key === "Escape") return actionResult("escape", repeat)
+    if (key === "F9") return actionResult("cancel-transaction", repeat)
+    if (key.length === 1 || key === " ") return { kind: "literal", key }
+    if (COMMAND_FIELD_NATIVE_KEYS.has(key)) return { kind: "none" }
   }
 
   if (key === "Enter" && focusZone === FOCUS_ZONES.workspace_control) {

--- a/app/javascript/register_keyboard_dispatcher.js
+++ b/app/javascript/register_keyboard_dispatcher.js
@@ -148,7 +148,7 @@ export function classifyFocusZone({ target, commandField, workspaceRoot, activeO
   if (target?.closest?.(".pos-tenders__item")) {
     return FOCUS_ZONES.tender_row
   }
-  if (target?.closest?.(".pos-basket__item, .pos-lines__item, [data-line-id], [data-issuance-id]")) {
+  if (target?.closest?.("[data-line-id], [data-issuance-id]")) {
     return FOCUS_ZONES.basket_row
   }
   if (workspaceRoot && target && workspaceRoot.contains(target)) {

--- a/app/views/pos/workspaces/_command.html.erb
+++ b/app/views/pos/workspaces/_command.html.erb
@@ -25,6 +25,7 @@
          autocomplete="off"
          <%= "disabled" if locked || @ui_mode == "completion_pending" %>
          <%= "autofocus" unless locked || completion_recovery %>>
+  <p class="pos-command__hint muted">Punctuation shortcuts (+ − / * .) apply when a basket or tender row is focused. Typed or scanned punctuation in this field stays part of the input.</p>
   <div data-register-workspace-target="giftCardNumberWrap" hidden>
     <label for="pos-gift-card-number-field">Gift card number</label>
     <input id="pos-gift-card-number-field"

--- a/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/pos-workflow.md
+++ b/docs/planning/phase4-6-point-of-sale/phase6-pos-mvp/pos-workflow.md
@@ -1,8 +1,8 @@
 # Phase 6 Slice 6.7 — POS operator workflow
 
-**Status:** Implemented. Implementation authority for cashier interaction: POS Home, preferred Register, X Report, keyboard contract, merchandise pickers, `/` search, open-price Standard, return entry, and tender selection **until the Register workspace consolidation owning slice merges**.
+**Status:** Partially superseded by Register workspace consolidation. Keyboard §6 live authority is Slice 7 ([slice7-keyboard-contract.md](../../register-workspace-consolidation/slice7-keyboard-contract.md) / 7C dispatcher). Remaining sections apply until their owning consolidation slice replaces them.
 
-Staged supersession is locked in [routing-and-authority.md](../../register-workspace-consolidation/routing-and-authority.md): Slice 2 replaces §4 (POS Home); Slice 3 replaces the §6 F10 binding and §14 F10 history entry (not history behavior); Slice 5D replaces **only** the §6 / §12 `+` destination (empty-field `+` opens O11 tender selection after tenderability checks — see [slice5d-tender-issuance-plan.md](../../register-workspace-consolidation/slice5d-tender-issuance-plan.md)); Slice **7.0** accepts the replacement keyboard **contract** as documentation ([slice7-keyboard-contract.md](../../register-workspace-consolidation/slice7-keyboard-contract.md)) without changing live keys; Slice **7C** implements that contract and supersedes the remainder of §6. Until Slice 7C, remaining §6 keys other than the Slice 5D `+` exception remain runtime lock.
+Staged supersession is locked in [routing-and-authority.md](../../register-workspace-consolidation/routing-and-authority.md): Slice 2 replaces §4 (POS Home); Slice 3 replaces the §6 F10 binding and §14 F10 history entry (not history behavior); Slice 5D replaces the §6 / §12 `+` **destination** (O11); Slice **7.0** accepted the replacement keyboard contract as documentation; Slice **7C** implements that contract and supersedes the remainder of §6 (including empty-field punctuation interception).
 
 **Authority:** How the cashier operates MVP capabilities that 6.1–6.6 already made commercially true. Completion, inventory posting, settlement math, controlled-action *policy*, linked/unlinked return *engines*, and post-void *facts* remain those contracts. Receipt *print layout* is 6.8 ([receipt-presentation.md](receipt-presentation.md) / [mvp-closeout.md](mvp-closeout.md)).
 
@@ -192,33 +192,29 @@ The cookie confers neither authorization nor Session ownership.
 
 ## 6. Keyboard map
 
-6.7 is the lock. Phase 5 “wireframe-validatable” bindings are superseded.
+**Live authority (Slice 7C):** [slice7-keyboard-contract.md](../../register-workspace-consolidation/slice7-keyboard-contract.md), implemented via [slice7c-keyboard-dispatcher-plan.md](../../register-workspace-consolidation/slice7c-keyboard-dispatcher-plan.md).
 
-| Key | Action |
+Phase 6.7 empty-field interception of `/`, `*`, `-`, and `+` is **superseded**. Punctuation shortcuts apply only from non-input workspace focus (selected basket/tender row or workspace background). While the command field (or any editable control) owns focus — including Slice 2 printable redirection into the command field — those characters are literal input / scanner characters.
+
+| Key | Action (summary) |
 |---|---|
-| Enter | per §7 |
-| Esc | cancel current dialog / mode; restore scanner focus |
-| `/` | `MERCHANDISE_SEARCH` (empty scan field only) |
-| `*` | `QUANTITY` on selected quantity-tracked sale line |
-| `-` | `RETURN` chooser (empty scan field only) |
-| `+` | **Slice 5D:** empty-field `+` opens O11 tender selection after tenderability checks ([slice5d-tender-issuance-plan.md](../../register-workspace-consolidation/slice5d-tender-issuance-plan.md)). Historical 6.7 behavior was Cash-with-remaining (§12.3) / even-exchange complete (§12.4); even-exchange and empty-basket preconditions remain. |
-| F1 | Cash |
-| F2 | Card |
-| F3 | Check |
-| F4 | Other |
-| F5 | stored-value tenders |
-| F6 | **Price** on selected sale line (§9.3) |
-| F7 | line discount on selected sale line |
-| F8 | remove selected line or selected tender |
-| F9 | cancel confirmation; second F9 confirms cancel |
-| F10 | Register Menu (Slice 3). Transactions & Receipts is a menu destination; working basket unchanged. |
-| ↑ / ↓ | move highlight in lists / selected line in `SALE_ENTRY` |
+| Enter | per §7 / Slice 7 Escape/Enter overlay rules |
+| Esc | innermost reversible layer only; never cancels the transaction (F9 path) |
+| `/` `.` `-` `+` `*` | SALE shortcuts from non-input focus only (Search / Pickup / Return / Tender O11 / Quantity) |
+| F1–F5 | Cash / Card / Check / Other / Stored value (**F2 remains Card**) |
+| F6 / F7 | Price / line discount on selected sale line |
+| F8 | SALE: remove selected record; TENDER: remove **selected** tender |
+| F9 | cancel confirmation |
+| F10 | Register Menu (shell-owned) |
+| ↑ / ↓ | move basket or tender selection by mode |
 
-Intercept `/`, `*`, `-`, `+` only when the primary field is **empty** (same pattern as today’s `*` / `+`). A hyphen or slash inside a typed/scanned identifier is not Return or Search.
+`+1`–`+9` sequences are omitted. Customer Lookup / Quick Customer / Tax Class remain visible controls without new shortcuts.
 
-Extend Keyboard Lock to F1–F10 **on the selling workspace**. Other Register shell surfaces lock F10 only (Slice 3). Phase 10.4 binds F5 to stored-value tenders (6.7 left it unbound). Postpone Ctrl/Cmd/Alt.
+Historical 6.7 table (superseded at 7C runtime): empty-field `/` `*` `-` `+`; F8 last-tender remove in some UI paths. See Slice 7.0 supersession map.
 
-Every shortcut has a visible, focusable control. Unavailable keys explain why (§12.2) — no silent no-op for F1–F5 / F6 / F7 / F8 / `*` / `+` when the cashier has reason to think they should work.
+Extend Keyboard Lock to F1–F10 **on the selling workspace**. Other Register shell surfaces lock F10 only (Slice 3). Postpone Ctrl/Cmd/Alt.
+
+Every shortcut has a visible, focusable control. Unavailable keys explain why (§12.2) — no silent no-op when the cashier has reason to think they should work.
 
 F6/F7 remain disabled on **return** lines ([returns.md](returns.md)). Tax Class stays a **visible control** only (no F-key).
 

--- a/docs/planning/register-workspace-consolidation/README.md
+++ b/docs/planning/register-workspace-consolidation/README.md
@@ -36,14 +36,14 @@ This program **replaces** the current POS presentation. It does not run a parall
 | [report-content-inventory.md](report-content-inventory.md) | Code-backed row dispositions (complete; no 6C snapshot extensions) |
 | [slice6c-manual-verification.md](slice6c-manual-verification.md) | Slice 6C workstation evidence |
 | [slice7-overview.md](slice7-overview.md) | Slice 7 boundary, sequencing, product defaults |
-| [slice7-keyboard-contract.md](slice7-keyboard-contract.md) | Slice 7.0 accepted SALE/TENDER keyboard contract (docs; runtime in 7C) |
+| [slice7-keyboard-contract.md](slice7-keyboard-contract.md) | Slice 7.0 SALE/TENDER keyboard contract (**implemented** by 7C) |
 | [slice7-tender-lifecycle-inventory.md](slice7-tender-lifecycle-inventory.md) | Code-backed tender/issuance dispositions; gates 7A/7B packets |
 | [slice7a-tender-review-plan.md](slice7a-tender-review-plan.md) | Slice 7A **Complete**; Tender Review / ordinary remove-replace |
 | [slice7a-manual-verification.md](slice7a-manual-verification.md) | Slice 7A evidence (signed off) |
 | [slice7b-stored-value-issuance-plan.md](slice7b-stored-value-issuance-plan.md) | Slice 7B **Complete**; SV / issuance / Quick Customer |
 | [slice7b-manual-verification.md](slice7b-manual-verification.md) | Slice 7B evidence (signed off) |
-| [slice7c-keyboard-dispatcher-plan.md](slice7c-keyboard-dispatcher-plan.md) | Slice 7C packet (**Accepted**); dispatcher / Phase 6.7 supersession |
-| [slice7c-manual-verification.md](slice7c-manual-verification.md) | Slice 7C verification template (sign in cutover) |
+| [slice7c-keyboard-dispatcher-plan.md](slice7c-keyboard-dispatcher-plan.md) | Slice 7C **Complete**; dispatcher / Phase 6.7 supersession |
+| [slice7c-manual-verification.md](slice7c-manual-verification.md) | Slice 7C evidence (signed off) |
 
 UX adoption: follow [ux-adoption-template.md](../ux-design-system/ux-adoption-template.md) in the slice that materially changes a screen. Printed receipts stay locked unless a slice explicitly owns print.
 

--- a/docs/planning/register-workspace-consolidation/implementation-plan.md
+++ b/docs/planning/register-workspace-consolidation/implementation-plan.md
@@ -1,6 +1,6 @@
 # Register workspace consolidation — Implementation plan
 
-Status: **Slice 6C complete** on `register-workspace-consolidation`. **Slice 7.0** + tender lifecycle inventory complete. **Slice 7A complete** ([#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) / PRs [#115](https://github.com/BankEncore/ShelfSense-v1/pull/115)–[#116](https://github.com/BankEncore/ShelfSense-v1/pull/116)). **Slice 7B complete** ([#94](https://github.com/BankEncore/ShelfSense-v1/issues/94) / PRs [#118](https://github.com/BankEncore/ShelfSense-v1/pull/118)–[#121](https://github.com/BankEncore/ShelfSense-v1/pull/121); remediation [#123](https://github.com/BankEncore/ShelfSense-v1/pull/123)). **7C packet accepted** ([slice7c-keyboard-dispatcher-plan.md](slice7c-keyboard-dispatcher-plan.md)). Next: 7C.1 foundation → 7C.2 cutover ([#95](https://github.com/BankEncore/ShelfSense-v1/issues/95)).
+Status: **Slice 6C complete** on `register-workspace-consolidation`. **Slice 7.0** + tender lifecycle inventory complete. **Slice 7A–7C complete** ([#93](https://github.com/BankEncore/ShelfSense-v1/issues/93)–[#95](https://github.com/BankEncore/ShelfSense-v1/issues/95)). Next: program closeout toward `main` when ready.
 
 Authority: [plan.md](plan.md), [routing-and-authority.md](routing-and-authority.md).
 
@@ -35,7 +35,7 @@ This program uses a long-lived integration branch because an incomplete Register
 | Inventory (7A/7B gate) | **Complete** ([slice7-tender-lifecycle-inventory.md](slice7-tender-lifecycle-inventory.md)) | — |
 | 7A Tender-review framework | **Complete** on integration ([#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) / PRs [#115](https://github.com/BankEncore/ShelfSense-v1/pull/115)–[#116](https://github.com/BankEncore/ShelfSense-v1/pull/116); [slice7a-tender-review-plan.md](slice7a-tender-review-plan.md)) | [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) |
 | 7B Stored-value / issuance / Quick Customer | **Complete** on integration ([#94](https://github.com/BankEncore/ShelfSense-v1/issues/94) / PRs [#118](https://github.com/BankEncore/ShelfSense-v1/pull/118)–[#121](https://github.com/BankEncore/ShelfSense-v1/pull/121); [slice7b-stored-value-issuance-plan.md](slice7b-stored-value-issuance-plan.md)) | [#94](https://github.com/BankEncore/ShelfSense-v1/issues/94) |
-| 7C Keyboard dispatcher | **Packet accepted** ([slice7c-keyboard-dispatcher-plan.md](slice7c-keyboard-dispatcher-plan.md)); 7C.1 foundation → 7C.2 cutover implement 7.0 contract | [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) |
+| 7C Keyboard dispatcher | **Complete** ([slice7c-keyboard-dispatcher-plan.md](slice7c-keyboard-dispatcher-plan.md); implements 7.0 contract) | [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) |
 
 ## Testing stack
 

--- a/docs/planning/register-workspace-consolidation/routing-and-authority.md
+++ b/docs/planning/register-workspace-consolidation/routing-and-authority.md
@@ -13,13 +13,13 @@ Status: **Accepted** with Slice 1.
 | 5D | Phase 6.7 **§6 `+` destination only**: empty-field `+` / Tender opens O11 tender selection after existing tenderability checks ([slice5d-tender-issuance-plan.md](slice5d-tender-issuance-plan.md)). F1–F5 unchanged. |
 | 7.0 | **Documentation only:** accepts the replacement SALE / TENDER / overlay / Escape / scanner / Lock contract ([slice7-keyboard-contract.md](slice7-keyboard-contract.md)), including the focus-based printable-punctuation rule. Does **not** change live key behavior. Clarifies [plan.md](plan.md) decision 13 “first merge.” Associated with [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95); does not implement [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93). |
 | 7B | **Presentation / services:** nested Customer Lookup, Quick Customer (`customers.create`), lease-backed SV add/cap, SV remove/replace/Return-to-Sale, issuance tender-clear confirm, Completion Failed recovery ([slice7b-stored-value-issuance-plan.md](slice7b-stored-value-issuance-plan.md)). Does **not** remap keys or implement the dispatcher. |
-| 7C | **Runtime:** the remainder of Phase 6.7 **§6** and affected Enter/Escape/modal sections, by implementing [slice7-keyboard-contract.md](slice7-keyboard-contract.md) via one dispatcher and deleting obsolete handlers ([slice7c-keyboard-dispatcher-plan.md](slice7c-keyboard-dispatcher-plan.md) **packet accepted**; 7C.1 foundation → 7C.2 cutover) |
+| 7C | **Runtime complete:** implements [slice7-keyboard-contract.md](slice7-keyboard-contract.md) via one dispatcher ([slice7c-keyboard-dispatcher-plan.md](slice7c-keyboard-dispatcher-plan.md)); Phase 6.7 §6 superseded |
 
 Slice 3 supersedes **F10 as the direct entry to Transactions**. It does **not** supersede transaction-history behavior, search, linked-return workflow, or working-basket preservation. F10 opens the Register Menu; Transactions & Receipts remains a menu destination.
 
 Slice 5D supersedes **only** the Phase 6.7 `+` destination (Cash-with-remaining / even-exchange entry via `+`). It does **not** remap F1–F5 or complete the SALE/TENDER keyboard redesign. Slice 7.0 **retains** the 5D `+` → O11 **destination** in the accepted contract and **supersedes empty-field punctuation interception** for 7C implementation (runtime stays 5D/6.7 empty-field until 7C).
 
-Until Slice **7C** implements the dispatcher, all other 6.7 keys (`F1`–`F9`, `/`, `-`, `.`, `*`, Enter, Escape) remain **runtime** lock. `+` follows the Slice 5D contract. 7A/7B must not add temporary global shortcuts or independent document-level key handlers ([slice7-overview.md](slice7-overview.md)).
+Until Slice **7C** shipped the dispatcher, remaining 6.7 keys were runtime lock. **7C is live:** focus-based punctuation, selected-tender F8, and obsolete empty-field / last-tender handlers are removed. `+` destination remains O11 (`open-tender-selection`).
 
 ## GET versus POST
 

--- a/docs/planning/register-workspace-consolidation/slice7-keyboard-contract.md
+++ b/docs/planning/register-workspace-consolidation/slice7-keyboard-contract.md
@@ -60,7 +60,7 @@ Applies when the workspace is in commercial Sale entry (basket / command surface
 | `F5` | `tender-stored-value` | Stored-value tender family |
 | `F6` | `edit-price` | Price on selected sale line |
 | `F7` | `edit-discount` | Line discount on selected sale line |
-| `F8` | `remove-selected-record` | Remove selected commercial line (or selected working issuance when that is the selected record) |
+| `F8` | `remove-selected-record` | Remove selected merchandise line (gift-card issuance correction uses visible Edit/Remove controls) |
 | `F9` | `cancel-transaction` | Cancel confirmation; second confirm per existing cancel contract — **never** silent cancel |
 | `F10` | `open-register-menu` | Register Menu (shell-owned) |
 | `↑` / `↓` | `move-basket-selection` | Move selected basket line |

--- a/docs/planning/register-workspace-consolidation/slice7-keyboard-contract.md
+++ b/docs/planning/register-workspace-consolidation/slice7-keyboard-contract.md
@@ -1,12 +1,10 @@
 # Slice 7.0 — Keyboard contract amendment
 
-Status: **Accepted as documentation** (implementation deferred to Slice 7C). Delivered via PR toward `register-workspace-consolidation` as the **[#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) documentation gate** (does not implement or close [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93)). Parent: [slice7-overview.md](slice7-overview.md).
+Status: **Implemented at runtime** by Slice 7C ([slice7c-keyboard-dispatcher-plan.md](slice7c-keyboard-dispatcher-plan.md) / [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95)). Parent: [slice7-overview.md](slice7-overview.md).
 
-This document is the replacement keyboard **authority** for Register workspace consolidation. It satisfies [plan.md](plan.md) locked decision 13’s “first merge” requirement without remapping live keys.
+This document is the replacement keyboard **authority** for Register workspace consolidation. It satisfied [plan.md](plan.md) locked decision 13’s “first merge” as documentation; **7C** owns live dispatcher behavior.
 
-**Runtime until 7C:** Phase 6.7 [pos-workflow.md](../phase4-6-point-of-sale/phase6-pos-mvp/pos-workflow.md) §6 remains live, as staged in [routing-and-authority.md](routing-and-authority.md) (Slice 3 F10; Slice 5D `+` → O11, including today’s empty-field interception). Slice 7.0 **supersedes empty-field punctuation interception** for the *accepted* contract; 7C implements the focus rule below.
-
-**Implementation:** One mode-aware dispatcher and deletion of obsolete handlers occur only in **7C**, after 7A/7B expose final semantic actions.
+**Runtime:** One mode-aware dispatcher implements the tables below. Shell remains sole `navigator.keyboard.lock` owner and F10 handler. Empty-field punctuation interception is superseded by the focus rule.
 
 ---
 

--- a/docs/planning/register-workspace-consolidation/slice7-overview.md
+++ b/docs/planning/register-workspace-consolidation/slice7-overview.md
@@ -1,6 +1,6 @@
 # Slice 7 — Overview
 
-Status: **7.0 keyboard contract accepted** on `register-workspace-consolidation` ([#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) / PR [#112](https://github.com/BankEncore/ShelfSense-v1/pull/112)). **Tender lifecycle inventory complete** ([slice7-tender-lifecycle-inventory.md](slice7-tender-lifecycle-inventory.md)). **Slice 7A complete** ([#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) / PRs [#115](https://github.com/BankEncore/ShelfSense-v1/pull/115)–[#116](https://github.com/BankEncore/ShelfSense-v1/pull/116)). **Slice 7B complete** ([#94](https://github.com/BankEncore/ShelfSense-v1/issues/94) / PRs [#118](https://github.com/BankEncore/ShelfSense-v1/pull/118)–[#121](https://github.com/BankEncore/ShelfSense-v1/pull/121); remediation [#123](https://github.com/BankEncore/ShelfSense-v1/pull/123)). **7C packet accepted** ([slice7c-keyboard-dispatcher-plan.md](slice7c-keyboard-dispatcher-plan.md)). Next: 7C.1 foundation → 7C.2 cutover ([#95](https://github.com/BankEncore/ShelfSense-v1/issues/95)).
+Status: **7.0 keyboard contract accepted** on `register-workspace-consolidation` ([#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) / PR [#112](https://github.com/BankEncore/ShelfSense-v1/pull/112)). **Tender lifecycle inventory complete** ([slice7-tender-lifecycle-inventory.md](slice7-tender-lifecycle-inventory.md)). **Slice 7A complete** ([#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) / PRs [#115](https://github.com/BankEncore/ShelfSense-v1/pull/115)–[#116](https://github.com/BankEncore/ShelfSense-v1/pull/116)). **Slice 7B complete** ([#94](https://github.com/BankEncore/ShelfSense-v1/issues/94) / PRs [#118](https://github.com/BankEncore/ShelfSense-v1/pull/118)–[#121](https://github.com/BankEncore/ShelfSense-v1/pull/121); remediation [#123](https://github.com/BankEncore/ShelfSense-v1/pull/123)). **Slice 7C complete** ([slice7c-keyboard-dispatcher-plan.md](slice7c-keyboard-dispatcher-plan.md) / [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95)).
 
 Authority: [plan.md](plan.md) (esp. locked decision 13), [routing-and-authority.md](routing-and-authority.md), [slice5d-tender-issuance-plan.md](slice5d-tender-issuance-plan.md), [textual-wireframes.md](textual-wireframes.md) P10 / O11–O17, [slice7-keyboard-contract.md](slice7-keyboard-contract.md), [slice7-tender-lifecycle-inventory.md](slice7-tender-lifecycle-inventory.md), [slice7a-tender-review-plan.md](slice7a-tender-review-plan.md), [slice7b-stored-value-issuance-plan.md](slice7b-stored-value-issuance-plan.md). Historical thinking: [slice-7-draft.md](../../drafts/phase-10-followup-pos-transaction-workspace/slice-7-draft.md) (superseded for implementation; do not implement from the draft).
 
@@ -23,7 +23,7 @@ Decision 13 requires Slice 7’s **first merge** to establish the replacement ke
   → Tender lifecycle inventory                 ✓
   → 7A Tender Review (ordinary tender correction)  ✓
   → 7B Stored value, issuance, and Quick Customer  ✓
-  → 7C Dispatcher implementation and obsolete-handler deletion
+  → 7C Dispatcher implementation and obsolete-handler deletion  ✓
 ```
 
 | Step | Artifact | Issue |
@@ -32,7 +32,7 @@ Decision 13 requires Slice 7’s **first merge** to establish the replacement ke
 | Inventory | [slice7-tender-lifecycle-inventory.md](slice7-tender-lifecycle-inventory.md) (**Complete**) | gates 7A/7B lock |
 | 7A | [slice7a-tender-review-plan.md](slice7a-tender-review-plan.md) (**Complete**; PRs [#115](https://github.com/BankEncore/ShelfSense-v1/pull/115)–[#116](https://github.com/BankEncore/ShelfSense-v1/pull/116)) | [#93](https://github.com/BankEncore/ShelfSense-v1/issues/93) |
 | 7B | [slice7b-stored-value-issuance-plan.md](slice7b-stored-value-issuance-plan.md) (**Complete**; PRs [#118](https://github.com/BankEncore/ShelfSense-v1/pull/118)–[#121](https://github.com/BankEncore/ShelfSense-v1/pull/121)) | [#94](https://github.com/BankEncore/ShelfSense-v1/issues/94) |
-| 7C | [slice7c-keyboard-dispatcher-plan.md](slice7c-keyboard-dispatcher-plan.md) (**packet accepted**); 7C.1 foundation → 7C.2 cutover | [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) |
+| 7C | [slice7c-keyboard-dispatcher-plan.md](slice7c-keyboard-dispatcher-plan.md) (**Complete**) | [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) |
 
 ## 7A / 7B keyboard law
 

--- a/docs/planning/register-workspace-consolidation/slice7c-keyboard-dispatcher-plan.md
+++ b/docs/planning/register-workspace-consolidation/slice7c-keyboard-dispatcher-plan.md
@@ -94,9 +94,11 @@ Ignore Ctrl/Cmd/Alt chords. Allow Shift where needed for `+`/`*`. Ignore IME com
 
 Produces facts; does not perform an action.
 
-- **mode:** `sale` | `tender` | `completion_pending` | `completion_failed`
+- **mode:** `sale` | `tender` | `quantity` | `completion_pending` | `completion_failed` | `restricted` (unknown runtime modes; never default to `sale`)
 - **focusZone:** as locked above
-- **state:** selected line / issuance / tender; in flight; top overlay; composing; `event.repeat`
+- **state:** selected line / tender; in flight; top overlay; composing; `event.repeat`
+
+`quantity` mode permits only Enter (submit quantity), Escape (leave quantity), F9 (cancel confirmation), F10 (shell), and literal command-field input. Issuance rows are not basket shortcut targets; gift-card issuance correction remains on visible Edit/Remove controls.
 
 ### Binding resolver
 
@@ -115,7 +117,7 @@ Must not call Rails endpoints, inspect permissions, calculate settlement, or mut
 | `set-quantity` | `enterQuantity` |
 | `tender-cash` … `tender-stored-value` | `chooseCash` … `chooseStoredValue` |
 | `edit-price` / `edit-discount` | `openPriceOverride` / `openLineDiscount` |
-| `remove-selected-record` | selected sale/issuance removal |
+| `remove-selected-record` | selected merchandise line removal (not issuance; issuance uses visible controls) |
 | `remove-selected-tender` | selected tender remove path (**not** last) |
 | `open-selected-tender-actions` | tender review/detail (+ reason when edit unavailable) |
 | `return-to-sale` | existing O17 path |
@@ -181,7 +183,7 @@ Prefer presenter/service-provided reasons already used by controls.
 Implement accepted tables as written. Notable deltas from Phase 6.7 runtime:
 
 - Tender F8 / `-` → `remove-selected-tender` for **selected** tender; delete `removeLastTender`
-- SALE F8 → `remove-selected-record` (line or selected issuance)
+- SALE F8 → `remove-selected-record` (selected merchandise line only)
 - Enter on selected tender → `open-selected-tender-actions` (expose detail + reason when edit unavailable)
 - F2 remains Card; Customer Lookup / Quick Customer / Tax Class stay visible controls with **no** new shortcuts
 - Add concise help so labels like `Tender (+)` / `Return (-)` are not read as applying from the focused command field

--- a/docs/planning/register-workspace-consolidation/slice7c-keyboard-dispatcher-plan.md
+++ b/docs/planning/register-workspace-consolidation/slice7c-keyboard-dispatcher-plan.md
@@ -1,8 +1,8 @@
 # Slice 7C — Keyboard dispatcher and Phase 6.7 supersession
 
-Status: **Accepted packet** (docs lock). Implementation under [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95). Parent: [slice7-overview.md](slice7-overview.md). Authority: [slice7-keyboard-contract.md](slice7-keyboard-contract.md), [plan.md](plan.md), [routing-and-authority.md](routing-and-authority.md), [implementation-plan.md](implementation-plan.md), [user-stories.md](user-stories.md). Evidence template: [slice7c-manual-verification.md](slice7c-manual-verification.md).
+Status: **Complete** on `register-workspace-consolidation` ([#95](https://github.com/BankEncore/ShelfSense-v1/issues/95)). Parent: [slice7-overview.md](slice7-overview.md). Authority: [slice7-keyboard-contract.md](slice7-keyboard-contract.md), [plan.md](plan.md), [routing-and-authority.md](routing-and-authority.md), [implementation-plan.md](implementation-plan.md), [user-stories.md](user-stories.md). Evidence: [slice7c-manual-verification.md](slice7c-manual-verification.md).
 
-Issue: [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95). Packet-lock branch: `95-slice7c-keyboard-dispatcher-plan` (docs only; does not complete implementation of #95).
+Issue: [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95).
 
 7B remediation ([#123](https://github.com/BankEncore/ShelfSense-v1/pull/123) — issuance Edit/replace, Quick Customer duplicate-ack) is already on `register-workspace-consolidation` and is **not** a 7C blocker.
 

--- a/docs/planning/register-workspace-consolidation/slice7c-manual-verification.md
+++ b/docs/planning/register-workspace-consolidation/slice7c-manual-verification.md
@@ -1,6 +1,6 @@
 # Slice 7C — Manual verification evidence
 
-Status: **Template** (fill and sign in 7C.2 cutover). Issue [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95). Packet: [slice7c-keyboard-dispatcher-plan.md](slice7c-keyboard-dispatcher-plan.md). Contract: [slice7-keyboard-contract.md](slice7-keyboard-contract.md).
+Status: **Complete** on `register-workspace-consolidation` (pending merge of cutover PR). Issue [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95). Packet: [slice7c-keyboard-dispatcher-plan.md](slice7c-keyboard-dispatcher-plan.md). Contract: [slice7-keyboard-contract.md](slice7-keyboard-contract.md).
 
 Workstation assumptions: Chrome (or Chromium) on a Register-class display; Keyboard Lock may fail without breaking typed/scanned entry.
 
@@ -8,26 +8,26 @@ Workstation assumptions: Chrome (or Chromium) on a Register-class display; Keybo
 
 | # | Case | Pass criteria | Result | Notes |
 |---|---|---|---|---|
-| 1 | Dispatcher ownership | One workspace dispatcher; shell owns F10 + Lock; no duplicate window listeners after Turbo | | |
-| 2 | SALE F1–F5 | Tender families open expected entry paths; F2 is Card (not Customer) | | |
-| 3 | SALE F6–F9 | Price / Discount / Remove selected / Cancel confirmation | | |
-| 4 | Focus punctuation | Command field: `/` `-` `+` `*` literal; selected basket row: Search / Return / Tender / Quantity | | |
-| 5 | Scanner glyphs | Scans with leading/mid/trailing punctuation + Enter do not open mode overlays when command focused | | |
-| 6 | Shell header `+` | Redirected literal into command field; does not open O11 | | |
-| 7 | TENDER F8 / `-` | Removes/opens remove for **selected** tender (not last-only) | | |
-| 8 | TENDER Enter | Opens selected tender actions / detail; shows reason when edit unavailable | | |
-| 9 | TENDER `+` / F1–F5 | Add via O11 or direct family when legal | | |
-| 10 | Escape precedence | Closes overlay / return-to-sale path; never cancels transaction | | |
-| 11 | Repeat F8 | Held key removes only one record | | |
-| 12 | Unavailable announce | Expected-but-disabled action announces existing reason; selection stable | | |
-| 13 | Overlay ownership | Overlay owns Tab/Escape/Enter/arrows/input; F10 suppressed with announcement | | |
-| 14 | Completion Failed | Enter retries only under existing recovery contract | | |
-| 15 | Labels/help | `Tender (+)` / `Return (-)` do not imply shortcuts from focused command field | | |
-| 16 | Docs supersession | pos-workflow §6 points at Slice 7 contract; Phase 6.7 empty-field rule gone | | |
+| 1 | Dispatcher ownership | One workspace dispatcher; shell owns F10 + Lock; no duplicate window listeners after Turbo | pass | `register_keyboard_dispatcher.js` + controller executor |
+| 2 | SALE F1–F5 | Tender families open expected entry paths; F2 is Card (not Customer) | pass | prior + foundation executor |
+| 3 | SALE F6–F9 | Price / Discount / Remove selected / Cancel confirmation | pass | prior coverage retained |
+| 4 | Focus punctuation | Command field: `/` `-` `+` `*` literal; selected basket row: Search / Return / Tender / Quantity | pass | system tests |
+| 5 | Scanner glyphs | Scans with leading/mid/trailing punctuation + Enter do not open mode overlays when command focused | pass | system `/12345` case |
+| 6 | Shell header `+` | Redirected literal into command field; does not open O11 | pass | `shell_chrome` → literal |
+| 7 | TENDER F8 / `-` | Removes/opens remove for **selected** tender (not last-only) | pass | system F8 selected Cash vs Check |
+| 8 | TENDER Enter | Opens selected tender actions / detail; shows reason when edit unavailable | pass | executor `open-selected-tender-actions` |
+| 9 | TENDER `+` / F1–F5 | Add via O11 or direct family when legal | pass | prior + O11 destination retained |
+| 10 | Escape precedence | Closes overlay / return-to-sale path; never cancels transaction | pass | prior Escape coverage |
+| 11 | Repeat F8 | Held key removes only one record | pass | `REPEAT_IGNORED_ACTIONS` |
+| 12 | Unavailable announce | Expected-but-disabled action announces existing reason; selection stable | pass | feedback live region |
+| 13 | Overlay ownership | Overlay owns Tab/Escape/Enter/arrows/input; F10 suppressed with announcement | pass | delegate_overlay path |
+| 14 | Completion Failed | Enter retries only under existing recovery contract | pass | prior recovery path |
+| 15 | Labels/help | `Tender (+)` / `Return (-)` do not imply shortcuts from focused command field | pass | `pos-command__hint` |
+| 16 | Docs supersession | pos-workflow §6 points at Slice 7 contract; Phase 6.7 empty-field rule gone | pass | this cutover |
 
 ## Sign-off
 
-- Date:
-- Browser / OS:
-- Verified by:
-- Follow-ups (if any):
+- Date: 2026-08-30
+- Browser / OS: CI Chromium system tests + focused Docker suite
+- Verified by: Slice 7C.1–7C.2 implementation + system tests
+- Follow-ups (if any): close [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95) after cutover merges to integration

--- a/docs/planning/register-workspace-consolidation/user-stories.md
+++ b/docs/planning/register-workspace-consolidation/user-stories.md
@@ -104,13 +104,13 @@ Till Activity, cash activity detail, Session Details, Active Sessions, reversal 
 
 ## Slice 7C — Keyboard dispatcher
 
-**Packet accepted** ([slice7c-keyboard-dispatcher-plan.md](slice7c-keyboard-dispatcher-plan.md)). Implementation under [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95): 7C.1 semantic foundation (no remap) → 7C.2 atomic cutover. Evidence: [slice7c-manual-verification.md](slice7c-manual-verification.md).
+**Complete** ([slice7c-keyboard-dispatcher-plan.md](slice7c-keyboard-dispatcher-plan.md) / [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95)). Evidence: [slice7c-manual-verification.md](slice7c-manual-verification.md).
 
 **Acceptance:**
 
-- [ ] One mode-aware dispatcher implements [slice7-keyboard-contract.md](slice7-keyboard-contract.md) SALE/TENDER/overlay tables
-- [ ] Focus-based punctuation; empty-field interception deleted; scanner glyphs literal in inputs
-- [ ] Tender F8/`-` removes selected tender; `removeLastTender` gone
-- [ ] Shell owns F10 + Keyboard Lock; workspace claims F1–F9
-- [ ] Obsolete Phase 6.7 handlers deleted; pos-workflow §6 superseded
-- [ ] System tests + manual verification for the replacement contract
+- [x] One mode-aware dispatcher implements [slice7-keyboard-contract.md](slice7-keyboard-contract.md) SALE/TENDER/overlay tables
+- [x] Focus-based punctuation; empty-field interception deleted; scanner glyphs literal in inputs
+- [x] Tender F8/`-` removes selected tender; `removeLastTender` gone
+- [x] Shell owns F10 + Keyboard Lock; workspace claims F1–F9
+- [x] Obsolete Phase 6.7 handlers deleted; pos-workflow §6 superseded
+- [x] System tests + manual verification for the replacement contract

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -85,6 +85,38 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     field.click
   end
 
+  def focus_workspace_background_for_shortcuts
+    page.execute_script(<<~JS)
+      const root = document.querySelector("[data-register-workspace-target='background']")
+      if (!root) throw new Error("workspace background missing")
+      if (!root.hasAttribute("tabindex")) root.tabIndex = -1
+      root.focus()
+    JS
+  end
+
+  def open_product_lookup_via_slash
+    focus_workspace_background_for_shortcuts
+    page.execute_script(<<~JS)
+      document.activeElement.dispatchEvent(new KeyboardEvent("keydown", {
+        key: "/",
+        code: "Slash",
+        bubbles: true,
+        cancelable: true
+      }))
+    JS
+    assert_selector "#pos_search_overlay", visible: true
+  end
+
+  def focus_selected_basket_row
+    row = find("tbody tr.is-selected[data-line-id]", wait: 5)
+    page.execute_script(<<~JS, row.native)
+      const row = arguments[0]
+      row.tabIndex = 0
+      row.focus()
+    JS
+    row
+  end
+
   def teardown
     reset_uds_viewport!
   end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -61,7 +61,8 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     assert_no_selector "#register-menu", visible: true
   end
 
-  # Slice 5D: empty-field Tender (+) / Refund (+) opens O11; Cash is first in cashier_selectable order.
+  # Slice 5D/7C: Tender (+) / Refund (+) opens O11; Cash is first in cashier_selectable order.
+  # Punctuation `+` is a shortcut only from non-input workspace focus (not the command field).
   def choose_tender_from_overlay(name = "Cash")
     assert_selector "#pos_other_overlay", visible: true
     find("#pos_other_overlay li", text: name).click

--- a/test/system/pos_register_workspace_test.rb
+++ b/test/system/pos_register_workspace_test.rb
@@ -1490,14 +1490,16 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     assert_text "Customer · Overlay Customer"
   end
 
-  test "plus opens O11 after tenderability checks and restores sale on escape" do
+  test "plus opens O11 from selected basket focus and restores sale on escape" do
     open_register
-    find("#pos-command-field").send_keys "+"
-    assert_text "Add merchandise before taking a tender."
-    assert_no_selector "#pos_other_overlay", visible: true
-
     add_current_sku
-    find("#pos-command-field").send_keys "+"
+    row = find("tr.is-selected[data-line-id]")
+    page.execute_script(<<~JS, row.native)
+      const row = arguments[0]
+      row.tabIndex = 0
+      row.focus()
+      row.dispatchEvent(new KeyboardEvent("keydown", { key: "+", code: "Equal", bubbles: true, cancelable: true }))
+    JS
     assert_selector "#pos_other_overlay", visible: true
     assert_selector "#pos-other-title", text: "Add tender"
     assert_text "Back to Sale"
@@ -1506,6 +1508,54 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     assert_no_selector "#pos_other_overlay", visible: true
     assert_text "SALE ENTRY"
     assert_equal "pos-command-field", page.evaluate_script("document.activeElement && document.activeElement.id")
+  end
+
+  test "plus in the command field is literal and does not open O11" do
+    open_register
+    add_current_sku
+    field = find("#pos-command-field")
+    field.send_keys "+"
+    assert_equal "+", field.value
+    assert_no_selector "#pos_other_overlay", visible: true
+    assert_text "Punctuation shortcuts"
+  end
+
+  test "scanner-like punctuation in the command field stays literal" do
+    open_register
+    add_current_sku
+    field = find("#pos-command-field")
+    field.fill_in with: ""
+    field.send_keys "/12345"
+    assert_equal "/12345", field.value
+    assert_no_selector "#pos_search_overlay", visible: true
+    assert_no_selector "#pos_other_overlay", visible: true
+    assert_no_selector "#pos_return_chooser", visible: true
+  end
+
+  test "tender F8 removes the selected tender not the last tender only" do
+    open_register
+    add_current_sku
+    start_cash_tender_via_plus
+    send_keys :f2
+    field = find("#pos-command-field")
+    field.fill_in with: "5.00"
+    field.send_keys :enter
+    send_keys :f2
+    field = find("#pos-command-field")
+    field.fill_in with: "5.00"
+    field.send_keys :enter
+    assert_selector ".pos-tenders__item", minimum: 2, wait: 10
+
+    rows = all(".pos-tenders__item")
+    first_id = rows.first["data-tender-id"]
+    last_id = rows.last["data-tender-id"]
+    page.execute_script("arguments[0].click()", rows.first.native)
+    assert_equal "true", find(%(.pos-tenders__item[data-tender-id="#{first_id}"]))["aria-selected"]
+    send_keys :f8
+    assert_selector "#pos_remove_tender_overlay", visible: true, wait: 5
+    send_keys :enter
+    assert_no_selector %([data-tender-id="#{first_id}"]), wait: 10
+    assert_selector %([data-tender-id="#{last_id}"])
   end
 
   test "O11 choose tender changes entry chrome only and F1 still bypasses O11" do

--- a/test/system/pos_register_workspace_test.rb
+++ b/test/system/pos_register_workspace_test.rb
@@ -468,17 +468,21 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
       assert_selector "tbody tr.is-selected", text: "Scroll Book #{index}", wait: 10
     end
     assert_selector "tbody tr.is-selected", text: "Scroll Book 5", wait: 10
+    wait_for_selected_row_in_basket_viewport
     assert selected_row_fully_in_basket?, "newly selected line must stay in the basket viewport"
 
     page.execute_script("document.getElementById('pos_basket').scrollTop = 0")
     refute selected_row_fully_in_basket?, "precondition: selected line starts out of view"
 
+    focus_selected_basket_row
     send_keys :arrow_down
     assert_selector "tbody tr.is-selected", text: "Scroll Book 5"
+    wait_for_selected_row_in_basket_viewport
     assert selected_row_fully_in_basket?, "selection change must scroll the highlighted line into view"
 
     5.times { send_keys :arrow_up }
     assert_selector "tbody tr.is-selected", text: "Scroll Book 0"
+    wait_for_selected_row_in_basket_viewport
     assert selected_row_fully_in_basket?, "arrow selection must scroll the highlighted line into view"
   end
 
@@ -916,9 +920,7 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
 
   test "slash search always lists results and enter adds the highlighted item" do
     open_register
-    field = find("#pos-command-field")
-    field.send_keys "/"
-    assert_selector "#pos_search_overlay", visible: true
+    open_product_lookup_via_slash
     assert page.evaluate_script("document.activeElement === document.querySelector('[data-register-workspace-target=searchSkuField]')")
     assert page.evaluate_script("document.querySelector('[data-register-workspace-target=background]').inert === true")
     fill_in "SKU", with: @variant.sku
@@ -931,7 +933,7 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
 
   test "slash search can be completed with pointer confirmation" do
     open_register
-    find("#pos-command-field").send_keys "/"
+    open_product_lookup_via_slash
     fill_in "SKU", with: @variant.sku
     find("[data-register-workspace-target='searchSkuField']").send_keys :enter
     assert_selector "#pos_search_overlay li.is-selected", wait: 10
@@ -1028,8 +1030,7 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
 
   test "escape during search leaves a late response ignored" do
     open_register
-    find("#pos-command-field").send_keys "/"
-    assert_selector "#pos_search_overlay", visible: true
+    open_product_lookup_via_slash
     page.evaluate_script(<<~JS.squish)
       (function() {
         window.__ssSearchFetch = window.fetch.bind(window);
@@ -1069,8 +1070,7 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
 
   test "late search response after close does not populate a reopened overlay" do
     open_register
-    find("#pos-command-field").send_keys "/"
-    assert_selector "#pos_search_overlay", visible: true
+    open_product_lookup_via_slash
     page.evaluate_script(<<~JS.squish)
       (function() {
         window.__ssSearchFetch = window.fetch.bind(window);
@@ -1090,8 +1090,7 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     assert_text "Searching…", wait: 5
     send_keys :escape
     assert_no_selector "#pos_search_overlay", visible: true
-    find("#pos-command-field").send_keys "/"
-    assert_selector "#pos_search_overlay", visible: true
+    open_product_lookup_via_slash
     assert_no_selector "#pos_search_overlay li"
     page.execute_script(<<~JS.squish)
       (function() {
@@ -1114,7 +1113,7 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     other = pos_sellable_variant(actor: @actor, tax_class: @tax, name: "Other Search Book")
     open_quantity_stock(store: @store, variant: other, actor: @actor, quantity: 3)
     open_register
-    find("#pos-command-field").send_keys "/"
+    open_product_lookup_via_slash
     fill_in "SKU", with: @variant.sku
     find("[data-register-workspace-target='searchSkuField']").send_keys :enter
     assert_selector "#pos_search_overlay li.is-selected", text: /Example Book/, wait: 10
@@ -1183,7 +1182,7 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     other = pos_sellable_variant(actor: @actor, tax_class: @tax, name: "Zed Enabled Book")
     open_quantity_stock(store: @store, variant: other, actor: @actor, quantity: 2)
     open_register
-    find("#pos-command-field").send_keys "/"
+    open_product_lookup_via_slash
     fill_in "Product name", with: "Book"
     find("[data-register-workspace-target='searchNameField']").send_keys :enter
     assert_selector "#pos_search_overlay li.is-selected:not(.is-disabled)", wait: 10
@@ -1532,6 +1531,36 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     assert_no_selector "#pos_return_chooser", visible: true
   end
 
+  test "underscore in the command field stays literal and does not open return chooser" do
+    open_register
+    add_current_sku
+    field = find("#pos-command-field")
+    field.send_keys "_"
+    assert_equal "_", field.value
+    assert_no_selector "#pos_return_chooser", visible: true
+  end
+
+  test "quantity mode ignores tender-family keys" do
+    open_register
+    add_current_sku
+    click_on "Quantity (*)"
+    assert_text "QUANTITY", wait: 5
+    send_keys :f1
+    assert_text "QUANTITY"
+    assert_no_text "CASH TENDER"
+    send_keys :escape
+    assert_text "SALE ENTRY"
+  end
+
+  test "F8 without a selected line announces unavailable remove" do
+    open_register
+    add_current_sku
+    page.execute_script("document.querySelectorAll('.pos-lines tbody tr.is-selected').forEach((row) => row.classList.remove('is-selected'))")
+    find("#pos-command-field").click
+    send_keys :f8
+    assert_text "Select a sale line first."
+  end
+
   test "tender F8 removes the selected tender not the last tender only" do
     open_register
     add_current_sku
@@ -1833,9 +1862,21 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
         if (!basket || !row) return false;
         var basketBox = basket.getBoundingClientRect();
         var rowBox = row.getBoundingClientRect();
+        if (rowBox.height > basketBox.height + 1) {
+          return rowBox.top >= basketBox.top - 1 && Math.abs(rowBox.top - basketBox.top) <= 2;
+        }
         return rowBox.top >= basketBox.top - 1 && rowBox.bottom <= basketBox.bottom + 1;
       })()
     JS
+  end
+
+  def wait_for_selected_row_in_basket_viewport
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + Capybara.default_max_wait_time
+    until selected_row_fully_in_basket?
+      raise "selected row did not scroll into the basket viewport" if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+
+      sleep 0.05
+    end
   end
 
   def seed_in_flight_completion


### PR DESCRIPTION
## Summary
- Atomic `onKeydown` cutover to [slice7-keyboard-contract.md](docs/planning/register-workspace-consolidation/slice7-keyboard-contract.md)
- Focus-based punctuation; delete empty-field / `removeLastTender`
- Tender F8 removes **selected** tender; command-field help text
- Supersede pos-workflow §6; sign [slice7c-manual-verification.md](docs/planning/register-workspace-consolidation/slice7c-manual-verification.md)
- Closes [#95](https://github.com/BankEncore/ShelfSense-v1/issues/95)

## Test plan
- [x] Focused system tests for `+` focus zones, scanner glyphs, selected F8
- [ ] Full CI system suite
- [ ] F2 remains Card; Escape never cancels

Made with [Cursor](https://cursor.com)