### PR TITLE
Revamp thermal customer receipts and gift-card vouchers (D1/D2)

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -172,6 +172,8 @@
   --font-serif: "Source Serif 4", Georgia, "Times New Roman", serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
   --font-receipt: "Inconsolata", "Courier New", Courier, ui-monospace, monospace;
+  --font-thermal-body: "Noto Sans Mono", "Cascadia Code", "Consolas", "SF Mono", "Segoe UI Mono", sans-serif;
+  --font-thermal-display: "Plus Jakarta Sans", "Source Sans 3", system-ui, sans-serif;
 }
 
 *,
@@ -2081,7 +2083,7 @@ body.is-authorized-print .pos-shift-end-tape {
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
-  font-family: var(--font-receipt);
+  font-family: var(--font-thermal-body);
   font-weight: 700;
 }
 
@@ -2516,7 +2518,218 @@ body.is-authorized-print .pos-shift-end-tape {
   align-items: center;
 }
 
-.pos-receipt__print,
+/* Thermal customer documents (D1 + D2) — docs/planning/receipts-and-reports-revamp/visual-system.md */
+.pos-receipt__print.pos-thermal,
+.pos-gift-card-voucher.pos-thermal {
+  font-family: var(--font-thermal-body);
+  font-weight: 400;
+  font-size: 11px;
+  line-height: 1.35;
+  font-variant-numeric: slashed-zero tabular-nums;
+  color: #000;
+}
+
+.pos-thermal__display {
+  font-family: var(--font-thermal-display);
+}
+
+.pos-thermal__center {
+  text-align: center;
+}
+
+.pos-thermal__divider-solid {
+  border-bottom: 2px solid #000;
+  margin: 6px 0;
+}
+
+.pos-thermal__divider-dashed {
+  border-bottom: 1px dashed #000;
+  margin: 6px 0;
+}
+
+.pos-thermal__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5em;
+  width: 100%;
+}
+
+.pos-thermal__row--bold,
+.pos-thermal__amount--bold {
+  font-weight: 700;
+}
+
+.pos-thermal__column-header {
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.pos-thermal__store-name {
+  font-size: 16px;
+  font-weight: 800;
+  letter-spacing: 0.5px;
+  margin-bottom: 2px;
+}
+
+.pos-thermal__store-address {
+  font-size: 10px;
+  margin-bottom: 2px;
+}
+
+.pos-thermal__status {
+  font-weight: 700;
+  font-size: 12px;
+  margin: 4px 0;
+}
+
+.pos-thermal__meta {
+  font-size: 10px;
+  margin-bottom: 4px;
+}
+
+.pos-thermal__meta-note {
+  font-size: 10px;
+  margin: 2px 0;
+}
+
+.pos-thermal__item-block {
+  margin-bottom: 6px;
+  break-inside: avoid;
+}
+
+.pos-thermal__item-title {
+  font-weight: 600;
+  font-size: 11px;
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.pos-thermal__item-meta {
+  font-size: 9.5px;
+  padding-left: 8px;
+  margin: 1px 0;
+}
+
+.pos-thermal__badge {
+  display: inline-block;
+  font-size: 8.5px;
+  font-weight: 700;
+  padding: 1px 4px;
+  border: 1px solid #000;
+  background: transparent;
+  text-transform: uppercase;
+}
+
+.pos-thermal__section-title {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  margin: 6px 0 2px;
+}
+
+.pos-thermal__amount {
+  font-weight: 700;
+  white-space: nowrap;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.pos-thermal__tax-indicator {
+  font-size: 9px;
+  font-weight: 700;
+}
+
+.pos-thermal__tax-row {
+  font-size: 10px;
+}
+
+.pos-thermal__total-banner {
+  font-size: 15px;
+  font-weight: 800;
+  padding: 4px 0;
+  border-top: 2px solid #000;
+  border-bottom: 2px solid #000;
+  margin: 8px 0;
+}
+
+.pos-thermal__savings-box {
+  border: 1px dashed #000;
+  padding: 4px;
+  text-align: center;
+  font-weight: 700;
+  margin: 8px 0;
+}
+
+.pos-thermal__barcode {
+  margin-top: 10px;
+}
+
+.pos-thermal__barcode svg {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  height: 52px;
+  margin: 0 auto;
+}
+
+.pos-gift-card-voucher .pos-thermal__barcode svg {
+  height: 48px;
+  margin: 0 auto 0.35em;
+}
+
+.pos-thermal__barcode-text {
+  font-size: 9.5px;
+  margin-top: 2px;
+}
+
+.pos-thermal__message {
+  white-space: pre-wrap;
+  font-size: 10px;
+  margin: 8px 0;
+}
+
+.pos-thermal__error {
+  font-weight: 700;
+}
+
+.pos-thermal__voucher-meta {
+  font-size: 10px;
+  margin: 0.6em 0 1.1em;
+}
+
+.pos-thermal__voucher-amount {
+  font-size: 22px;
+  font-weight: 800;
+  line-height: 1.05;
+  margin: 0.9em 0 0.25em;
+}
+
+.pos-thermal__voucher-title {
+  font-size: 16px;
+  font-weight: 800;
+  margin: 0 0 1.1em;
+}
+
+.pos-thermal__voucher-number {
+  font-size: 10px;
+  word-break: break-word;
+  margin-top: 2px;
+}
+
+.pos-thermal__voucher-footer {
+  display: block;
+  width: 100%;
+  font-size: 9pt;
+  line-height: 1.3;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  margin: 1.2em 0 0;
+}
+
+.pos-receipt__print:not(.pos-thermal),
 .pos-report-print {
   font-family: var(--font-receipt);
   font-weight: 700;
@@ -2710,7 +2923,19 @@ body.is-authorized-print .pos-shift-end-tape {
     color: #000;
   }
 
-  .pos-receipt__print,
+  .pos-receipt__print.pos-thermal,
+  .pos-gift-card-voucher.pos-thermal {
+    font-family: var(--font-thermal-body);
+    font-weight: 400;
+    color: #000;
+    font-size: 11px;
+    line-height: 1.35;
+    font-variant-numeric: slashed-zero tabular-nums;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  .pos-receipt__print:not(.pos-thermal),
   .pos-report-print {
     font-family: var(--font-receipt);
     font-weight: 700;
@@ -2722,7 +2947,20 @@ body.is-authorized-print .pos-shift-end-tape {
     print-color-adjust: exact;
   }
 
-  .pos-gift-card-voucher {
+  .pos-gift-card-voucher.pos-thermal {
+    text-align: center;
+  }
+
+  .pos-gift-card-voucher.pos-thermal .pos-gift-card-voucher__card {
+    padding-bottom: 10mm;
+  }
+
+  .pos-gift-card-voucher.pos-thermal .pos-gift-card-voucher__card + .pos-gift-card-voucher__card {
+    break-before: page;
+    page-break-before: always;
+  }
+
+  .pos-gift-card-voucher:not(.pos-thermal) {
     font-family: var(--font-receipt);
     font-weight: 700;
     color: #000;
@@ -2866,6 +3104,16 @@ body.is-authorized-print .pos-shift-end-tape {
     justify-content: space-between;
     gap: 0.5em;
     width: 100%;
+  }
+
+  .pos-thermal__barcode svg {
+    width: 100%;
+    max-width: 100%;
+    height: 52px;
+  }
+
+  .pos-gift-card-voucher .pos-thermal__barcode svg {
+    height: 48px;
   }
 
   .pos-receipt__print .pos-receipt__barcode svg {

--- a/app/helpers/pos_helper.rb
+++ b/app/helpers/pos_helper.rb
@@ -61,6 +61,12 @@ module PosHelper
     Pos::Code128.svg(payload).html_safe
   end
 
+  def pos_tax_group_summary_label(group)
+    rate = number_with_precision(group.rate_percent, precision: 3)
+    basis = format_money_cents(group.basis_cents.abs)
+    "[#{group.letter}] #{group.name} (#{rate}% on #{basis})"
+  end
+
   def pos_receipt_print_header(transaction)
     Pos::ReceiptIdentity.header(
       store_number: transaction.store_number_snapshot,

--- a/app/javascript/controllers/pos_receipt_controller.js
+++ b/app/javascript/controllers/pos_receipt_controller.js
@@ -86,10 +86,11 @@ export default class extends Controller {
   async prepareFonts() {
     if (document.fonts && document.fonts.load) {
       try {
-        await document.fonts.load('700 12px "Inconsolata"')
+        await document.fonts.load('700 11px "Noto Sans Mono"')
+        await document.fonts.load('800 16px "Plus Jakarta Sans"')
         await document.fonts.ready
       } catch (_error) {
-        // Print with the stack fallback if the local face is unavailable.
+        // Print with the stack fallback if the Google Font is unavailable.
       }
     }
   }

--- a/app/services/pos/code128.rb
+++ b/app/services/pos/code128.rb
@@ -33,12 +33,11 @@ module Pos
     def svg(module_width: 1, height: 40)
       bits = bar_widths
       quiet = 10 * module_width
-      content_width = bits.sum * module_width
-      width = content_width + (quiet * 2)
+      width = (bits.sum * module_width) + (quiet * 2)
       x = quiet
       bars = +""
-      bits.each_with_index do |w, index|
-        bar_width = w * module_width
+      bits.each_with_index do |units, index|
+        bar_width = units * module_width
         bars << %(<rect x="#{x}" y="0" width="#{bar_width}" height="#{height}"/>) if index.even?
         x += bar_width
       end

--- a/app/services/pos/customer_receipt.rb
+++ b/app/services/pos/customer_receipt.rb
@@ -5,29 +5,40 @@ module Pos
     MISSING_LEGAL_NAME = "This Store cannot print a customer receipt until its legal name is configured."
     LETTERS = ("A".."Z").to_a.freeze
 
-    Line = Struct.new(
-      :kind_banner, :identifier, :condition, :description, :amount_cents, :tax_indicators,
-      :quantity, :unit_price_cents, :show_unit_price, :extended_price_cents, :discount_cents,
-      :discount_label, :original_reference, :unlinked, keyword_init: true
+    MerchandiseLine = Struct.new(
+      :kind_banner, :description, :amount_cents, :tax_indicators,
+      :identifier_label, :identifier_value, :condition,
+      :quantity, :unit_price_cents, :show_quantity_detail,
+      :regular_price_cents, :discount_cents, :discount_label,
+      :original_reference, :unlinked, keyword_init: true
+    )
+    StoredValueIssuanceLine = Struct.new(
+      :title, :masked_card, :amount_cents, :activation, keyword_init: true
     )
     TaxGroup = Struct.new(:letter, :name, :rate_percent, :basis_cents, :tax_cents, keyword_init: true)
-    TenderLine = Struct.new(:label, :amount_cents, :presented_cents, :change_cents, keyword_init: true)
-    RemainingBalanceNote = Struct.new(:label, :masked_card, :balance_cents, keyword_init: true)
+    PaymentLine = Struct.new(
+      :label, :amount_cents, :cash_tendered_cents, :cash_applied_cents, :change_cents,
+      :inline_balance_note, keyword_init: true
+    )
+    BalanceNote = Struct.new(:label, :masked_card, :balance_cents, keyword_init: true)
 
     def self.build(transaction)
       new(transaction).tap(&:prepare!)
     end
 
-    attr_reader :transaction, :error, :lines, :tax_groups, :tenders, :remaining_balance_notes
+    attr_reader :transaction, :error, :merchandise_lines, :stored_value_issuances,
+                :tax_groups, :payments, :tender_balance_notes, :issued_balance_notes
 
     def initialize(transaction)
       @transaction = transaction
       @store = transaction.store
       @error = nil
-      @lines = []
+      @merchandise_lines = []
+      @stored_value_issuances = []
       @tax_groups = []
-      @tenders = []
-      @remaining_balance_notes = []
+      @payments = []
+      @tender_balance_notes = []
+      @issued_balance_notes = []
       @indicator_by_key = {}
     end
 
@@ -38,11 +49,26 @@ module Pos
       end
 
       assign_tax_groups!
-      @lines = customer_lines
-      @tenders = customer_tenders
-      @remaining_balance_notes = remaining_balance_notes_for_print
+      @merchandise_lines = build_merchandise_lines
+      @stored_value_issuances = build_stored_value_issuances
+      @payments = build_payments
+      @tender_balance_notes = tender_balance_notes_for_print
+      @issued_balance_notes = issued_balance_notes_for_print
       verify_total!
       self
+    end
+
+    # Backward-compatible alias for tests and callers expecting a single line list.
+    def lines
+      merchandise_lines
+    end
+
+    def tenders
+      payments
+    end
+
+    def remaining_balance_notes
+      tender_balance_notes + issued_balance_notes
     end
 
     def printable?
@@ -64,7 +90,7 @@ module Pos
       locality = [ @store.city.presence, @store.region_code.presence ].compact.join(", ")
       locality = [ locality.presence, @store.postal_code.presence ].compact.join(" ")
       lines << locality.presence
-      lines << @store.phone.presence
+      lines << "Ph: #{@store.phone}" if @store.phone.present?
       lines.compact
     end
 
@@ -78,7 +104,7 @@ module Pos
 
     def completed_at_label
       zone = ActiveSupport::TimeZone[@store.timezone] || ActiveSupport::TimeZone["UTC"]
-      @transaction.completed_at.in_time_zone(zone).strftime("%-d %b %y %-l:%M%P")
+      @transaction.completed_at.in_time_zone(zone).strftime("%-d %b %Y %-l:%M%P")
     end
 
     def identity_header
@@ -87,6 +113,13 @@ module Pos
         register_number: @transaction.register_number_snapshot,
         receipt_sequence: @transaction.receipt_sequence
       )
+    end
+
+    def identity_compact_label
+      store = Pos::ReceiptIdentity.pad(@transaction.store_number_snapshot, 3)
+      register = Pos::ReceiptIdentity.pad(@transaction.register_number_snapshot, 2)
+      trans = Pos::ReceiptIdentity.pad(@transaction.receipt_sequence, 7)
+      "#{store} / #{register} / #{trans}"
     end
 
     def compact_reference
@@ -117,8 +150,16 @@ module Pos
       -(@transaction.return_subtotal_cents - @transaction.return_discount_cents)
     end
 
-    def subtotal_cents
+    def net_merchandise_cents
       merchandise_cents + discounts_cents + returns_cents
+    end
+
+    def activation_issuance_cents
+      stored_value_issuances.select(&:activation).sum(&:amount_cents)
+    end
+
+    def reload_issuance_cents
+      stored_value_issuances.reject(&:activation).sum(&:amount_cents)
     end
 
     def total_tax_cents
@@ -129,26 +170,58 @@ module Pos
       @transaction.signed_net_cents
     end
 
+    def show_merchandise_section?
+      merchandise_lines.any?
+    end
+
+    def show_stored_value_section?
+      stored_value_issuances.any?
+    end
+
+    def show_activation_section?
+      stored_value_issuances.any?(&:activation)
+    end
+
+    def show_reload_section?
+      stored_value_issuances.any? { |line| !line.activation }
+    end
+
     def show_detail_totals?
       @transaction.discount_cents.positive? || @transaction.return_total_cents.positive? ||
-        @transaction.stored_value_issuance_cents.to_i != 0 ||
+        activation_issuance_cents != 0 || reload_issuance_cents != 0 ||
         @transaction.pos_transaction_lines.any?(&:return?)
+    end
+
+    def show_tax_section?
+      tax_groups.any? && total_tax_cents != 0
     end
 
     def refund_total?
       signed_net_cents.negative?
     end
 
+    def even_exchange?
+      signed_net_cents.zero? && show_merchandise_section? &&
+        @transaction.pos_transaction_lines.any?(&:return?)
+    end
+
     def total_label
-      refund_total? ? "REFUND TOTAL" : "TOTAL"
+      return "REFUND TOTAL" if refund_total?
+      return "NET TOTAL" if even_exchange?
+
+      "TOTAL DUE"
     end
 
     def total_display_cents
       signed_net_cents.abs
     end
 
-    def show_tenders?
-      signed_net_cents != 0
+    def show_payments_section?
+      signed_net_cents != 0 && payments.any?
+    end
+
+    def show_issued_balances_section?
+      issued_balance_notes.any?
     end
 
     def items_sold
@@ -157,6 +230,10 @@ module Pos
 
     def items_returned
       ordinary_lines.select(&:return?).sum(&:quantity)
+    end
+
+    def show_item_counts?
+      !post_void_reversal? && (items_sold.positive? || items_returned.positive?)
     end
 
     def you_saved_cents
@@ -203,9 +280,9 @@ module Pos
         ]
       end
 
-      @tax_groups = ordered.each_with_index.map do |(key, members), index|
+      @tax_groups = ordered.each_with_index.map do |(_key, members), index|
         letter = LETTERS.fetch(index)
-        @indicator_by_key[key] = letter
+        @indicator_by_key[[ members.first.last.store_tax_id, members.first.last.rate_percent ]] = letter
         sample = members.first.last
         basis = members.sum { |line, component| signed_amount(line, component.taxable_basis_cents) }
         tax = members.sum { |line, component| signed_amount(line, component.tax_cents) }
@@ -223,52 +300,50 @@ module Pos
       line.return? ? -cents : cents
     end
 
-    def customer_lines
-      @transaction.pos_transaction_lines.map { |line| build_line(line) } + issuance_lines
+    def build_merchandise_lines
+      @transaction.pos_transaction_lines.map { |line| build_merchandise_line(line) }
     end
 
-    def issuance_lines
-      @transaction.pos_stored_value_issuances.ordered.map do |issuance|
-        label = issuance.activation? ? "Gift card activation" : "Gift card reload"
-        masked = issuance.masked_card_snapshot
-        Line.new(
-          kind_banner: nil,
-          identifier: masked.to_s,
-          condition: nil,
-          description: [ label, issuance.gift_card_program&.name, masked ].compact.join(" · "),
-          amount_cents: issuance.post_void_generated? ? -issuance.amount_cents : issuance.amount_cents,
-          tax_indicators: "",
-          quantity: 1,
-          unit_price_cents: issuance.amount_cents,
-          show_unit_price: false,
-          extended_price_cents: issuance.amount_cents,
-          discount_cents: 0,
-          discount_label: nil,
-          original_reference: nil,
-          unlinked: false
-        )
-      end
-    end
-
-    def build_line(line)
+    def build_merchandise_line(line)
       snapshot = line.merchandise_snapshot.is_a?(Hash) ? line.merchandise_snapshot : {}
-      identifier = snapshot["unit_identifier"].presence || snapshot["sku"].presence || ""
-      Line.new(
+      identifier_value = snapshot["unit_identifier"].presence || snapshot["sku"].presence
+      identifier_label =
+        if snapshot["unit_identifier"].present?
+          "Unit"
+        elsif snapshot["sku"].present?
+          "SKU"
+        end
+      has_discount = line.manual_discount_cents.to_i.positive?
+      MerchandiseLine.new(
         kind_banner: line_banner(line),
-        identifier: identifier,
-        condition: used_condition(snapshot),
         description: snapshot["description"].presence || "Description unavailable",
         amount_cents: signed_amount(line, line.net_merchandise_amount_cents),
         tax_indicators: tax_indicators_for(line),
+        identifier_label: identifier_label,
+        identifier_value: identifier_value,
+        condition: used_condition(snapshot),
         quantity: line.quantity,
         unit_price_cents: line.selling_unit_price_cents,
-        show_unit_price: line.quantity > 1 || line.manual_discount_cents.to_i.positive?,
-        extended_price_cents: line.extended_selling_amount_cents,
-        discount_cents: line.manual_discount_cents.to_i.positive? ? -line.manual_discount_cents : 0,
+        show_quantity_detail: line.quantity > 1,
+        regular_price_cents: has_discount ? line.extended_selling_amount_cents : nil,
+        discount_cents: has_discount ? -line.manual_discount_cents : 0,
         discount_label: discount_label(line),
         original_reference: original_reference_for(line),
         unlinked: line.unlinked_return?
       )
+    end
+
+    def build_stored_value_issuances
+      @transaction.pos_stored_value_issuances.ordered.map do |issuance|
+        program_name = issuance.gift_card_program&.name.presence || "Store Gift Card"
+        masked = issuance.masked_card_snapshot
+        StoredValueIssuanceLine.new(
+          title: program_name,
+          masked_card: masked,
+          amount_cents: issuance.post_void_generated? ? -issuance.amount_cents : issuance.amount_cents,
+          activation: issuance.activation?
+        )
+      end
     end
 
     def line_banner(line)
@@ -298,7 +373,7 @@ module Pos
 
       percent = line.manual_discount_basis_points / 100.0
       formatted = (percent % 1).zero? ? percent.to_i.to_s : ActiveSupport::NumberHelper.number_to_rounded(percent, precision: 2)
-      "Discount #{formatted}%:"
+      "Discount (#{formatted}%):"
     end
 
     def original_reference_for(line)
@@ -310,14 +385,31 @@ module Pos
       original.transaction_reference
     end
 
-    def customer_tenders
-      return [] unless show_tenders?
+    def build_payments
+      return [] if signed_net_cents.zero?
 
       @transaction.pos_tenders.sort_by(&:tender_number).map do |tender|
         label = tender.direction == "refund" ? "#{tender.tender_name} Refund" : tender.tender_name
-        presented = pos_cash_payment?(tender) ? tender.amount_presented_cents : nil
-        change = pos_cash_payment?(tender) ? tender.change_cents : nil
-        TenderLine.new(label: label, amount_cents: tender.amount_cents, presented_cents: presented, change_cents: change)
+        inline_balance = inline_balance_note_for_tender(tender)
+        if pos_cash_payment?(tender)
+          PaymentLine.new(
+            label: label,
+            amount_cents: tender.amount_cents,
+            cash_tendered_cents: tender.amount_presented_cents,
+            cash_applied_cents: tender.amount_cents,
+            change_cents: tender.change_cents,
+            inline_balance_note: inline_balance
+          )
+        else
+          PaymentLine.new(
+            label: label,
+            amount_cents: tender.amount_cents,
+            cash_tendered_cents: nil,
+            cash_applied_cents: nil,
+            change_cents: nil,
+            inline_balance_note: inline_balance
+          )
+        end
       end
     end
 
@@ -325,30 +417,64 @@ module Pos
       tender.cash? && tender.direction == "payment"
     end
 
-    def remaining_balance_notes_for_print
+    def inline_balance_note_for_tender(tender)
+      detail = tender.stored_value_tender_detail
+      return if detail.blank?
+
+      balance_cents = balance_after_cents_for_tender(detail)
+      return if balance_cents.nil?
+
+      masked = masked_reference_for_tender(detail)
+      BalanceNote.new(label: balance_label_for_tender(detail), masked_card: masked, balance_cents: balance_cents)
+    end
+
+    def tender_balance_notes_for_print
+      payments.filter_map(&:inline_balance_note)
+    end
+
+    def issued_balance_notes_for_print
       notes = []
       @transaction.pos_stored_value_issuances.ordered.each do |issuance|
         card = issuance.gift_card
         next unless card
 
-        notes << RemainingBalanceNote.new(
-          label: "Remaining balance",
-          masked_card: issuance.masked_card_snapshot.presence || card.masked_number,
-          balance_cents: card.balance_cents
-        )
-      end
-      @transaction.pos_tenders.ordered.each do |tender|
-        detail = tender.stored_value_tender_detail
-        card = detail&.gift_card
-        next unless card
+        balance_cents = balance_after_cents_for_issuance(issuance)
+        next if balance_cents.nil?
 
-        notes << RemainingBalanceNote.new(
-          label: "Remaining balance",
-          masked_card: detail.masked_card_snapshot.presence || card.masked_number,
-          balance_cents: card.balance_cents
+        notes << BalanceNote.new(
+          label: "New Balance",
+          masked_card: issuance.masked_card_snapshot.presence || card.masked_number,
+          balance_cents: balance_cents
         )
       end
       notes
+    end
+
+    def balance_after_cents_for_issuance(issuance)
+      account_id = issuance.gift_card&.stored_value_account_id
+      balance_after_cents_for_operation(issuance.stored_value_operation, account_id)
+    end
+
+    def balance_after_cents_for_tender(detail)
+      account_id = detail.stored_value_account_id || detail.gift_card&.stored_value_account_id
+      balance_after_cents_for_operation(detail.stored_value_operation, account_id)
+    end
+
+    def balance_after_cents_for_operation(operation, account_id)
+      return if operation.blank? || account_id.blank?
+
+      entry = operation.stored_value_entries.find_by(stored_value_account_id: account_id)
+      entry&.balance_after_cents
+    end
+
+    def masked_reference_for_tender(detail)
+      detail.masked_card_snapshot.presence ||
+        detail.gift_card&.masked_number ||
+        "Store Credit"
+    end
+
+    def balance_label_for_tender(detail)
+      detail.new_gift_card? ? "New Balance" : "Remaining Balance"
     end
 
     def verify_total!
@@ -357,7 +483,7 @@ module Pos
         raise Pos::Error, "receipt tax components do not equal persisted tax"
       end
 
-      computed = subtotal_cents + total_tax_cents + @transaction.stored_value_issuance_cents.to_i
+      computed = net_merchandise_cents + total_tax_cents + @transaction.stored_value_issuance_cents.to_i
       return if computed == signed_net_cents
 
       raise Pos::Error, "receipt total does not equal signed_net_cents"

--- a/app/services/pos/customer_receipt.rb
+++ b/app/services/pos/customer_receipt.rb
@@ -236,6 +236,30 @@ module Pos
       !post_void_reversal? && (items_sold.positive? || items_returned.positive?)
     end
 
+    def item_counts_label
+      sold = items_sold.positive?
+      returned = items_returned.positive?
+      if sold && returned
+        "Items Sold / Returned:"
+      elsif sold
+        "Items Sold:"
+      else
+        "Items Returned"
+      end
+    end
+
+    def item_counts_value
+      sold = items_sold.positive?
+      returned = items_returned.positive?
+      if sold && returned
+        "#{items_sold} / #{items_returned}"
+      elsif sold
+        items_sold.to_s
+      else
+        items_returned.to_s
+      end
+    end
+
     def you_saved_cents
       return 0 if @transaction.post_void?
 

--- a/app/services/pos/first_print.rb
+++ b/app/services/pos/first_print.rb
@@ -6,8 +6,18 @@ module Pos
       :kind, :masked_number, :number, :number_prefix, :amount_cents, :program_name, :store, :issued_at,
       keyword_init: true
     ) do
+      RECOVERY_KINDS = %w[print_recovery replacement].freeze
+
       def presented_number
         GiftCards::Number.present(number, prefix: number_prefix)
+      end
+
+      def recovery?
+        RECOVERY_KINDS.include?(kind.to_s)
+      end
+
+      def status_banner
+        recovery? ? "*** REPLACEMENT PRINT COPY ***" : nil
       end
 
       def legal_name
@@ -31,7 +41,7 @@ module Pos
         return if issued_at.blank? || store.blank?
 
         zone = ActiveSupport::TimeZone[store.timezone] || ActiveSupport::TimeZone["UTC"]
-        issued_at.in_time_zone(zone).strftime("%-d %b %y %-l:%M%P")
+        issued_at.in_time_zone(zone).strftime("%-d %b %Y %-l:%M%P")
       end
     end
 

--- a/app/views/admin/gift_cards/credential.html.erb
+++ b/app/views/admin/gift_cards/credential.html.erb
@@ -1,3 +1,6 @@
+<% content_for :head do %>
+  <%= render "pos/receipts/thermal_fonts" %>
+<% end %>
 <% content_for :title, "Print replacement gift card" %>
 <%= render "shared/breadcrumbs", crumbs: [
   { name: "Home", path: root_path },

--- a/app/views/admin/gift_cards/print_recovery.html.erb
+++ b/app/views/admin/gift_cards/print_recovery.html.erb
@@ -1,3 +1,6 @@
+<% content_for :head do %>
+  <%= render "pos/receipts/thermal_fonts" %>
+<% end %>
 <% content_for :title, "Recover gift-card print" %>
 <%= render "shared/breadcrumbs", crumbs: [
   { name: "Home", path: root_path },

--- a/app/views/layouts/pos.html.erb
+++ b/app/views/layouts/pos.html.erb
@@ -6,8 +6,8 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= yield :head %>
+    <%= render "pos/receipts/thermal_fonts" %>
     <%= stylesheet_link_tag "application" %>
-    <%= preload_link_tag "inconsolata-latin-700.woff2", as: :font, type: "font/woff2", crossorigin: "anonymous" %>
     <%= javascript_importmap_tags "pos" %>
   </head>
   <body class="pos-body density-standard">

--- a/app/views/pos/receipts/_gift_card_voucher.html.erb
+++ b/app/views/pos/receipts/_gift_card_voucher.html.erb
@@ -4,28 +4,32 @@
 <% credentials = Array(local_assigns[:credentials]) %>
 <% footer = SystemSettings.current.printed_gift_card_voucher_footer %>
 <% if credentials.any? %>
-  <section class="pos-gift-card-voucher pos-print-only" aria-hidden="true">
+  <section class="pos-gift-card-voucher pos-print-only pos-thermal" aria-hidden="true">
     <% credentials.each do |credential| %>
       <div class="pos-gift-card-voucher__card">
+        <% if credential.status_banner.present? %>
+          <p class="pos-thermal__status pos-thermal__center pos-thermal__display"><%= credential.status_banner %></p>
+        <% end %>
         <% if credential.legal_name.present? %>
-          <div class="pos-gift-card-voucher__store">
-            <p class="pos-gift-card-voucher__legal-name"><%= credential.legal_name %></p>
+          <div class="pos-thermal__center pos-thermal__display">
+            <div class="pos-thermal__store-name"><%= credential.legal_name %></div>
             <% credential.address_lines.each do |line| %>
-              <p><%= line %></p>
+              <div class="pos-thermal__store-address"><%= line %></div>
             <% end %>
           </div>
+          <div class="pos-thermal__divider-solid"></div>
         <% end %>
         <% if credential.issued_at_label.present? %>
-          <p class="pos-gift-card-voucher__issued">Issued: <%= credential.issued_at_label %></p>
+          <p class="pos-thermal__voucher-meta pos-thermal__center">Issued: <%= credential.issued_at_label %></p>
         <% end %>
-        <p class="pos-gift-card-voucher__amount"><%= format_money_cents(credential.amount_cents) %></p>
-        <p class="pos-gift-card-voucher__title">Gift Card</p>
-        <div class="pos-gift-card-voucher__barcode">
+        <p class="pos-thermal__voucher-amount pos-thermal__display pos-thermal__center"><%= format_money_cents(credential.amount_cents) %></p>
+        <p class="pos-thermal__voucher-title pos-thermal__display pos-thermal__center">Gift Card</p>
+        <div class="pos-thermal__barcode pos-gift-card-voucher__barcode pos-thermal__center">
           <%= pos_code128_svg(GiftCards::Number.normalize(credential.number)) %>
-          <p class="pos-gift-card-voucher__number"><%= credential.presented_number %></p>
+          <p class="pos-thermal__voucher-number"><%= credential.presented_number %></p>
         </div>
         <% if footer.present? %>
-          <p class="pos-receipt__message pos-gift-card-voucher__footer"><%= footer %></p>
+          <p class="pos-thermal__voucher-footer pos-thermal__center"><%= footer %></p>
         <% end %>
       </div>
     <% end %>

--- a/app/views/pos/receipts/_print.html.erb
+++ b/app/views/pos/receipts/_print.html.erb
@@ -2,156 +2,40 @@
   locals: transaction:, tenders: nil, reprint: false
 %>
 <% receipt = Pos::CustomerReceipt.build(transaction) %>
-<section class="pos-receipt__print pos-print-only" aria-hidden="true">
+<section class="pos-receipt__print pos-print-only pos-thermal" aria-hidden="true">
   <% unless receipt.printable? %>
-    <p class="pos-receipt__print-error" role="alert"><%= receipt.error %></p>
+    <p class="pos-thermal__error" role="alert"><%= receipt.error %></p>
   <% else %>
-    <% if receipt.post_voided_original? %>
-      <p class="pos-receipt__reprint">*** POST-VOIDED ***</p>
-      <p class="pos-receipt__post-void-note">This transaction has been post-voided and is no longer valid.</p>
-      <p>Post-voided by: <%= receipt.reversing_reference %></p>
-    <% elsif receipt.post_void_reversal? %>
-      <p class="pos-receipt__reprint">*** POST-VOID ***</p>
-      <p>Original: <%= receipt.original_reference %></p>
-    <% end %>
-    <% if local_assigns.fetch(:reprint, false) %>
-      <p class="pos-receipt__reprint">*** REPRINT ***</p>
-    <% end %>
-
-    <div class="pos-receipt__store">
-      <p class="pos-receipt__legal-name"><%= receipt.legal_name %></p>
-      <% receipt.address_lines.each do |line| %>
-        <p class="pos-receipt__address"><%= line %></p>
-      <% end %>
-    </div>
+    <%= render "pos/receipts/thermal/store_header", receipt: receipt %>
 
     <% if receipt.header_message.present? %>
-      <pre class="pos-receipt__message"><%= receipt.header_message %></pre>
+      <pre class="pos-thermal__message pos-thermal__center"><%= receipt.header_message %></pre>
     <% end %>
 
-    <div class="pos-receipt__identity">
-      <p><%= receipt.completed_at_label %></p>
-      <p class="pos-receipt__print-header"><%= receipt.identity_header %></p>
-      <p>Cashier: <%= receipt.cashier_name %></p>
-      <% if receipt.customer_name.present? %>
-        <p>Customer: <%= receipt.customer_name %></p>
-      <% end %>
-    </div>
+    <%= render "pos/receipts/thermal/status", receipt: receipt, reprint: local_assigns.fetch(:reprint, false) %>
 
-    <div class="pos-receipt__print-lines">
-      <% receipt.lines.each do |line| %>
-        <div class="pos-receipt__line-group">
-          <% if line.kind_banner.present? %>
-            <p class="pos-receipt__line-banner"><%= line.kind_banner %></p>
-          <% end %>
-          <p class="pos-receipt__line-main">
-            <span>
-              <%= line.identifier %>
-              <% if line.condition.present? %>
-                <%= line.condition %>
-              <% end %>
-            </span>
-            <span class="pos-receipt__amount">
-              <%= pos_print_amount(line.amount_cents) %>
-              <% if line.tax_indicators.present? %>
-                <%= line.tax_indicators %>
-              <% end %>
-            </span>
-          </p>
-          <div class="pos-receipt__line-rest">
-            <p class="pos-receipt__line-description"><%= line.description %></p>
-            <% if line.quantity > 1 %>
-              <p class="pos-receipt__line-detail"><%= line.quantity %> @ <%= format_money_cents(line.unit_price_cents) %></p>
-            <% elsif line.discount_cents.negative? %>
-              <p class="pos-receipt__line-main">
-                <span>Price:</span>
-                <span class="pos-receipt__amount"><%= pos_print_amount(line.extended_price_cents) %></span>
-              </p>
-            <% end %>
-            <% if line.discount_cents.negative? %>
-              <p class="pos-receipt__line-main">
-                <span><%= line.discount_label %></span>
-                <span class="pos-receipt__amount"><%= pos_print_amount(line.discount_cents) %></span>
-              </p>
-            <% end %>
-            <% if line.unlinked %>
-              <p class="pos-receipt__line-detail">Original receipt: Not provided</p>
-            <% elsif line.original_reference.present? %>
-              <p class="pos-receipt__line-detail">Original: <%= line.original_reference %></p>
-            <% end %>
-          </div>
-        </div>
-      <% end %>
-    </div>
+    <%= render "pos/receipts/thermal/metadata", receipt: receipt %>
 
-    <dl class="pos-receipt__print-totals">
-      <% if receipt.show_detail_totals? %>
-        <% if receipt.merchandise_cents != 0 %>
-          <div><dt>Merchandise</dt><dd><%= pos_print_amount(receipt.merchandise_cents) %></dd></div>
-        <% end %>
-        <% if receipt.discounts_cents != 0 %>
-          <div><dt>Discounts</dt><dd><%= pos_print_amount(receipt.discounts_cents) %></dd></div>
-        <% end %>
-        <% if receipt.returns_cents != 0 %>
-          <div><dt>Returns</dt><dd><%= pos_print_amount(receipt.returns_cents) %></dd></div>
-        <% end %>
-      <% end %>
-      <div><dt>Subtotal</dt><dd><%= pos_print_amount(receipt.subtotal_cents) %></dd></div>
-      <% receipt.tax_groups.each do |group| %>
-        <div class="pos-receipt__tax">
-          <dt>
-            Tax <%= group.letter %>
-            <% if receipt.tax_groups.size > 1 %>
-              (<%= format_money_cents(group.basis_cents) %> @ <%= number_with_precision(group.rate_percent, precision: 3) %>%)
-            <% end %>
-          </dt>
-          <dd><%= pos_print_amount(group.tax_cents) %></dd>
-        </div>
-      <% end %>
-      <% if receipt.tax_groups.size > 1 %>
-        <div><dt>Total Tax</dt><dd><%= pos_print_amount(receipt.total_tax_cents) %></dd></div>
-      <% end %>
-      <div class="pos-receipt__total">
-        <dt><%= receipt.total_label %></dt>
-        <dd><%= pos_print_amount(receipt.total_display_cents) %></dd>
+    <% if receipt.show_merchandise_section? %>
+      <div class="pos-thermal__divider-dashed"></div>
+      <div class="pos-thermal__row pos-thermal__column-header">
+        <span>ITEM DESCRIPTION</span>
+        <span>PRICE</span>
       </div>
-      <% if receipt.show_tenders? %>
-        <% receipt.tenders.each do |tender| %>
-          <div><dt><%= tender.label %></dt><dd><%= pos_print_amount(tender.amount_cents) %></dd></div>
-          <% if tender.presented_cents %>
-            <div><dt>Cash presented</dt><dd><%= pos_print_amount(tender.presented_cents) %></dd></div>
-            <div><dt>Change</dt><dd><%= pos_print_amount(tender.change_cents) %></dd></div>
-          <% end %>
-        <% end %>
-      <% end %>
-      <% receipt.remaining_balance_notes.each do |note| %>
-        <div><dt><%= note.label %> <%= note.masked_card %></dt><dd><%= pos_print_amount(note.balance_cents) %></dd></div>
-      <% end %>
-    </dl>
-
-    <% unless receipt.post_void_reversal? %>
-      <% if receipt.items_sold.positive? || receipt.items_returned.positive? %>
-        <div class="pos-receipt__counts">
-          <% if receipt.items_sold.positive? %>
-            <p>Items Sold: <%= receipt.items_sold %></p>
-          <% end %>
-          <% if receipt.items_returned.positive? %>
-            <p>Items Returned: <%= receipt.items_returned %></p>
-          <% end %>
-        </div>
-      <% end %>
-      <% if receipt.you_saved_cents.positive? %>
-        <p class="pos-receipt__saved">You Saved: <%= format_money_cents(receipt.you_saved_cents) %></p>
-      <% end %>
+      <div class="pos-thermal__divider-dashed"></div>
+      <%= render "pos/receipts/thermal/merchandise_lines", lines: receipt.merchandise_lines %>
     <% end %>
 
-    <div class="pos-receipt__barcode">
-      <%= pos_code128_svg(receipt.compact_reference) %>
-      <p class="pos-receipt__barcode-text"><%= receipt.compact_reference %></p>
-    </div>
+    <%= render "pos/receipts/thermal/issuance_lines", receipt: receipt %>
 
-    <% if receipt.footer_message.present? %>
-      <pre class="pos-receipt__message"><%= receipt.footer_message %></pre>
-    <% end %>
+    <%= render "pos/receipts/thermal/summary", receipt: receipt %>
+
+    <%= render "pos/receipts/thermal/payments", receipt: receipt %>
+
+    <%= render "pos/receipts/thermal/balance_notes", notes: receipt.issued_balance_notes, title: "ISSUED GIFT CARD BALANCES" %>
+
+    <%= render "pos/receipts/thermal/counts_and_savings", receipt: receipt %>
+
+    <%= render "pos/receipts/thermal/barcode_footer", receipt: receipt %>
   <% end %>
 </section>

--- a/app/views/pos/receipts/_thermal_fonts.html.erb
+++ b/app/views/pos/receipts/_thermal_fonts.html.erb
@@ -1,0 +1,3 @@
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+Mono:wght@400;500;600;700&family=Plus+Jakarta+Sans:wght@700;800&display=swap" rel="stylesheet">

--- a/app/views/pos/receipts/thermal/_balance_notes.html.erb
+++ b/app/views/pos/receipts/thermal/_balance_notes.html.erb
@@ -1,0 +1,10 @@
+<% if notes.any? %>
+  <div class="pos-thermal__section-title"><%= title %></div>
+  <% notes.each do |note| %>
+    <div class="pos-thermal__row pos-thermal__balance-row">
+      <span>Card <%= note.masked_card %></span>
+      <span><%= pos_print_amount(note.balance_cents) %></span>
+    </div>
+  <% end %>
+  <div class="pos-thermal__divider-dashed"></div>
+<% end %>

--- a/app/views/pos/receipts/thermal/_barcode_footer.html.erb
+++ b/app/views/pos/receipts/thermal/_barcode_footer.html.erb
@@ -1,0 +1,8 @@
+<div class="pos-thermal__barcode pos-receipt__barcode pos-thermal__center">
+  <%= pos_code128_svg(receipt.compact_reference) %>
+  <p class="pos-thermal__barcode-text"><%= receipt.compact_reference %></p>
+</div>
+
+<% if receipt.footer_message.present? %>
+  <pre class="pos-thermal__message pos-thermal__center pos-thermal__display"><%= receipt.footer_message %></pre>
+<% end %>

--- a/app/views/pos/receipts/thermal/_counts_and_savings.html.erb
+++ b/app/views/pos/receipts/thermal/_counts_and_savings.html.erb
@@ -1,0 +1,13 @@
+<% unless receipt.post_void_reversal? %>
+  <% if receipt.show_item_counts? %>
+    <div class="pos-thermal__row">
+      <span>Items Sold / Returned:</span>
+      <span class="pos-thermal__row--bold"><%= receipt.items_sold %> / <%= receipt.items_returned %></span>
+    </div>
+  <% end %>
+  <% if receipt.you_saved_cents.positive? %>
+    <div class="pos-thermal__savings-box pos-thermal__display pos-thermal__center">
+      YOU SAVED: <%= format_money_cents(receipt.you_saved_cents) %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/pos/receipts/thermal/_counts_and_savings.html.erb
+++ b/app/views/pos/receipts/thermal/_counts_and_savings.html.erb
@@ -1,8 +1,8 @@
 <% unless receipt.post_void_reversal? %>
   <% if receipt.show_item_counts? %>
     <div class="pos-thermal__row">
-      <span>Items Sold / Returned:</span>
-      <span class="pos-thermal__row--bold"><%= receipt.items_sold %> / <%= receipt.items_returned %></span>
+      <span><%= receipt.item_counts_label %></span>
+      <span class="pos-thermal__row--bold"><%= receipt.item_counts_value %></span>
     </div>
   <% end %>
   <% if receipt.you_saved_cents.positive? %>

--- a/app/views/pos/receipts/thermal/_issuance_lines.html.erb
+++ b/app/views/pos/receipts/thermal/_issuance_lines.html.erb
@@ -1,0 +1,31 @@
+<% if receipt.show_activation_section? %>
+  <div class="pos-thermal__divider-dashed"></div>
+  <div class="pos-thermal__section-title">GIFT CARDS ACTIVATED</div>
+  <% receipt.stored_value_issuances.select(&:activation).each do |line| %>
+    <div class="pos-thermal__item-block">
+      <div class="pos-thermal__row">
+        <span class="pos-thermal__item-title"><%= line.title %></span>
+        <span class="pos-thermal__amount pos-thermal__amount--bold"><%= pos_print_amount(line.amount_cents) %></span>
+      </div>
+      <% if line.masked_card.present? %>
+        <div class="pos-thermal__item-meta">Card ID: <%= line.masked_card %></div>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>
+
+<% if receipt.show_reload_section? %>
+  <div class="pos-thermal__divider-dashed"></div>
+  <div class="pos-thermal__section-title">GIFT CARDS RELOADED</div>
+  <% receipt.stored_value_issuances.reject(&:activation).each do |line| %>
+    <div class="pos-thermal__item-block">
+      <div class="pos-thermal__row">
+        <span class="pos-thermal__item-title"><%= line.title %></span>
+        <span class="pos-thermal__amount pos-thermal__amount--bold"><%= pos_print_amount(line.amount_cents) %></span>
+      </div>
+      <% if line.masked_card.present? %>
+        <div class="pos-thermal__item-meta">Card ID: <%= line.masked_card %></div>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/pos/receipts/thermal/_merchandise_lines.html.erb
+++ b/app/views/pos/receipts/thermal/_merchandise_lines.html.erb
@@ -1,0 +1,47 @@
+<% lines.each do |line| %>
+  <div class="pos-thermal__item-block">
+    <% if line.kind_banner.present? && line.kind_banner != "UNLINKED RETURN" %>
+      <p class="pos-thermal__item-meta"><%= line.kind_banner %></p>
+    <% end %>
+    <div class="pos-thermal__row">
+      <span class="pos-thermal__item-title"><%= line.description %></span>
+      <span class="pos-thermal__amount">
+        <%= pos_print_amount(line.amount_cents) %>
+        <% if line.tax_indicators.present? %>
+          <span class="pos-thermal__tax-indicator">[<%= line.tax_indicators %>]</span>
+        <% end %>
+      </span>
+    </div>
+    <% if line.unlinked %>
+      <div class="pos-thermal__item-meta"><span class="pos-thermal__badge">[UNLINKED RETURN]</span></div>
+    <% end %>
+    <% if line.condition.present? %>
+      <div class="pos-thermal__item-meta"><%= line.condition %></div>
+    <% end %>
+    <% if line.identifier_value.present? %>
+      <div class="pos-thermal__item-meta"><%= line.identifier_label %>: <%= line.identifier_value %></div>
+    <% end %>
+    <% if line.show_quantity_detail %>
+      <div class="pos-thermal__item-meta pos-thermal__row">
+        <span><%= line.quantity %> @ <%= format_money_cents(line.unit_price_cents) %></span>
+      </div>
+    <% end %>
+    <% if line.regular_price_cents %>
+      <div class="pos-thermal__item-meta pos-thermal__row">
+        <span>Regular Price:</span>
+        <span><%= pos_print_amount(line.regular_price_cents) %></span>
+      </div>
+    <% end %>
+    <% if line.discount_cents.negative? %>
+      <div class="pos-thermal__item-meta pos-thermal__row">
+        <span><%= line.discount_label %></span>
+        <span><%= pos_print_amount(line.discount_cents) %></span>
+      </div>
+    <% end %>
+    <% if line.original_reference.present? %>
+      <div class="pos-thermal__item-meta">Original: <%= line.original_reference %></div>
+    <% elsif line.unlinked %>
+      <div class="pos-thermal__item-meta">Original receipt: Not provided</div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/pos/receipts/thermal/_metadata.html.erb
+++ b/app/views/pos/receipts/thermal/_metadata.html.erb
@@ -1,0 +1,10 @@
+<div class="pos-thermal__meta">
+  <div class="pos-thermal__row"><span>Date:</span> <span><%= receipt.completed_at_label %></span></div>
+  <div class="pos-thermal__row"><span>Store/Reg/Trans:</span> <span><%= receipt.identity_compact_label %></span></div>
+  <div class="pos-thermal__row"><span>Cashier:</span> <span><%= receipt.cashier_name %></span></div>
+  <% if receipt.customer_name.present? %>
+    <div class="pos-thermal__row"><span>Customer:</span> <span><%= receipt.customer_name %></span></div>
+  <% end %>
+</div>
+
+<div class="pos-thermal__divider-dashed"></div>

--- a/app/views/pos/receipts/thermal/_payments.html.erb
+++ b/app/views/pos/receipts/thermal/_payments.html.erb
@@ -1,0 +1,23 @@
+<% if receipt.show_payments_section? %>
+  <div class="pos-thermal__section-title">PAYMENTS APPLIED</div>
+  <% receipt.payments.each do |payment| %>
+    <% if payment.cash_tendered_cents %>
+      <div class="pos-thermal__row"><span>Cash Tendered</span> <span><%= pos_print_amount(payment.cash_tendered_cents) %></span></div>
+      <div class="pos-thermal__item-meta pos-thermal__row"><span>Cash Applied:</span> <span><%= pos_print_amount(payment.cash_applied_cents) %></span></div>
+      <div class="pos-thermal__item-meta pos-thermal__row"><span>Change:</span> <span><%= pos_print_amount(payment.change_cents) %></span></div>
+    <% else %>
+      <div class="pos-thermal__row"><span><%= payment.label %></span> <span><%= pos_print_amount(payment.amount_cents) %></span></div>
+    <% end %>
+    <% if payment.inline_balance_note %>
+      <% note = payment.inline_balance_note %>
+      <div class="pos-thermal__item-meta pos-thermal__row">
+        <span><%= note.label %></span>
+        <span><%= pos_print_amount(note.balance_cents) %></span>
+      </div>
+      <% if note.masked_card.present? %>
+        <div class="pos-thermal__item-meta"><%= note.masked_card %></div>
+      <% end %>
+    <% end %>
+  <% end %>
+  <div class="pos-thermal__divider-dashed"></div>
+<% end %>

--- a/app/views/pos/receipts/thermal/_status.html.erb
+++ b/app/views/pos/receipts/thermal/_status.html.erb
@@ -1,0 +1,11 @@
+<% if receipt.post_voided_original? %>
+  <p class="pos-thermal__status pos-thermal__center pos-thermal__display">*** POST-VOIDED ***</p>
+  <p class="pos-thermal__meta-note pos-thermal__center">This transaction is no longer valid.</p>
+  <p class="pos-thermal__meta-note pos-thermal__center">Post-voided by: <%= receipt.reversing_reference %></p>
+<% elsif receipt.post_void_reversal? %>
+  <p class="pos-thermal__status pos-thermal__center pos-thermal__display">*** POST-VOID ***</p>
+  <p class="pos-thermal__meta-note pos-thermal__center">Original: <%= receipt.original_reference %></p>
+<% end %>
+<% if local_assigns.fetch(:reprint, false) %>
+  <p class="pos-thermal__status pos-thermal__center pos-thermal__display">*** REPRINT ***</p>
+<% end %>

--- a/app/views/pos/receipts/thermal/_store_header.html.erb
+++ b/app/views/pos/receipts/thermal/_store_header.html.erb
@@ -1,0 +1,8 @@
+<div class="pos-thermal__center pos-thermal__display">
+  <div class="pos-thermal__store-name"><%= receipt.legal_name %></div>
+  <% receipt.address_lines.each do |line| %>
+    <div class="pos-thermal__store-address"><%= line %></div>
+  <% end %>
+</div>
+
+<div class="pos-thermal__divider-solid"></div>

--- a/app/views/pos/receipts/thermal/_summary.html.erb
+++ b/app/views/pos/receipts/thermal/_summary.html.erb
@@ -1,0 +1,46 @@
+<% if receipt.show_merchandise_section? || receipt.show_stored_value_section? || receipt.show_tax_section? %>
+  <div class="pos-thermal__divider-dashed"></div>
+
+  <% if receipt.show_detail_totals? %>
+    <% if receipt.merchandise_cents != 0 %>
+      <div class="pos-thermal__row"><span>Merchandise Subtotal</span> <span><%= pos_print_amount(receipt.merchandise_cents) %></span></div>
+    <% end %>
+    <% if receipt.discounts_cents != 0 %>
+      <div class="pos-thermal__row"><span>Item Discounts</span> <span><%= pos_print_amount(receipt.discounts_cents) %></span></div>
+    <% end %>
+    <% if receipt.returns_cents != 0 %>
+      <div class="pos-thermal__row"><span>Returns Subtotal</span> <span><%= pos_print_amount(receipt.returns_cents) %></span></div>
+    <% end %>
+    <% if receipt.activation_issuance_cents != 0 %>
+      <div class="pos-thermal__row"><span>Gift Cards Activated</span> <span><%= pos_print_amount(receipt.activation_issuance_cents) %></span></div>
+    <% end %>
+    <% if receipt.reload_issuance_cents != 0 %>
+      <div class="pos-thermal__row"><span>Gift Cards Reloaded</span> <span><%= pos_print_amount(receipt.reload_issuance_cents) %></span></div>
+    <% end %>
+  <% elsif receipt.net_merchandise_cents != 0 %>
+    <div class="pos-thermal__row"><span>Merchandise Subtotal</span> <span><%= pos_print_amount(receipt.net_merchandise_cents) %></span></div>
+  <% end %>
+
+  <% if receipt.show_tax_section? %>
+    <% receipt.tax_groups.each do |group| %>
+      <div class="pos-thermal__row pos-thermal__tax-row">
+        <span><%= pos_tax_group_summary_label(group) %></span>
+        <span><%= pos_print_amount(group.tax_cents) %></span>
+      </div>
+    <% end %>
+    <% if receipt.tax_groups.size > 1 %>
+      <div class="pos-thermal__row pos-thermal__row--bold"><span>Total Tax</span> <span><%= pos_print_amount(receipt.total_tax_cents) %></span></div>
+    <% end %>
+  <% end %>
+
+  <div class="pos-thermal__row pos-thermal__total-banner pos-thermal__display">
+    <span><%= receipt.total_label %></span>
+    <span><%= pos_print_amount(receipt.total_display_cents) %></span>
+  </div>
+<% elsif receipt.show_stored_value_section? %>
+  <div class="pos-thermal__divider-dashed"></div>
+  <div class="pos-thermal__row pos-thermal__total-banner pos-thermal__display">
+    <span><%= receipt.total_label %></span>
+    <span><%= pos_print_amount(receipt.total_display_cents) %></span>
+  </div>
+<% end %>

--- a/docs/adr/ADR-022-warm-parchment-visual-tokens.md
+++ b/docs/adr/ADR-022-warm-parchment-visual-tokens.md
@@ -2,7 +2,8 @@
 
 - **Status:** Implemented
 - **Date:** 2026-08-22
-- **Related:** [Phase 2.2 UX foundation](../planning/phase2.2-ux-foundation/phase-2.2-ux-foundation.md), [UX conventions](../ux-conventions.md), [UX design system](../planning/ux-design-system/README.md), [UDS-1 implementation plan](../planning/ux-design-system/uds-1-plan.md), [Warm Parchment](../planning/ux-design-system/warm-parchment.md), [Button and action semantics](../planning/ux-design-system/button-action-semantics.md)
+- **Amended:** 2026-08-31 (thermal customer-document fonts)
+- **Related:** [Phase 2.2 UX foundation](../planning/phase2.2-ux-foundation/phase-2.2-ux-foundation.md), [UX conventions](../ux-conventions.md), [UX design system](../planning/ux-design-system/README.md), [UDS-1 implementation plan](../planning/ux-design-system/uds-1-plan.md), [Warm Parchment](../planning/ux-design-system/warm-parchment.md), [Button and action semantics](../planning/ux-design-system/button-action-semantics.md), [Receipts and reports revamp](../planning/receipts-and-reports-revamp/README.md)
 
 ## Context
 
@@ -17,9 +18,10 @@ The UX design-system foundation (UDS-1) ships Warm Parchment for screen chrome:
 1. **Supersede the Phase 2.2 color palette** with the Warm Parchment token vocabulary documented in [warm-parchment.md](../planning/ux-design-system/warm-parchment.md), including controlled temporary aliases from existing `--color-*` names.
 2. **Preserve Phase 2.2 architecture:** Propshaft and component classes; shared partials/helpers; money display/parse boundaries; accessibility rules (visible focus; meaning not by color alone); admin / purchasing-ops / Register runtime boundaries; no business logic in presentation code.
 3. **Contrast:** Enforce WCAG **AA** for ordinary interface text and solid button label combinations. Do not claim blanket AAA. Solid brand default is `#A84320`.
-4. **Fonts:** Package webfonts locally or use system stacks. Source Sans 3 (latin 400/700) is packaged under `app/assets/fonts/`. Do not depend on Google Fonts or other CDNs at runtime. Receipt mono remains Inconsolata.
-5. **Shells remain distinct:** Warm Parchment is one design system expressed through different shells—not a universal sidebar/drawer IA. Deferred chrome patterns stay in [deferred-patterns.md](../planning/ux-design-system/deferred-patterns.md).
-6. **Actions:** Visual brand tokens supply colors; [button-action-semantics.md](../planning/ux-design-system/button-action-semantics.md) and `ActionButtonHelper` are authoritative for wording, intent, style, size, and review escalation (including Post-Void as danger, not routine primary). Broad view adoption is UDS-2.
+4. **Fonts:** Package webfonts locally or use system stacks for **screen chrome**. Source Sans 3 (latin 400/700) is packaged under `app/assets/fonts/`. Do not depend on Google Fonts or other CDNs for admin, ops, or Register **screen** UI.
+5. **Thermal customer documents (amended 2026-08-31):** Customer transaction receipts (`.pos-receipt__print`) and gift-card credential vouchers (`.pos-gift-card-voucher`) may load **Noto Sans Mono** and **Plus Jakarta Sans** from Google Fonts (`fonts.googleapis.com`, `fonts.gstatic.com`) in print-capable layouts. This is a narrow exception for D1/D2 thermal output only. Register screen chrome, admin, and ops remain on locally packaged faces. X/Z reports, session tapes, and other `.pos-report-print` surfaces keep locally packaged **Inconsolata** until a later presentation packet supersedes them. Print must wait for `document.fonts.ready` when supported. Fallback stacks (`Cascadia Code`, `Consolas`, `SF Mono`, `Segoe UI Mono`, system sans-serif) must remain so blocked CDN access still produces legible output. Future offline Terminal print ([ADR-018](ADR-018-pos-runtime-and-deployment.md)) is not satisfied by this exception; a later decision must package equivalent faces locally or define an offline print channel. If Content-Security-Policy is enabled, `style-src` and `font-src` must allow the Google Fonts hosts for Register print layouts.
+6. **Shells remain distinct:** Warm Parchment is one design system expressed through different shells—not a universal sidebar/drawer IA. Deferred chrome patterns stay in [deferred-patterns.md](../planning/ux-design-system/deferred-patterns.md).
+7. **Actions:** Visual brand tokens supply colors; [button-action-semantics.md](../planning/ux-design-system/button-action-semantics.md) and `ActionButtonHelper` are authoritative for wording, intent, style, size, and review escalation (including Post-Void as danger, not routine primary). Broad view adoption is UDS-2.
 
 Delivery record: [uds-1-plan.md](../planning/ux-design-system/uds-1-plan.md) (UDS-1a–1d).
 
@@ -29,4 +31,4 @@ Delivery record: [uds-1-plan.md](../planning/ux-design-system/uds-1-plan.md) (UD
 - [ux-conventions.md](../ux-conventions.md) palette section points at Warm Parchment; Phase 2.2 architecture conventions remain.
 - Temporary legacy `--color-*` aliases and button shorthand remain until retirement conditions in the migration matrix are met.
 - Inspirational drafts under `docs/drafts/phase-7.1-ux-refactor/` stay non-authoritative.
-- Reject runtime CDN fonts and silent token-meaning changes without migration notes.
+- Reject runtime CDN fonts for **screen chrome** and silent token-meaning changes without migration notes. Thermal customer-document CDN fonts are limited to the D1/D2 exception above.

--- a/docs/drafts/receipts_and_reports_revamp/receipt-report-revamp-draft-spec.md
+++ b/docs/drafts/receipts_and_reports_revamp/receipt-report-revamp-draft-spec.md
@@ -1,0 +1,880 @@
+# Receipt and report revamp — draft specification
+
+Status: **Draft for review**  
+Program: Follow-on Register refinement  
+Scope: Customer receipts, gift-card vouchers, cash-operation slips, session tapes, X/Z reports, and their shared thermal presentation system
+
+## 1. Authority and intent
+
+This specification defines a presentation and projection revamp over existing ShelfSense transaction, tender, Store Tax, stored-value, cash, session, and reporting-period authority.
+
+The supplied HTML mockups establish visual direction for:
+
+- information density;
+- hierarchy;
+- thermal typography;
+- dividers and section labels;
+- total and status emphasis;
+- description-first merchandise lines;
+- grouped tenders and stored-value activity;
+- receipt/report chrome.
+
+They are not independently authoritative for keyboard mappings, routes, permissions, lifecycle rules, financial formulas, or terminology. Mock values are illustrative and must not be copied into calculation contracts.
+
+Repository domain authority continues to govern:
+
+- completed transaction facts;
+- receipt identity;
+- tender direction and settlement;
+- Store Tax components;
+- stored-value entries and `balance_after_cents`;
+- cash custody entries;
+- session close snapshots;
+- reporting-period finalization;
+- authorization and audit.
+
+## 2. Goals
+
+1. Make customer receipts understandable without exposing internal operational detail.
+2. Make cash and reporting documents independently reconcilable.
+3. Give all thermal documents a coherent ShelfSense visual system.
+4. Render from persisted authority without repricing or reconstructing completed facts.
+5. Support original print, retry, reprint, post-void, reversal, and recovery states explicitly.
+6. Separate customer documents, custody evidence, and management reports rather than forcing them into one template.
+7. Preserve keyboard access and predictable focus on every screen surface used to preview or print a document.
+8. Build a scenario fixture suite that exercises mutually exclusive receipt/report states.
+
+## 3. Non-goals
+
+This program does not:
+
+- remap Register keyboard shortcuts;
+- redesign transaction, tender, stored-value, cash, session, or Z domain semantics;
+- create a new generic Receipt aggregate without a demonstrated lifecycle need;
+- store raw printer bytes or image snapshots merely for reprint;
+- require pixel-identical historical reprints;
+- expose full gift-card numbers on ordinary customer receipts;
+- expose Tax Class names as customer Store Tax labels;
+- print expected drawer cash where authorization or blind-count policy prohibits it;
+- print manager credentials, internal operation IDs, GL classifications, or other audit-only detail on customer receipts.
+
+## 4. Document families
+
+| Family | Documents | Audience | Authority |
+| --- | --- | --- | --- |
+| D1. Customer transaction | Original receipt, reprint, return/refund receipt, exchange receipt, post-void documents | Customer and store | Completed transaction, lines, tax components, tenders, stored-value operations |
+| D2. Stored-value credential | Gift-card voucher, recovered/replacement print copy | Customer; management-authorized generation | Protected credential-delivery/recovery authority |
+| D3. Customer cash-out | Gift-card cash-out receipt | Customer and store | Stored-value cash-out operation plus cash entries |
+| D4. Cash custody | Paid In, Paid Out, Cash Drop, Cash Replenishment, reversal slip | Cashier and management | Immutable cash operation and entries |
+| D5. Session | Session close tape, closed-session summary print | Cashier and management | Frozen session close facts |
+| D6. Interim report | X Report | Authorized cashier/management | Current open-session facts as of print time |
+| D7. Final report | Z Report | Management/accounting | Finalized reporting-period facts |
+
+## 5. Core invariants
+
+### 5.1 Printing is presentation, not posting
+
+Printing, retrying a failed print, and reprinting:
+
+- do not create or modify financial activity;
+- do not alter inventory;
+- do not allocate a new receipt identity;
+- do not update tender or stored-value balances;
+- do not open, close, or finalize sessions or reporting periods.
+
+### 5.2 Completed facts remain authoritative
+
+A document must consume persisted facts. A renderer may group, label, format, and omit inapplicable rows, but it must not:
+
+- look up current product prices;
+- reapply current discount rules;
+- recalculate tax using current Store Tax configuration;
+- rename completed tenders from current configuration where a tender snapshot governs;
+- display a live stored-value balance as though it were the balance produced by a historical transaction;
+- reconstruct a closed-session or finalized-Z total from mutable current state.
+
+### 5.3 Factual reproduction, not pixel identity
+
+Reprints retain the original receipt identity and historical commercial facts. The current approved renderer may present those facts differently from the original print where existing policy allows current descriptive or presentation configuration.
+
+This program does not require raw print-byte retention or an image of the original receipt.
+
+### 5.4 Direction remains visible
+
+Sales, returns, payments, refunds, stored-value issuance, stored-value redemption, and cash custody movements must preserve direction. A zero or net total must not hide gross activity.
+
+### 5.5 Unlike reconciliations remain separate
+
+Reports must not combine merchandise activity, stored-value liability activity, tender settlement, and physical cash custody into an ambiguous single Net Total.
+
+## 6. Data-authority map
+
+| Presented fact | Required authority |
+| --- | --- |
+| Store/Register/receipt identity | Completed transaction receipt identity snapshots/sequence |
+| Completion date/time | Completed transaction occurrence/completion time |
+| Business date | Completed transaction/session/reporting-period fact where document requires it |
+| Cashier | Completed cashier snapshot or session authority as appropriate |
+| Merchandise description, SKU/unit identifier, condition | Completed line merchandise snapshot |
+| Quantity, selling price, discount, direction | Completed transaction line facts |
+| Linked-return original reference | Original completed transaction/line link |
+| Store Tax letter/name/rate/basis/amount | Completed line Store Tax components and their snapshots |
+| Tender name/direction/applied amount | Completed tender facts/snapshots |
+| Cash tendered and change | Completed Cash tender facts |
+| Printable tender reference | Explicit receipt-safe policy and completed safe value; never arbitrary exposure by accident |
+| Stored-value type/program/masked reference | Completed issuance/tender detail and permitted descriptive presentation |
+| Stored-value post-operation balance | Applicable persisted stored-value entry `balance_after_cents` |
+| Full gift-card number | Protected voucher first-print or recovery credential only |
+| Cash operation effects | Immutable cash entries for the operation |
+| Session expected/count/variance | Frozen close facts after count/close; live expected only where authorized |
+| X totals | Current open-session report presenter as of print time |
+| Z totals | Finalized reporting-period snapshots/facts |
+
+## 7. Shared thermal design system
+
+All document families should reuse shared print primitives while retaining distinct semantics.
+
+### 7.1 Primitives
+
+- Store header.
+- Document title and status banner.
+- Metadata label/value rows.
+- Section title.
+- Solid and dashed divider.
+- Description-first item block.
+- Signed money row.
+- Source/destination transfer row.
+- Tax-group row.
+- Tender/payment row.
+- Total banner.
+- Original/reversal reference block.
+- Performer/approver block.
+- Signature block.
+- Barcode and human-readable reference.
+- Footer/policy message.
+- Reprint/recovery designation.
+
+### 7.2 Width and print behavior
+
+- Primary target: 80 mm thermal roll.
+- Printable content must remain safe at the narrower effective driver width already used by ShelfSense.
+- Screen controls never appear in print.
+- Long content wraps without overlapping monetary columns.
+- Print typography uses local/fallback-safe fonts; printing waits for requested fonts when supported.
+- Barcodes are generated by the approved Code 128 encoder, not decorative hand-built bars.
+- Long X/Z/session tapes flow continuously and do not create misleading repeated totals at page breaks.
+- Black-and-white output remains legible; meaning never depends on color.
+
+### 7.3 Status vocabulary
+
+Use explicit document states:
+
+- `REPRINT`
+- `POST-VOIDED`
+- `POST-VOID`
+- `INTERIM — SESSION REMAINS OPEN`
+- `CLOSED`
+- `FINALIZED`
+- `REPLACEMENT PRINT COPY` or the final approved recovery term
+- `REVERSAL`
+
+Automatic retry of an initial failed print and an intentional later reprint are distinct operational events. Final customer-facing labeling remains a policy decision where not already locked.
+
+## 8. Customer transaction receipt
+
+### 8.1 Default order
+
+1. Store identity and address.
+2. Optional configured header message.
+3. Reprint/post-void designation.
+4. Completion time, Store/Register/Transaction, cashier, and optional customer.
+5. Merchandise sales and returns.
+6. Stored-value activations/reloads.
+7. Merchandise/discount/return/stored-value summary.
+8. Store Tax breakdown.
+9. Total Due, Refund Total, or Net Total.
+10. Payments or refunds applied.
+11. Stored-value post-operation balance notes.
+12. Sold/returned counts and savings when applicable.
+13. Receipt identity barcode.
+14. Optional footer/return-policy message.
+
+### 8.2 Store and transaction identity
+
+Print:
+
+- customer-facing Store identity required by receipt policy;
+- address and phone where configured;
+- actual completion date/time;
+- compact Store/Register/Transaction identity;
+- cashier name;
+- customer name only when attached and permitted.
+
+Do not print a blank Customer row when none is attached.
+
+### 8.3 Merchandise lines
+
+Use description-first hierarchy:
+
+```text
+Product description                       $10.99 [A]
+SKU: 2210000000063
+```
+
+Conditional detail may include:
+
+- quantity and unit price for quantity greater than one;
+- actual completed regular/selling price and meaningful discount;
+- used-unit identifier and condition;
+- linked-return original receipt reference;
+- explicit `UNLINKED RETURN` designation;
+- tax indicator letters.
+
+Customer receipt lines should not expose:
+
+- internal reference-price variance merely because a price was overridden;
+- manager username;
+- approval reason or note;
+- internal Tax Class name;
+- internal operation identifiers.
+
+### 8.4 Discounts
+
+Where a line discount exists, show enough information for the customer to understand the charged price:
+
+```text
+Regular Price:                              $9.99
+Discount (15%):                            -$1.50
+```
+
+Use completed selling and discount facts. Do not calculate against the current catalog price.
+
+### 8.5 Returns
+
+#### Linked return
+
+Show:
+
+- return direction;
+- returned item and quantity;
+- signed return amount;
+- original receipt reference.
+
+Whether the customer-facing return reason prints remains a policy decision.
+
+#### Unlinked return
+
+Show an explicit no-original-receipt designation. Do not imply linkage that does not exist.
+
+#### Refund-total receipt
+
+Use `REFUND TOTAL`, not a negative `TOTAL DUE`. Refund tenders use directional labels such as `Cash Refund` or `Refund to Store Credit`.
+
+#### Even exchange
+
+Show both gross sale and return activity and a `$0.00` Net Total. Do not create a fictitious zero-dollar tender.
+
+### 8.6 Stored-value issuance and reload
+
+Do not mix issuance lines into ordinary merchandise presentation. Use a distinct section:
+
+```text
+GIFT CARDS ACTIVATED
+
+Store Gift Card · #801....5940             $15.00
+```
+
+Use distinct labels for:
+
+- activation;
+- reload;
+- post-void/reversal where applicable.
+
+For activation/reload, the balance note may use `New Balance`. Activation amount and balance may be equal; reload amount and resulting balance often are not.
+
+### 8.7 Summary and Store Tax
+
+Applicable rows may include:
+
+- Merchandise Subtotal.
+- Item Discounts.
+- Returns Subtotal.
+- Gift Cards Activated/Reloaded or customer-facing stored-value issuance label.
+- Net Merchandise Subtotal.
+- Total Store Tax.
+
+Avoid a universal `TAXABLE SUBTOTAL` row unless the value is semantically valid. Different Store Taxes can have different taxable bases.
+
+Each Store Tax row uses the persisted Store Tax name:
+
+```text
+[A] Michigan Sales Tax
+    6.000% on $29.99                        $1.80
+[B] Local Prepared Food Tax
+    1.250% on $5.50                         $0.07
+Total Tax                                   $1.87
+```
+
+Tax Class controls applicability and belongs in operational review/provenance. It is not substituted for the Store Tax name on the customer receipt.
+
+Single-tax, multiple-tax, no-tax, exempt/zero-rated, and return-tax-reversal scenarios require explicit fixtures.
+
+### 8.8 Payments and refunds applied
+
+Use a dedicated section:
+
+```text
+PAYMENTS APPLIED
+Check                                      $10.00
+External Card                             $40.00
+```
+
+For Cash payment, preserve all three facts:
+
+```text
+Cash Tendered                              $20.00
+Cash Applied                               $11.86
+Change                                      $8.14
+```
+
+For Cash refund:
+
+```text
+Cash Refund                                $12.00
+```
+
+Stored-value tender examples:
+
+```text
+Gift Card · #801....5940                   $20.00
+Remaining Balance                           $3.75
+```
+
+```text
+Refund to Store Credit                     $12.00
+New Store Credit Balance                   $34.25
+```
+
+Receipt-safe references are category/policy driven. ShelfSense must not print arbitrary `external_reference` content by default.
+
+### 8.9 Stored-value balances
+
+Balance presentation must use the applicable persisted stored-value entry attached to the completed issuance/tender operation:
+
+```text
+operation
+→ entry for the represented account/instrument
+→ balance_after_cents
+```
+
+Do not use the account or gift card's current live balance on historical receipts.
+
+Terminology:
+
+- Redemption: `Remaining Balance`.
+- Activation/reload/refund: `New Balance`.
+
+For an operation with multiple entries, select the entry for the receipt line's account/instrument rather than taking an arbitrary last entry.
+
+### 8.10 Counts, savings, barcode, and footer
+
+Print when applicable:
+
+- items sold/returned;
+- customer savings from completed discounts;
+- Code 128 transaction reference;
+- configured header/footer/return-policy content.
+
+These sections collapse cleanly when inapplicable.
+
+## 9. Customer receipt state variants
+
+### 9.1 Original receipt
+
+No `REPRINT` designation.
+
+### 9.2 Reprint
+
+- Same receipt identity.
+- Same completed commercial facts.
+- Clear `REPRINT` designation according to final policy.
+- No financial or inventory mutation.
+
+### 9.3 Post-voided original
+
+```text
+*** POST-VOIDED ***
+This transaction is no longer valid.
+Post-voided by: S001-R01-T0000062
+```
+
+### 9.4 Post-void reversal
+
+```text
+*** POST-VOID ***
+Original: S001-R01-T0000056
+```
+
+The reversal receipt preserves reversed merchandise, tax, tenders, and stored-value direction.
+
+### 9.5 Pure stored-value transaction
+
+Omit empty merchandise and Store Tax sections. Show issuance/reload, total, payments, balance, and voucher availability.
+
+### 9.6 Pure return
+
+Omit empty sales/issuance sections. Show returns, tax reversal, Refund Total, and refund tenders.
+
+## 10. Gift-card voucher
+
+The voucher is a separate protected print artifact.
+
+Print:
+
+- Store identity;
+- issued time;
+- amount;
+- customer-facing program/type;
+- full normalized gift-card number;
+- Code 128 barcode of the full number;
+- configured voucher footer.
+
+The ordinary receipt remains masked.
+
+### 10.1 First print
+
+- Credential disclosure follows the existing first-print authority.
+- A printer failure does not create another gift card or funding operation.
+- Retry behavior must not accidentally consume or duplicate credential delivery outside the established lifecycle.
+
+### 10.2 Recovery/replacement print
+
+- Requires established management authorization and reason/audit behavior.
+- Customer voucher carries an approved recovery designation, such as `REPLACEMENT PRINT COPY`.
+- Internal recovery reason, manager identity, and audit reference belong in management evidence, not necessarily on the customer copy.
+
+## 11. Gift-card cash-out receipt
+
+This is a customer/store receipt distinct from a sales receipt.
+
+Print:
+
+- Store/Register and cashier;
+- stable cash-out reference;
+- masked gift-card number;
+- persisted balance before where available/required;
+- Cash paid;
+- persisted balance after;
+- customer-facing cash-out reason/policy where appropriate;
+- acknowledgment/signature line if Store policy requires it;
+- barcode/reference.
+
+It must not print the full gift-card number or a live later balance.
+
+## 12. Cash-custody slips
+
+### 12.1 Shared content
+
+- Document type and direction.
+- Date/time and business date.
+- Store/Register/session context where applicable.
+- Stable operation reference.
+- Amount.
+- Customer-facing/internal reason name as appropriate.
+- From and To cash locations for transfers.
+- Signed entry effects.
+- Performer and approver where recorded.
+- Custody signature lines where Store policy requires them.
+
+Do not print expected cash merely to decorate a custody slip.
+
+### 12.2 Paid In
+
+Show drawer effect as positive and the persisted source/reason/note fields that policy permits.
+
+### 12.3 Paid Out
+
+Show drawer effect as negative. Print payee only if an authoritative payee field exists; do not overload a note and relabel it as payee.
+
+### 12.4 Cash Drop
+
+Show drawer-to-safe direction and both immutable entry effects from the same atomic operation.
+
+### 12.5 Cash Replenishment
+
+Show safe-to-drawer direction and both immutable entry effects from the same atomic operation.
+
+### 12.6 Reversal
+
+The reversal is a separate document with:
+
+- original operation reference/type/amount;
+- reversal reference;
+- compensating effects;
+- reversal reason;
+- performer/approver;
+- explicit statement that the original remains on record.
+
+## 13. Session close tape
+
+The close tape is produced after the count and uses frozen close facts.
+
+Print:
+
+- Store/Register/session/cashier;
+- business date and open/close times;
+- opening float;
+- Cash payments and refunds;
+- gift-card cash-outs;
+- Paid In/Out;
+- Drops and Replenishments;
+- relevant cash-operation reversals;
+- frozen Expected Cash;
+- Counted Cash;
+- variance;
+- variance reason/approval where applicable;
+- counted-cash transfer to safe;
+- drawer balance/status after close;
+- `CLOSED` designation.
+
+The tape must not be generated from a new live calculation after close.
+
+## 14. X Report
+
+### 14.1 Semantics
+
+An X Report is:
+
+- scoped to an open session;
+- interim as of a specific print time;
+- non-closing and non-mutating;
+- visibly labeled `INTERIM — SESSION REMAINS OPEN`;
+- permission-controlled.
+
+Between sessions has no current X Report. Historical totals belong to session/Z reporting.
+
+### 14.2 Sections
+
+#### Identity
+
+- Store/Register.
+- business date.
+- session/cashier.
+- printed-at timestamp.
+
+#### Merchandise activity
+
+- Gross merchandise sales.
+- discounts.
+- net merchandise sales.
+- returns.
+- discount reversals.
+- net returns.
+- net merchandise activity.
+
+#### Stored-value liability activity
+
+- Gift cards activated.
+- Gift cards reloaded.
+- Other stored-value issuance/refund categories in scope.
+
+Do not treat issuance as merchandise revenue.
+
+#### Store Tax
+
+Use persisted Store Tax names and amounts. Include bases/rates only if the report content contract requires that density.
+
+#### Tenders
+
+Show payment, refund, and net by tender category, with permitted child tender types. Tender totals reconcile to transaction settlement.
+
+#### Cash custody
+
+- Opening float.
+- net Cash tender.
+- gift-card cash-outs.
+- Paid In/Out.
+- Drops/Replenishments.
+- reversals.
+
+Expected Cash is omitted unless the viewer has the approved before-count permission. Known operation effects may still print without revealing expected balance.
+
+## 15. Z Report
+
+### 15.1 Semantics
+
+A Z Report is:
+
+- scoped to one finalized reporting period/store business date;
+- based on finalized/frozen facts;
+- visibly labeled `FINALIZED`;
+- non-mutating on view or reprint.
+
+### 15.2 Sections
+
+- Store/business date/Z identity and finalizer.
+- Merchandise sales, discounts, returns, and net activity.
+- Stored-value liability activity.
+- Store Tax summary.
+- Tender payments/refunds/net.
+- Session count and reconciliation summary.
+- Cash transferred to safe.
+- Safe/deposit/reconciliation status only to the extent already in the reporting-period contract.
+- Finalized status and time.
+
+Do not combine unlike merchandise, liability, tender, and custody facts into one ambiguous Net Total.
+
+## 16. Screen preview and keyboard behavior
+
+### 16.1 Host surfaces
+
+The following screen surfaces may host or launch document printing:
+
+- Transaction Complete.
+- Transaction Review.
+- gift-card recovery.
+- cash-operation detail.
+- Session Details/Closed Session.
+- X Report.
+- Z Report.
+- report print surface.
+
+### 16.2 Requirements
+
+- Print/Reprint controls are reachable by keyboard.
+- F10 behavior remains governed by Register shell authority where the surface is Register-owned.
+- Initial focus is appropriate to the task, not silently trapped on hidden print markup.
+- Enter does not trigger an unrelated print or navigation action.
+- Print errors are announced accessibly and provide a keyboard recovery action.
+- Authorized iframe printing does not strand focus permanently in the iframe.
+- Printing a voucher does not also print the customer receipt, and vice versa.
+- Screen preview communicates document status and scope even when it is not pixel-identical to the thermal output.
+
+## 17. Component architecture
+
+### 17.1 Current components to preserve or refactor
+
+- `Pos::CustomerReceipt` completed-fact projection.
+- `Pos::ReceiptIdentity`.
+- `Pos::ReceiptMessages`.
+- approved Code 128 encoder/helper.
+- protected first-print/recovery services.
+- receipt/voucher print controller.
+- existing report presenters and finalized snapshots.
+
+### 17.2 Customer-receipt projection direction
+
+Prefer explicit collections/sections over one mixed line collection:
+
+```text
+CustomerReceipt
+├── identity
+├── merchandise_lines
+├── stored_value_issuances
+├── summary_rows
+├── store_tax_groups
+├── payment_or_refund_lines
+├── stored_value_balance_notes
+├── counts_and_savings
+└── messages_and_barcode
+```
+
+Exact Ruby structures are implementation detail, but each section must expose persisted facts without view-level domain reconstruction.
+
+### 17.3 Print partial direction
+
+Decompose the current monolithic customer receipt into reusable, semantically named print partials/components where doing so eliminates duplication:
+
+- receipt header/identity;
+- document status;
+- merchandise lines;
+- stored-value issuance lines;
+- summary and Store Tax groups;
+- payments/refunds;
+- balance notes;
+- counts/savings;
+- barcode/footer.
+
+Do not create abstraction merely to share markup between semantically different documents. Cash slips and reports should reuse primitives, not pretend to be transaction receipts.
+
+### 17.4 Screen versus print projections
+
+Transaction Complete, Transaction Review, and the thermal receipt may have different density, but they should consume a coherent completed-transaction projection or clearly mapped projections. Avoid three independent sets of labels/formulas that can drift.
+
+## 18. Scenario fixture suite
+
+The supplied receipt mockup remains the complex mixed-sale fixture. Add focused fixtures for mutually exclusive branches.
+
+### 18.1 Customer receipt fixtures
+
+1. Ordinary single-tender sale.
+2. Complex mixed sale with quantity, discount, unlinked return, two Store Taxes, issuance, and Cash/Card/Check.
+3. Linked return with partial quantity and original reference.
+4. Return-only Cash refund.
+5. Mixed even exchange with no tender.
+6. Post-voided original reprint.
+7. Post-void reversal.
+8. Gift-card activation only.
+9. Gift-card reload with a preexisting balance.
+10. Gift-card redemption plus Cash.
+11. Store Credit refund.
+12. Trade Credit redemption/refund where supported.
+13. Used individual item with condition and unit identifier.
+14. Open-price item showing only appropriate customer facts.
+15. One Store Tax.
+16. Multiple Store Taxes with different bases.
+17. No-tax/exempt scenario.
+18. Customerless sale.
+19. Long-content stress receipt.
+20. Missing historical description fail-closed/presentation fallback.
+
+### 18.2 Other document fixtures
+
+- First-print gift-card voucher.
+- Recovered/replacement voucher.
+- Gift-card cash-out receipt.
+- Paid In.
+- Paid Out.
+- Cash Drop.
+- Cash Replenishment.
+- Cash-operation reversal.
+- Zero-variance session close.
+- Over/short session close.
+- X Report with expected cash hidden.
+- X Report with authorized expected cash.
+- Finalized Z Report.
+- Long thermal X/Z tape.
+
+## 19. Automated acceptance requirements
+
+### 19.1 Reconciliation
+
+- Printed customer receipt rows reconcile to completed `signed_net_cents` under sale, return, mixed, issuance, and post-void scenarios.
+- Store Tax group sum equals persisted transaction tax direction.
+- Tender/payment/refund rows reconcile to completed settlement.
+- Cash tendered equals Cash applied plus change.
+- Cash-operation slip effects equal persisted entries.
+- Session tape uses frozen close totals.
+- Z report uses finalized period facts.
+
+### 19.2 Historical integrity
+
+- Reprint after current catalog price/name change preserves completed line facts.
+- Reprint after current Store Tax configuration changes preserves completed Store Tax facts.
+- Reprint after tender configuration changes preserves completed tender facts.
+- Reprint after later stored-value activity prints the original operation's applicable `balance_after_cents`.
+- Print/reprint creates no commercial rows or new receipt sequence.
+
+### 19.3 Protection and authorization
+
+- Ordinary receipt never contains a full gift-card number.
+- Voucher contains the authorized full number and valid barcode.
+- Prefix/last-four administrative inquiry cannot become possession authority for redemption, reload, cash-out, or voucher recovery.
+- Expected Cash remains absent without the required permission.
+- Arbitrary tender external references do not print without receipt-safe policy.
+
+### 19.4 Print behavior
+
+- Receipt-only, voucher-only, and tape-only modes select the correct artifact.
+- Print controls do not appear in output.
+- Print failure/retry does not duplicate posting.
+- Long content remains readable at thermal width.
+- Barcode payloads match their printed human-readable references.
+
+## 20. Manual verification
+
+For every fixture, inspect:
+
+- 80 mm screen preview;
+- actual browser print preview at effective driver width;
+- black-and-white legibility;
+- long-name wrapping;
+- column alignment;
+- barcode scannability;
+- original versus reprint status;
+- keyboard-only Print/Reprint flow;
+- focus after print cancellation and print error;
+- 200% zoom on host screen surfaces.
+
+## 21. Recommended implementation sequence
+
+### Slice R1 — Content and authority lock
+
+- Lock document-family boundaries.
+- Lock customer receipt ordering and conditional rows.
+- Lock Store Tax naming.
+- Lock stored-value `balance_after_cents` selection.
+- Resolve receipt-safe tender-reference policy.
+- Resolve remaining customer-facing labels.
+
+### Slice R2 — Shared thermal primitives
+
+- Establish print tokens, width, typography, dividers, status, money rows, totals, barcode, and footer primitives.
+- Add stress fixtures and render verification.
+
+### Slice R3 — Customer receipt projection and template
+
+- Separate merchandise and stored-value sections.
+- Implement Store Tax names/bases/rates.
+- Implement payment/refund and Cash tendered/applied/change hierarchy.
+- Implement receipt state variants and scenario tests.
+
+### Slice R4 — Voucher and cash-out documents
+
+- Revise first-print/recovery voucher presentation.
+- Add cash-out receipt.
+- Verify protected-number and audit boundaries.
+
+### Slice R5 — Cash-custody slips
+
+- Paid In/Out, Drop, Replenishment, and reversal print projections/templates.
+- Add custody/signature policy hooks only where supported.
+
+### Slice R6 — Session close tape
+
+- Render frozen close and transfer facts.
+- Verify blind-count boundaries and post-count visibility.
+
+### Slice R7 — X/Z report revamp
+
+- Apply report content contract.
+- Separate merchandise, liability, tender, and custody sections.
+- Enforce X interim and Z finalized semantics.
+- Verify long thermal output.
+
+### Slice R8 — Host-surface and closeout
+
+- Align Transaction Complete, Transaction Review, report preview, and print actions with Register chrome.
+- Complete keyboard/focus and printer-failure recovery.
+- Remove superseded presentation paths and obsolete tests.
+- Run the full fixture/manual matrix.
+
+## 22. Pending decisions
+
+1. Exact customer-facing label for net pretax merchandise activity; avoid universally assuming one taxable subtotal.
+2. Whether and when a linked/unlinked return reason appears on the customer receipt.
+3. Receipt-safe tender reference fields and formatting by tender category.
+4. Exact original-print retry versus intentional-reprint designation.
+5. Exact voucher recovery designation.
+6. Which Store identity fields are legally required versus current presentation configuration.
+7. Whether exempt/zero-rated treatment prints explicitly or through absence of a tax indicator.
+8. Whether custody signature lines are always printed, configurable, or omitted for selected operation types.
+9. X Report Store Tax detail density: amounts only versus name/rate/basis/amount.
+10. Final Z safe/deposit section based on the accepted reporting-period scope.
+
+## 23. Exit criteria
+
+The revamp is complete when:
+
+- every thermal artifact belongs to one document family;
+- every document consumes named persisted authority;
+- customer receipt fixtures cover sale, return, exchange, post-void, stored value, used merchandise, and tax variants;
+- receipt tax rows use Store Tax names;
+- historical stored-value balance notes use the applicable persisted `balance_after_cents`;
+- X and Z retain distinct interim/final semantics;
+- reports separate merchandise, stored-value liability, tender, and cash custody reconciliations;
+- full gift-card numbers appear only on authorized vouchers;
+- print, retry, reprint, and recovery are non-commercial and tested;
+- all host print controls are keyboard reachable with reliable focus recovery;
+- thermal print output passes the documented visual, stress, and barcode checks;
+- superseded receipt/report markup and duplicate calculation paths are removed.

--- a/docs/drafts/receipts_and_reports_revamp/receipt.html
+++ b/docs/drafts/receipts_and_reports_revamp/receipt.html
@@ -1,0 +1,423 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Thermal Receipt - S001-R01-T0000056</title>
+
+  <!-- Preconnect for fast Google Font fetching -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+
+  <!-- Load Google Fonts -->
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+Mono:wght@400;500;600;700&family=Plus+Jakarta+Sans:wght@700;800&display=swap" rel="stylesheet">
+
+  <style>
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      background-color: #e5e5e5;
+      /* Robust font stack: Google Font -> Modern System Monospace -> Sans-Serif fallback */
+      font-family: 'Noto Sans Mono', 'Cascadia Code', 'Consolas', 'SF Mono', 'Segoe UI Mono', sans-serif;
+      font-variant-numeric: slashed-zero;
+      color: #000000;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 20px;
+    }
+
+    /* Screen UI Control Bar (Hidden when printing) */
+    .controls-bar {
+      margin-bottom: 16px;
+    }
+
+    .btn-print {
+      font-family: 'Plus Jakarta Sans', sans-serif;
+      font-weight: 700;
+      font-size: 14px;
+      background-color: #000000;
+      color: #ffffff;
+      border: none;
+      padding: 10px 20px;
+      border-radius: 6px;
+      cursor: pointer;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+      transition: background-color 0.2s ease;
+    }
+
+    .btn-print:hover {
+      background-color: #333333;
+    }
+
+    /* 80mm Thermal Paper Simulation Container */
+    .receipt-paper {
+      width: 80mm;
+      min-height: 220mm;
+      background: #ffffff;
+      padding: 6mm 4mm;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+      font-size: 11px;
+      line-height: 1.35;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    /* Typography & Utilities */
+    .text-center { text-align: center; }
+    .text-right { text-align: right; }
+    .bold { font-weight: 700; }
+    .sans { font-family: 'Plus Jakarta Sans', sans-serif; }
+
+    /* Dividers */
+    .divider-solid { border-bottom: 2px solid #000; margin: 6px 0; }
+    .divider-dashed { border-bottom: 1px dashed #000; margin: 6px 0; }
+
+    /* Alignment Rows */
+    .row {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+    }
+
+    /* Store Header */
+    .store-name {
+      font-size: 16px;
+      font-weight: 800;
+      letter-spacing: 0.5px;
+      margin-bottom: 2px;
+    }
+
+    .store-address {
+      font-size: 10px;
+      margin-bottom: 6px;
+    }
+
+    .reprint-badge {
+      font-weight: 700;
+      font-size: 12px;
+      margin: 4px 0;
+    }
+
+    .meta-details {
+      font-size: 10px;
+      margin-bottom: 4px;
+    }
+
+    /* Item Blocks */
+    .item-block {
+      margin-bottom: 6px;
+    }
+
+    .item-title {
+      font-weight: 600;
+      font-size: 11px;
+    }
+
+    .item-meta {
+      font-size: 9.5px;
+      padding-left: 8px;
+      color: #000;
+    }
+
+    /* Non-Reverse Outlined Badges (Prints clearly on non-reverse printers) */
+    .badge {
+      display: inline-block;
+      font-size: 8.5px;
+      font-weight: 700;
+      padding: 1px 4px;
+      border: 1px solid #000;
+      background: transparent;
+      color: #000000;
+      margin: 2px 0;
+      text-transform: uppercase;
+    }
+
+    /* Section Headers */
+    .section-title {
+      font-size: 10px;
+      font-weight: 700;
+      text-transform: uppercase;
+      margin: 6px 0 2px 0;
+    }
+
+    /* Totals & Financials */
+    .total-banner {
+      font-size: 15px;
+      font-weight: 800;
+      padding: 4px 0;
+      border-top: 2px solid #000;
+      border-bottom: 2px solid #000;
+      margin: 8px 0;
+    }
+
+    .savings-box {
+      border: 1px dashed #000;
+      padding: 4px;
+      text-align: center;
+      font-weight: 700;
+      margin: 8px 0;
+    }
+
+    /* Native SVG Barcode Container */
+    .barcode-container {
+      margin-top: 10px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 2px;
+    }
+
+    .barcode-svg {
+      width: 180px;
+      height: 40px;
+    }
+
+    /* Thermal Print Overrides */
+    @media print {
+      body {
+        background: none;
+        padding: 0;
+      }
+      .controls-bar {
+        display: none !important;
+      }
+      .receipt-paper {
+        width: 72mm;
+        box-shadow: none;
+        padding: 0;
+      }
+      @page {
+        size: 80mm auto;
+        margin: 0;
+      }
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Screen Control Bar -->
+  <div class="controls-bar">
+    <button class="btn-print" onclick="printReceipt()">🖨️ Print Thermal Receipt</button>
+  </div>
+
+  <!-- Thermal Receipt Sheet -->
+  <div class="receipt-paper">
+    
+    <!-- Store Header -->
+    <div class="text-center sans">
+      <div class="store-name">BLOOMFIELD BOOKS</div>
+      <div class="store-address">
+        9999 S Telegraph Road<br>
+        Bloomfield Township, MI 48302<br>
+        Ph: 248-555-2665
+      </div>
+    </div>
+
+    <div class="divider-solid"></div>
+
+    <div class="text-center reprint-badge sans">*** REPRINT ***</div>
+
+    <!-- Metadata -->
+    <div class="meta-details">
+      <div class="row"><span>Date:</span> <span>30 Aug 2026 12:09 AM</span></div>
+      <div class="row"><span>Store/Reg/Trans:</span> <span>001 / 01 / 0000056</span></div>
+      <div class="row"><span>Cashier:</span> <span>Cashier C.</span></div>
+      <div class="row"><span>Customer:</span> <span>Smith, David</span></div>
+    </div>
+
+    <div class="divider-dashed"></div>
+
+    <!-- Table Header -->
+    <div class="row bold" style="font-size: 10px;">
+      <span>ITEM DESCRIPTION</span>
+      <span>PRICE</span>
+    </div>
+    <div class="divider-dashed"></div>
+
+    <!-- Purchased Items -->
+    <div class="item-block">
+      <div class="row">
+        <span class="item-title">Winnie-the-Pooh Notecards</span>
+        <span class="bold">$10.99 <span style="font-size: 9px;">[A]</span></span>
+      </div>
+      <div class="item-meta">SKU: 2210000000063</div>
+    </div>
+
+    <div class="item-block">
+      <div class="row">
+        <span class="item-title">Book (General Trade)</span>
+        <span class="bold">$16.00 <span style="font-size: 9px;">[A]</span></span>
+      </div>
+      <div class="item-meta">SKU: 2210000000001</div>
+    </div>
+
+    <div class="item-block">
+      <div class="row">
+        <span class="item-title">Winnie-the-Pooh Notecards</span>
+        <span class="bold">$8.49 <span style="font-size: 9px;">[A]</span></span>
+      </div>
+      <div class="item-meta">SKU: 2210000000063</div>
+      <div class="item-meta row"><span>Regular Price:</span> <span>$9.99</span></div>
+      <div class="item-meta row"><span>Discount (15%):</span> <span>-$1.50</span></div>
+    </div>
+
+    <!-- Returned Item (Unlinked Return) -->
+    <div class="item-block">
+      <div class="row">
+        <span class="item-title">Winnie-the-Pooh Notecards</span>
+        <span class="bold">-$10.99 <span style="font-size: 9px;">[A]</span></span>
+      </div>
+      <div class="item-meta"><span class="badge">[UNLINKED RETURN]</span></div>
+      <div class="item-meta">SKU: 2210000000063</div>
+    </div>
+
+    <div class="item-block">
+      <div class="row">
+        <span class="item-title">Book (General Trade)</span>
+        <span class="bold">$5.50 <span style="font-size: 9px;">[AB]</span></span>
+      </div>
+      <div class="item-meta">SKU: 2210000000001</div>
+      <di class="item-meta">2 @ $2.75</di>
+    </div>
+
+    <!-- Gift Cards Sold -->
+    <div class="divider-dashed"></div>
+    <div class="section-title">GIFT CARDS ACTIVATED</div>
+    
+    <div class="item-block">
+      <div class="row">
+        <span class="item-title">Store Gift Card</span>
+        <span class="bold">$15.00</span>
+      </div>
+      <div class="item-meta">Card ID: #801....5940</div>
+    </div>
+
+    <div class="item-block">
+      <div class="row">
+        <span class="item-title">Store Gift Card</span>
+        <span class="bold">$15.00</span>
+      </div>
+      <div class="item-meta">Card ID: #801....2314</div>
+    </div>
+
+    <div class="divider-dashed"></div>
+
+    <!-- Subtotals -->
+    <div class="row"><span>Merchandise Subtotal</span> <span>$42.48</span></div>
+    <div class="row"><span>Item Discounts</span> <span>-$1.50</span></div>
+    <div class="row"><span>Returns Subtotal</span> <span>-$10.99</span></div>
+    <div class="row"><span>Gift Cards Sold</span> <span>$30.00</span></div>
+    
+    <div class="divider-dashed"></div>
+    <div class="row bold"><span>TAXABLE SUBTOTAL</span> <span>$29.99</span></div>
+
+    <div style="margin-top: 4px;"></div>
+
+    <!-- Explicit Named Tax Breakdown -->
+    <div class="row" style="font-size: 10px;"><span>[A] Sales Tax (6.000% on $29.99)</span> <span>$1.80</span></div>
+    <div class="row" style="font-size: 10px;"><span>[B] Food/Bev (1.250% on $5.50)</span> <span>$0.07</span></div>
+    <div class="row bold"><span>Total Tax</span> <span>$1.87</span></div>
+
+    <!-- Final Total Banner -->
+    <div class="row total-banner sans">
+      <span>TOTAL DUE</span>
+      <span>$61.86</span>
+    </div>
+
+    <!-- Payments / Tenders -->
+    <div class="bold" style="margin-bottom: 2px;">PAYMENTS APPLIED</div>
+    <div class="row"><span>Check (Ref 12345)</span> <span>$10.00</span></div>
+    <div class="row"><span>External Card (Ref 123456)</span> <span>$40.00</span></div>
+    
+    <!-- Requested Cash Flow Sequence -->
+    <div class="row"><span>Cash Paid</span> <span>$20.00</span></div>
+    <div class="item-meta row"><span>Cash Applied:</span> <span>$11.86</span></div>
+    <div class="item-meta row"><span>Cash Change:</span> <span>$8.14</span></div>
+
+    <div class="divider-dashed"></div>
+
+    <!-- Issued Gift Card Balances -->
+    <div class="bold" style="margin-bottom: 2px;">ISSUED GIFT CARD BALANCES</div>
+    <div class="row" style="font-size: 10px;"><span>Card #801....5940</span> <span>$15.00</span></div>
+    <div class="row" style="font-size: 10px;"><span>Card #801....2314</span> <span>$15.00</span></div>
+
+    <div class="divider-dashed"></div>
+
+    <!-- Items Summary -->
+    <div class="row"><span>Items Sold / Returned:</span> <span class="bold">4 / 1</span></div>
+    <div class="savings-box sans">YOU SAVED: $1.50</div>
+
+    <!-- Native SVG Vector Barcode (Guaranteed to print on thermal drivers) -->
+    <div class="barcode-container text-center">
+      <svg class="barcode-svg" viewBox="0 0 180 40" xmlns="http://www.w3.org/2000/svg">
+        <rect x="0" y="0" width="3" height="40" fill="#000000"/>
+        <rect x="5" y="0" width="1" height="40" fill="#000000"/>
+        <rect x="8" y="0" width="2" height="40" fill="#000000"/>
+        <rect x="13" y="0" width="4" height="40" fill="#000000"/>
+        <rect x="19" y="0" width="1" height="40" fill="#000000"/>
+        <rect x="22" y="0" width="3" height="40" fill="#000000"/>
+        <rect x="27" y="0" width="2" height="40" fill="#000000"/>
+        <rect x="31" y="0" width="1" height="40" fill="#000000"/>
+        <rect x="34" y="0" width="4" height="40" fill="#000000"/>
+        <rect x="40" y="0" width="2" height="40" fill="#000000"/>
+        <rect x="44" y="0" width="3" height="40" fill="#000000"/>
+        <rect x="49" y="0" width="1" height="40" fill="#000000"/>
+        <rect x="52" y="0" width="2" height="40" fill="#000000"/>
+        <rect x="56" y="0" width="4" height="40" fill="#000000"/>
+        <rect x="62" y="0" width="1" height="40" fill="#000000"/>
+        <rect x="65" y="0" width="3" height="40" fill="#000000"/>
+        <rect x="70" y="0" width="2" height="40" fill="#000000"/>
+        <rect x="74" y="0" width="1" height="40" fill="#000000"/>
+        <rect x="77" y="0" width="4" height="40" fill="#000000"/>
+        <rect x="83" y="0" width="2" height="40" fill="#000000"/>
+        <rect x="87" y="0" width="3" height="40" fill="#000000"/>
+        <rect x="92" y="0" width="1" height="40" fill="#000000"/>
+        <rect x="95" y="0" width="2" height="40" fill="#000000"/>
+        <rect x="99" y="0" width="4" height="40" fill="#000000"/>
+        <rect x="105" y="0" width="1" height="40" fill="#000000"/>
+        <rect x="108" y="0" width="3" height="40" fill="#000000"/>
+        <rect x="113" y="0" width="2" height="40" fill="#000000"/>
+        <rect x="117" y="0" width="1" height="40" fill="#000000"/>
+        <rect x="120" y="0" width="4" height="40" fill="#000000"/>
+        <rect x="126" y="0" width="2" height="40" fill="#000000"/>
+        <rect x="130" y="0" width="3" height="40" fill="#000000"/>
+        <rect x="135" y="0" width="1" height="40" fill="#000000"/>
+        <rect x="138" y="0" width="2" height="40" fill="#000000"/>
+        <rect x="142" y="0" width="4" height="40" fill="#000000"/>
+        <rect x="148" y="0" width="1" height="40" fill="#000000"/>
+        <rect x="151" y="0" width="3" height="40" fill="#000000"/>
+        <rect x="156" y="0" width="2" height="40" fill="#000000"/>
+        <rect x="160" y="0" width="1" height="40" fill="#000000"/>
+        <rect x="163" y="0" width="4" height="40" fill="#000000"/>
+        <rect x="169" y="0" width="2" height="40" fill="#000000"/>
+        <rect x="173" y="0" width="3" height="40" fill="#000000"/>
+        <rect x="178" y="0" width="2" height="40" fill="#000000"/>
+      </svg>
+      <span style="font-size: 9.5px;">S001-R01-T0000056</span>
+    </div>
+
+    <div class="text-center sans bold" style="margin-top: 10px; font-size: 10px;">
+      Thank you for shopping with us!
+    </div>
+
+  </div>
+
+  <script>
+    function printReceipt() {
+      // Prevents the browser from print-spooling before web fonts finish loading
+      if (document.fonts && document.fonts.ready) {
+        document.fonts.ready.then(function() {
+          window.print();
+        });
+      } else {
+        window.print();
+      }
+    }
+  </script>
+
+</body>
+</html>

--- a/docs/planning/receipts-and-reports-revamp/README.md
+++ b/docs/planning/receipts-and-reports-revamp/README.md
@@ -1,0 +1,38 @@
+# Receipts and reports revamp
+
+Status: **Accepted packet** — implementation slices R1–R4.
+
+**Program type:** Register follow-on (not a numbered domain phase). Runs after [Register workspace consolidation](../register-workspace-consolidation/README.md) on `main`. Does not reopen transaction, tender, stored-value, cash, session, or reporting-period domain semantics.
+
+This program **reformats** customer receipts and gift-card vouchers for thermal readability. Domain services, persisted financial facts, authorization, and print lifecycle remain.
+
+| Document | Purpose |
+|---|---|
+| [plan.md](plan.md) | Goal, locked decisions, scope, slices R1–R4 |
+| [implementation-plan.md](implementation-plan.md) | Slice status, merge policy, testing stack |
+| [content-contract.md](content-contract.md) | D1 customer receipt and D2 voucher presentation authority |
+| [visual-system.md](visual-system.md) | Shared thermal primitives, typography, print behavior |
+| [user-stories.md](user-stories.md) | GitHub-issue-ready slice stories |
+| [test-matrix.md](test-matrix.md) | Fixture scenarios and automated acceptance |
+
+Visual reference: [receipt.html](../../drafts/receipts_and_reports_revamp/receipt.html) (density, hierarchy, dividers — not domain authority).
+
+Historical draft superseded for D1/D2 implementation: [receipt-report-revamp-draft-spec.md](../../drafts/receipts_and_reports_revamp/receipt-report-revamp-draft-spec.md). Document families D3–D7 remain deferred companions in that draft until a later packet.
+
+## Supersedes
+
+- [receipt-presentation.md](../phase4-6-point-of-sale/phase6-pos-mvp/receipt-presentation.md) — layout, merchandise grammar, tax summary presentation, totals/tender chrome, one-line description clamp
+- [phase10-gift-card-numbering.md](../phase10-stored-value/phase10-gift-card-numbering.md) §5 — printed voucher chrome only (protection and lifecycle unchanged)
+
+## Does not reopen
+
+- [ADR-006](../../adr/ADR-006-receipt-numbering.md) receipt identity
+- [ADR-026](../../adr/ADR-026-gift-card-number-protection.md) credential delivery
+- Print-is-not-posting, no receipts table, legal-name fail-closed, header/footer inheritance
+
+## Deferred (later packet)
+
+- D3 Gift-card cash-out receipt
+- D4 Cash-custody slips
+- D5 Session close tape restyle
+- D6/D7 X/Z report visual revamp ([report-content-contract.md](../register-workspace-consolidation/report-content-contract.md) remains semantic authority)

--- a/docs/planning/receipts-and-reports-revamp/content-contract.md
+++ b/docs/planning/receipts-and-reports-revamp/content-contract.md
@@ -1,0 +1,133 @@
+# Receipt and voucher content contract (D1 + D2)
+
+Status: **Accepted** for slices R1–R4.
+
+Authority for completed facts: [ADR-020](../../adr/ADR-020-pos-operation-envelope-and-core-facts.md), [receipt-identity.md](../phase4-6-point-of-sale/phase4-point-of-sale/receipt-identity.md), [ADR-006](../../adr/ADR-006-receipt-numbering.md), [ADR-019](../../adr/ADR-019-pos-sales-tax-model.md), [ADR-026](../../adr/ADR-026-gift-card-number-protection.md).
+
+## Core invariants
+
+1. **Printing is presentation, not posting.** Print, retry, and reprint do not create or modify financial activity.
+2. **Completed facts remain authoritative.** No repricing, no current-catalog lookup, no live stored-value balance on historical receipts.
+3. **Factual reproduction, not pixel identity.** Reprints may use the current approved renderer.
+4. **Direction remains visible.** Sales, returns, payments, refunds, and stored-value activity preserve direction.
+5. **Full gift-card numbers** appear only on authorized D2 vouchers.
+
+## D1 — Customer transaction receipt
+
+### Default order
+
+1. Store identity and address
+2. Optional configured header message
+3. Reprint / post-void designation
+4. Completion time, Store/Register/Transaction, cashier, optional customer
+5. Merchandise sales and returns (description-first)
+6. Stored-value activations/reloads (distinct section)
+7. Merchandise/discount/return/stored-value summary
+8. Store Tax breakdown (named Store Taxes)
+9. `TOTAL DUE`, `REFUND TOTAL`, or `NET TOTAL`
+10. Payments or refunds applied
+11. Stored-value post-operation balance notes
+12. Items sold/returned and savings when applicable
+13. Receipt identity barcode
+14. Optional footer message
+
+Blank sections collapse.
+
+### Merchandise lines
+
+Description-first:
+
+```text
+Product description                       $10.99 [A]
+SKU: 2210000000063
+```
+
+Conditional detail:
+
+- Quantity and unit price when quantity > 1
+- Regular price and discount when `manual_discount_cents` > 0
+- Used unit identifier and condition
+- Linked-return original reference
+- `[UNLINKED RETURN]` badge for unlinked returns
+- Tax indicator letters (receipt-local, not persisted)
+
+Do **not** print: internal reference-price variance, manager username, approval reason, Tax Class name, internal operation IDs.
+
+### Stored-value issuance
+
+Distinct section (`GIFT CARDS ACTIVATED` or `GIFT CARDS RELOADED`):
+
+```text
+Store Gift Card · #801....5940             $15.00
+```
+
+### Summary and Store Tax
+
+When applicable:
+
+- Merchandise Subtotal
+- Item Discounts
+- Returns Subtotal
+- Gift Cards Activated / Gift Cards Reloaded
+
+Each Store Tax row:
+
+```text
+[A] Michigan Sales Tax
+    6.000% on $29.99                        $1.80
+```
+
+When multiple groups: `Total Tax` row. Do not print a universal `TAXABLE SUBTOTAL`.
+
+### Payments
+
+Dedicated `PAYMENTS APPLIED` section. Cash payment:
+
+```text
+Cash Tendered                              $20.00
+  Cash Applied:                            $11.86
+  Change:                                   $8.14
+```
+
+Stored-value tender with balance note uses persisted `balance_after_cents` and `Remaining Balance` or `New Balance` as appropriate.
+
+Customer receipts omit arbitrary tender `external_reference` unless a future receipt-safe policy adds it.
+
+### Receipt state variants
+
+| State | Banner |
+|---|---|
+| Reprint | `*** REPRINT ***` |
+| Post-voided original | `*** POST-VOIDED ***` + invalid note + reversing reference |
+| Post-void reversal | `*** POST-VOID ***` + original reference |
+| Pure stored-value | Omit empty merchandise and tax sections |
+| Pure return | Omit empty sales/issuance sections; use `REFUND TOTAL` |
+| Even exchange | Show gross activity; `NET TOTAL $0.00`; no fictitious tender |
+
+## D2 — Gift-card voucher
+
+Separate protected print artifact. Print:
+
+- Store identity
+- Issued time
+- Amount
+- `Gift Card` title
+- Full normalized presented number
+- Code 128 barcode of normalized digits
+- Configured voucher footer
+- `*** REPLACEMENT PRINT COPY ***` when recovery/replacement authorized
+
+Ordinary receipt stays masked. Voucher content order follows [phase10-gift-card-numbering.md](../phase10-stored-value/phase10-gift-card-numbering.md) §5 with updated chrome from [visual-system.md](visual-system.md).
+
+## Superseded presentation (Phase 6)
+
+The following Phase 6 receipt-presentation rules are **superseded** by this contract:
+
+- Identifier-first merchandise layout (§11)
+- One-line description ellipsis clamp (§11.3)
+- Generic `Tax A` summary without Store Tax name (§17.3 compact form may remain for single-tax simple sales at implementer discretion — prefer named tax when any detail row is shown)
+- Mixed issuance into merchandise lines
+- `Cash presented` label (now `Cash Tendered` on customer copy)
+- `Subtotal` without merchandise context label (now `Merchandise Subtotal` when detail totals shown)
+
+Identity strings, barcode payload, legal-name requirement, and header/footer inheritance remain from Phase 6.

--- a/docs/planning/receipts-and-reports-revamp/implementation-plan.md
+++ b/docs/planning/receipts-and-reports-revamp/implementation-plan.md
@@ -1,0 +1,49 @@
+# Receipts and reports revamp — Implementation plan
+
+Status: **In progress**
+
+Authority: [plan.md](plan.md), [content-contract.md](content-contract.md), [visual-system.md](visual-system.md).
+
+## Merge policy
+
+- Slice branches from `main`: `<issue-number>-receipt-r<n>-<short-description>` or focused PR per slice.
+- Each slice PR targets `main` directly (no long-lived integration branch required).
+- Delete superseded print markup in the owning slice. No runtime compatibility flags.
+
+## Slice status
+
+| Slice | Status | Scope |
+|---|---|---|
+| R1 Packet + ADR | **Complete** | Docs, ADR-022 amendment, roadmap pointer |
+| R2 Thermal primitives | **Complete** | CSS, fonts, print behavior |
+| R3 Customer receipt | **Complete** | Projection, partials, tests |
+| R4 Voucher closeout | **Complete** | Voucher chrome, recovery designation, protection tests |
+
+## Testing stack
+
+- **Service/unit:** `Pos::CustomerReceipt` section projections, tax reconciliation, `balance_after_cents` selection, total verification.
+- **Request/integration:** print partial rendering, voucher masking, first-print delivery, `Cache-Control: no-store`.
+- **System (manual):** 80 mm print preview, barcode scannability, receipt-only vs voucher-only modes, keyboard Print/Reprint.
+
+Run during development:
+
+```sh
+./dev/rails-docker bin/rails test test/services/pos/customer_receipt_test.rb
+./dev/rails-docker bin/rails test test/integration/pos_gift_card_voucher_test.rb
+```
+
+Full CI before handoff: `./dev/rails-docker bin/ci`
+
+## Components touched
+
+| Area | Files |
+|---|---|
+| Projection | `app/services/pos/customer_receipt.rb` |
+| Print partials | `app/views/pos/receipts/_print*.html.erb`, `app/views/pos/receipts/thermal/*` |
+| Voucher | `app/views/pos/receipts/_gift_card_voucher.html.erb` |
+| Styles | `app/assets/stylesheets/application.css` (thermal scope only) |
+| Fonts / layout | `app/views/layouts/pos.html.erb`, admin credential/recovery views |
+| Print controller | `app/javascript/controllers/pos_receipt_controller.js` |
+| First print | `app/services/pos/first_print.rb` (recovery designation on `Credential`) |
+
+Do **not** restyle `.pos-report-print` or `.pos-shift-end-tape` in this program.

--- a/docs/planning/receipts-and-reports-revamp/plan.md
+++ b/docs/planning/receipts-and-reports-revamp/plan.md
@@ -1,0 +1,71 @@
+# Receipts and reports revamp — Plan
+
+Status: **Accepted**
+
+Companions: [content-contract.md](content-contract.md), [visual-system.md](visual-system.md), [receipt-presentation.md](../phase4-6-point-of-sale/phase6-pos-mvp/receipt-presentation.md) (superseded sections), [ADR-022](../../adr/ADR-022-warm-parchment-visual-tokens.md) (amended for thermal fonts).
+
+## Goal
+
+Make customer receipts and gift-card vouchers easier to read on 80 mm thermal output, using a coherent ShelfSense visual system aligned with the approved HTML mockup. Render from persisted completed facts without repricing or reconstructing historical activity.
+
+## Non-goals
+
+- Remap Register keyboard shortcuts
+- Redesign transaction, tender, stored-value, cash, session, or Z domain semantics
+- Store raw printer bytes or image snapshots for reprint
+- Require pixel-identical historical reprints
+- Expose full gift-card numbers on ordinary customer receipts
+- Print expected drawer cash where authorization prohibits it
+- Rewrite Transaction Complete / Transaction Review screen density
+- ESC/POS or raw printer drivers
+
+## Locked decisions
+
+1. **First packet scope:** document families D1 (customer transaction receipts) and D2 (gift-card vouchers) only.
+2. **Visual authority:** [receipt.html](../../drafts/receipts_and_reports_revamp/receipt.html) for density, hierarchy, dividers, description-first lines, section titles, total banner, savings box, and barcode chrome.
+3. **Data authority:** completed transaction facts, receipt identity snapshots, Store Tax components, tender snapshots, stored-value entries (`balance_after_cents`), first-print/recovery services — unchanged.
+4. **Description-first merchandise:** product description on the primary line; SKU or unit identifier on indented meta; tax indicators on the amount line.
+5. **Separate stored-value issuance:** gift-card activation/reload in a distinct section, not mixed into merchandise lines.
+6. **Store Tax names:** persisted `store_tax_name_snapshot` on customer receipt tax rows; Tax Class names are not customer labels.
+7. **No universal taxable subtotal:** omit `TAXABLE SUBTOTAL` unless a row is semantically valid for all applicable Store Taxes.
+8. **Historical stored-value balances:** balance notes use the applicable persisted `stored_value_entries.balance_after_cents` for the operation, not live account balance.
+9. **Typography:** Noto Sans Mono + Plus Jakarta Sans via Google Fonts for thermal customer documents only ([ADR-022](../../adr/ADR-022-warm-parchment-visual-tokens.md) amendment). Screen chrome stays locally packaged. Reports/tapes keep Inconsolata until a later packet.
+10. **Receipt-only / voucher-only print modes** preserved via `pos_receipt_controller.js` body classes.
+11. **Operator screen vs thermal print** remain distinct projections; this packet changes hidden print markup and voucher print, not Transaction Complete screen layout.
+
+## Slices
+
+| Slice | Deliverable |
+|---|---|
+| **R1** | Planning packet, ADR-022 amendment, label locks, roadmap pointer |
+| **R2** | Shared thermal CSS primitives, Google Fonts load, font-ready print, wrapping |
+| **R3** | Sectioned `Pos::CustomerReceipt`, decomposed print partials, scenario tests |
+| **R4** | Voucher chrome aligned to thermal system, recovery designation, protection tests |
+
+## Label locks (customer receipt)
+
+| Element | Label |
+|---|---|
+| Merchandise subtotal | `Merchandise Subtotal` |
+| Discounts | `Item Discounts` |
+| Returns | `Returns Subtotal` |
+| Issuance | `Gift Cards Activated` / `Gift Cards Reloaded` |
+| Sale total | `TOTAL DUE` |
+| Refund total | `REFUND TOTAL` |
+| Zero net | `NET TOTAL` |
+| Payments section | `PAYMENTS APPLIED` |
+| Cash presented | `Cash Tendered` |
+| Cash settlement | `Cash Applied` |
+| Change | `Change` |
+| Issuance balance note | `New Balance` |
+| Redemption balance note | `Remaining Balance` |
+| Issued balances section | `ISSUED GIFT CARD BALANCES` (when multiple activations) |
+| Item counts | `Items Sold / Returned:` |
+| Savings | `YOU SAVED:` |
+| Date/time | Store timezone, four-digit year (e.g. `30 Aug 2026 12:09 AM`) |
+
+Identity header: restyle `Pos::ReceiptIdentity.header` as label/value rows (`Store/Reg/Trans:`) without changing canonical strings.
+
+## Voucher recovery designation
+
+Customer voucher for authorized recovery/replacement carries `*** REPLACEMENT PRINT COPY ***`. Manager identity, internal reason, and audit reference stay off the customer copy.

--- a/docs/planning/receipts-and-reports-revamp/plan.md
+++ b/docs/planning/receipts-and-reports-revamp/plan.md
@@ -60,7 +60,7 @@ Make customer receipts and gift-card vouchers easier to read on 80 mm thermal ou
 | Issuance balance note | `New Balance` |
 | Redemption balance note | `Remaining Balance` |
 | Issued balances section | `ISSUED GIFT CARD BALANCES` (when multiple activations) |
-| Item counts | `Items Sold / Returned:` |
+| Item counts | `Items Sold:` or `Items Returned` when one direction only; `Items Sold / Returned:` when both |
 | Savings | `YOU SAVED:` |
 | Date/time | Store timezone, four-digit year (e.g. `30 Aug 2026 12:09 AM`) |
 

--- a/docs/planning/receipts-and-reports-revamp/test-matrix.md
+++ b/docs/planning/receipts-and-reports-revamp/test-matrix.md
@@ -1,0 +1,66 @@
+# Receipts and reports revamp — Test matrix
+
+Status: **Accepted** for slices R3–R4.
+
+## Automated — customer receipt (D1)
+
+| # | Scenario | Assertions |
+|---|---|---|
+| 1 | Ordinary single-tender sale | Subtotal + tax = signed_net; named tax when shown |
+| 2 | Complex mixed sale | Merchandise + issuance sections separate; multiple tax groups |
+| 3 | Linked return | Original reference on line |
+| 4 | Return-only Cash refund | `REFUND TOTAL`; refund tender label |
+| 5 | Even exchange | `NET TOTAL` $0; no tender section |
+| 6 | Post-voided original | POST-VOIDED banner |
+| 7 | Post-void reversal | POST-VOID + original reference |
+| 8 | Gift-card activation only | Issuance section; no empty merchandise |
+| 9 | Gift-card reload | Reload section label |
+| 10 | Gift-card redemption + Cash | Remaining Balance from entry |
+| 11 | Used unit | Condition on meta line |
+| 12 | Open-price | No override provenance |
+| 13 | Multiple Store Taxes | Named rows; Total Tax |
+| 14 | No tax / exempt | No tax rows when none apply |
+| 15 | Customerless | No Customer row |
+| 16 | Missing description | `Description unavailable` |
+| 17 | Legal name blank | Fail closed |
+| 18 | Reprint after balance change | Balance note uses historical `balance_after_cents` |
+
+## Automated — voucher (D2)
+
+| # | Scenario | Assertions |
+|---|---|---|
+| 1 | First-print activation | Full number on voucher only; masked receipt |
+| 2 | Barcode | SVG aria-label = normalized number |
+| 3 | Footer | System settings footer present |
+| 4 | After delivery | No full number on completed view |
+| 5 | Recovery print | REPLACEMENT PRINT COPY designation |
+
+## Reconciliation (all D1 fixtures)
+
+- Tax group sum = persisted transaction tax direction
+- Tender rows reconcile to settlement
+- Cash: presented = applied + change
+- Print/reprint creates no commercial rows
+
+## Manual verification
+
+For priority fixtures:
+
+- 80 mm screen preview and browser print preview
+- Long-name wrapping without column overlap
+- Barcode scannability
+- Receipt-only vs voucher-only print
+- Keyboard Print / Print gift card
+- Black-and-white legibility
+
+## Existing test files
+
+| File | Role |
+|---|---|
+| `test/services/pos/customer_receipt_test.rb` | Projection unit tests |
+| `test/integration/pos_gift_card_voucher_test.rb` | Voucher protection integration |
+| `test/services/pos/receipt_identity_test.rb` | Identity strings unchanged |
+
+## Out of scope (deferred packet)
+
+X Report, Z Report, session tape, cash slips, gift-card cash-out receipt fixtures.

--- a/docs/planning/receipts-and-reports-revamp/user-stories.md
+++ b/docs/planning/receipts-and-reports-revamp/user-stories.md
@@ -1,0 +1,55 @@
+# Receipts and reports revamp — User stories
+
+GitHub issues should usually be one focused PR per slice.
+
+## Slice R1 — Content and authority lock
+
+**Outcome:** Accepted planning packet, ADR-022 amendment, supersession documented, label locks recorded.
+
+**Acceptance:**
+
+- [ ] `docs/planning/receipts-and-reports-revamp/` README and companions exist
+- [ ] ADR-022 amended for thermal Google Fonts exception
+- [ ] Roadmap cross-phase section references this program
+- [ ] Draft spec D3–D7 marked deferred in README
+
+## Slice R2 — Shared thermal primitives
+
+**Outcome:** Thermal CSS tokens, Google Fonts in print layouts, font-ready print, wrapping without ellipsis clamp on print descriptions.
+
+**Acceptance:**
+
+- [ ] `--font-thermal-body` and `--font-thermal-display` defined
+- [ ] `pos.html.erb` loads Google Fonts with preconnect
+- [ ] `pos_receipt_controller.js` preloads new faces
+- [ ] Print partials use thermal primitive classes
+- [ ] Report/tape print CSS unchanged (Inconsolata)
+
+## Slice R3 — Customer receipt projection and template
+
+**Outcome:** Sectioned `Pos::CustomerReceipt`, description-first print template, Store Tax names, payment hierarchy, `balance_after_cents`, scenario tests.
+
+**Acceptance:**
+
+- [ ] Merchandise and stored-value issuance in separate sections
+- [ ] Description-first layout matches content contract
+- [ ] Tax rows use `store_tax_name_snapshot`
+- [ ] Cash Tendered / Applied / Change hierarchy
+- [ ] Historical balance notes use persisted `balance_after_cents`
+- [ ] Post-void, reprint, refund, even-exchange variants render correctly
+- [ ] `test/services/pos/customer_receipt_test.rb` covers priority fixtures
+- [ ] Receipt totals reconcile to `signed_net_cents`
+
+## Slice R4 — Voucher presentation closeout
+
+**Outcome:** Voucher chrome aligned to thermal system; replacement designation; ADR-026 protection preserved.
+
+**Acceptance:**
+
+- [ ] Voucher shares store header, dividers, fonts with receipt
+- [ ] Recovery voucher shows `*** REPLACEMENT PRINT COPY ***`
+- [ ] Full number only on voucher, never ordinary receipt
+- [ ] Receipt-only and voucher-only print modes unchanged
+- [ ] `test/integration/pos_gift_card_voucher_test.rb` passes
+
+**Exclusions:** Transaction Complete screen redesign, X/Z restyle, cash-out receipt.

--- a/docs/planning/receipts-and-reports-revamp/visual-system.md
+++ b/docs/planning/receipts-and-reports-revamp/visual-system.md
@@ -1,0 +1,77 @@
+# Thermal visual system (D1 + D2)
+
+Status: **Accepted**
+
+Reference mockup: [receipt.html](../../drafts/receipts_and_reports_revamp/receipt.html)
+
+Typography authority: [ADR-022](../../adr/ADR-022-warm-parchment-visual-tokens.md) (amended).
+
+## Scope
+
+Applies to:
+
+- `.pos-receipt__print` (customer receipt)
+- `.pos-gift-card-voucher` (credential voucher)
+
+Does **not** apply to:
+
+- `.pos-report-print` (X/Z/session reports — Inconsolata until later packet)
+- `.pos-shift-end-tape`
+- Register screen chrome (Warm Parchment / Source Sans 3)
+
+## Typography
+
+| Role | Face | Weight |
+|---|---|---|
+| Store name, total banner, savings box, section emphasis | Plus Jakarta Sans | 700–800 |
+| Body, money, meta, tax rows | Noto Sans Mono | 400–700 |
+
+CSS variables:
+
+```text
+--font-thermal-body: "Noto Sans Mono", "Cascadia Code", "Consolas", "SF Mono", "Segoe UI Mono", sans-serif
+--font-thermal-display: "Plus Jakarta Sans", "Source Sans 3", system-ui, sans-serif
+```
+
+Load from Google Fonts in print-capable layouts only. Print waits for `document.fonts.ready`. Fallback stack prints when CDN is unavailable.
+
+## Layout
+
+- Primary target: 80 mm thermal roll
+- Printable content width: ~72 mm (`@page` margin 4mm 3mm; body width 72mm in print)
+- Screen preview: 80 mm paper simulation with shadow (Register print preview uses hidden print block)
+
+## Primitives
+
+Shared BEM-style classes under thermal scope:
+
+| Primitive | Class | Use |
+|---|---|---|
+| Solid divider | `.pos-thermal__divider-solid` | After store header |
+| Dashed divider | `.pos-thermal__divider-dashed` | Section breaks |
+| Label/value row | `.pos-thermal__row` | Meta, totals, payments |
+| Section title | `.pos-thermal__section-title` | Uppercase section headers |
+| Item block | `.pos-thermal__item-block` | Merchandise / issuance line group |
+| Item title | `.pos-thermal__item-title` | Primary description |
+| Item meta | `.pos-thermal__item-meta` | SKU, discount detail, indented |
+| Badge | `.pos-thermal__badge` | `[UNLINKED RETURN]` |
+| Total banner | `.pos-thermal__total-banner` | TOTAL DUE / REFUND TOTAL |
+| Savings box | `.pos-thermal__savings-box` | YOU SAVED |
+| Barcode container | `.pos-thermal__barcode` | Code 128 + human reference |
+| Status banner | `.pos-thermal__status` | REPRINT, POST-VOID, replacement |
+| Store header | `.pos-thermal__store-name` | Legal name |
+| Center | `.pos-thermal__center` | Header/footer centering |
+
+## Print behavior
+
+- Screen controls (`.pos-no-print`, `.pos-receipt__actions`) hidden in `@media print`
+- Long content wraps; money column stays right-aligned with `font-variant-numeric: tabular-nums slashed-zero`
+- Barcodes from approved Code 128 encoder (`Pos::Code128`)
+- Black-and-white legible; meaning never depends on color
+- Multiple voucher cards: page break between cards
+
+## Voucher alignment
+
+Voucher reuses store header, dividers, typography, and barcode container. Amount remains prominent (display face, larger size). Voucher is centered; receipt is left-aligned body with flex rows.
+
+Recovery designation uses `.pos-thermal__status` centered above store block when `credential.recovery?`.

--- a/docs/planning/roadmap.md
+++ b/docs/planning/roadmap.md
@@ -106,6 +106,16 @@ Replaces generic POS Home with state-aware Register entry and a shared shell. Pr
 
 > Authorized cashiers enter Register and immediately work from the correct operational state, with consistent custody context, without a generic POS Home, and without a second financial model.
 
+### Receipts and reports revamp
+
+**Status:** **Accepted packet** — slices R1–R4. Not a numbered domain phase.
+
+Authoritative packet: [receipts-and-reports-revamp/](receipts-and-reports-revamp/README.md). Follow-on after Register workspace consolidation; owns customer receipt and gift-card voucher thermal presentation (D1 + D2). Cash-out receipts, cash slips, session tapes, and X/Z visual restyle deferred.
+
+**Deliverable:**
+
+> Customer receipts and gift-card vouchers print with description-first hierarchy, named Store Tax rows, separated stored-value sections, and a shared thermal visual system aligned to the approved mockup—without altering completed transaction facts or credential protection.
+
 ## Phase 7.1 — Purchasing workflow and presentation closeout
 
 **Status:** **Complete** — **7.1.1–7.1.3 on `main`** (PR #35, PR #40); **UDS-4.1/4.2 on `main`**; **7.1.4 deferred**.

--- a/test/integration/gift_cards_admin_test.rb
+++ b/test/integration/gift_cards_admin_test.rb
@@ -97,6 +97,7 @@ class GiftCardsAdminTest < ActionDispatch::IntegrationTest
     post print_recovery_admin_gift_card_path(card), params: { reason: "printer jammed" }
     assert_response :success
     assert_includes response.body, card.number
+    assert_includes response.body, "REPLACEMENT PRINT COPY"
     assert_match(/no-store/, response.headers["Cache-Control"].to_s)
   end
 

--- a/test/integration/pos_close_z_test.rb
+++ b/test/integration/pos_close_z_test.rb
@@ -35,7 +35,7 @@ class PosCloseZTest < ActionDispatch::IntegrationTest
     assert_select ".pos-no-print"
     assert_select ".pos-thermal__store-name", text: "Example Books LLC"
     assert_select ".pos-receipt__print .pos-thermal__meta"
-    assert_select ".pos-receipt__print", text: /Items Sold \/ Returned:/
+    assert_select ".pos-receipt__print", text: /Items Sold:/
     assert_select ".pos-receipt__print .pos-thermal__total-banner"
     assert_select ".pos-receipt__print .pos-thermal__item-meta"
     assert_select ".pos-receipt__print .pos-thermal__tax-row"

--- a/test/integration/pos_close_z_test.rb
+++ b/test/integration/pos_close_z_test.rb
@@ -29,29 +29,27 @@ class PosCloseZTest < ActionDispatch::IntegrationTest
     assert_select "button", text: "Print receipt"
     assert_match "New transaction", response.body
     assert_match "Close register", response.body
-    assert_match "Store: 001   Reg: 01   Trans:", response.body
+    assert_match "Store/Reg/Trans:", response.body
     assert_match "Example Book", response.body
     assert_select ".pos-print-only"
     assert_select ".pos-no-print"
-    assert_select ".pos-receipt__legal-name", text: "Example Books LLC"
-    assert_select ".pos-receipt__print .pos-receipt__store"
-    assert_select ".pos-receipt__print .pos-receipt__identity"
-    assert_select ".pos-receipt__print .pos-receipt__counts", text: /Items Sold:/
-    assert_select ".pos-receipt__print .pos-receipt__total"
-    assert_select ".pos-receipt__print .pos-receipt__line-rest"
-    assert_select ".pos-receipt__print .pos-receipt__tax"
+    assert_select ".pos-thermal__store-name", text: "Example Books LLC"
+    assert_select ".pos-receipt__print .pos-thermal__meta"
+    assert_select ".pos-receipt__print", text: /Items Sold \/ Returned:/
+    assert_select ".pos-receipt__print .pos-thermal__total-banner"
+    assert_select ".pos-receipt__print .pos-thermal__item-meta"
+    assert_select ".pos-receipt__print .pos-thermal__tax-row"
     assert_select ".pos-receipt__print", text: /Business date/, count: 0
-    assert_select ".pos-receipt__barcode"
+    assert_select ".pos-thermal__barcode"
     assert_select "input[name='session_id'][value='#{transaction.pos_session_id}']"
-    assert_select "link[rel=preload][as=font][type='font/woff2']"
+    assert_select "link[href*='fonts.googleapis.com']"
     assert_select ".pos-receipt-font-loader", text: "0"
-    stylesheet_href = css_select("link[rel=stylesheet]").first["href"]
-    get stylesheet_href
+    stylesheet_href = css_select("link[rel='stylesheet'][href*='application']").first["href"]
+    get stylesheet_href.sub(/\Ahttps?:\/\/[^\/]+/, "")
     assert_response :success
     assert_match "@font-face", response.body
     assert_match "Inconsolata", response.body
-    assert_match "inconsolata-latin-700", response.body
-    refute_match "fonts.googleapis.com", response.body
+    assert_match "Noto Sans Mono", response.body
     assert transaction.reload.completed?
     assert_equal 1, PosTransaction.completed.where(id: transaction.id).count
   end

--- a/test/integration/pos_customer_attach_test.rb
+++ b/test/integration/pos_customer_attach_test.rb
@@ -90,7 +90,7 @@ class PosCustomerAttachTest < ActionDispatch::IntegrationTest
     }
     follow_redirect!
     assert_match "Customer · Attachable Reader", response.body
-    assert_match "Customer: Attachable Reader", response.body
+    assert_select ".pos-receipt__print .pos-thermal__row", text: /Customer:\s*Attachable Reader/
 
     receipt = Pos::CustomerReceipt.build(transaction.reload)
     assert_equal "Attachable Reader", receipt.customer_name

--- a/test/integration/pos_mixed_return_workspace_test.rb
+++ b/test/integration/pos_mixed_return_workspace_test.rb
@@ -183,7 +183,7 @@ class PosMixedReturnWorkspaceTest < ActionDispatch::IntegrationTest
     assert_match original.transaction_reference, response.body
     assert_select ".pos-history__detail", text: /Original receipt/
     assert_select ".pos-receipt__print", text: /Original: #{Regexp.escape(original.transaction_reference)}/
-    assert_select ".pos-receipt__reprint", text: "*** REPRINT ***"
+    assert_select ".pos-receipt__print .pos-thermal__status", text: "*** REPRINT ***"
     assert_equal 0, Pos::Returnability.remaining_quantity(original.pos_transaction_lines.first)
   end
 

--- a/test/integration/pos_mvp_closeout_test.rb
+++ b/test/integration/pos_mvp_closeout_test.rb
@@ -125,7 +125,7 @@ class PosMvpCloseoutTest < ActionDispatch::IntegrationTest
     refute_match "Renamed Catalog Book", response.body
     assert_match "Applied Tax Class", response.body
     assert_match "Performed by", response.body
-    assert_select ".pos-receipt__reprint", text: "*** REPRINT ***"
+    assert_select ".pos-receipt__print .pos-thermal__status", text: "*** REPRINT ***"
 
     post pos_register_continue_path
     follow_redirect!

--- a/test/integration/pos_post_void_workspace_test.rb
+++ b/test/integration/pos_post_void_workspace_test.rb
@@ -51,7 +51,7 @@ class PosPostVoidWorkspaceTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_select ".pos-receipt__screen .pos-receipt__reprint", text: /POST-VOID of/
-    assert_select ".pos-receipt__print .pos-receipt__reprint", text: "*** POST-VOID ***"
+    assert_select ".pos-receipt__print .pos-thermal__status", text: "*** POST-VOID ***"
     refute_match(/RETURN #{Regexp.escape("Example Book")}/, response.body)
     assert_match sale.transaction_reference, response.body
 
@@ -61,9 +61,9 @@ class PosPostVoidWorkspaceTest < ActionDispatch::IntegrationTest
     assert_select ".pos-history__detail .pos-receipt__post-void-note",
                   text: "This transaction has been post-voided and is no longer valid."
     assert_select ".pos-history__detail", text: /Post-voided by/
-    assert_select ".pos-receipt__print .pos-receipt__reprint", text: "*** POST-VOIDED ***"
-    assert_select ".pos-receipt__print .pos-receipt__post-void-note",
-                  text: "This transaction has been post-voided and is no longer valid."
+    assert_select ".pos-receipt__print .pos-thermal__status", text: "*** POST-VOIDED ***"
+    assert_select ".pos-receipt__print .pos-thermal__meta-note",
+                  text: "This transaction is no longer valid."
     assert_select ".pos-receipt__print", text: /Post-voided by:/
     assert_select "a", text: reversal.transaction_reference
     assert_select "a", text: "Return items", count: 0

--- a/test/integration/pos_transaction_history_test.rb
+++ b/test/integration/pos_transaction_history_test.rb
@@ -39,7 +39,7 @@ class PosTransactionHistoryTest < ActionDispatch::IntegrationTest
     assert_match transaction.transaction_reference, response.body
     assert_match "Example Book", response.body
     assert_match "REPRINT", response.body
-    assert_select ".pos-receipt__reprint", text: "*** REPRINT ***"
+    assert_select ".pos-receipt__print .pos-thermal__status", text: "*** REPRINT ***"
     assert_nil session[:pos_register_id]
   end
 
@@ -179,7 +179,7 @@ class PosTransactionHistoryTest < ActionDispatch::IntegrationTest
     refute_match "Bank Card", response.body
     assert_select ".pos-history__header dd", text: "Not captured"
     assert_select ".pos-receipt__print", text: /AUTH-77/, count: 0
-    assert_select ".pos-receipt__reprint", text: "*** REPRINT ***"
+    assert_select ".pos-receipt__print .pos-thermal__status", text: "*** REPRINT ***"
     assert_equal counts, commercial_counts
     assert_equal transaction.receipt_sequence, transaction.reload.receipt_sequence
   end
@@ -253,8 +253,8 @@ class PosTransactionHistoryTest < ActionDispatch::IntegrationTest
     transaction = complete_cash_sale!
     get pos_transaction_path(transaction)
     assert_response :success
-    assert_select ".pos-receipt"
-    assert_select ".pos-receipt__line-description", text: /Example Book/
+    assert_select ".pos-receipt", text: /Example Book/
+    assert_select ".pos-receipt__print .pos-thermal__item-title", text: /Example Book/
     assert_match transaction.transaction_reference, response.body
   end
 
@@ -266,7 +266,7 @@ class PosTransactionHistoryTest < ActionDispatch::IntegrationTest
     assert_select "header.pos-header.pos-no-print"
     assert_select "[data-register-shell-target=status].pos-no-print"
     assert_select ".pos-register-menu.pos-no-print"
-    assert_select ".pos-receipt__print .pos-receipt__reprint", text: "*** REPRINT ***"
+    assert_select ".pos-receipt__print .pos-thermal__status", text: "*** REPRINT ***"
     assert_select ".pos-history__title-row.pos-no-print"
     assert_select ".pos-history__detail.pos-no-print"
   end

--- a/test/services/pos/code128_test.rb
+++ b/test/services/pos/code128_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Pos::Code128Test < ActiveSupport::TestCase
+  PAYLOAD = "S001-R01-T0000001"
+
+  test "svg encodes payload with quiet zone for thermal print scaling" do
+    svg = Pos::Code128.svg(PAYLOAD)
+
+    assert_includes svg, PAYLOAD
+    assert_includes svg, "<svg"
+    assert_includes svg, "<rect"
+    assert_match(/viewBox="0 0 (\d+) 40"/, svg)
+    width = svg.match(/viewBox="0 0 (\d+) 40"/)[1].to_i
+    assert_operator width, :>, 200
+  end
+
+  test "checksum uses the deployed Code 128 B weighting" do
+    values = [ Pos::Code128::START_B, "A".ord - 32 ]
+    checksum = values.each_with_index.sum { |value, index| value * [ 1, index ].max } % 103
+
+    assert_equal 34, checksum
+  end
+
+  test "changing payload changes encoded bar pattern" do
+    first = Pos::Code128.svg(PAYLOAD)
+    second = Pos::Code128.svg("S001-R01-T0000002")
+
+    refute_equal first, second
+  end
+end

--- a/test/services/pos/customer_receipt_test.rb
+++ b/test/services/pos/customer_receipt_test.rb
@@ -31,6 +31,8 @@ class Pos::CustomerReceiptTest < ActiveSupport::TestCase
     assert_equal transaction.signed_net_cents.abs, receipt.total_display_cents
     assert_equal "Example Books LLC", receipt.legal_name
     assert_equal "TOTAL DUE", receipt.total_label
+    assert_equal "Items Sold:", receipt.item_counts_label
+    assert_equal "1", receipt.item_counts_value
     refute_includes receipt.address_lines, @store.name
     refute_equal receipt.completed_at_label, transaction.business_date.iso8601
     assert_match(/\A\d{1,2} [A-Z][a-z]{2} \d{4} \d{1,2}:\d{2}(am|pm)\z/, receipt.completed_at_label)

--- a/test/services/pos/customer_receipt_test.rb
+++ b/test/services/pos/customer_receipt_test.rb
@@ -22,17 +22,21 @@ class Pos::CustomerReceiptTest < ActiveSupport::TestCase
     @store.update!(legal_name: "Example Books LLC", street_address_1: "1234 Any Street", city: "Any Town", region_code: "MI", postal_code: "99999")
   end
 
-  test "print totals equal signed_net_cents and omit business date" do
+  test "print totals equal signed_net_cents and use four-digit completion year" do
     transaction = complete_sale!
 
     receipt = Pos::CustomerReceipt.build(transaction)
     assert receipt.printable?
-    assert_equal transaction.signed_net_cents, receipt.subtotal_cents + receipt.total_tax_cents
+    assert_equal transaction.signed_net_cents, receipt.net_merchandise_cents + receipt.total_tax_cents
     assert_equal transaction.signed_net_cents.abs, receipt.total_display_cents
     assert_equal "Example Books LLC", receipt.legal_name
+    assert_equal "TOTAL DUE", receipt.total_label
     refute_includes receipt.address_lines, @store.name
     refute_equal receipt.completed_at_label, transaction.business_date.iso8601
-    assert_match(/\A\d{1,2} [A-Z][a-z]{2} \d{2} \d{1,2}:\d{2}(am|pm)\z/, receipt.completed_at_label)
+    assert_match(/\A\d{1,2} [A-Z][a-z]{2} \d{4} \d{1,2}:\d{2}(am|pm)\z/, receipt.completed_at_label)
+    assert receipt.merchandise_lines.one?
+    assert_equal @variant.sku, receipt.merchandise_lines.first.identifier_value
+    assert_equal "SKU", receipt.merchandise_lines.first.identifier_label
   end
 
   test "fails closed when legal_name is blank" do
@@ -47,12 +51,14 @@ class Pos::CustomerReceiptTest < ActiveSupport::TestCase
   test "open-price lines do not print override provenance" do
     transaction = complete_sale!
     receipt = Pos::CustomerReceipt.build(transaction)
-    text = receipt.lines.map { |line| [ line.kind_banner, line.description, line.discount_label ] }.flatten.compact.join(" ")
+    text = receipt.merchandise_lines.map { |line|
+      [ line.kind_banner, line.description, line.discount_label ]
+    }.flatten.compact.join(" ")
 
     refute_match(/override|open price|reference price/i, text)
   end
 
-  test "used freeze snapshots include condition_name" do
+  test "used freeze snapshots include condition_name on meta line" do
     _variant, unit = pos_on_hand_unit(store: @store, actor: @actor, tax_class: @tax)
     transaction = Pos::StartTransaction.call(session: @context[:session], actor: @actor)
     Pos::AddMerchandise.call(
@@ -66,7 +72,7 @@ class Pos::CustomerReceiptTest < ActiveSupport::TestCase
 
     assert_equal unit.product_variant.merchandise_condition.name, snapshot.fetch("condition_name")
     receipt = Pos::CustomerReceipt.build(transaction)
-    assert_equal "Used #{snapshot.fetch("condition_name")}", receipt.lines.first.condition
+    assert_equal "Used #{snapshot.fetch("condition_name")}", receipt.merchandise_lines.first.condition
   end
 
   test "code 128 encodes the compact reference" do
@@ -92,7 +98,46 @@ class Pos::CustomerReceiptTest < ActiveSupport::TestCase
     PosTransactionLine.where(id: line.id).update_all(merchandise_snapshot: snapshot)
 
     receipt = Pos::CustomerReceipt.build(transaction.reload)
-    assert_equal "Used VG", receipt.lines.first.condition
+    assert_equal "Used VG", receipt.merchandise_lines.first.condition
+  end
+
+  test "tax groups use persisted store tax names" do
+    transaction = complete_sale!
+    receipt = Pos::CustomerReceipt.build(transaction)
+
+    assert_equal 1, receipt.tax_groups.size
+    assert_equal "Illinois State", receipt.tax_groups.first.name
+    assert_equal "A", receipt.tax_groups.first.letter
+  end
+
+  test "stored-value activation uses persisted balance_after_cents" do
+    GiftCards::Programs.seed!
+    program = GiftCardProgram.find_by!(code: "generated")
+    transaction = Pos::StartTransaction.call(session: @context[:session], actor: @actor)
+    Pos::AddStoredValueIssuance.call(
+      transaction: transaction,
+      actor: @actor,
+      expected_lock_version: transaction.lock_version,
+      issuance_type: "activation",
+      amount_cents: 2500,
+      gift_card_program: program,
+      operation_id: SecureRandom.uuid_v7
+    )
+    cash_and_complete!(transaction.reload)
+    issuance = transaction.pos_stored_value_issuances.sole
+    card = issuance.gift_card
+    entry_balance = issuance.stored_value_operation.stored_value_entries.sole.balance_after_cents
+
+    GiftCards::Fund.call(gift_card: card, amount_cents: 500, store: @store, performed_by: @actor)
+
+    receipt = Pos::CustomerReceipt.build(transaction.reload)
+    note = receipt.issued_balance_notes.sole
+    assert_equal "New Balance", note.label
+    assert_equal card.masked_number, note.masked_card
+    assert_equal entry_balance, note.balance_cents
+    refute_equal card.balance_cents, note.balance_cents
+    assert receipt.stored_value_issuances.one?
+    assert receipt.stored_value_issuances.first.activation
   end
 
   private

--- a/test/system/pos_close_z_test.rb
+++ b/test/system/pos_close_z_test.rb
@@ -66,7 +66,7 @@ class PosCloseZTest < ApplicationSystemTestCase
     assert_button "Print receipt"
     assert_text "New transaction"
     assert_text "Close register"
-    assert_selector ".pos-receipt__print-header", visible: :all, text: /Store: 001\s+Reg: 01\s+Trans:/
+    assert_selector ".pos-receipt__print .pos-thermal__meta", visible: :all, text: /Store\/Reg\/Trans:/
     transaction = PosTransaction.completed.find_by!(register: @register)
     send_keys :enter
     assert_text "Transaction complete"
@@ -127,7 +127,7 @@ class PosCloseZTest < ApplicationSystemTestCase
     assert_text "Transaction complete", wait: 10
     assert_text "Change"
     assert_button "Print receipt"
-    assert_selector ".pos-receipt__print-header", visible: :all, text: /Store: 001\s+Reg: 01\s+Trans:/
+    assert_selector ".pos-receipt__print .pos-thermal__meta", visible: :all, text: /Store\/Reg\/Trans:/
     transaction = PosTransaction.completed.find_by!(register: @register)
     assert transaction.completed?
 

--- a/test/system/pos_linked_return_test.rb
+++ b/test/system/pos_linked_return_test.rb
@@ -64,7 +64,7 @@ class PosLinkedReturnTest < ApplicationSystemTestCase
     click_on "Transactions"
     assert_text format_signed(returned.signed_net_cents)
     click_on returned.transaction_reference
-    assert_selector ".pos-receipt__reprint", visible: :all, text: "REPRINT"
+    assert_selector ".pos-receipt__print .pos-thermal__status", visible: :all, text: "REPRINT"
 
     visit pos_completed_transaction_path(returned)
     click_on "Close register"

--- a/test/system/pos_mixed_return_test.rb
+++ b/test/system/pos_mixed_return_test.rb
@@ -39,7 +39,7 @@ class PosMixedReturnTest < ApplicationSystemTestCase
     assert_text format_signed(completed.signed_net_cents)
     click_on completed.transaction_reference
     assert_text "Unlinked return"
-    assert_selector ".pos-receipt__reprint", visible: :all, text: "REPRINT"
+    assert_selector ".pos-receipt__print .pos-thermal__status", visible: :all, text: "REPRINT"
   end
 
   test "negative net split refunds cash and card" do

--- a/test/system/pos_register_shell_test.rb
+++ b/test/system/pos_register_shell_test.rb
@@ -59,9 +59,9 @@ class PosRegisterShellTest < ApplicationSystemTestCase
     assert_text(/Opening float|invalid|not a number|must be/i)
     with_viewport(width: 1280, height: 720, zoom: 2) do
       assert shell_body_scrollable?
-      submit = find(:button, "Open register")
-      scroll_to submit
-      assert submit.visible?
+      # Re-query after scroll: validation re-render + zoom can stale a held node.
+      scroll_to find(:button, "Open register")
+      assert_selector :button, "Open register", visible: true
     end
   end
 

--- a/test/system/pos_register_workspace_test.rb
+++ b/test/system/pos_register_workspace_test.rb
@@ -804,7 +804,7 @@ class PosRegisterWorkspaceTest < ApplicationSystemTestCase
     click_on "Transactions"
     assert_text completed.transaction_reference
     click_on completed.transaction_reference
-    assert_selector ".pos-receipt__reprint", text: "REPRINT", visible: :all
+    assert_selector ".pos-receipt__print .pos-thermal__status", text: "REPRINT", visible: :all
     assert_text "Example Book"
     assert_equal counts[:transactions], PosTransaction.count
     assert_equal counts[:tenders], PosTender.count


### PR DESCRIPTION
## Summary

- Adds the receipts-and-reports-revamp planning packet (R1–R4) and amends ADR-022 for Google Fonts on thermal customer documents only.
- Refactors `Pos::CustomerReceipt` into sectioned projection and decomposes receipt print into thermal partials with shared CSS primitives (description-first layout, one-line tax rows, updated totals/tender labels, balance notes from persisted entries).
- Restyles gift-card vouchers to the same thermal system, including replacement-print designation via `Pos::FirstPrint::Credential#recovery?`.
- Preserves ADR-006 receipt identity strings, ADR-026 credential protection, and the deployed Code 128 SVG print contract (`width: 100%`, `height: 52px`) verified scannable on Star TSP100 FuturePRNT.

## Test plan

- [x] `./dev/rails-docker bin/rails test test/services/pos/code128_test.rb test/services/pos/customer_receipt_test.rb`
- [x] `./dev/rails-docker bin/rails test test/integration/pos_gift_card_voucher_test.rb test/integration/gift_cards_admin_test.rb test/integration/pos_close_z_test.rb`
- [x] Complete a sale and print receipt — confirm layout, tax rows, totals, and transaction-reference barcode scans on hardware imager
- [x] Issue a gift card and print voucher — confirm voucher layout, masked number on receipt, full number on voucher only, and barcode scans
- [x] Print a replacement/recovery voucher — confirm `*** REPLACEMENT PRINT COPY ***` banner
- [x] Reprint receipt from transaction history — confirm `*** REPRINT ***` and unchanged barcode behavior
- [x] Confirm X/Z/tape reports still use Inconsolata (unchanged scope)


Made with [Cursor](https://cursor.com)