### PR TITLE
Accept Customer core packet (standard widths, sprint closeout)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,7 +50,7 @@ This directory contains the project’s technical authority, development guidanc
 | [Canonical roadmap](planning/roadmap.md) | Implemented milestones, forward phases 11–14, UDS, Terminal program |
 | [Planning packets](planning/README.md) | Phase and UX packet index |
 | [UX design system](planning/ux-design-system/README.md) | Warm Parchment UDS-1–3 operationally complete; UDS-4.0–4.2 and UDS-5 on `main` |
-| [Admin Page Frame Program](planning/admin-page-frame/README.md) | **Accepted.** Slice 1 **Implemented on `apf-development`** (PR [#133](https://github.com/BankEncore/ShelfSense-v1/pull/133)); not on `main` |
+| [Admin Page Frame Program](planning/admin-page-frame/README.md) | **Accepted.** Slice 1 **Implemented on `apf-development`** (PR [#133](https://github.com/BankEncore/ShelfSense-v1/pull/133)); Customer core **Accepted**; not on `main` until sprint closeout |
 | [POS Phases 4–6 plan](planning/phase4-6-point-of-sale/spec.md) | Multi-phase POS sequencing (foundation → cash register → MVP); §6 deferred to the Phase 6 packet |
 | [Glossary](glossary.md) | Canonical domain terms (stored value and project-wide) |
 | [UX conventions](ux-conventions.md) | Shared admin page anatomy, partials, currency boundaries, and Warm Parchment tokens |

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -72,7 +72,7 @@ Branch naming: `<issue-number>-<short-description>` (lowercase, hyphenated). Mer
 Active exceptions:
 
 - [Register workspace consolidation](planning/register-workspace-consolidation/implementation-plan.md) uses integration branch `register-workspace-consolidation` until [closeout](planning/register-workspace-consolidation/closeout-plan.md). An incomplete Register replacement on `main` would leave cashiers without POS Home and without F10. Slice PRs for that program target the integration branch; merge `main` into it regularly. Phase 11 used the same pattern and has merged.
-- [Admin Page Frame Program](planning/admin-page-frame/README.md) uses integration branch `apf-development` until a later closeout merge to `main`. Slice 1 is on that branch (PR [#133](https://github.com/BankEncore/ShelfSense-v1/pull/133)), not on `main`. Later authorized APF packets target `apf-development`. This is not a restyle sweep and does not authorize [adoption-outlook.md](planning/admin-page-frame/adoption-outlook.md).
+- [Admin Page Frame Program](planning/admin-page-frame/README.md) uses temporary sprint branch `apf-development` until Customer core is validated and the branch merges to `main`. Slice 1 is on that branch (PR [#133](https://github.com/BankEncore/ShelfSense-v1/pull/133)). [Customer core](planning/admin-page-frame/customer-core.md) is **Accepted**; implement it into `apf-development`, then merge to `main` and retire the branch. Do not add another Admin family to `apf-development`. This is not a restyle sweep and does not authorize [adoption-outlook.md](planning/admin-page-frame/adoption-outlook.md).
 
 PR structure:
 

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -43,7 +43,7 @@ Phases 12–14 and the Terminal program are sequenced in [roadmap.md](roadmap.md
 | [UX design system](ux-design-system/README.md) | UDS-1–3 operationally complete; UDS-4.0–4.2 on `main`; UDS-5 complete on `main` (PR #57) |
 | [UDS-4 plan](ux-design-system/uds-4-plan.md) | Grouped navigation and non-purchasing adoption |
 | [UDS-5 plan](ux-design-system/uds-5-plan.md) | Administrative composition; 5.0–5.5 complete on `main`; 5.0 gate **Passed**; serif adopted |
-| [Admin Page Frame Program](admin-page-frame/README.md) | **Accepted.** Slice 1 **Implemented on `apf-development`** (PR [#133](https://github.com/BankEncore/ShelfSense-v1/pull/133)). Not a restyle sweep |
+| [Admin Page Frame Program](admin-page-frame/README.md) | **Accepted.** Slice 1 **Implemented on `apf-development`**. Customer core **Accepted**. Not a restyle sweep |
 
 Further screen migration belongs to the feature phase that materially changes the screen, except the bounded frame infrastructure and Adjustment Reasons reference in the [Admin Page Frame Program](admin-page-frame/README.md) locked allowlist. That program does not authorize a general restyle.
 

--- a/docs/planning/admin-page-frame/README.md
+++ b/docs/planning/admin-page-frame/README.md
@@ -2,7 +2,7 @@
 
 **Program name:** Admin Page Frame Program (not UDS-6, UDS-7, or UDS-8)
 
-**Status:** **Accepted.** Slice 0 complete. Slice 1 **Implemented on `apf-development`** (PR [#133](https://github.com/BankEncore/ShelfSense-v1/pull/133)); not on `main` until a later closeout merge. Further family adoption is not authorized by this packet.
+**Status:** **Accepted.** Slice 0 complete. Slice 1 **Implemented on `apf-development`** (PR [#133](https://github.com/BankEncore/ShelfSense-v1/pull/133)). [Customer core](customer-core.md) **Accepted** (not yet implemented). Not on `main` until this sprint’s closeout merge. [adoption-outlook.md](adoption-outlook.md) is not authorized.
 
 This is a UDS-adjacent administrative composition program, not a numbered domain phase and not a numbered UDS slice. UDS-6 (staff history) and UDS-7 (sidebar / Cmd+K) remain parked.
 
@@ -25,7 +25,7 @@ Slice 0 choices: [choices.md](choices.md) (APF-001–APF-008).
 | [user-stories.md](user-stories.md) | Issue-ready stories for Slice 0 (complete) and Slice 1 (complete) |
 | [test-matrix.md](test-matrix.md) | Slice 1 tests, frozen suites, viewport gates |
 | [slice-1.md](slice-1.md) | Slice 1 completion and viewport/CSS sign-off |
-| [customer-core.md](customer-core.md) | Proposed Customer core family packet — **not authorized** until Accepted |
+| [customer-core.md](customer-core.md) | Customer core family packet — **Accepted**; implement on `apf-development`, then merge to `main` |
 | [adoption-outlook.md](adoption-outlook.md) | Former family-migration slices — **not authorized** |
 
 ## Authorized program
@@ -35,15 +35,13 @@ Slice 0 choices: [choices.md](choices.md) (APF-001–APF-008).
 | **Slice 0** — Inventory, evidence, and contract | **Complete** | None |
 | **Slice 1** — Frame + Adjustment Reasons | **Implemented on `apf-development`** (PR [#133](https://github.com/BankEncore/ShelfSense-v1/pull/133)) | Frame API + Adjustment Reasons only |
 | **Closeout gate** | **Complete** | Product consuming the frame is a separately approved later slice |
-| **Customer core** | **Proposed** ([customer-core.md](customer-core.md)) | None until Accepted |
+| **Customer core** | **Accepted** ([customer-core.md](customer-core.md)) | None until the implementation PR |
 
 [adoption-outlook.md](adoption-outlook.md) is not a delivery plan.
 
 ## Next action
 
-Do not start family restyles from leftover Slice 1 energy. Remaining Admin surfaces adopt `admin/shared/page` through a separately approved family or feature slice on `apf-development`. Product consuming the frame is **not** implied. [adoption-outlook.md](adoption-outlook.md) remains non-authoritative.
-
-The next candidate family packet is [customer-core.md](customer-core.md) (**Proposed**). Do not implement it until that packet is Accepted.
+Implement [customer-core.md](customer-core.md) on a feature branch targeting `apf-development`. After that implementation is validated, merge `apf-development` to `main` and retire the branch. Do not add another Admin family to `apf-development`. Product consuming the frame is **not** implied. [adoption-outlook.md](adoption-outlook.md) remains non-authoritative.
 
 ## Does not reopen
 

--- a/docs/planning/admin-page-frame/adoption-outlook.md
+++ b/docs/planning/admin-page-frame/adoption-outlook.md
@@ -12,7 +12,7 @@ Authority for what may ship now: [plan.md](plan.md), [change-allowlist.md](chang
 
 After Slice 1 closeout, choose **feature-led adoption** (UDS-5.5, remaining the default for domain chrome) or write a **new bounded family packet**. Do not start the work below from leftover energy in this program.
 
-A Proposed Customer core packet lives at [customer-core.md](customer-core.md). Until that packet is **Accepted**, it has no implementation authority and does not authorize the Index or Record family rows below.
+[customer-core.md](customer-core.md) is **Accepted** as a bounded family packet (index/show/new/edit at `standard`). It does not authorize the Index or Record family rows below, merge review, or any other family on `apf-development`.
 
 ## Possible later family packets
 

--- a/docs/planning/admin-page-frame/customer-core.md
+++ b/docs/planning/admin-page-frame/customer-core.md
@@ -2,9 +2,13 @@
 
 **Program name:** Admin Page Frame Program (not UDS-6, UDS-7, or UDS-8)
 
-**Status:** **Proposed.** Not implementation authority until Accepted. Not a numbered APF-2–6 slice and not UDS-6, UDS-7, or UDS-8.
+**Status:** **Accepted.** Not a numbered APF-2–6 slice and not UDS-6, UDS-7, or UDS-8. Implementation follows this packet on `apf-development`. Not on `main` until the sprint closeout merge.
 
-**Integration:** After acceptance, implement on a feature branch and open a PR into `apf-development`. Do not target `main`. Do not merge `apf-development` to `main` as part of this packet.
+**Integration:** After acceptance, implement on a dedicated feature branch and open a PR into `apf-development`, the temporary integration branch for this bounded APF sprint.
+
+After Customer core is accepted and validated, merge `apf-development` to `main` before beginning or authorizing another Admin family. Do not add another family to `apf-development`. Retire the integration branch after it merges to `main`.
+
+Status progression: Proposed → Accepted → Implemented on `apf-development` → Implemented on `main` → integration branch retired.
 
 Companions: [README.md](README.md), [plan.md](plan.md), [choices.md](choices.md) (APF-001–APF-008), [slice-1.md](slice-1.md), [change-allowlist.md](change-allowlist.md), [adoption-outlook.md](adoption-outlook.md).
 
@@ -12,9 +16,9 @@ This packet is the next bounded **reference family** after Slice 1. It does not 
 
 ## Why this family
 
-Customers already have breadcrumbs, a page header, a two-control GET filter form, a data table with empty-vs-filtered copy, and a show record with aliases, stored value, merge entry, and related requests. That is a real `wide` candidate without being a hub or a UDS-5 Product clone.
+Customers already have breadcrumbs, a page header, a two-control GET filter form, a data table with empty-vs-filtered copy, and a show record with aliases, stored value, merge entry, and related requests. That is a meaningful test of the frame’s tools region and of complex record preservation, without being a hub or a UDS-5 Product clone.
 
-Slice 0 inventory ([slice-0.md](slice-0.md)): index `wide`; show `wide/workspace`; new/edit `standard`; merge `workspace`. Evidence ([slice-0-evidence.md](slice-0-evidence.md)): four index columns fit in 72rem; tools-region grouping helps more than width; filters sit on the canvas instead of a padded tools surface (APF-006).
+Slice 0 inventory ([slice-0.md](slice-0.md)): index `wide`; show `wide/workspace`; new/edit `standard`; merge `workspace`. Evidence ([slice-0-evidence.md](slice-0-evidence.md)): four index columns fit in 72rem; tools-region grouping helps more than width; filters sit on the canvas instead of a padded tools surface (APF-006). No 1440/1920 show captures exist. This packet therefore does not use `wide`.
 
 ## Locked choices (CC-001–CC-008)
 
@@ -22,7 +26,7 @@ These choices are the packet. Accepting the packet accepts all eight. Reopening 
 
 ### CC-001 — Surfaces
 
-**Proposed lock.** Production templates only:
+**Accepted.** Production templates only:
 
 ```text
 app/views/admin/customers/index.html.erb
@@ -41,33 +45,38 @@ Each wraps `render layout: "admin/shared/page"` with the width and regions below
 | `app/views/admin/customer_requests/**` | Out of scope |
 | Stored-value **workflow** templates (`stored_value_adjustments/new`, `stored_value_transfers/new`, gift-card association/adjust) | Out of scope. Existing Customer show sections stay as **body** content. Do not change Adjust / Add store credit / Add trade credit / Transfer credit command destinations or parameters |
 | `app/views/admin/customers/_form.html.erb` | Frozen (CC-006) |
+| `app/controllers/admin/customers_controller.rb` | Frozen |
 
 The merge-into GET form on Customer show remains body content. It continues to navigate to `merge_review`. This packet does not restyle that destination.
 
 ### CC-002 — Widths
 
-**Proposed lock.**
+**Accepted.**
 
 | Surface | Width |
 |---|---|
-| Customers index | `wide` |
-| Customer show | `wide` |
+| Customers index | `standard` |
+| Customer show | `standard` |
 | New customer | `standard` |
 | Edit customer | `standard` |
 
-Show is `wide`, not `workspace`. Merge review stays unmigrated; `workspace` is not authorized here.
+Customer core validates frame adoption and the first production tools-region consumer. It does not use `wide` merely to exercise the provisional token.
 
-New/edit are `standard`, not Slice 1’s `narrow`. The Customer form is longer than Adjustment Reasons and can redisplay a duplicate-suggestions panel; `--form-max: 40rem` still bounds field measure inside `standard`.
+Customer show may change to `wide` before implementation only if rendered evidence at 1440 and 1920 demonstrates a material scanning or overflow benefit. That change requires a recorded CC-002 amendment.
+
+`wide` remains available for a later surface whose information density or table geometry materially requires it. Merge review stays unmigrated; `workspace` is not authorized here.
 
 ### CC-003 — Provisional `wide` measurement (does not reopen APF-003)
 
-**Proposed lock.** This is the first production `wide` call site. It uses the Slice 1 token `--admin-content-wide: 90rem` as-is. This packet does **not** finalize that rem value, change `:root --content-max`, or introduce a second wide token.
+**Accepted.** This packet introduces **no** production `wide` call site. Leave `--admin-content-wide: 90rem` untouched. Do not change `:root --content-max` or introduce a second wide token.
 
 Changing `90rem` requires an explicit APF-003 reopening recorded in [choices.md](choices.md). Silent tuning in the Customer PR is forbidden.
 
 ### CC-004 — Tools (index filters)
 
-**Proposed lock.** Capture the existing GET filter form into the page-frame `tools:` local.
+**Accepted.** Capture the existing GET filter form into the page-frame `tools:` local.
+
+The existing GET filter form is captured into `tools:` and receives `class: "filters surface customer-filters"`. The form itself is the padded surface; do not add an extra `.surface` wrapper around it.
 
 Preserve:
 
@@ -77,35 +86,44 @@ Preserve:
 - Empty-collection copy vs empty-filter copy (`No customers yet` / `No matching customers` and their bodies)
 - Table columns Name, Email, Phone, Status and current cell contents (including matched-former-record annotation)
 
-**Surface treatment:** wrap that form in a padded `.surface` inside `.admin-page__tools`. Keep `class: "filters"` on the form. Do **not** capture-only (leaving `.filters` on the canvas or as an unsurfaced tools child). APF-006 assigns multi-control filters a padded surface; Slice 0 recorded that this index currently misses that rule.
-
 Do **not** copy Product composition: no `product-filters`, no `form-field--grow`, no flush `surface--flush` around the table unless a later packet reopens those. The index table stays in the body as `shared/data_table` (same as Adjustment Reasons). Do not add a new global tools-surface primitive.
 
 Header “New customer” remains a page-header action gated on `customers.manage`.
 
 ### CC-005 — Show composition
 
-**Proposed lock.** Frame adoption only: breadcrumbs, page header (existing title, lifecycle badge, Edit / Deactivate / Reactivate), body.
+**Accepted.** Frame adoption only: breadcrumbs, page header (existing title, lifecycle badge, Edit / Deactivate / Reactivate), body.
 
-Keep current stacked sections as body content (merged-alias notice, identity definition list, merged aliases table, merge-into form, stored-value accounts and activity, associated gift cards, recent requests, back link). Do not introduce Product-like `.content-grid`, `.product-panels`, `.metric-strip`, or cover treatments. Default is **no** unless a later accepted packet says otherwise.
+No content grid, metric strip, Product panel composition, or new show-page primitive is authorized. Existing show sections remain in their current source order inside `.admin-page__body`.
+
+Selecting `wide` for Customer show, if later accepted, does not authorize rearranging those sections into columns. Any structural show-page composition requires a separate accepted choice.
 
 Do not extract show sections into new shared primitives.
 
 ### CC-006 — Frozen `_form`
 
-**Proposed lock.** [`_form.html.erb`](../../../app/views/admin/customers/_form.html.erb) stays frozen. New/edit wrap the frame around `render "form"`. Name no inner change in this packet.
+**Accepted.** [`_form.html.erb`](../../../app/views/admin/customers/_form.html.erb) stays frozen. New/edit wrap the frame around `render "form"`. Name no inner change in this packet.
 
-Protect with assertions, not incidental edits. Duplicate-suggestions checkbox, `lock_version`, `return_to`, `idempotency_key`, and Cancel targets stay as they are. 422 redisplay of new/edit must still render the frame around the unchanged form.
+Protect with assertions, not incidental edits. The form has no address, receipt-preference, or lifecycle/status fields. Assert the fields that exist:
+
+- `given_name`, `family_name`, `display_name`, `email`, `phone`, `preferred_contact_method`, `notes`
+- duplicate-suggestion block and `acknowledge_duplicates` on 422
+- `lock_version`, `return_to` (when present), `idempotency_key`
+- submit labels “Create Customer” / “Save Changes”
+- Cancel → index (new) or show (edit)
+- retained values after ordinary validation failure and after duplicate detection
+
+Do not duplicate domain behavior already covered by `customers_admin_test`. 422 redisplay of new/edit must still render the frame around the unchanged form.
 
 ### CC-007 — Presentation only
 
-**Proposed lock.** No controller, query, pagination, filter-param, authorization, lifecycle-command, routing, or persisted-value changes. `customers_admin_test` is frozen: do not rewrite it to make the frame pass. Add new composition/system tests instead.
+**Accepted.** No controller, query, pagination, filter-param, authorization, lifecycle-command, routing, or persisted-value changes. `customers_admin_test` is frozen: do not rewrite it to make the frame pass. Add new composition/system tests instead.
 
 Shared primitives (`shared/breadcrumbs`, `shared/page_header`, `shared/data_table`, `shared/empty_state`, `shared/definition_list`, `shared/form_errors`) keep their semantics. Ops, Register, print, and `Admin::NavigationCatalog` stay frozen.
 
 ### CC-008 — Tests
 
-**Proposed lock.** New tests plus frozen regressions:
+**Accepted.** New tests plus frozen regressions:
 
 ```text
 test/integration/admin_customer_page_frame_test.rb
@@ -114,17 +132,20 @@ test/system/admin_customers_composition_test.rb
 
 | Layer | Asserts |
 |---|---|
-| Request | One `.admin-page` on migrated Customer pages; index/show `main.app-content.app-content--wide`; new/edit `app-content--standard`; tools present on index only; `q` / `lifecycle` fields inside `.admin-page__tools`; unmigrated Users and `merge_review` have no width modifier; frozen `_form` contract (422 duplicate redisplay still contains “Possible duplicates”) |
-| System | `assert_layout_usable` at 320 and 1280@200% zoom on index (`wide`, tools, `.table-scroll`) and new/edit (`standard`, Cancel). At 1920: unmigrated Users and Adjustment Reasons index remain ≤ 72rem and match each other; Customer index used width is greater than Users and ≤ `90rem` used width + 1px |
+| Request | One `.admin-page` on migrated Customer pages; index/show/new/edit `main.app-content.app-content--standard`; tools present on index only; `form.filters.surface.customer-filters` inside `.admin-page__tools`; filtered GET retains `q` and `lifecycle`; empty-vs-filtered copy; matched-former-record annotation; table columns unchanged; merge-review transition from the show form; unmigrated Users and `merge_review` have no width modifier and no `.admin-page`; frozen `_form` contract including 422 retain and “Possible duplicates”; scoped CSS selector present without token changes |
+| System | `assert_layout_usable` at 320 and 1280@200% on index, show, new, and edit. Index preserves intentional table scrolling. Show retains lifecycle, merge, stored-value, gift-card, and request regions without page-level overflow or clipped actions. New/edit retain reachable Cancel and submit actions. At 1920, Customer index used width matches Adjustment Reasons index and unmigrated Users within 1px; all ≤ 72rem |
 
 Always run, do not rewrite:
 
 ```sh
 ./dev/rails-docker bin/rails test \
+  test/helpers/admin_page_helper_test.rb \
+  test/views/admin_page_partial_test.rb \
+  test/integration/admin_page_frame_test.rb \
+  test/system/admin_adjustment_reasons_composition_test.rb \
   test/integration/customers_admin_test.rb \
   test/system/admin_product_composition_test.rb \
-  test/system/admin_grouped_navigation_test.rb \
-  test/system/admin_adjustment_reasons_composition_test.rb
+  test/system/admin_grouped_navigation_test.rb
 ```
 
 Full `./dev/rails-docker bin/ci` before handoff.
@@ -138,9 +159,25 @@ app/views/admin/customers/index.html.erb
 app/views/admin/customers/show.html.erb
 app/views/admin/customers/new.html.erb
 app/views/admin/customers/edit.html.erb
+app/assets/stylesheets/application.css
 ```
 
-CSS: only if a Customer-scoped rule is required to keep the padded tools surface from double-margin with `.filters { margin-bottom }`. Prefer a local adjustment under `.admin-page__tools`, not a global `.filters` change. Do not change `:root --content-max` or `--admin-content-wide`.
+`application.css` may change only to add the Customer-scoped `.admin-page__tools > .customer-filters` spacing rule. Do not change global `.filters`, `.surface`, `.admin-page__tools`, width tokens, or other frame selectors.
+
+```css
+.admin-page__tools > .customer-filters {
+  margin-bottom: 0;
+}
+```
+
+### Frozen
+
+```text
+app/views/admin/customers/_form.html.erb
+app/views/admin/customers/merge_review.html.erb
+app/controllers/admin/customers_controller.rb
+app/views/admin/customer_requests/**
+```
 
 ### Tests
 
@@ -157,9 +194,10 @@ docs/planning/admin-page-frame/README.md
 docs/planning/admin-page-frame/plan.md
 docs/planning/roadmap.md
 docs/planning/ux-design-system/migration-matrix.md
+docs/github-workflow.md
 ```
 
-Status pointers after implementation: **Implemented on `apf-development`**, not on `main`.
+Status after the implementation PR: **Implemented on `apf-development`**. Status after the sprint closeout merge: **Implemented on `main`**; retire `apf-development`.
 
 ## Forbidden
 
@@ -168,31 +206,27 @@ Status pointers after implementation: **Implemented on `apf-development`**, not 
 - Rewriting `test/integration/customers_admin_test.rb`
 - Copying Product index/show composition onto Customer show
 - Authorizing `workspace` or changing `--admin-content-wide`
+- Using `wide` to exercise the provisional token
 - Expanding into Users, Products, Stores, or any other family
 - Treating this packet as APF-2 or as [adoption-outlook.md](adoption-outlook.md) authority
-- Merging to `main`
+- Adding another family to `apf-development`
 
-## Acceptance bar (this docs packet)
+## Implementation bar
 
-- [ ] Packet Accepted (status line in this file and the program README)
-- [ ] CC-001–CC-008 unchanged except by explicit review callout
-- [ ] No production Customer view changes in the acceptance PR unless that PR is the later implementation
-
-## Implementation bar (later PR, after Accepted)
-
-- [ ] Four listed templates consume `admin/shared/page` with CC-002 widths
+- [ ] Four listed templates consume `admin/shared/page` at `standard`
 - [ ] Index tools capture preserves `q`, `lifecycle`, empty-vs-filtered copy, and table contents
-- [ ] Tools use a padded `.surface`; `_form` and `merge_review` untouched
-- [ ] Show has no Product content-grid/panels
-- [ ] New tests green; frozen `customers_admin_test`, Product, nav, and Adjustment Reasons system suites green
-- [ ] `assert_layout_usable` on index and new/edit; 1920 wide-vs-standard comparison
+- [ ] Filter form is `filters surface customer-filters` with no extra wrapper; `_form` and `merge_review` untouched
+- [ ] Show has no Product content-grid/panels; sections stay in current source order
+- [ ] New tests green; frozen `customers_admin_test`, Product, nav, Adjustment Reasons, and shared frame suites green
+- [ ] `assert_layout_usable` on index, show, new, and edit; 1920 standard-vs-Users comparison
 - [ ] Roadmap/packet status: Implemented on `apf-development` (cite the implementation PR)
+- [ ] After validation: merge `apf-development` to `main` and retire the branch
 
 ## Does not reopen
 
 - Slice 1 Adjustment Reasons contracts
 - APF-001 page-frame API (Customer consumes it)
-- APF-003 rem values (CC-003 uses the provisional `90rem` token)
+- APF-003 rem values (this packet does not introduce production `wide`)
 - UDS-5 Product as a template to copy
 - UDS-6 / UDS-7
 - Register workspace, Ops, print

--- a/docs/planning/admin-page-frame/plan.md
+++ b/docs/planning/admin-page-frame/plan.md
@@ -2,7 +2,7 @@
 
 **Program name:** Admin Page Frame Program (not UDS-6, UDS-7, or UDS-8)
 
-**Status:** **Accepted.** Slice 0 complete. Slice 1 **Implemented on `apf-development`** (PR [#133](https://github.com/BankEncore/ShelfSense-v1/pull/133)). Not on `main` until a later closeout merge. Further family adoption is not authorized by this packet.
+**Status:** **Accepted.** Slice 0 complete. Slice 1 **Implemented on `apf-development`** (PR [#133](https://github.com/BankEncore/ShelfSense-v1/pull/133)). [Customer core](customer-core.md) **Accepted** (not yet implemented). Not on `main` until this sprint’s closeout merge. Further family adoption beyond Customer core is not authorized.
 
 Companions: [choices.md](choices.md), [slice-0.md](slice-0.md), [change-allowlist.md](change-allowlist.md), [test-matrix.md](test-matrix.md), [UDS-5](../ux-design-system/uds-5-plan.md), [ux-conventions.md](../../ux-conventions.md).
 
@@ -192,7 +192,7 @@ No disposable fixture. Non-regression: Users, Customers, Products, and Store wit
 
 ### Closeout gate (after Slice 1)
 
-**Complete.** The frame is accepted for Adjustment Reasons on `apf-development` (PR [#133](https://github.com/BankEncore/ShelfSense-v1/pull/133)), not on `main`. Product consuming the frame is a **separately approved** later slice, not leftover Slice 1 work. Width rem values for `wide` / `workspace` remain provisional (APF-003). Next adoption is feature-led or an explicitly bounded family packet. [customer-core.md](customer-core.md) is **Proposed** and has no implementation authority until Accepted. Do not begin [adoption-outlook.md](adoption-outlook.md) work from this packet.
+**Complete.** The frame is accepted for Adjustment Reasons on `apf-development` (PR [#133](https://github.com/BankEncore/ShelfSense-v1/pull/133)), not on `main`. Product consuming the frame is a **separately approved** later slice, not leftover Slice 1 work. Width rem values for `wide` / `workspace` remain provisional (APF-003). [customer-core.md](customer-core.md) is **Accepted**; implement it on `apf-development`, then merge that branch to `main` and retire it. Do not add another family to `apf-development`. Do not begin [adoption-outlook.md](adoption-outlook.md) work from this packet.
 
 ## Principles
 

--- a/docs/planning/admin-page-frame/slice-1.md
+++ b/docs/planning/admin-page-frame/slice-1.md
@@ -70,6 +70,6 @@ Optional headed Chromium at 1440, 768, and remaining gates was not required to c
 - Merged to `apf-development` as PR [#133](https://github.com/BankEncore/ShelfSense-v1/pull/133) (merge commit `8a4542c`). GitHub CI on that PR: lint, scan_js, scan_ruby, test (~13m), test_system (~5m), uds_accessibility — all success. The workflow runs on pull requests and on push to `main` only, so the merge commit itself has no second check suite.
 - No GitHub issue existed for Slice 1 (nothing to close).
 - Product consuming the frame is a separately approved later slice.
-- Next adoption is feature-led or an explicitly bounded family packet on `apf-development`. A Proposed Customer core packet is [customer-core.md](customer-core.md); it has no implementation authority until Accepted.
+- Next adoption is the Accepted [customer-core.md](customer-core.md) packet on `apf-development`, then merge that branch to `main` and retire it.
 - [adoption-outlook.md](adoption-outlook.md) remains **not authorized**.
 - Do not rename this program to UDS-6/7/8. Do not merge `apf-development` to `main` as part of this closeout.

--- a/docs/planning/roadmap.md
+++ b/docs/planning/roadmap.md
@@ -96,9 +96,9 @@ Persistent sidebar and global search remain parked ([#56](https://github.com/Ban
 
 ### Admin Page Frame Program
 
-**Status:** **Accepted.** Slice 0 complete. Slice 1 **Implemented on `apf-development`** (PR [#133](https://github.com/BankEncore/ShelfSense-v1/pull/133)). Not on `main` until a later closeout merge. Further family adoption is not authorized. Not a numbered domain phase and not UDS-6, UDS-7, or UDS-8.
+**Status:** **Accepted.** Slice 0 complete. Slice 1 **Implemented on `apf-development`** (PR [#133](https://github.com/BankEncore/ShelfSense-v1/pull/133)). [Customer core](admin-page-frame/customer-core.md) **Accepted** (not yet implemented). Not on `main` until this sprint’s closeout merge. Not a numbered domain phase and not UDS-6, UDS-7, or UDS-8.
 
-Authoritative packet: [admin-page-frame/](admin-page-frame/README.md). Integration branch: `apf-development` (not `main`). Follow-on after UDS-5: a shared administrative page-frame contract (width modes, region order, orchestration of existing shared partials). Unmigrated pages keep today’s `72rem` `.app-content` behavior. Slice 1 is the frame plus Adjustment Reasons only. Remaining surfaces stay feature-led or require a later bounded family packet targeting `apf-development`. [Customer core](admin-page-frame/customer-core.md) is **Proposed** and not authorized. UDS-6 and UDS-7 stay parked.
+Authoritative packet: [admin-page-frame/](admin-page-frame/README.md). Temporary sprint branch: `apf-development` (not `main` until closeout). Follow-on after UDS-5: a shared administrative page-frame contract (width modes, region order, orchestration of existing shared partials). Unmigrated pages keep today’s `72rem` `.app-content` behavior. Slice 1 is the frame plus Adjustment Reasons. [Customer core](admin-page-frame/customer-core.md) is **Accepted** and is the last family on this sprint branch; after it is validated, merge `apf-development` to `main` and retire the branch. Do not add another family to `apf-development`. UDS-6 and UDS-7 stay parked.
 
 **Deliverable:**
 
@@ -417,7 +417,7 @@ The following remain out of scope until a planning packet and ADR review justify
 | Phase 7.1 — Purchasing workflow closeout | **Complete** on `main` ([packet](phase7.1-purchasing-polish/README.md)) |
 | UDS-4 — Navigation and information architecture | **UDS-4.0–4.2 on `main`** ([uds-4-plan.md](ux-design-system/uds-4-plan.md)) |
 | UDS-5 — Administrative composition | **Complete** on `main` (PR #57; [uds-5-plan.md](ux-design-system/uds-5-plan.md)) |
-| Admin Page Frame Program | **Accepted** — Slice 1 **Implemented on `apf-development`** (PR [#133](https://github.com/BankEncore/ShelfSense-v1/pull/133)) — [packet](admin-page-frame/README.md) |
+| Admin Page Frame Program | **Accepted** — Slice 1 **Implemented on `apf-development`** (PR [#133](https://github.com/BankEncore/ShelfSense-v1/pull/133)); Customer core **Accepted** — [packet](admin-page-frame/README.md) |
 | Phase 8 — Customer foundation (MVP) | **Complete** on `main` (PR #42) |
 | Phase 9 — Catalog and bibliographic enrichment | **Implemented** |
 | Phase 10 — Stored value | **Implemented** on `main`; [manual test plan](phase10-stored-value/phase10-manual-test-plan.md) executed |


### PR DESCRIPTION
## Summary
- Accept the Customer core choice packet with all four surfaces at `standard`, surface-on-form tools, scoped CSS permission, and stronger test gates.
- `apf-development` remains a temporary sprint branch: implement Customer core into it, then merge to `main` and retire the branch. Do not add another family.

## Test plan
- [ ] Docs-only: CC-002 is `standard` on index/show/new/edit; no production `wide`
- [ ] CC-004 places `.surface` on the filter form (`customer-filters`), not a wrapper
- [ ] Integration lifecycle says merge to `main` after this family and retire `apf-development`
- [ ] [adoption-outlook.md](docs/planning/admin-page-frame/adoption-outlook.md) stays unauthorized for other families
- [ ] CI green against `apf-development`


Made with [Cursor](https://cursor.com)